### PR TITLE
fix(pipeline): ReAct failure recovery instead of abort

### DIFF
--- a/backend/agents/pipeline.py
+++ b/backend/agents/pipeline.py
@@ -50,6 +50,7 @@ async def react_loop(
     Yields ReactStepEvent for each step (for SSE streaming).
     """
     history: list[Observation] = []
+    failure_count = 0
     accumulated_results: list[StepResult] = []
     executor_context: dict[str, object] = {"locale": locale}
     if context and context.get("last_location"):
@@ -188,14 +189,24 @@ async def react_loop(
                 )
 
                 if not resolve_result.success:
+                    failure_count += 1
+                    if failure_count >= 2:
+                        yield ReactStepEvent(
+                            type="error",
+                            thought="Guard: resolve_anime failed after retries",
+                            message=(
+                                f"Could not resolve anime title: {resolve_result.error}"
+                            ),
+                        )
+                        return
                     yield ReactStepEvent(
-                        type="error",
-                        thought="Guard: resolve_anime failed",
-                        message=(
-                            f"Could not resolve anime title: {resolve_result.error}"
-                        ),
+                        type="step",
+                        thought="Guard: resolve_anime failed, planner will recover",
+                        tool="resolve_anime",
+                        status="failed",
+                        observation=resolve_obs.summary,
                     )
-                    return
+                    continue
             # ── End guard ──
 
             # Yield "running" event
@@ -213,6 +224,7 @@ async def react_loop(
             # Update executor context (same as original pipeline)
             if step_result.success and hasattr(step, "tool"):
                 executor_context[step.tool.value] = step_result.data
+                failure_count = 0  # reset on success
 
             # Format observation for planner
             obs = ExecutorAgent.format_observation(step_result)
@@ -229,14 +241,29 @@ async def react_loop(
                 step_result=step_result,
             )
 
-            # If step failed, stop the loop
+            # If step failed, let planner recover
             if not step_result.success:
+                failure_count += 1
+                if failure_count >= 2:
+                    yield ReactStepEvent(
+                        type="error",
+                        thought="Too many consecutive failures",
+                        message=(
+                            f"Stopped after {failure_count} failures. "
+                            f"Last: {step_result.error}"
+                        ),
+                    )
+                    return
+                # Planner already has the failure observation in history
+                # Just yield a failed step event and continue the loop
                 yield ReactStepEvent(
-                    type="error",
+                    type="step",
                     thought=react_step.thought,
-                    message=f"Step {tool_name} failed: {step_result.error}",
+                    tool=tool_name,
+                    status="failed",
+                    observation=obs.summary,
                 )
-                return
+                continue
 
             # If clarify, pause and wait for user input
             if tool_name == "clarify":

--- a/backend/agents/planner_agent.py
+++ b/backend/agents/planner_agent.py
@@ -150,6 +150,17 @@ If the user's message mentions an anime title (in any language), you MUST call
 resolve_anime BEFORE calling search_bangumi. Do NOT call search_bangumi without
 a bangumi_id from a prior resolve_anime observation. Skipping resolve_anime causes
 0 results and a broken user experience.
+
+## Failure recovery
+
+If a tool fails (you see a \u2717 observation), analyze the error and recover:
+- plan_route failed "no points found": you need to run search_bangumi first to load spots
+- resolve_anime failed: try an alternative spelling or the original language title
+- search_bangumi failed "no bangumi_id": run resolve_anime first
+- Any tool timed out: retry once with the same parameters
+
+Do NOT give up after one failure. Try to recover by running prerequisite steps.
+Maximum 2 consecutive failures before stopping.
 """
 )
 


### PR DESCRIPTION
## Summary
- Replace `return` with `continue` on step failure in react_loop
- Add failure_count tracker (max 2 consecutive failures then hard stop)
- Feed failure observation back to planner as history entry
- Add failure recovery instructions to REACT_SYSTEM_PROMPT
- Reset failure_count on successful step

## Findings addressed
- T02 from production bugfix spec (issue #60)
- pipeline.py:232-239 aborted on ANY step failure with no recovery

## Test plan
- [ ] Step failure → planner sees it → recovers → final result correct
- [ ] Max 2 failures then hard stop with error message
- [ ] `uv run pytest backend/tests/unit -x -q` passes (418 passed)
- [ ] `uv run mypy backend/ --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced resilience: The system now intelligently tracks and recovers from consecutive failures, allowing graceful recovery before termination
  * Improved error handling: Added specific recovery strategies when operations fail and automatic retry logic for timed-out requests
  * Better failure recovery: System implements intelligent recovery behaviors to minimize disruptions and allow process continuation after failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->