### PR TITLE
fix(ux): auto-open results + mobile login button

### DIFF
--- a/frontend/components/auth/AuthGate.tsx
+++ b/frontend/components/auth/AuthGate.tsx
@@ -166,7 +166,7 @@ export default function AuthGate() {
           <button
             type="button"
             onClick={() => setShowAuthModal(true)}
-            className="hidden min-h-[44px] px-3 text-[13px] text-[var(--color-muted-fg)] sm:block"
+            className="min-h-[44px] px-3 text-[13px] text-[var(--color-muted-fg)]"
           >
             {lh.login}
           </button>

--- a/frontend/components/layout/AppShell.tsx
+++ b/frontend/components/layout/AppShell.tsx
@@ -126,7 +126,6 @@ export default function AppShell() {
     lastSyncedResponseIdRef.current = latestConversationResponse.responseId;
   }, [latestConversationResponse, upsertConversation]);
 
-  // Click-to-open only: no auto-open for visual responses (Task 12)
   const activeMessage = useMemo(
     () =>
       activeMessageId
@@ -164,6 +163,25 @@ export default function AppShell() {
       setFullscreenOpen(false);
     }
   }, []);
+
+  // Auto-open result panel when a visual response arrives
+  useEffect(() => {
+    if (messages.length === 0) return;
+    const last = messages[messages.length - 1];
+    if (
+      last.role === "assistant" &&
+      !last.loading &&
+      last.response &&
+      isVisualResponse(last.response)
+    ) {
+      setActiveMessageId(last.id);
+      if (isMobile) {
+        setDrawerOpen(true);
+      } else {
+        openOverlayForResponse(last.response);
+      }
+    }
+  }, [messages, isMobile, openOverlayForResponse]);
 
   const handleConversationSelect = useCallback(
     async (selectedSessionId: string) => {


### PR DESCRIPTION
## Summary
- Auto-open result panel when visual response arrives (no more two-click)
- On mobile, auto-open drawer for visual responses
- Login button visible on all screen sizes (removed hidden sm:block)

## Findings addressed
- T10, T12 from production bugfix spec (issue #60)

## Test plan
- [ ] Search results auto-open in result panel
- [ ] On mobile, drawer auto-opens
- [ ] Login button visible on mobile
- [ ] `cd frontend && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)