### PR TITLE
fix(ui): show thinking indicator instead of blank bubble

### DIFF
--- a/frontend/components/chat/ThinkingProcess.tsx
+++ b/frontend/components/chat/ThinkingProcess.tsx
@@ -27,7 +27,15 @@ export default function ThinkingProcess({
   const [expanded, setExpanded] = useState(isStreaming);
   const t = useDict();
 
-  if (steps.length === 0) return null;
+  if (steps.length === 0) {
+    if (!isStreaming) return null;
+    return (
+      <div className="mb-2 flex items-center gap-1.5 text-xs text-[var(--color-muted-fg)]">
+        <span className="animate-pulse">🧠</span>
+        <span>{t.chat?.thinking || "Thinking..."}</span>
+      </div>
+    );
+  }
 
   const summary = steps
     .filter((s) => s.status === "done")


### PR DESCRIPTION
## Summary
- Show pulsing "Thinking..." when `isStreaming && steps.length === 0`
- Transitions to step-by-step display once first step arrives
- Returns null only when not streaming (completed with no steps)
- i18n keys already present in all 3 locales (ja/zh/en)

## Findings addressed
- T04 from production bugfix spec (issue #60)
- ThinkingProcess.tsx returned null during streaming, causing blank bubble

## Test plan
- [ ] Sending a message shows "Thinking..." immediately
- [ ] Indicator transitions to steps when first step arrives
- [ ] `cd frontend && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)