### PR TITLE
fix(i18n+ux): remove lang switchers + conversation error handling

### DIFF
--- a/backend/tests/conftest_db.py
+++ b/backend/tests/conftest_db.py
@@ -36,7 +36,7 @@ def _apply_migrations_sync(dsn: str) -> None:
         for line in lines:
             skip = False
             for ext in SKIP_EXTENSIONS:
-                if f"CREATE EXTENSION" in line and ext in line:
+                if "CREATE EXTENSION" in line and ext in line:
                     skip = True
                     break
             if not skip:

--- a/frontend/components/layout/ChatHeader.tsx
+++ b/frontend/components/layout/ChatHeader.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useDict, useLocale, useSetLocale } from "../../lib/i18n-context";
-import { LOCALES, LOCALE_LABELS } from "../../lib/i18n";
+import { useDict } from "../../lib/i18n-context";
 
 interface ChatHeaderProps {
   onNewChat?: () => void;
@@ -10,8 +9,6 @@ interface ChatHeaderProps {
 
 export default function ChatHeader({ onNewChat, onMenuToggle }: ChatHeaderProps) {
   const { header: t, sidebar: s } = useDict();
-  const locale = useLocale();
-  const setLocale = useSetLocale();
 
   return (
     <header className="flex h-14 items-center justify-between border-b border-[var(--color-border)] px-5">
@@ -32,22 +29,6 @@ export default function ChatHeader({ onNewChat, onMenuToggle }: ChatHeaderProps)
         <h1 className="font-[family-name:var(--app-font-display)] text-sm font-semibold text-[var(--color-fg)]">
           {t.title}
         </h1>
-        <div className="flex gap-0.5 rounded-md border border-[var(--color-border)] p-0.5">
-          {LOCALES.map((loc) => (
-            <button
-              type="button"
-              key={loc}
-              onClick={() => setLocale(loc)}
-              className={`rounded px-2 py-1 text-xs transition-colors ${
-                locale === loc
-                  ? "bg-white font-semibold text-[var(--color-fg)] shadow-sm"
-                  : "text-[var(--color-muted-fg)] hover:text-[var(--color-fg)]"
-              }`}
-            >
-              {LOCALE_LABELS[loc]}
-            </button>
-          ))}
-        </div>
       </div>
       {onNewChat && (
         <button

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -10,8 +10,7 @@ import {
 } from "react";
 import { getConversationDisplayTitle } from "../../lib/conversation-history";
 import type { ConversationRecord } from "../../lib/types";
-import { useDict, useLocale, useSetLocale } from "../../lib/i18n-context";
-import { LOCALES, type Locale } from "../../lib/i18n";
+import { useDict, useLocale } from "../../lib/i18n-context";
 
 interface SidebarProps {
   conversations: ConversationRecord[];
@@ -31,12 +30,6 @@ interface RouteHistoryEntry {
   point_count: number;
   created_at: string;
 }
-
-const LOCALE_LABELS: Record<Locale, string> = {
-  ja: "日本語",
-  zh: "中文",
-  en: "EN",
-};
 
 /** Route-related keywords used to select the 📍 icon. */
 const ROUTE_KEYWORDS = /route|ルート|路线|plan|計画|计划/i;
@@ -213,7 +206,6 @@ export default function Sidebar({
 }: SidebarProps) {
   const { sidebar: t } = useDict();
   const locale = useLocale();
-  const setLocale = useSetLocale();
 
   return (
     <aside className="hidden w-[240px] shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-sidebar)] lg:flex">
@@ -295,24 +287,6 @@ export default function Sidebar({
         </div>
       )}
 
-      {/* Footer — 44px locale switcher buttons */}
-      <div className="border-t border-[var(--color-sidebar-border)] px-5 py-4">
-        <div className="flex items-center gap-2">
-          {LOCALES.map((l) => (
-            <button
-              key={l}
-              type="button"
-              onClick={() => setLocale(l)}
-              data-active={locale === l}
-              className="min-h-[44px] min-w-[44px] rounded-full px-3 py-2 text-[10px] font-light tracking-wide transition data-[active=true]:bg-[var(--color-primary)] data-[active=true]:text-white hover:bg-[var(--color-primary)]/10"
-              style={{ transitionDuration: "var(--duration-fast)" }}
-            >
-              {LOCALE_LABELS[l]}
-            </button>
-          ))}
-          <span className="ml-auto text-sm text-[var(--color-primary)] opacity-30">◈</span>
-        </div>
-      </div>
     </aside>
   );
 }

--- a/frontend/hooks/useConversationHistory.ts
+++ b/frontend/hooks/useConversationHistory.ts
@@ -16,7 +16,6 @@ export function useConversationHistory() {
 
   useEffect(() => {
     let active = true;
-    setIsLoading(true);
 
     void fetchConversations()
       .then((records) => {

--- a/frontend/hooks/useConversationHistory.ts
+++ b/frontend/hooks/useConversationHistory.ts
@@ -53,21 +53,32 @@ export function useConversationHistory() {
       renameConversationRecord(prev, sessionId, trimmedTitle),
     );
 
-    void patchConversationTitle(sessionId, trimmedTitle).catch(
-      (err: unknown) => {
+    void patchConversationTitle(sessionId, trimmedTitle)
+      .then(() => {
+        setError(null);
+      })
+      .catch((err: unknown) => {
         console.error("patchConversationTitle failed:", err);
+        setError(
+          err instanceof Error ? err.message : "Failed to rename conversation",
+        );
         // Refetch to restore correct state
         void fetchConversations()
           .then((records) => {
             setConversations((prev) =>
               mergeConversationLists(prev, records),
             );
+            setError(null);
           })
           .catch((refetchErr: unknown) => {
             console.error("refetch after rename failure:", refetchErr);
+            setError(
+              refetchErr instanceof Error
+                ? refetchErr.message
+                : "Failed to reload conversations",
+            );
           });
-      },
-    );
+      });
   }, []);
 
   return { conversations, upsert, rename, error, isLoading };

--- a/frontend/hooks/useConversationHistory.ts
+++ b/frontend/hooks/useConversationHistory.ts
@@ -11,16 +11,29 @@ import type { ConversationRecord } from "../lib/types";
 
 export function useConversationHistory() {
   const [conversations, setConversations] = useState<ConversationRecord[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let active = true;
+    setIsLoading(true);
 
     void fetchConversations()
       .then((records) => {
         if (!active) return;
         setConversations((prev) => mergeConversationLists(prev, records));
+        setError(null);
       })
-      .catch(() => {});
+      .catch((err: unknown) => {
+        if (!active) return;
+        console.error("fetchConversations failed:", err);
+        setError(
+          err instanceof Error ? err.message : "Failed to load conversations",
+        );
+      })
+      .finally(() => {
+        if (active) setIsLoading(false);
+      });
 
     return () => {
       active = false;
@@ -41,14 +54,22 @@ export function useConversationHistory() {
       renameConversationRecord(prev, sessionId, trimmedTitle),
     );
 
-    void patchConversationTitle(sessionId, trimmedTitle).catch(() => {
-      void fetchConversations()
-        .then((records) => {
-          setConversations((prev) => mergeConversationLists(prev, records));
-        })
-        .catch(() => {});
-    });
+    void patchConversationTitle(sessionId, trimmedTitle).catch(
+      (err: unknown) => {
+        console.error("patchConversationTitle failed:", err);
+        // Refetch to restore correct state
+        void fetchConversations()
+          .then((records) => {
+            setConversations((prev) =>
+              mergeConversationLists(prev, records),
+            );
+          })
+          .catch((refetchErr: unknown) => {
+            console.error("refetch after rename failure:", refetchErr);
+          });
+      },
+    );
   }, []);
 
-  return { conversations, upsert, rename };
+  return { conversations, upsert, rename, error, isLoading };
 }

--- a/frontend/lib/i18n-context.tsx
+++ b/frontend/lib/i18n-context.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import type { Dict, Locale } from "./i18n";
-import { DEFAULT_LOCALE, detectLocale, loadDict, persistLocale } from "./i18n";
+import { DEFAULT_LOCALE, detectLocale, loadDict } from "./i18n";
 import defaultDict from "./dictionaries/ja.json";
 
 interface I18nCtx {
@@ -30,7 +30,6 @@ export function LocaleProvider({ children }: { children: React.ReactNode }) {
 
   const setLocale = useCallback((newLocale: Locale) => {
     setLocaleState(newLocale);
-    persistLocale(newLocale);
     document.documentElement.lang = newLocale;
     loadDict(newLocale).then((d) => setDict(d as Dict));
   }, []);

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -9,12 +9,8 @@ export const LOCALE_LABELS: Record<Locale, string> = {
   en: "EN",
 };
 
-const STORAGE_KEY = "seichi_lang";
-
 export function detectLocale(): Locale {
   if (typeof window === "undefined") return DEFAULT_LOCALE;
-  const stored = localStorage.getItem(STORAGE_KEY) as Locale | null;
-  if (stored && (LOCALES as readonly string[]).includes(stored)) return stored;
   for (const lang of navigator.languages ?? []) {
     const code = lang.toLowerCase();
     if (code.startsWith("zh")) return "zh";
@@ -22,10 +18,6 @@ export function detectLocale(): Locale {
     if (code.startsWith("en")) return "en";
   }
   return DEFAULT_LOCALE;
-}
-
-export function persistLocale(locale: Locale): void {
-  localStorage.setItem(STORAGE_KEY, locale);
 }
 
 export async function loadDict(locale: Locale) {


### PR DESCRIPTION
## Summary
- Remove language switcher from ChatHeader and Sidebar footer
- Remove persistLocale() and localStorage storage
- Browser auto-detect only (detectLocale reads navigator.languages)
- Add error/loading state to useConversationHistory
- Replace empty catch blocks with console.error + error state

## Findings addressed
- T13, T14 from production bugfix spec (issue #60)

## Test plan
- [ ] No language toggle anywhere in UI
- [ ] UI language follows browser setting
- [ ] API failure shows error in console
- [ ] `cd frontend && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed language/locale switching controls from the chat header and sidebar.
  * Locale preference no longer persists across browser sessions.

* **Bug Fixes**
  * Enhanced conversation loading with improved error tracking and loading state indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->