### PR TITLE
fix(session): parse response_data JSON string in hydration

### DIFF
--- a/frontend/components/layout/AppShell.tsx
+++ b/frontend/components/layout/AppShell.tsx
@@ -82,7 +82,9 @@ export default function AppShell() {
         }));
         appendMessages(...hydrated);
       })
-      .catch(() => {});
+      .catch((err) => {
+        console.error("Session hydration failed:", err);
+      });
     return () => { active = false; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -23,6 +23,16 @@ const SELECTED_ROUTE_ACTION_TEXT = {
   },
 } as const;
 
+/** Safely parse response_data which may be a JSON string, object, or null. */
+function parseResponseData(raw: unknown): Record<string, unknown> | null {
+  if (!raw) return null;
+  if (typeof raw === "string") {
+    try { return JSON.parse(raw) as Record<string, unknown>; } catch { return null; }
+  }
+  if (typeof raw === "object") return raw as Record<string, unknown>;
+  return null;
+}
+
 async function getAuthHeaders(): Promise<Record<string, string>> {
   const supabase = getSupabaseClient();
   if (!supabase) return {};
@@ -294,11 +304,11 @@ export async function fetchConversationMessages(
   );
 
   if (!res.ok) return [];
-  const data: { messages: Array<{ role: string; content: string; response_data: Record<string, unknown> | null; created_at: string }> } = await res.json();
+  const data: { messages: Array<{ role: string; content: string; response_data: unknown; created_at: string }> } = await res.json();
   return data.messages.map((m) => ({
     role: m.role as "user" | "assistant",
     content: m.content,
-    data: m.response_data,
+    data: parseResponseData(m.response_data),
     timestamp: m.created_at,
   }));
 }


### PR DESCRIPTION
## Summary
- Add `parseResponseData()` helper to safely parse string/object/null response_data
- Fix `fetchConversationMessages` to use the helper (api.ts:301)
- Update type annotation from `Record<string, unknown> | null` to `unknown`
- Add `console.error` to hydration catch block in AppShell.tsx

## Findings addressed
- T05 from production bugfix spec (issue #60)
- response_data stored as JSON string, frontend cast directly to RuntimeResponse

## Test plan
- [ ] Click sidebar conversation → messages load with full result panel data
- [ ] Old conversations with null response_data show text-only gracefully
- [ ] Console shows diagnostic on hydration failure
- [ ] `cd frontend && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)