### PR TITLE
fix(sidebar): variant prop for mobile overlay visibility

### DIFF
--- a/frontend/components/layout/AppShell.tsx
+++ b/frontend/components/layout/AppShell.tsx
@@ -388,6 +388,7 @@ export default function AppShell() {
                 onSelectConversation={(id) => { handleConversationSelect(id); setSidebarOpen(false); }}
                 routes={routes}
                 onCollapse={() => setSidebarOpen(false)}
+                variant="mobile"
               />
             </div>
           </>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -21,6 +21,7 @@ interface SidebarProps {
   onSelectConversation?: (sessionId: string) => void;
   routes?: RouteHistoryEntry[];
   onCollapse?: () => void;
+  variant?: "desktop" | "mobile";
 }
 
 interface RouteHistoryEntry {
@@ -210,13 +211,14 @@ export default function Sidebar({
   onSelectConversation,
   routes,
   onCollapse,
+  variant = "desktop",
 }: SidebarProps) {
   const { sidebar: t } = useDict();
   const locale = useLocale();
   const setLocale = useSetLocale();
 
   return (
-    <aside className="hidden w-[240px] shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-sidebar)] lg:flex">
+    <aside className={`${variant === "mobile" ? "flex" : "hidden lg:flex"} w-[240px] shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-sidebar)]`}>
       {/* Logo + collapse toggle */}
       <div className="flex h-16 items-center justify-between border-b border-[var(--color-sidebar-border)] px-5">
         <div className="flex flex-col gap-0.5">


### PR DESCRIPTION
## Summary
- Add variant prop to Sidebar: mobile (always flex) vs desktop (hidden lg:flex)
- AppShell passes variant=mobile to overlay Sidebar
- Desktop sidebar unchanged

## Findings addressed
- T09 from production bugfix spec (issue #60)

## Test plan
- [ ] Mobile hamburger opens overlay with visible conversation list
- [ ] Desktop sidebar unchanged
- [ ] `cd frontend && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced sidebar rendering with improved responsiveness for mobile and desktop displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->