### PR TITLE
iter5: QA fixes + animations + grouping + E2E tests

### DIFF
--- a/backend/tests/integration/test_e2e_smoke.py
+++ b/backend/tests/integration/test_e2e_smoke.py
@@ -1,0 +1,124 @@
+"""End-to-end smoke tests for the production API.
+
+These tests call the live HTTP service and require environment variables:
+  - SEICHI_API_URL: base URL of the running service (e.g. http://localhost:8080)
+  - SEICHI_API_KEY: a valid API key (sk_...) or Supabase JWT
+
+Run with:
+  SEICHI_API_URL=http://localhost:8080 SEICHI_API_KEY=sk_xxx \
+    pytest backend/tests/integration/test_e2e_smoke.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from typing import cast
+
+import pytest
+
+_API_URL = os.environ.get("SEICHI_API_URL", "")
+_API_KEY = os.environ.get("SEICHI_API_KEY", "")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _API_URL or not _API_KEY,
+        reason="SEICHI_API_URL and SEICHI_API_KEY required for E2E tests",
+    ),
+]
+
+
+def _headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_API_KEY}", "Content-Type": "application/json"}
+
+
+async def _post(path: str, body: dict[str, object]) -> tuple[int, dict[str, object]]:
+    """POST JSON to the API and return (status, body)."""
+    import aiohttp
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{_API_URL}{path}",
+            json=body,
+            headers=_headers(),
+        ) as resp:
+            status = resp.status
+            data = cast(dict[str, object], await resp.json())
+            return status, data
+
+
+async def _get(path: str) -> tuple[int, object]:
+    """GET from the API and return (status, body)."""
+    import aiohttp
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            f"{_API_URL}{path}",
+            headers=_headers(),
+        ) as resp:
+            status = resp.status
+            data = await resp.json()
+            return status, data
+
+
+class TestHealthCheck:
+    """Verify the health endpoint is reachable."""
+
+    async def test_healthz_returns_ok(self) -> None:
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{_API_URL}/healthz") as resp:
+                assert resp.status == 200
+                body = await resp.json()
+                assert body.get("status") == "ok"
+
+
+class TestRuntimeEndpoint:
+    """Smoke tests for the /v1/runtime POST endpoint."""
+
+    async def test_search_anime_returns_results(self) -> None:
+        status, body = await _post(
+            "/v1/runtime",
+            {"text": "響け！ユーフォニアムの聖地を探して", "locale": "ja"},
+        )
+        assert status == 200
+        assert body.get("success") is True
+
+    async def test_greeting_returns_response(self) -> None:
+        status, body = await _post(
+            "/v1/runtime",
+            {"text": "こんにちは", "locale": "ja"},
+        )
+        assert status == 200
+        assert body.get("success") is True
+        assert isinstance(body.get("message"), str)
+
+    async def test_missing_text_returns_error(self) -> None:
+        status, _body = await _post("/v1/runtime", {"locale": "ja"})
+        assert status in (400, 422)
+
+
+class TestConversationsEndpoint:
+    """Smoke tests for the /v1/conversations GET endpoint."""
+
+    async def test_list_conversations(self) -> None:
+        status, body = await _get("/v1/conversations")
+        assert status == 200
+        assert isinstance(body, list)
+
+
+class TestFeedbackEndpoint:
+    """Smoke test for the /v1/feedback POST endpoint."""
+
+    async def test_submit_feedback(self) -> None:
+        status, body = await _post(
+            "/v1/feedback",
+            {
+                "query_text": "test query",
+                "intent": "search_bangumi",
+                "rating": "good",
+            },
+        )
+        # 200 or 201 depending on implementation
+        assert status in (200, 201, 204)

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,5 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Session } from "@supabase/supabase-js";
+import { getSupabaseClient } from "@/lib/supabase";
 import ApiKeysPage from "@/components/settings/ApiKeysPage";
 
 export default function SettingsPage() {
+  const authClient = getSupabaseClient();
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!authClient) {
+      setLoading(false);
+      return;
+    }
+
+    authClient.auth.getSession().then(({ data: { session: s } }) => {
+      setSession(s);
+      setLoading(false);
+    });
+
+    const {
+      data: { subscription },
+    } = authClient.auth.onAuthStateChange((_event, s) => {
+      setSession(s);
+    });
+
+    return () => subscription.unsubscribe();
+  }, [authClient]);
+
+  useEffect(() => {
+    if (!loading && !session) {
+      window.location.href = "/";
+    }
+  }, [loading, session]);
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-[var(--color-bg)]">
+        <div className="text-[var(--color-muted-fg)]">Loading...</div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return null;
+  }
+
   return <ApiKeysPage />;
 }

--- a/frontend/components/auth/AuthGate.tsx
+++ b/frontend/components/auth/AuthGate.tsx
@@ -92,7 +92,7 @@ export default function AuthGate() {
     <div className="flex min-h-screen flex-col bg-[var(--color-bg)] lg:flex-row">
 
       {/* ── Left panel: brand ────────────────────────────────────── */}
-      <div className="flex flex-1 flex-col justify-between px-10 py-12 lg:px-16 lg:py-16">
+      <div className="flex flex-1 flex-col justify-between px-6 py-8 sm:px-10 sm:py-12 lg:px-16 lg:py-16">
 
         {/* Logo */}
         <div className="flex flex-col gap-0.5">
@@ -105,11 +105,11 @@ export default function AuthGate() {
         </div>
 
         {/* Hero copy */}
-        <div className="space-y-6 py-12 lg:py-0">
-          <h1 className="font-[family-name:var(--app-font-display)] text-4xl font-semibold leading-snug text-[var(--color-fg)] lg:text-5xl">
+        <div className="space-y-4 py-8 sm:space-y-6 sm:py-12 lg:py-0">
+          <h1 className="font-[family-name:var(--app-font-display)] text-3xl font-semibold leading-snug text-[var(--color-fg)] sm:text-4xl lg:text-5xl">
             聖地巡礼
           </h1>
-          <p className="mt-2 text-lg text-[var(--color-text-secondary)]">
+          <p className="mt-2 text-base text-[var(--color-text-secondary)] sm:text-lg">
             {land.subtitle}
           </p>
 
@@ -127,7 +127,7 @@ export default function AuthGate() {
         </div>
 
         {/* Footer note */}
-        <p className="text-xs text-[var(--color-muted-fg)]/40 py-4">
+        <p className="hidden text-xs text-[var(--color-muted-fg)]/40 py-4 sm:block">
           聖地巡礼
         </p>
       </div>
@@ -137,7 +137,7 @@ export default function AuthGate() {
       <div className="h-px bg-[var(--color-border)] lg:hidden" />
 
       {/* ── Right panel: auth form ────────────────────────────────── */}
-      <div className="flex w-full flex-col justify-center px-10 py-12 lg:w-[420px] lg:px-16 lg:py-16">
+      <div className="flex w-full flex-col justify-center px-6 py-8 sm:px-10 sm:py-12 lg:w-[420px] lg:px-16 lg:py-16">
 
         <div className="mb-8">
           <h2 className="text-base font-medium text-[var(--color-fg)]">

--- a/frontend/components/chat/MessageList.tsx
+++ b/frontend/components/chat/MessageList.tsx
@@ -30,7 +30,10 @@ export default function MessageList({
   if (messages.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center px-6 py-8">
-        <div className="w-full max-w-md rounded-[28px] border border-[var(--color-border)] bg-[color-mix(in_oklab,var(--color-card)_88%,white)] p-6 shadow-[0_24px_80px_rgba(15,23,42,0.06)]">
+        <div
+          className="w-full max-w-md rounded-[28px] border border-[var(--color-border)] bg-[color-mix(in_oklab,var(--color-card)_88%,white)] p-6 shadow-[0_24px_80px_rgba(15,23,42,0.06)]"
+          style={{ animation: "slide-up-fade 400ms var(--ease-out-quint) both" }}
+        >
           <div className="space-y-3">
             <p className="font-[family-name:var(--app-font-display)] text-3xl text-[var(--color-fg)]">
               {t.welcome_title}
@@ -41,13 +44,16 @@ export default function MessageList({
           </div>
 
           <div className="mt-5 flex flex-col gap-2.5">
-            {clarification.suggestions.map((s) => (
+            {clarification.suggestions.map((s, idx) => (
               <button
                 key={s.label}
                 type="button"
                 onClick={() => onSuggest?.(s.query)}
                 className="flex items-center justify-between rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-3 text-left text-sm font-light text-[var(--color-fg)] transition-colors hover:border-[var(--color-primary)]/50 hover:text-[var(--color-primary)]"
-                style={{ transitionDuration: "var(--duration-fast)" }}
+                style={{
+                  transitionDuration: "var(--duration-fast)",
+                  animation: `slide-up-fade 350ms var(--ease-out-quint) ${100 + idx * 60}ms both`,
+                }}
               >
                 <span>{s.label}</span>
                 <span aria-hidden>→</span>
@@ -55,7 +61,10 @@ export default function MessageList({
             ))}
           </div>
 
-          <p className="mt-5 text-xs font-light leading-6 text-[var(--color-muted-fg)]">
+          <p
+            className="mt-5 text-xs font-light leading-6 text-[var(--color-muted-fg)]"
+            style={{ animation: "slide-up-fade 350ms var(--ease-out-quint) 320ms both" }}
+          >
             {t.welcome_helper}
           </p>
         </div>
@@ -75,14 +84,20 @@ export default function MessageList({
     <div className="flex-1 overflow-y-auto py-6">
       <div className="mx-auto w-full max-w-2xl space-y-5 px-5">
         {messages.map((msg, idx) => (
-          <MessageBubble
+          <div
             key={msg.id}
-            message={msg}
-            userQuery={msg.role === "assistant" ? precedingUserText[idx] : undefined}
-            onActivate={onActivate}
-            isActive={msg.id === activeMessageId}
-            onOpenDrawer={onOpenDrawer}
-          />
+            style={{
+              animation: `slide-up-fade 300ms var(--ease-out-quint) ${Math.min(idx * 40, 200)}ms both`,
+            }}
+          >
+            <MessageBubble
+              message={msg}
+              userQuery={msg.role === "assistant" ? precedingUserText[idx] : undefined}
+              onActivate={onActivate}
+              isActive={msg.id === activeMessageId}
+              onOpenDrawer={onOpenDrawer}
+            />
+          </div>
         ))}
         <div ref={endRef} />
       </div>

--- a/frontend/components/generative/PilgrimageGrid.tsx
+++ b/frontend/components/generative/PilgrimageGrid.tsx
@@ -212,8 +212,8 @@ export default function PilgrimageGrid({ data }: PilgrimageGridProps) {
 
       <Tabs defaultValue="episode">
         <TabsList variant="line">
-          <TabsTrigger value="episode">按集数</TabsTrigger>
-          <TabsTrigger value="area">按地区</TabsTrigger>
+          <TabsTrigger value="episode">{t.tab_episode}</TabsTrigger>
+          <TabsTrigger value="area">{t.tab_area}</TabsTrigger>
         </TabsList>
 
         <TabsContent value="episode">
@@ -221,7 +221,7 @@ export default function PilgrimageGrid({ data }: PilgrimageGridProps) {
             {episodeGroups.map(([key, points]) => (
               <GroupSection
                 key={key}
-                label={key === "__other__" ? "その他" : `EP ${key}`}
+                label={key === "__other__" ? (t.other_label) : `EP ${key}`}
                 count={points.length}
                 points={points}
                 episodeLabel={t.episode}
@@ -238,7 +238,7 @@ export default function PilgrimageGrid({ data }: PilgrimageGridProps) {
               <GroupSection
                 key={key}
                 label={key === "__unknown__"
-                  ? (resolveUnknownName(points[0].latitude, points[0].longitude) ?? "不明")
+                  ? (resolveUnknownName(points[0].latitude, points[0].longitude) ?? t.unknown_area)
                   : key}
                 count={points.length}
                 points={points}

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -147,6 +147,18 @@ function ConversationItem({
   );
 }
 
+/** Deduplicate conversations by session_id, keeping the first occurrence. */
+function deduplicateConversations(
+  conversations: ConversationRecord[],
+): ConversationRecord[] {
+  const seen = new Set<string>();
+  return conversations.filter((record) => {
+    if (seen.has(record.session_id)) return false;
+    seen.add(record.session_id);
+    return true;
+  });
+}
+
 export default function Sidebar({
   conversations,
   activeSessionId,
@@ -204,7 +216,7 @@ export default function Sidebar({
             <p className="pb-3 text-[10px] font-medium uppercase tracking-widest text-[var(--color-sidebar-fg)] opacity-60">
               {t.recent}
             </p>
-            {conversations.map((record) => (
+            {deduplicateConversations(conversations).map((record) => (
               <ConversationItem
                 key={record.session_id}
                 active={record.session_id === activeSessionId}

--- a/frontend/lib/dictionaries/en.json
+++ b/frontend/lib/dictionaries/en.json
@@ -81,7 +81,11 @@
   "grid": {
     "no_results": "No results found. Try a different anime title.",
     "count": "{count} spots",
-    "episode": "Ep. {ep}"
+    "episode": "Ep. {ep}",
+    "tab_episode": "By Episode",
+    "tab_area": "By Area",
+    "other_label": "Other",
+    "unknown_area": "Unknown"
   },
   "route": {
     "no_results": "Could not create a route.",

--- a/frontend/lib/dictionaries/ja.json
+++ b/frontend/lib/dictionaries/ja.json
@@ -81,7 +81,11 @@
   "grid": {
     "no_results": "見つかりませんでした。別の作品名で試してください。",
     "count": "{count}件",
-    "episode": "第{ep}話"
+    "episode": "第{ep}話",
+    "tab_episode": "集数別",
+    "tab_area": "地域別",
+    "other_label": "その他",
+    "unknown_area": "不明"
   },
   "route": {
     "no_results": "ルートを作成できませんでした。",

--- a/frontend/lib/dictionaries/zh.json
+++ b/frontend/lib/dictionaries/zh.json
@@ -81,7 +81,11 @@
   "grid": {
     "no_results": "没有找到结果，请尝试其他作品名。",
     "count": "{count}个",
-    "episode": "第{ep}集"
+    "episode": "第{ep}集",
+    "tab_episode": "按集数",
+    "tab_area": "按地区",
+    "other_label": "其他",
+    "unknown_area": "未知"
   },
   "route": {
     "no_results": "无法创建路线。",


### PR DESCRIPTION
## Summary
- Settings page auth guard redirect (Task 7)
- Deduplicate sidebar conversation entries (Task 8)
- Entrance animations for messages + welcome card (Task 10)
- PilgrimageGrid episode/area grouping tabs (Task 11)
- Landing page mobile responsive (Task 15)
- Production API integration tests + E2E smoke (Task 33)

Plan 6 of 7 — Iter 5 spec tasks 7, 8, 10, 11, 15, 33.

## Test plan
- [ ] `make check` passes
- [ ] `cd frontend && npm run build` succeeds
- [ ] Settings redirects when not logged in
- [ ] No duplicate sidebar entries
- [ ] Messages animate on entrance
- [ ] PilgrimageGrid has area/episode tabs
- [ ] Landing page stacks on mobile (375px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication requirement to the settings page
  * Enhanced message and suggestion animations with staggered transitions
  * Improved localization with proper translated labels for navigation tabs and categories

* **Bug Fixes**
  * Fixed duplicate conversations appearing in the sidebar

* **Style**
  * Refined responsive layout and typography on the authentication page

* **Tests**
  * Added end-to-end smoke tests for API endpoints

* **Chores**
  * Updated translation dictionaries with new UI labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->