### PR TITLE
fix(frontend): hydrate stored session messages on page load

### DIFF
--- a/frontend/components/layout/AppShell.tsx
+++ b/frontend/components/layout/AppShell.tsx
@@ -61,6 +61,32 @@ export default function AppShell() {
     fetchRouteHistory().then(setRoutes).catch(() => {});
   }, []);
 
+  // Hydrate messages on mount when a stored session exists
+  useEffect(() => {
+    if (!sessionId) return;
+    let active = true;
+    fetchConversationMessages(sessionId)
+      .then((msgs) => {
+        if (!active) return;
+        if (msgs.length === 0) {
+          // No messages stored for this session — start fresh
+          clearSession();
+          return;
+        }
+        const hydrated = msgs.map((m, i) => ({
+          id: `hydrated-${i}-${Date.now()}`,
+          role: m.role,
+          text: m.content,
+          response: m.data ? (m.data as unknown as RuntimeResponse) : undefined,
+          timestamp: new Date(m.timestamp).getTime(),
+        }));
+        appendMessages(...hydrated);
+      })
+      .catch(() => {});
+    return () => { active = false; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const latestConversationResponse = useMemo(
     () => {
       for (let index = messages.length - 1; index >= 0; index -= 1) {


### PR DESCRIPTION
## Summary
- Adds a useEffect on mount in AppShell.tsx that fetches stored conversation messages when sessionId exists in localStorage
- Returning users see their previous conversation instead of a blank welcome screen
- If the stored session has no messages in the backend, the session is cleared so the user starts fresh

## Test plan
- [ ] Return to app with existing session in localStorage — previous messages should render
- [ ] Return with a sessionId whose backend has no messages — session clears, welcome screen shows
- [ ] Start a new chat (clearSession) — works normally with no stale hydration
- [ ] Click an already-active conversation in sidebar — no double-fetch or duplicate messages
- [ ] npm run build passes
- [ ] npm run lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation messages are now automatically restored when returning to a previous session, enabling seamless continuation of chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->