### PR TITLE
feat(agent): declarative step dependency graph

### DIFF
--- a/backend/agents/models.py
+++ b/backend/agents/models.py
@@ -24,6 +24,21 @@ class ToolName(str, Enum):
     CLARIFY = "clarify"
 
 
+# Declarative step dependency graph.
+# Key = tool that has prerequisites, Value = list of tools that must succeed first.
+# The result_validator reads this to enforce prerequisites before tool execution.
+STEP_DEPENDENCIES: dict[ToolName, list[ToolName]] = {
+    ToolName.SEARCH_BANGUMI: [ToolName.RESOLVE_ANIME],
+    ToolName.PLAN_ROUTE: [ToolName.SEARCH_BANGUMI],
+    ToolName.PLAN_SELECTED: [],
+    ToolName.SEARCH_NEARBY: [],
+    ToolName.RESOLVE_ANIME: [],
+    ToolName.GREET_USER: [],
+    ToolName.ANSWER_QUESTION: [],
+    ToolName.CLARIFY: [],
+}
+
+
 class PlanStep(BaseModel):
     """One step in an execution plan produced by ReActPlannerAgent."""
 

--- a/backend/tests/unit/test_step_dependencies.py
+++ b/backend/tests/unit/test_step_dependencies.py
@@ -1,0 +1,48 @@
+"""Unit tests for step dependency graph."""
+
+from backend.agents.models import STEP_DEPENDENCIES, ToolName
+
+
+class TestStepDependencies:
+    def test_all_tools_have_entries(self) -> None:
+        """Every ToolName must appear in STEP_DEPENDENCIES."""
+        for tool in ToolName:
+            assert tool in STEP_DEPENDENCIES, f"{tool} missing from STEP_DEPENDENCIES"
+
+    def test_search_bangumi_requires_resolve(self) -> None:
+        assert ToolName.RESOLVE_ANIME in STEP_DEPENDENCIES[ToolName.SEARCH_BANGUMI]
+
+    def test_plan_route_requires_search(self) -> None:
+        assert ToolName.SEARCH_BANGUMI in STEP_DEPENDENCIES[ToolName.PLAN_ROUTE]
+
+    def test_leaf_tools_have_no_deps(self) -> None:
+        leaf_tools = [
+            ToolName.RESOLVE_ANIME,
+            ToolName.SEARCH_NEARBY,
+            ToolName.GREET_USER,
+            ToolName.ANSWER_QUESTION,
+            ToolName.CLARIFY,
+        ]
+        for tool in leaf_tools:
+            assert STEP_DEPENDENCIES[tool] == [], f"{tool} should have no deps"
+
+    def test_no_circular_deps(self) -> None:
+        """Dependency graph must be a DAG (no cycles)."""
+        visited: set[ToolName] = set()
+        path: set[ToolName] = set()
+
+        def dfs(tool: ToolName) -> bool:
+            if tool in path:
+                return False  # cycle detected
+            if tool in visited:
+                return True
+            path.add(tool)
+            for dep in STEP_DEPENDENCIES.get(tool, []):
+                if not dfs(dep):
+                    return False
+            path.remove(tool)
+            visited.add(tool)
+            return True
+
+        for tool in ToolName:
+            assert dfs(tool), f"Circular dependency detected involving {tool}"


### PR DESCRIPTION
## Summary
- Add STEP_DEPENDENCIES dict to models.py
- Declares tool prerequisites (search_bangumi needs resolve_anime, etc.)
- 5 unit tests including cycle detection
- Foundation for result_validator in Phase 2

## Part of
Agent architecture v2 spec (Phase 1)

## Test plan
- [ ] `uv run pytest backend/tests/unit/test_step_dependencies.py -x -q` passes
- [ ] All existing unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for tool execution prerequisites and dependency relationships.

* **Chores**
  * Added prerequisite dependency tracking to ensure tools execute in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->