### PR TITLE
feat(agent): result_validator replaces deterministic guards

### DIFF
--- a/backend/agents/pipeline.py
+++ b/backend/agents/pipeline.py
@@ -9,11 +9,10 @@ import structlog
 from pydantic_ai.models import Model
 
 from backend.agents.executor_agent import ExecutorAgent, PipelineResult, StepResult
+from backend.agents.intent_classifier import classify_intent
 from backend.agents.models import (
     ExecutionPlan,
     Observation,
-    PlanStep,
-    ToolName,
 )
 from backend.agents.planner_agent import ReActPlannerAgent
 
@@ -48,6 +47,8 @@ async def react_loop(
     """ReAct loop: planner thinks → executor acts → observe → repeat.
 
     Yields ReactStepEvent for each step (for SSE streaming).
+    The planner's output_validator enforces step prerequisites and rejects
+    premature "done" signals — no deterministic guards needed here.
     """
     history: list[Observation] = []
     failure_count = 0
@@ -56,10 +57,17 @@ async def react_loop(
     if context and context.get("last_location"):
         executor_context["last_location"] = context["last_location"]
 
+    # Classify intent once for the entire loop
+    classified_intent, _confidence = classify_intent(text, locale)
+
     for turn in range(max_steps):
-        # 1. Planner thinks
+        # 1. Planner thinks (output_validator enforces prerequisites)
         react_step = await planner.step(
-            text=text, locale=locale, context=context, history=history
+            text=text,
+            locale=locale,
+            context=context,
+            history=history,
+            classified_intent=classified_intent,
         )
 
         logger.info(
@@ -70,62 +78,8 @@ async def react_loop(
             has_done=react_step.done is not None,
         )
 
-        # 2. If done, check if we actually searched before stopping
+        # 2. If done, yield final event
         if react_step.done is not None:
-            # Guard: if we resolved an anime but never searched, inject search_bangumi
-            has_resolve = any(
-                r.tool == "resolve_anime" and r.success for r in accumulated_results
-            )
-            has_search = any(
-                r.tool in ("search_bangumi", "search_nearby") and r.success
-                for r in accumulated_results
-            )
-            if has_resolve and not has_search:
-                resolve_data = next(
-                    (
-                        r.data
-                        for r in accumulated_results
-                        if r.tool == "resolve_anime"
-                        and r.success
-                        and isinstance(r.data, dict)
-                    ),
-                    None,
-                )
-                bangumi_id = resolve_data.get("bangumi_id") if resolve_data else None
-                if bangumi_id:
-                    logger.info(
-                        "react_guard_inject_search_after_done", bangumi_id=bangumi_id
-                    )
-                    search_step = PlanStep(
-                        tool=ToolName.SEARCH_BANGUMI,
-                        params={"bangumi_id": bangumi_id},
-                    )
-                    yield ReactStepEvent(
-                        type="step",
-                        thought="Guard: planner stopped early, injecting search_bangumi",
-                        tool="search_bangumi",
-                        status="running",
-                    )
-                    search_result = await executor._execute_step(
-                        search_step, executor_context
-                    )
-                    accumulated_results.append(search_result)
-                    if search_result.success and hasattr(search_step, "tool"):
-                        executor_context[search_step.tool.value] = search_result.data
-                    search_obs = ExecutorAgent.format_observation(search_result)
-                    history.append(search_obs)
-                    yield ReactStepEvent(
-                        type="step",
-                        thought="Guard: search_bangumi completed",
-                        tool="search_bangumi",
-                        status="done",
-                        observation=search_obs.summary,
-                        data=search_result.data
-                        if isinstance(search_result.data, dict)
-                        else {},
-                        step_result=search_result,
-                    )
-
             yield ReactStepEvent(
                 type="done",
                 thought=react_step.thought,
@@ -140,74 +94,6 @@ async def react_loop(
             tool_name = (
                 step.tool.value if hasattr(step.tool, "value") else str(step.tool)
             )
-
-            # ── Deterministic guard: ensure resolve_anime before search_bangumi ──
-            has_resolved = any(o.tool == "resolve_anime" for o in history)
-            if (
-                tool_name == "search_bangumi"
-                and not has_resolved
-                and not (step.params or {}).get("bangumi_id")
-            ):
-                logger.info("react_guard_inject_resolve_anime", query=text)
-                resolve_step = PlanStep(
-                    tool=ToolName.RESOLVE_ANIME,
-                    params={"title": text},
-                )
-
-                # Yield running event for injected step
-                yield ReactStepEvent(
-                    type="step",
-                    thought="Guard: injecting resolve_anime before search_bangumi",
-                    tool="resolve_anime",
-                    status="running",
-                )
-
-                # Execute the injected resolve_anime
-                resolve_result = await executor._execute_step(
-                    resolve_step, executor_context
-                )
-                accumulated_results.append(resolve_result)
-
-                if resolve_result.success and hasattr(resolve_step, "tool"):
-                    executor_context[resolve_step.tool.value] = resolve_result.data
-
-                resolve_obs = ExecutorAgent.format_observation(resolve_result)
-                history.append(resolve_obs)
-
-                yield ReactStepEvent(
-                    type="step",
-                    thought="Guard: resolve_anime completed",
-                    tool="resolve_anime",
-                    status="done",
-                    observation=resolve_obs.summary,
-                    data=(
-                        resolve_result.data
-                        if isinstance(resolve_result.data, dict)
-                        else {}
-                    ),
-                    step_result=resolve_result,
-                )
-
-                if not resolve_result.success:
-                    failure_count += 1
-                    if failure_count >= 2:
-                        yield ReactStepEvent(
-                            type="error",
-                            thought="Guard: resolve_anime failed after retries",
-                            message=(
-                                f"Could not resolve anime title: {resolve_result.error}"
-                            ),
-                        )
-                        return
-                    yield ReactStepEvent(
-                        type="step",
-                        thought="Guard: resolve_anime failed, planner will recover",
-                        tool="resolve_anime",
-                        status="failed",
-                        observation=resolve_obs.summary,
-                    )
-                    continue
-            # ── End guard ──
 
             # Yield "running" event
             yield ReactStepEvent(

--- a/backend/agents/planner_agent.py
+++ b/backend/agents/planner_agent.py
@@ -233,16 +233,15 @@ class ReActPlannerAgent:
 
             # 1. Reject premature "done" when required work isn't complete
             if result.done is not None:
-                has_search = any(
-                    o.tool in ("search_bangumi", "search_nearby") and o.success
-                    for o in history
+                has_bangumi_search = any(
+                    o.tool == "search_bangumi" and o.success for o in history
                 )
-                needs_search = intent in (
+                needs_bangumi_search = intent in (
                     QueryIntent.ANIME_SEARCH,
                     QueryIntent.ROUTE_PLAN,
                 )
 
-                if needs_search and not has_search:
+                if needs_bangumi_search and not has_bangumi_search:
                     raise ModelRetry(
                         "You resolved the anime but haven't searched for spots yet. "
                         "Call search_bangumi with the bangumi_id from your "
@@ -250,7 +249,11 @@ class ReActPlannerAgent:
                     )
 
                 has_route = any(o.tool == "plan_route" and o.success for o in history)
-                if intent == QueryIntent.ROUTE_PLAN and not has_route and has_search:
+                if (
+                    intent == QueryIntent.ROUTE_PLAN
+                    and not has_route
+                    and has_bangumi_search
+                ):
                     raise ModelRetry(
                         "The user asked for a route but you only searched for "
                         "spots. Call plan_route with the search results."

--- a/backend/agents/planner_agent.py
+++ b/backend/agents/planner_agent.py
@@ -6,10 +6,30 @@ to produce an ExecutionPlan from free-text user input.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
+from pydantic_ai import Agent, ModelRetry
 from pydantic_ai.models import Model
 
 from backend.agents.base import create_agent, get_default_model
-from backend.agents.models import ExecutionPlan, Observation, ReactStep
+from backend.agents.intent_classifier import QueryIntent
+from backend.agents.models import (
+    STEP_DEPENDENCIES,
+    ExecutionPlan,
+    Observation,
+    ReactStep,
+)
+
+
+@dataclass
+class ReActDeps:
+    """Dependencies injected into the ReAct step agent."""
+
+    history: list[Observation] = field(default_factory=list)
+    classified_intent: QueryIntent = QueryIntent.AMBIGUOUS
+    query: str = ""
+    locale: str = "ja"
+
 
 PLANNER_SYSTEM_PROMPT = """\
 You are a planning agent for an anime pilgrimage (聖地巡礼) search app.
@@ -192,12 +212,62 @@ class ReActPlannerAgent:
             output_type=ExecutionPlan,
             retries=2,
         )
-        self._step_agent = create_agent(
+        self._step_agent: Agent[ReActDeps, ReactStep] = Agent(
             selected_model,
             system_prompt=REACT_SYSTEM_PROMPT,
             output_type=ReactStep,
+            deps_type=ReActDeps,
             retries=2,
         )
+
+        @self._step_agent.output_validator
+        async def validate_react_step(ctx: object, result: ReactStep) -> ReactStep:
+            """Validate ReactStep: reject premature done, enforce prerequisites."""
+            from pydantic_ai import RunContext
+
+            run_ctx = ctx
+            assert isinstance(run_ctx, RunContext)
+            deps: ReActDeps = run_ctx.deps
+            history = deps.history
+            intent = deps.classified_intent
+
+            # 1. Reject premature "done" when required work isn't complete
+            if result.done is not None:
+                has_search = any(
+                    o.tool in ("search_bangumi", "search_nearby") and o.success
+                    for o in history
+                )
+                needs_search = intent in (
+                    QueryIntent.ANIME_SEARCH,
+                    QueryIntent.ROUTE_PLAN,
+                )
+
+                if needs_search and not has_search:
+                    raise ModelRetry(
+                        "You resolved the anime but haven't searched for spots yet. "
+                        "Call search_bangumi with the bangumi_id from your "
+                        "resolve_anime observation."
+                    )
+
+                has_route = any(o.tool == "plan_route" and o.success for o in history)
+                if intent == QueryIntent.ROUTE_PLAN and not has_route and has_search:
+                    raise ModelRetry(
+                        "The user asked for a route but you only searched for "
+                        "spots. Call plan_route with the search results."
+                    )
+
+            # 2. Reject actions with unmet prerequisites
+            if result.action is not None:
+                tool = result.action.tool
+                dep_list = STEP_DEPENDENCIES.get(tool, [])
+                for dep in dep_list:
+                    if not any(o.tool == dep.value and o.success for o in history):
+                        raise ModelRetry(
+                            f"{tool.value} requires {dep.value} to run first. "
+                            f"Call {dep.value} before {tool.value}."
+                        )
+
+            return result
 
     async def create_plan(
         self,
@@ -221,10 +291,12 @@ class ReActPlannerAgent:
         locale: str = "ja",
         context: dict[str, object] | None = None,
         history: list[Observation] | None = None,
+        classified_intent: QueryIntent = QueryIntent.AMBIGUOUS,
     ) -> ReactStep:
         """Single ReAct step: observe history, emit next action or done."""
         context_prefix = _format_context_block(context)
-        history_prefix = _format_react_history(history or [])
+        obs_history = history or []
+        history_prefix = _format_react_history(obs_history)
 
         parts: list[str] = []
         if context_prefix:
@@ -234,5 +306,11 @@ class ReActPlannerAgent:
         parts.append(f"[locale={locale}] {text}")
 
         prompt = "\n".join(parts)
-        result = await self._step_agent.run(prompt)
+        deps = ReActDeps(
+            history=obs_history,
+            classified_intent=classified_intent,
+            query=text,
+            locale=locale,
+        )
+        result = await self._step_agent.run(prompt, deps=deps)
         return result.output

--- a/backend/agents/planner_agent.py
+++ b/backend/agents/planner_agent.py
@@ -225,9 +225,9 @@ class ReActPlannerAgent:
             """Validate ReactStep: reject premature done, enforce prerequisites."""
             from pydantic_ai import RunContext
 
-            run_ctx = ctx
-            assert isinstance(run_ctx, RunContext)
-            deps: ReActDeps = run_ctx.deps
+            if not isinstance(ctx, RunContext):
+                raise TypeError(f"Expected RunContext, got {type(ctx).__name__}")
+            deps: ReActDeps = ctx.deps
             history = deps.history
             intent = deps.classified_intent
 

--- a/backend/tests/unit/test_planner_agent.py
+++ b/backend/tests/unit/test_planner_agent.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -82,10 +82,16 @@ class TestReActPlannerAgent:
         assert lines[1] == "summary: previous summary"
 
     async def test_create_plan_returns_execution_plan(self, mock_plan_bangumi):
-        with patch("backend.agents.planner_agent.create_agent") as mock_create:
+        with (
+            patch("backend.agents.planner_agent.create_agent") as mock_create,
+            patch("backend.agents.planner_agent.Agent") as mock_agent_cls,
+        ):
             mock_agent = AsyncMock()
             mock_agent.run.return_value = AsyncMock(output=mock_plan_bangumi)
             mock_create.return_value = mock_agent
+            mock_step = MagicMock()
+            mock_step.output_validator = MagicMock(side_effect=lambda f: f)
+            mock_agent_cls.return_value = mock_step
 
             planner = ReActPlannerAgent()
             plan = await planner.create_plan("吹響の聖地在哪", locale="ja")
@@ -95,10 +101,16 @@ class TestReActPlannerAgent:
         assert len(plan.steps) >= 1
 
     async def test_create_plan_passes_locale_in_prompt(self, mock_plan_bangumi):
-        with patch("backend.agents.planner_agent.create_agent") as mock_create:
+        with (
+            patch("backend.agents.planner_agent.create_agent") as mock_create,
+            patch("backend.agents.planner_agent.Agent") as mock_agent_cls,
+        ):
             mock_agent = AsyncMock()
             mock_agent.run.return_value = AsyncMock(output=mock_plan_bangumi)
             mock_create.return_value = mock_agent
+            mock_step = MagicMock()
+            mock_step.output_validator = MagicMock(side_effect=lambda f: f)
+            mock_agent_cls.return_value = mock_step
 
             planner = ReActPlannerAgent()
             await planner.create_plan(
@@ -133,10 +145,16 @@ class TestReActPlannerAgent:
             locale="zh",
         )
 
-        with patch("backend.agents.planner_agent.create_agent") as mock_create:
+        with (
+            patch("backend.agents.planner_agent.create_agent") as mock_create,
+            patch("backend.agents.planner_agent.Agent") as mock_agent_cls,
+        ):
             mock_agent = AsyncMock()
             mock_agent.run.return_value = AsyncMock(output=greet_plan)
             mock_create.return_value = mock_agent
+            mock_step = MagicMock()
+            mock_step.output_validator = MagicMock(side_effect=lambda f: f)
+            mock_agent_cls.return_value = mock_step
 
             planner = ReActPlannerAgent()
             plan = await planner.create_plan("你好", locale="zh")
@@ -145,10 +163,16 @@ class TestReActPlannerAgent:
         assert plan.steps[0].tool == ToolName.GREET_USER
 
     async def test_create_plan_prefixes_context_block(self, mock_plan_bangumi):
-        with patch("backend.agents.planner_agent.create_agent") as mock_create:
+        with (
+            patch("backend.agents.planner_agent.create_agent") as mock_create,
+            patch("backend.agents.planner_agent.Agent") as mock_agent_cls,
+        ):
             mock_agent = AsyncMock()
             mock_agent.run.return_value = AsyncMock(output=mock_plan_bangumi)
             mock_create.return_value = mock_agent
+            mock_step = MagicMock()
+            mock_step.output_validator = MagicMock(side_effect=lambda f: f)
+            mock_agent_cls.return_value = mock_step
 
             planner = ReActPlannerAgent()
             await planner.create_plan(

--- a/backend/tests/unit/test_result_validator.py
+++ b/backend/tests/unit/test_result_validator.py
@@ -1,0 +1,281 @@
+"""Unit tests for the ReAct output_validator logic.
+
+Tests the validation rules directly without needing an LLM.
+The validator rejects premature done and enforces step prerequisites.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai import ModelRetry
+
+from backend.agents.intent_classifier import QueryIntent
+from backend.agents.models import (
+    DoneSignal,
+    Observation,
+    PlanStep,
+    ReactStep,
+    ToolName,
+)
+from backend.agents.planner_agent import ReActDeps
+
+
+def _obs(tool: str, *, success: bool = True, summary: str = "") -> Observation:
+    """Helper to create an Observation."""
+    return Observation(tool=tool, success=success, summary=summary or f"{tool} result")
+
+
+def _done_step(message: str = "Here are the results") -> ReactStep:
+    """Helper to create a ReactStep with done signal."""
+    return ReactStep(thought="done", done=DoneSignal(message=message))
+
+
+def _action_step(tool: ToolName, **params: object) -> ReactStep:
+    """Helper to create a ReactStep with an action."""
+    return ReactStep(
+        thought=f"calling {tool.value}",
+        action=PlanStep(tool=tool, params=params),
+    )
+
+
+def _deps(
+    history: list[Observation] | None = None,
+    intent: QueryIntent = QueryIntent.AMBIGUOUS,
+) -> ReActDeps:
+    """Helper to create ReActDeps."""
+    return ReActDeps(
+        history=history or [],
+        classified_intent=intent,
+        query="test query",
+        locale="ja",
+    )
+
+
+# ── Extract validator logic for direct testing ──
+# The actual validator is registered on the agent instance.
+# We test the logic by reimplementing the same checks.
+
+
+def _validate_done(deps: ReActDeps, result: ReactStep) -> ReactStep:
+    """Replicates the done-validation logic from the output_validator."""
+    if result.done is None:
+        return result
+
+    history = deps.history
+    intent = deps.classified_intent
+
+    has_bangumi_search = any(o.tool == "search_bangumi" and o.success for o in history)
+    needs_bangumi_search = intent in (
+        QueryIntent.ANIME_SEARCH,
+        QueryIntent.ROUTE_PLAN,
+    )
+
+    if needs_bangumi_search and not has_bangumi_search:
+        raise ModelRetry(
+            "You resolved the anime but haven't searched for spots yet. "
+            "Call search_bangumi with the bangumi_id from your "
+            "resolve_anime observation."
+        )
+
+    has_route = any(o.tool == "plan_route" and o.success for o in history)
+    if intent == QueryIntent.ROUTE_PLAN and not has_route and has_bangumi_search:
+        raise ModelRetry(
+            "The user asked for a route but you only searched for "
+            "spots. Call plan_route with the search results."
+        )
+
+    return result
+
+
+def _validate_action(deps: ReActDeps, result: ReactStep) -> ReactStep:
+    """Replicates the action-validation logic from the output_validator."""
+    from backend.agents.models import STEP_DEPENDENCIES
+
+    if result.action is None:
+        return result
+
+    tool = result.action.tool
+    dep_list = STEP_DEPENDENCIES.get(tool, [])
+    for dep in dep_list:
+        if not any(o.tool == dep.value and o.success for o in deps.history):
+            raise ModelRetry(
+                f"{tool.value} requires {dep.value} to run first. "
+                f"Call {dep.value} before {tool.value}."
+            )
+
+    return result
+
+
+class TestRejectPrematureDone:
+    """Tests for rejecting 'done' when required work isn't complete."""
+
+    def test_anime_search_done_without_search(self) -> None:
+        """Done after resolve_anime but no search_bangumi → reject."""
+        deps = _deps(
+            history=[_obs("resolve_anime")],
+            intent=QueryIntent.ANIME_SEARCH,
+        )
+        with pytest.raises(ModelRetry, match="haven't searched"):
+            _validate_done(deps, _done_step())
+
+    def test_anime_search_done_with_search(self) -> None:
+        """Done after resolve + search → accept."""
+        deps = _deps(
+            history=[_obs("resolve_anime"), _obs("search_bangumi")],
+            intent=QueryIntent.ANIME_SEARCH,
+        )
+        result = _validate_done(deps, _done_step())
+        assert result.done is not None
+
+    def test_route_done_without_search(self) -> None:
+        """Route intent, done without search → reject (missing search)."""
+        deps = _deps(
+            history=[_obs("resolve_anime")],
+            intent=QueryIntent.ROUTE_PLAN,
+        )
+        with pytest.raises(ModelRetry, match="haven't searched"):
+            _validate_done(deps, _done_step())
+
+    def test_route_done_with_search_no_route(self) -> None:
+        """Route intent, done after search but no plan_route → reject."""
+        deps = _deps(
+            history=[_obs("resolve_anime"), _obs("search_bangumi")],
+            intent=QueryIntent.ROUTE_PLAN,
+        )
+        with pytest.raises(ModelRetry, match="asked for a route"):
+            _validate_done(deps, _done_step())
+
+    def test_route_done_complete(self) -> None:
+        """Route intent, done after resolve + search + route → accept."""
+        deps = _deps(
+            history=[
+                _obs("resolve_anime"),
+                _obs("search_bangumi"),
+                _obs("plan_route"),
+            ],
+            intent=QueryIntent.ROUTE_PLAN,
+        )
+        result = _validate_done(deps, _done_step())
+        assert result.done is not None
+
+    def test_nearby_done_without_search_bangumi(self) -> None:
+        """Nearby intent can finish without search_bangumi → accept."""
+        deps = _deps(
+            history=[_obs("search_nearby")],
+            intent=QueryIntent.NEARBY_SEARCH,
+        )
+        result = _validate_done(deps, _done_step())
+        assert result.done is not None
+
+    def test_greeting_done_immediately(self) -> None:
+        """Greeting intent can finish with just greet_user → accept."""
+        deps = _deps(
+            history=[_obs("greet_user")],
+            intent=QueryIntent.GREETING,
+        )
+        result = _validate_done(deps, _done_step())
+        assert result.done is not None
+
+    def test_search_nearby_does_not_satisfy_anime_search(self) -> None:
+        """search_nearby should NOT satisfy ANIME_SEARCH completion."""
+        deps = _deps(
+            history=[_obs("resolve_anime"), _obs("search_nearby")],
+            intent=QueryIntent.ANIME_SEARCH,
+        )
+        with pytest.raises(ModelRetry, match="haven't searched"):
+            _validate_done(deps, _done_step())
+
+    def test_failed_search_does_not_satisfy(self) -> None:
+        """A failed search_bangumi should not count as completion."""
+        deps = _deps(
+            history=[_obs("resolve_anime"), _obs("search_bangumi", success=False)],
+            intent=QueryIntent.ANIME_SEARCH,
+        )
+        with pytest.raises(ModelRetry, match="haven't searched"):
+            _validate_done(deps, _done_step())
+
+    def test_ambiguous_intent_done_always_ok(self) -> None:
+        """Ambiguous intent has no required steps → done always accepted."""
+        deps = _deps(history=[], intent=QueryIntent.AMBIGUOUS)
+        result = _validate_done(deps, _done_step())
+        assert result.done is not None
+
+
+class TestRejectUnmetPrerequisites:
+    """Tests for rejecting actions with unmet prerequisites."""
+
+    def test_search_bangumi_without_resolve(self) -> None:
+        """search_bangumi before resolve_anime → reject."""
+        deps = _deps(history=[])
+        step = _action_step(ToolName.SEARCH_BANGUMI, bangumi_id="123")
+        with pytest.raises(ModelRetry, match="requires resolve_anime"):
+            _validate_action(deps, step)
+
+    def test_search_bangumi_after_resolve(self) -> None:
+        """search_bangumi after resolve_anime → accept."""
+        deps = _deps(history=[_obs("resolve_anime")])
+        step = _action_step(ToolName.SEARCH_BANGUMI, bangumi_id="123")
+        result = _validate_action(deps, step)
+        assert result.action is not None
+
+    def test_plan_route_without_search(self) -> None:
+        """plan_route before search_bangumi → reject."""
+        deps = _deps(history=[_obs("resolve_anime")])
+        step = _action_step(ToolName.PLAN_ROUTE)
+        with pytest.raises(ModelRetry, match="requires search_bangumi"):
+            _validate_action(deps, step)
+
+    def test_plan_route_after_search(self) -> None:
+        """plan_route after search_bangumi → accept."""
+        deps = _deps(history=[_obs("resolve_anime"), _obs("search_bangumi")])
+        step = _action_step(ToolName.PLAN_ROUTE)
+        result = _validate_action(deps, step)
+        assert result.action is not None
+
+    def test_resolve_anime_no_deps(self) -> None:
+        """resolve_anime has no prerequisites → always accept."""
+        deps = _deps(history=[])
+        step = _action_step(ToolName.RESOLVE_ANIME, title="Your Name")
+        result = _validate_action(deps, step)
+        assert result.action is not None
+
+    def test_search_nearby_no_deps(self) -> None:
+        """search_nearby has no prerequisites → always accept."""
+        deps = _deps(history=[])
+        step = _action_step(ToolName.SEARCH_NEARBY, location="Uji")
+        result = _validate_action(deps, step)
+        assert result.action is not None
+
+    def test_failed_resolve_does_not_satisfy_dep(self) -> None:
+        """A failed resolve_anime should not satisfy search_bangumi's dep."""
+        deps = _deps(history=[_obs("resolve_anime", success=False)])
+        step = _action_step(ToolName.SEARCH_BANGUMI, bangumi_id="123")
+        with pytest.raises(ModelRetry, match="requires resolve_anime"):
+            _validate_action(deps, step)
+
+    def test_greet_user_no_deps(self) -> None:
+        """greet_user has no prerequisites → always accept."""
+        deps = _deps(history=[])
+        step = _action_step(ToolName.GREET_USER, message="Hello")
+        result = _validate_action(deps, step)
+        assert result.action is not None
+
+
+class TestReActDeps:
+    """Tests for the ReActDeps dataclass."""
+
+    def test_deps_creation(self) -> None:
+        deps = ReActDeps(
+            history=[_obs("resolve_anime")],
+            classified_intent=QueryIntent.ANIME_SEARCH,
+            query="Your Name spots",
+            locale="en",
+        )
+        assert len(deps.history) == 1
+        assert deps.classified_intent == QueryIntent.ANIME_SEARCH
+        assert deps.locale == "en"
+
+    def test_deps_empty_history(self) -> None:
+        deps = _deps(history=[], intent=QueryIntent.GREETING)
+        assert deps.history == []
+        assert deps.classified_intent == QueryIntent.GREETING


### PR DESCRIPTION
## Summary
- Add Pydantic AI output_validator to step agent
- Reject premature "done" when search/route incomplete
- Reject actions with unmet prerequisites (STEP_DEPENDENCIES)
- Remove all 3 deterministic guards from pipeline.py (-140 lines)
- Intent classifier feeds context to validator
- LLM gets natural language retry feedback

## Part of
Agent architecture v2 spec (Phase 2 cutover)

## Test plan
- [ ] "plan a route for Your Name" → planner recovers if it tries plan_route before search
- [ ] "君の名はの聖地" → resolve → search → done (no guard injection)
- [ ] `uv run pytest backend/tests/unit -x -q` passes
- [ ] `uv run mypy backend/ --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prerequisite validation to ensure required steps are completed before dependent actions run.

* **Refactor**
  * Compute intent once at the start of processing.
  * Removed automatic injection of corrective steps; workflow is now simpler.
  * Improved dependency handling within the planner.

* **Tests**
  * Updated unit tests to reflect the new agent construction and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->