### PR TITLE
feat(sidebar): relative time, first_query title, route icon

### DIFF
--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -181,7 +181,7 @@ function ConversationItem({
               {itemTitle}
             </p>
             <p className="mt-0.5 truncate text-[10px] text-[var(--color-sidebar-fg)] opacity-60">
-              {meta} {spotsLabel ? ` \u00B7 ${spotsLabel}` : ""}
+              {meta}{spotsLabel ? ` \u00B7 ${spotsLabel}` : ""}
             </p>
           </>
         )}


### PR DESCRIPTION
## Summary
- Sidebar entries now show `first_query` (truncated) instead of LLM-generated title
- Relative time in ja/zh/en (2分前, 2分钟前, 2m ago)
- 🗾 icon for search, 📍 for route planning queries
- Active conversation highlighted with oklch accent
- Min 52px touch targets per item

## Bugs closed
- Design bug #12: sidebar duplicate titles, no timestamps

## Test plan
- [x] npm run lint passes
- [x] npm run build passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation type indicators with contextual emoji icons
  * Locale-aware relative last-updated times (e.g., "5 minutes ago") shown inline
  * Titles prefer custom renames when present, otherwise fall back to original query; titles truncated to 25 characters
  * Optional spots label appended to item display

* **Style**
  * Redesigned conversation item into icon + content columns; always-visible meta text, background-only hover/active styling, and pointer cursor for items
<!-- end of auto-generated comment: release notes by coderabbit.ai -->