### PR TITLE
refactor(api): decompose public_api.py + verify FastAPI cutover

### DIFF
--- a/backend/interfaces/public_api.py
+++ b/backend/interfaces/public_api.py
@@ -2,6 +2,9 @@
 
 This module provides a stable request/response contract that future HTTP or
 RPC adapters can wrap without depending directly on internal pipeline types.
+
+Orchestration logic only -- response building and session management are
+delegated to ``response_builder`` and ``session_facade`` respectively.
 """
 
 from __future__ import annotations
@@ -15,9 +18,7 @@ from uuid import uuid4
 import structlog
 from pydantic_ai.models import Model
 
-from backend.agents.base import create_agent, get_default_model
-from backend.agents.executor_agent import ExecutorAgent, PipelineResult, StepResult
-from backend.agents.models import ExecutionPlan, PlanStep, ToolName
+from backend.agents.executor_agent import ExecutorAgent, PipelineResult
 from backend.agents.pipeline import run_pipeline
 from backend.application.errors import ApplicationError, ErrorCode
 from backend.infrastructure.observability import (
@@ -25,10 +26,26 @@ from backend.infrastructure.observability import (
     record_runtime_request,
 )
 from backend.infrastructure.session import SessionStore, create_session_store
+from backend.interfaces.response_builder import (
+    application_error_response,
+    pipeline_result_to_public_response,
+)
 from backend.interfaces.schemas import (
     PublicAPIError,
     PublicAPIRequest,
     PublicAPIResponse,
+)
+from backend.interfaces.session_facade import (
+    COMPACT_THRESHOLD,
+    MAX_ROUTE_HISTORY,
+    build_context_block,
+    build_selected_points_plan,
+    build_session_summary,
+    build_updated_session_state,
+    compact_session_interactions,
+    extract_context_delta,
+    generate_and_save_title,
+    normalize_session_state,
 )
 
 # Re-export for backward compatibility
@@ -42,10 +59,10 @@ __all__ = [
 
 logger = structlog.get_logger(__name__)
 
-_COMPACT_THRESHOLD = 8
-_COMPACT_KEEP_RECENT = 2
-_MAX_INTERACTIONS = 20
-_MAX_ROUTE_HISTORY = 10
+# Backward-compatible aliases for private names used by tests
+_build_context_block = build_context_block
+_extract_context_delta = extract_context_delta
+_compact_session_interactions = compact_session_interactions
 
 
 class RuntimeAPI:
@@ -91,13 +108,13 @@ class RuntimeAPI:
                 previous_state = (
                     await self._load_session_state(session_id)
                     if session_id
-                    else _normalize_session_state(None)
+                    else normalize_session_state(None)
                 )
                 context_delta: dict[str, object] = {}
                 user_memory = await self._load_user_memory(user_id)
-                context = _build_context_block(previous_state, user_memory=user_memory)
+                context = build_context_block(previous_state, user_memory=user_memory)
                 synthetic_plan = (
-                    _build_selected_points_plan(request)
+                    build_selected_points_plan(request)
                     if request.selected_point_ids
                     else None
                 )
@@ -120,7 +137,7 @@ class RuntimeAPI:
                         )
                 except ApplicationError as exc:
                     span.record_exception(exc)
-                    response = _application_error_response(exc)
+                    response = application_error_response(exc)
                 except Exception as exc:
                     span.record_exception(exc)
                     response = PublicAPIResponse(
@@ -136,11 +153,11 @@ class RuntimeAPI:
                         ],
                     )
                 else:
-                    response = _pipeline_result_to_public_response(
+                    response = pipeline_result_to_public_response(
                         result,
                         include_debug=request.include_debug,
                     )
-                    context_delta = _extract_context_delta(result)
+                    context_delta = extract_context_delta(result)
 
                 if response.intent == "greet_user":
                     response.session_id = None
@@ -154,10 +171,13 @@ class RuntimeAPI:
 
                 response.session_id = session_id
 
-                session_state = _build_updated_session_state(
+                session_state = build_updated_session_state(
                     previous_state,
                     request=request,
-                    response=response,
+                    response_intent=response.intent,
+                    response_status=response.status,
+                    response_success=response.success,
+                    response_message=response.message,
                     context_delta=context_delta,
                 )
 
@@ -175,7 +195,7 @@ class RuntimeAPI:
                         list(raw_rh) if isinstance(raw_rh, list) else []
                     )
                     route_history.append(route_record)
-                    session_state["route_history"] = route_history[-_MAX_ROUTE_HISTORY:]
+                    session_state["route_history"] = route_history[-MAX_ROUTE_HISTORY:]
 
                 await self._persist_session(session_id, session_state, response)
                 await self._persist_user_state(
@@ -197,16 +217,16 @@ class RuntimeAPI:
                 user_message_persisted = True
                 raw_ints = session_state.get("interactions")
                 interaction_count = len(raw_ints) if isinstance(raw_ints, list) else 0
-                if interaction_count >= _COMPACT_THRESHOLD:
+                if interaction_count >= COMPACT_THRESHOLD:
                     asyncio.create_task(
-                        _compact_session_interactions(
+                        compact_session_interactions(
                             session_id,
                             session_state,
                             self._session_store,
                         )
                     )
 
-                response.session = _build_session_summary(session_state)
+                response.session = build_session_summary(session_state)
                 raw_rh2 = session_state["route_history"]
                 response.route_history = (
                     list(raw_rh2) if isinstance(raw_rh2, list) else []
@@ -277,12 +297,7 @@ class RuntimeAPI:
         response: PublicAPIResponse,
         persist_user_only: bool = False,
     ) -> None:
-        """Persist user and bot messages to conversation_messages (best-effort).
-
-        When ``persist_user_only`` is True (e.g. pipeline error), only the user
-        message is stored — the bot response is skipped because no valid result
-        was produced.
-        """
+        """Persist user and bot messages to conversation_messages (best-effort)."""
         insert_message = getattr(self._db, "insert_message", None)
         if insert_message is None:
             return
@@ -353,7 +368,7 @@ class RuntimeAPI:
                 )
                 if is_first_interaction:
                     asyncio.create_task(
-                        _generate_and_save_title(
+                        generate_and_save_title(
                             session_id=session_id,
                             first_query=request.text,
                             response_message=response.message,
@@ -381,7 +396,7 @@ class RuntimeAPI:
 
     async def _load_session_state(self, session_id: str) -> dict[str, object]:
         state = await self._session_store.get(session_id)
-        return _normalize_session_state(state)
+        return normalize_session_state(state)
 
     async def _persist_session(
         self,
@@ -474,92 +489,6 @@ async def handle_public_request(
     return await api.handle(request, model=model, user_id=user_id, on_step=on_step)
 
 
-_UI_MAP: dict[str, str] = {
-    "search_bangumi": "PilgrimageGrid",
-    "search_nearby": "NearbyMap",
-    "plan_route": "RoutePlannerWizard",
-    "plan_selected": "RoutePlannerWizard",
-    "general_qa": "GeneralAnswer",
-    "answer_question": "GeneralAnswer",
-    "greet_user": "GeneralAnswer",
-    "unclear": "Clarification",
-    "clarify": "Clarification",
-}
-
-
-def _pipeline_result_to_public_response(
-    result: PipelineResult,
-    *,
-    include_debug: bool,
-) -> PublicAPIResponse:
-    final_output = result.final_output or {}
-    raw_errors = final_output.get("errors", [])
-    error_list = raw_errors if isinstance(raw_errors, list) else []
-    errors = [
-        PublicAPIError(
-            code="pipeline_error",
-            message="A processing step failed." if not include_debug else str(error),
-        )
-        for error in error_list
-    ]
-    component = _UI_MAP.get(result.intent)
-    ui = {"component": component} if component else None
-    response = PublicAPIResponse(
-        success=bool(final_output.get("success", result.success)),
-        status=str(final_output.get("status", "ok" if result.success else "error")),
-        intent=result.intent,
-        message=str(final_output.get("message") or ""),
-        data={
-            k: final_output[k]
-            for k in ("results", "route")
-            if final_output.get(k) is not None
-        },
-        errors=errors,
-        ui=ui,
-    )
-
-    if include_debug:
-        response.debug = {
-            "plan": {
-                "intent": result.intent,
-                "reasoning": result.plan.reasoning,
-                "steps": [step.tool.value for step in result.plan.steps],
-            },
-            "step_results": [
-                _serialize_step_result(step) for step in result.step_results
-            ],
-        }
-
-    return response
-
-
-def _normalize_session_state(state: dict[str, object] | None) -> dict[str, object]:
-    base: dict[str, object] = {
-        "interactions": [],
-        "route_history": [],
-        "last_intent": None,
-        "last_status": None,
-        "last_message": "",
-        "summary": None,
-        "updated_at": datetime.now(UTC).isoformat(),
-    }
-    if state is None:
-        return base
-
-    normalized = dict(base)
-    normalized.update(state)
-    raw_interactions = normalized.get("interactions")
-    normalized["interactions"] = (
-        list(raw_interactions) if isinstance(raw_interactions, list) else []
-    )
-    raw_route_history = normalized.get("route_history")
-    normalized["route_history"] = (
-        list(raw_route_history) if isinstance(raw_route_history, list) else []
-    )
-    normalized["summary"] = _as_str_or_none(normalized.get("summary"))
-    return normalized
-
-
 def _runtime_model_label(model: object) -> str | None:
     if model is None:
         return None
@@ -570,53 +499,6 @@ def _runtime_model_label(model: object) -> str | None:
     if isinstance(label, str) and label:
         return label
     return type(model).__name__
-
-
-def _build_updated_session_state(
-    previous_state: dict[str, object],
-    *,
-    request: PublicAPIRequest,
-    response: PublicAPIResponse,
-    context_delta: dict[str, object] | None = None,
-) -> dict[str, object]:
-    raw = previous_state["interactions"]
-    interactions = list(raw) if isinstance(raw, list) else []
-    interactions.append(
-        {
-            "text": request.text,
-            "intent": response.intent,
-            "status": response.status,
-            "success": response.success,
-            "created_at": datetime.now(UTC).isoformat(),
-            "context_delta": context_delta or {},
-        }
-    )
-    interactions = interactions[-_MAX_INTERACTIONS:]
-
-    return {
-        **previous_state,
-        "interactions": interactions,
-        "last_intent": response.intent,
-        "last_status": response.status,
-        "last_message": response.message,
-        "updated_at": datetime.now(UTC).isoformat(),
-    }
-
-
-def _build_session_summary(state: dict[str, object]) -> dict[str, object]:
-    raw_interactions = state.get("interactions")
-    raw_route_history = state.get("route_history")
-    return {
-        "interaction_count": len(raw_interactions)
-        if isinstance(raw_interactions, list)
-        else 0,
-        "route_history_count": len(raw_route_history)
-        if isinstance(raw_route_history, list)
-        else 0,
-        "last_intent": state.get("last_intent"),
-        "last_status": state.get("last_status"),
-        "last_message": state.get("last_message", ""),
-    }
 
 
 def _get_plan_params(result: PipelineResult) -> dict[str, object]:
@@ -639,31 +521,6 @@ def _infer_bangumi_id(results: object) -> str | None:
     return str(bangumi_id) if bangumi_id is not None else None
 
 
-def _application_error_response(exc: ApplicationError) -> PublicAPIResponse:
-    return PublicAPIResponse(
-        success=False,
-        status="error",
-        intent="unknown",
-        message=exc.message,
-        errors=[
-            PublicAPIError(
-                code=exc.error_code.value,
-                message=exc.message,
-                details=exc.details,
-            )
-        ],
-    )
-
-
-def _serialize_step_result(step: StepResult) -> dict[str, object]:
-    return {
-        "tool": step.tool,
-        "success": step.success,
-        "error": step.error,
-        "data": step.data,
-    }
-
-
 def _extract_plan_steps(result: PipelineResult | None) -> list[str] | None:
     if result is None:
         return None
@@ -683,260 +540,3 @@ def _extract_plan_steps(result: PipelineResult | None) -> list[str] | None:
         steps.append(str(step))
 
     return steps
-
-
-def _build_context_block(
-    session_state: dict[str, object],
-    user_memory: dict[str, object] | None = None,
-) -> dict[str, object] | None:
-    raw_interactions = session_state.get("interactions")
-    interactions = raw_interactions if isinstance(raw_interactions, list) else []
-    summary = _as_str_or_none(session_state.get("summary"))
-    current_bangumi_id: str | None = None
-    current_anime_title: str | None = None
-    last_location: str | None = None
-    visited_bangumi_ids: list[str] = []
-
-    for interaction in reversed(interactions):
-        if not isinstance(interaction, dict):
-            continue
-        raw_delta = interaction.get("context_delta")
-        delta = raw_delta if isinstance(raw_delta, dict) else {}
-
-        bangumi_id = _as_str_or_none(delta.get("bangumi_id"))
-        anime_title = _as_str_or_none(delta.get("anime_title"))
-        location = _as_str_or_none(delta.get("location"))
-
-        if current_bangumi_id is None and bangumi_id:
-            current_bangumi_id = bangumi_id
-            current_anime_title = anime_title
-        if last_location is None and location:
-            last_location = location
-        if bangumi_id and bangumi_id not in visited_bangumi_ids:
-            visited_bangumi_ids.append(bangumi_id)
-
-        if current_bangumi_id and last_location:
-            break
-
-    if user_memory:
-        raw_visited = user_memory.get("visited_anime")
-        visited_anime = raw_visited if isinstance(raw_visited, list) else []
-        for entry in visited_anime:
-            if not isinstance(entry, dict):
-                continue
-            bangumi_id = _as_str_or_none(entry.get("bangumi_id"))
-            if bangumi_id and bangumi_id not in visited_bangumi_ids:
-                visited_bangumi_ids.append(bangumi_id)
-
-        if current_bangumi_id is None and visited_anime:
-            most_recent = max(
-                visited_anime,
-                key=lambda e: e.get("last_at", "") if isinstance(e, dict) else "",
-                default=None,
-            )
-            if isinstance(most_recent, dict):
-                current_bangumi_id = _as_str_or_none(most_recent.get("bangumi_id"))
-                current_anime_title = _as_str_or_none(most_recent.get("title"))
-
-    if (
-        not current_bangumi_id
-        and not last_location
-        and not visited_bangumi_ids
-        and not summary
-    ):
-        return None
-
-    return {
-        "summary": summary,
-        "current_bangumi_id": current_bangumi_id,
-        "current_anime_title": current_anime_title,
-        "last_location": last_location,
-        "last_intent": session_state.get("last_intent"),
-        "visited_bangumi_ids": visited_bangumi_ids,
-    }
-
-
-def _extract_context_delta(result: PipelineResult) -> dict[str, object]:
-    bangumi_id: str | None = None
-    anime_title: str | None = None
-    location: str | None = None
-
-    for step_result in result.step_results:
-        if step_result.tool != "resolve_anime" or not step_result.success:
-            continue
-
-        data = step_result.data if isinstance(step_result.data, dict) else {}
-        bangumi_id = _as_str_or_none(data.get("bangumi_id"))
-        anime_title = _as_str_or_none(data.get("title") or data.get("anime_title"))
-        break
-
-    for plan_step, step_result in zip(
-        result.plan.steps, result.step_results, strict=False
-    ):
-        if not step_result.success:
-            continue
-
-        if step_result.tool == "search_nearby" and location is None:
-            location = _as_str_or_none(plan_step.params.get("location"))
-
-        if step_result.tool != "search_bangumi" or bangumi_id is not None:
-            continue
-
-        data = step_result.data if isinstance(step_result.data, dict) else {}
-        rows = data.get("rows")
-        if isinstance(rows, list) and rows:
-            first_row = rows[0] if isinstance(rows[0], dict) else {}
-            bangumi_id = _as_str_or_none(first_row.get("bangumi_id"))
-            anime_title = _as_str_or_none(
-                first_row.get("title") or first_row.get("title_cn")
-            )
-        if bangumi_id is None:
-            bangumi_id = _as_str_or_none(
-                plan_step.params.get("bangumi_id") or plan_step.params.get("bangumi")
-            )
-
-    context_delta: dict[str, object] = {}
-    if bangumi_id is not None:
-        context_delta["bangumi_id"] = bangumi_id
-    if anime_title is not None:
-        context_delta["anime_title"] = anime_title
-    if location is not None:
-        context_delta["location"] = location
-    return context_delta
-
-
-async def _generate_and_save_title(
-    *,
-    session_id: str,
-    first_query: str,
-    response_message: str,
-    db: object,
-    user_id: str | None = None,
-) -> None:
-    title = first_query.strip()[:20] or first_query[:20]
-
-    try:
-        from backend.agents.base import create_agent, get_default_model
-
-        agent = create_agent(
-            get_default_model(),
-            system_prompt=(
-                "Generate a very short conversation title (<=15 characters) in the "
-                "same language as the query. Output only the title."
-            ),
-            retries=1,
-        )
-        result = await agent.run(
-            f"Query: {first_query}\nResponse summary: {response_message[:200]}"
-        )
-        candidate = str(result.output).strip()[:20]
-        if candidate:
-            title = candidate
-    except Exception:
-        logger.warning("conversation_title_generation_failed", session_id=session_id)
-
-    update_conversation_title = getattr(db, "update_conversation_title", None)
-    if update_conversation_title is None:
-        return
-
-    try:
-        await update_conversation_title(session_id, title, user_id=user_id)
-    except TypeError:
-        await update_conversation_title(session_id, title)
-    except Exception:
-        logger.warning("update_conversation_title_failed", session_id=session_id)
-
-
-def _build_selected_points_plan(request: PublicAPIRequest) -> ExecutionPlan:
-    point_ids = list(request.selected_point_ids or [])
-    return ExecutionPlan(
-        steps=[
-            PlanStep(
-                tool=ToolName.PLAN_SELECTED,
-                params={
-                    "point_ids": point_ids,
-                    "origin": request.origin,
-                },
-            )
-        ],
-        reasoning="User selected specific points for routing.",
-        locale=request.locale,
-    )
-
-
-async def _compact_session_interactions(
-    session_id: str,
-    session_state: dict[str, object],
-    session_store: SessionStore,
-) -> None:
-    """Compress older interactions into a short summary in the background."""
-    latest_state = await session_store.get(session_id)
-    current_state = _normalize_session_state(
-        latest_state if latest_state is not None else session_state
-    )
-    raw_interactions = current_state.get("interactions")
-    interactions = raw_interactions if isinstance(raw_interactions, list) else []
-    if len(interactions) < _COMPACT_THRESHOLD:
-        return
-
-    previous_summary = _as_str_or_none(current_state.get("summary"))
-    compacted = interactions[:-_COMPACT_KEEP_RECENT]
-    recent = interactions[-_COMPACT_KEEP_RECENT:]
-    if not compacted:
-        return
-
-    prompt_lines: list[str] = []
-    if previous_summary:
-        prompt_lines.append(f"Existing summary: {previous_summary}")
-    prompt_lines.append("Merge these interaction notes into a concise session summary:")
-    for entry in compacted:
-        if isinstance(entry, dict):
-            intent = entry.get("intent") or "unknown"
-            text = str(entry.get("text") or "").strip()[:120]
-        else:
-            intent = "unknown"
-            text = str(entry).strip()[:120]
-        prompt_lines.append(f"- [{intent}] {text}")
-
-    agent = create_agent(
-        get_default_model(),
-        system_prompt=(
-            "Summarize the session in 1-2 sentences. Capture what the user was "
-            "researching and keep the same language as the interaction text."
-        ),
-        retries=1,
-    )
-    try:
-        result = await agent.run("\n".join(prompt_lines))
-    except Exception:
-        logger.warning("compact_llm_failed", session_id=session_id)
-        return
-
-    summary = _as_str_or_none(getattr(result, "output", None))
-    if summary is None:
-        return
-
-    updated_state = {
-        **current_state,
-        "interactions": recent,
-        "summary": summary[:300],
-        "updated_at": datetime.now(UTC).isoformat(),
-    }
-    try:
-        await session_store.set(session_id, updated_state)
-    except Exception:
-        logger.warning("compact_write_failed", session_id=session_id)
-        return
-
-    logger.info(
-        "compact_complete",
-        session_id=session_id,
-        summary_length=len(str(updated_state["summary"])),
-    )
-
-
-def _as_str_or_none(value: object) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None

--- a/backend/interfaces/response_builder.py
+++ b/backend/interfaces/response_builder.py
@@ -1,0 +1,97 @@
+"""Response building utilities for the public API surface.
+
+Converts internal ``PipelineResult`` / ``ApplicationError`` instances into
+the stable ``PublicAPIResponse`` contract that HTTP adapters return.
+"""
+
+from __future__ import annotations
+
+from backend.agents.executor_agent import PipelineResult, StepResult
+from backend.application.errors import ApplicationError
+from backend.interfaces.schemas import PublicAPIError, PublicAPIResponse
+
+_UI_MAP: dict[str, str] = {
+    "search_bangumi": "PilgrimageGrid",
+    "search_nearby": "NearbyMap",
+    "plan_route": "RoutePlannerWizard",
+    "plan_selected": "RoutePlannerWizard",
+    "general_qa": "GeneralAnswer",
+    "answer_question": "GeneralAnswer",
+    "greet_user": "GeneralAnswer",
+    "unclear": "Clarification",
+    "clarify": "Clarification",
+}
+
+
+def pipeline_result_to_public_response(
+    result: PipelineResult,
+    *,
+    include_debug: bool,
+) -> PublicAPIResponse:
+    """Map a ``PipelineResult`` to the stable ``PublicAPIResponse``."""
+    final_output = result.final_output or {}
+    raw_errors = final_output.get("errors", [])
+    error_list = raw_errors if isinstance(raw_errors, list) else []
+    errors = [
+        PublicAPIError(
+            code="pipeline_error",
+            message="A processing step failed." if not include_debug else str(error),
+        )
+        for error in error_list
+    ]
+    component = _UI_MAP.get(result.intent)
+    ui = {"component": component} if component else None
+    response = PublicAPIResponse(
+        success=bool(final_output.get("success", result.success)),
+        status=str(final_output.get("status", "ok" if result.success else "error")),
+        intent=result.intent,
+        message=str(final_output.get("message") or ""),
+        data={
+            k: final_output[k]
+            for k in ("results", "route")
+            if final_output.get(k) is not None
+        },
+        errors=errors,
+        ui=ui,
+    )
+
+    if include_debug:
+        response.debug = {
+            "plan": {
+                "intent": result.intent,
+                "reasoning": result.plan.reasoning,
+                "steps": [step.tool.value for step in result.plan.steps],
+            },
+            "step_results": [
+                serialize_step_result(step) for step in result.step_results
+            ],
+        }
+
+    return response
+
+
+def application_error_response(exc: ApplicationError) -> PublicAPIResponse:
+    """Map an ``ApplicationError`` to a failed ``PublicAPIResponse``."""
+    return PublicAPIResponse(
+        success=False,
+        status="error",
+        intent="unknown",
+        message=exc.message,
+        errors=[
+            PublicAPIError(
+                code=exc.error_code.value,
+                message=exc.message,
+                details=exc.details,
+            )
+        ],
+    )
+
+
+def serialize_step_result(step: StepResult) -> dict[str, object]:
+    """Serialize a single ``StepResult`` for debug output."""
+    return {
+        "tool": step.tool,
+        "success": step.success,
+        "error": step.error,
+        "data": step.data,
+    }

--- a/backend/interfaces/session_facade.py
+++ b/backend/interfaces/session_facade.py
@@ -1,0 +1,364 @@
+"""Session management facade for the public API.
+
+Handles session state normalization, context building, interaction
+compaction, title generation, and selected-point plan construction.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+
+from backend.agents.base import create_agent, get_default_model
+from backend.agents.executor_agent import PipelineResult
+from backend.agents.models import ExecutionPlan, PlanStep, ToolName
+from backend.infrastructure.session import SessionStore
+from backend.interfaces.schemas import PublicAPIRequest
+
+logger = structlog.get_logger(__name__)
+
+COMPACT_THRESHOLD = 8
+COMPACT_KEEP_RECENT = 2
+MAX_INTERACTIONS = 20
+MAX_ROUTE_HISTORY = 10
+
+
+def normalize_session_state(state: dict[str, object] | None) -> dict[str, object]:
+    """Return a well-typed session state dict with all required keys."""
+    base: dict[str, object] = {
+        "interactions": [],
+        "route_history": [],
+        "last_intent": None,
+        "last_status": None,
+        "last_message": "",
+        "summary": None,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    if state is None:
+        return base
+
+    normalized = dict(base)
+    normalized.update(state)
+    raw_interactions = normalized.get("interactions")
+    normalized["interactions"] = (
+        list(raw_interactions) if isinstance(raw_interactions, list) else []
+    )
+    raw_route_history = normalized.get("route_history")
+    normalized["route_history"] = (
+        list(raw_route_history) if isinstance(raw_route_history, list) else []
+    )
+    normalized["summary"] = as_str_or_none(normalized.get("summary"))
+    return normalized
+
+
+def build_updated_session_state(
+    previous_state: dict[str, object],
+    *,
+    request: PublicAPIRequest,
+    response_intent: str,
+    response_status: str,
+    response_success: bool,
+    response_message: str = "",
+    context_delta: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Append the current interaction and return the updated session state."""
+    raw = previous_state["interactions"]
+    interactions = list(raw) if isinstance(raw, list) else []
+    interactions.append(
+        {
+            "text": request.text,
+            "intent": response_intent,
+            "status": response_status,
+            "success": response_success,
+            "created_at": datetime.now(UTC).isoformat(),
+            "context_delta": context_delta or {},
+        }
+    )
+    interactions = interactions[-MAX_INTERACTIONS:]
+
+    return {
+        **previous_state,
+        "interactions": interactions,
+        "last_intent": response_intent,
+        "last_status": response_status,
+        "last_message": response_message,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def build_session_summary(state: dict[str, object]) -> dict[str, object]:
+    """Build a compact summary dict suitable for the response payload."""
+    raw_interactions = state.get("interactions")
+    raw_route_history = state.get("route_history")
+    return {
+        "interaction_count": len(raw_interactions)
+        if isinstance(raw_interactions, list)
+        else 0,
+        "route_history_count": len(raw_route_history)
+        if isinstance(raw_route_history, list)
+        else 0,
+        "last_intent": state.get("last_intent"),
+        "last_status": state.get("last_status"),
+        "last_message": state.get("last_message", ""),
+    }
+
+
+def build_context_block(
+    session_state: dict[str, object],
+    user_memory: dict[str, object] | None = None,
+) -> dict[str, object] | None:
+    """Derive a context block from session history and cross-session memory."""
+    raw_interactions = session_state.get("interactions")
+    interactions = raw_interactions if isinstance(raw_interactions, list) else []
+    summary = as_str_or_none(session_state.get("summary"))
+    current_bangumi_id: str | None = None
+    current_anime_title: str | None = None
+    last_location: str | None = None
+    visited_bangumi_ids: list[str] = []
+
+    for interaction in reversed(interactions):
+        if not isinstance(interaction, dict):
+            continue
+        raw_delta = interaction.get("context_delta")
+        delta = raw_delta if isinstance(raw_delta, dict) else {}
+
+        bangumi_id = as_str_or_none(delta.get("bangumi_id"))
+        anime_title = as_str_or_none(delta.get("anime_title"))
+        location = as_str_or_none(delta.get("location"))
+
+        if current_bangumi_id is None and bangumi_id:
+            current_bangumi_id = bangumi_id
+            current_anime_title = anime_title
+        if last_location is None and location:
+            last_location = location
+        if bangumi_id and bangumi_id not in visited_bangumi_ids:
+            visited_bangumi_ids.append(bangumi_id)
+
+        if current_bangumi_id and last_location:
+            break
+
+    if user_memory:
+        raw_visited = user_memory.get("visited_anime")
+        visited_anime = raw_visited if isinstance(raw_visited, list) else []
+        for entry in visited_anime:
+            if not isinstance(entry, dict):
+                continue
+            bangumi_id = as_str_or_none(entry.get("bangumi_id"))
+            if bangumi_id and bangumi_id not in visited_bangumi_ids:
+                visited_bangumi_ids.append(bangumi_id)
+
+        if current_bangumi_id is None and visited_anime:
+            most_recent = max(
+                visited_anime,
+                key=lambda e: e.get("last_at", "") if isinstance(e, dict) else "",
+                default=None,
+            )
+            if isinstance(most_recent, dict):
+                current_bangumi_id = as_str_or_none(most_recent.get("bangumi_id"))
+                current_anime_title = as_str_or_none(most_recent.get("title"))
+
+    if (
+        not current_bangumi_id
+        and not last_location
+        and not visited_bangumi_ids
+        and not summary
+    ):
+        return None
+
+    return {
+        "summary": summary,
+        "current_bangumi_id": current_bangumi_id,
+        "current_anime_title": current_anime_title,
+        "last_location": last_location,
+        "last_intent": session_state.get("last_intent"),
+        "visited_bangumi_ids": visited_bangumi_ids,
+    }
+
+
+def extract_context_delta(result: PipelineResult) -> dict[str, object]:
+    """Extract bangumi_id / anime_title / location from step results."""
+    bangumi_id: str | None = None
+    anime_title: str | None = None
+    location: str | None = None
+
+    for step_result in result.step_results:
+        if step_result.tool != "resolve_anime" or not step_result.success:
+            continue
+
+        data = step_result.data if isinstance(step_result.data, dict) else {}
+        bangumi_id = as_str_or_none(data.get("bangumi_id"))
+        anime_title = as_str_or_none(data.get("title") or data.get("anime_title"))
+        break
+
+    for plan_step, step_result in zip(
+        result.plan.steps, result.step_results, strict=False
+    ):
+        if not step_result.success:
+            continue
+
+        if step_result.tool == "search_nearby" and location is None:
+            location = as_str_or_none(plan_step.params.get("location"))
+
+        if step_result.tool != "search_bangumi" or bangumi_id is not None:
+            continue
+
+        data = step_result.data if isinstance(step_result.data, dict) else {}
+        rows = data.get("rows")
+        if isinstance(rows, list) and rows:
+            first_row = rows[0] if isinstance(rows[0], dict) else {}
+            bangumi_id = as_str_or_none(first_row.get("bangumi_id"))
+            anime_title = as_str_or_none(
+                first_row.get("title") or first_row.get("title_cn")
+            )
+        if bangumi_id is None:
+            bangumi_id = as_str_or_none(
+                plan_step.params.get("bangumi_id") or plan_step.params.get("bangumi")
+            )
+
+    context_delta: dict[str, object] = {}
+    if bangumi_id is not None:
+        context_delta["bangumi_id"] = bangumi_id
+    if anime_title is not None:
+        context_delta["anime_title"] = anime_title
+    if location is not None:
+        context_delta["location"] = location
+    return context_delta
+
+
+async def compact_session_interactions(
+    session_id: str,
+    session_state: dict[str, object],
+    session_store: SessionStore,
+) -> None:
+    """Compress older interactions into a short summary in the background."""
+    latest_state = await session_store.get(session_id)
+    current_state = normalize_session_state(
+        latest_state if latest_state is not None else session_state
+    )
+    raw_interactions = current_state.get("interactions")
+    interactions = raw_interactions if isinstance(raw_interactions, list) else []
+    if len(interactions) < COMPACT_THRESHOLD:
+        return
+
+    previous_summary = as_str_or_none(current_state.get("summary"))
+    compacted = interactions[:-COMPACT_KEEP_RECENT]
+    recent = interactions[-COMPACT_KEEP_RECENT:]
+    if not compacted:
+        return
+
+    prompt_lines: list[str] = []
+    if previous_summary:
+        prompt_lines.append(f"Existing summary: {previous_summary}")
+    prompt_lines.append("Merge these interaction notes into a concise session summary:")
+    for entry in compacted:
+        if isinstance(entry, dict):
+            intent = entry.get("intent") or "unknown"
+            text = str(entry.get("text") or "").strip()[:120]
+        else:
+            intent = "unknown"
+            text = str(entry).strip()[:120]
+        prompt_lines.append(f"- [{intent}] {text}")
+
+    agent = create_agent(
+        get_default_model(),
+        system_prompt=(
+            "Summarize the session in 1-2 sentences. Capture what the user was "
+            "researching and keep the same language as the interaction text."
+        ),
+        retries=1,
+    )
+    try:
+        result = await agent.run("\n".join(prompt_lines))
+    except Exception:
+        logger.warning("compact_llm_failed", session_id=session_id)
+        return
+
+    summary = as_str_or_none(getattr(result, "output", None))
+    if summary is None:
+        return
+
+    updated_state = {
+        **current_state,
+        "interactions": recent,
+        "summary": summary[:300],
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    try:
+        await session_store.set(session_id, updated_state)
+    except Exception:
+        logger.warning("compact_write_failed", session_id=session_id)
+        return
+
+    logger.info(
+        "compact_complete",
+        session_id=session_id,
+        summary_length=len(str(updated_state["summary"])),
+    )
+
+
+async def generate_and_save_title(
+    *,
+    session_id: str,
+    first_query: str,
+    response_message: str,
+    db: object,
+    user_id: str | None = None,
+) -> None:
+    """Generate a short conversation title and persist it."""
+    title = first_query.strip()[:20] or first_query[:20]
+
+    try:
+        agent = create_agent(
+            get_default_model(),
+            system_prompt=(
+                "Generate a very short conversation title (<=15 characters) in the "
+                "same language as the query. Output only the title."
+            ),
+            retries=1,
+        )
+        result = await agent.run(
+            f"Query: {first_query}\nResponse summary: {response_message[:200]}"
+        )
+        candidate = str(result.output).strip()[:20]
+        if candidate:
+            title = candidate
+    except Exception:
+        logger.warning("conversation_title_generation_failed", session_id=session_id)
+
+    update_conversation_title = getattr(db, "update_conversation_title", None)
+    if update_conversation_title is None:
+        return
+
+    try:
+        await update_conversation_title(session_id, title, user_id=user_id)
+    except TypeError:
+        await update_conversation_title(session_id, title)
+    except Exception:
+        logger.warning("update_conversation_title_failed", session_id=session_id)
+
+
+def build_selected_points_plan(request: PublicAPIRequest) -> ExecutionPlan:
+    """Build a synthetic ``ExecutionPlan`` for user-selected point routing."""
+    point_ids = list(request.selected_point_ids or [])
+    return ExecutionPlan(
+        steps=[
+            PlanStep(
+                tool=ToolName.PLAN_SELECTED,
+                params={
+                    "point_ids": point_ids,
+                    "origin": request.origin,
+                },
+            )
+        ],
+        reasoning="User selected specific points for routing.",
+        locale=request.locale,
+    )
+
+
+def as_str_or_none(value: object) -> str | None:
+    """Coerce a value to a stripped string, returning ``None`` for blanks."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/backend/tests/unit/test_public_api.py
+++ b/backend/tests/unit/test_public_api.py
@@ -241,7 +241,7 @@ class TestCompact:
         )
 
         with patch(
-            "backend.interfaces.public_api.create_agent", return_value=mock_agent
+            "backend.interfaces.session_facade.create_agent", return_value=mock_agent
         ):
             await _compact_session_interactions(session_id, state, store)
 
@@ -269,7 +269,7 @@ class TestCompact:
             "summary": None,
         }
 
-        with patch("backend.interfaces.public_api.create_agent") as create_agent:
+        with patch("backend.interfaces.session_facade.create_agent") as create_agent:
             await _compact_session_interactions("sess-short", state, store)
 
         create_agent.assert_not_called()


### PR DESCRIPTION
Split public_api.py into response_builder.py + session_facade.py. Verified FastAPI adapter, entrypoints, and aiohttp removal already complete. All 59 tests pass, ruff/mypy clean.