### PR TITLE
feat(i18n): language switcher in chat header

### DIFF
--- a/frontend/components/layout/ChatHeader.tsx
+++ b/frontend/components/layout/ChatHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useDict, useLocale, useSetLocale } from "../../lib/i18n-context";
-import { LOCALES } from "../../lib/i18n";
+import { LOCALES, LOCALE_LABELS } from "../../lib/i18n";
 
 interface ChatHeaderProps {
   onNewChat?: () => void;
@@ -44,7 +44,7 @@ export default function ChatHeader({ onNewChat, onMenuToggle }: ChatHeaderProps)
                   : "text-[var(--color-muted-fg)] hover:text-[var(--color-fg)]"
               }`}
             >
-              {loc === "ja" ? "\u65E5\u672C\u8A9E" : loc === "zh" ? "\u4E2D\u6587" : "EN"}
+              {LOCALE_LABELS[loc]}
             </button>
           ))}
         </div>

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -2,6 +2,13 @@ export const LOCALES = ["ja", "zh", "en"] as const;
 export type Locale = (typeof LOCALES)[number];
 export const DEFAULT_LOCALE: Locale = "ja";
 
+/** Human-readable locale labels — single source of truth for all switchers. */
+export const LOCALE_LABELS: Record<Locale, string> = {
+  ja: "日本語",
+  zh: "中文",
+  en: "EN",
+};
+
 const STORAGE_KEY = "seichi_lang";
 
 export function detectLocale(): Locale {


### PR DESCRIPTION
Language switcher now visible without opening sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language selection control in the chat header, enabling users to easily switch between Japanese, Chinese, and English interfaces. The active language is visually highlighted for quick reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->