### PR TITLE
feat(ui): streaming thought display with natural language

### DIFF
--- a/backend/agents/executor_agent.py
+++ b/backend/agents/executor_agent.py
@@ -85,7 +85,8 @@ class ExecutorAgent:
         self,
         plan: ExecutionPlan,
         context_block: Mapping[str, object] | None = None,
-        on_step: Callable[[str, str, dict[str, object]], Awaitable[None]] | None = None,
+        on_step: Callable[[str, str, dict[str, object], str, str], Awaitable[None]]
+        | None = None,
     ) -> PipelineResult:
         """Execute all steps in the plan and return a PipelineResult."""
         primary_tool = _infer_primary_tool(plan)
@@ -96,12 +97,12 @@ class ExecutorAgent:
         for step in plan.steps:
             tool_name = getattr(getattr(step, "tool", None), "value", "unknown")
             if on_step is not None:
-                await on_step(tool_name, "running", {})
+                await on_step(tool_name, "running", {}, "", "")
             step_result = await self._execute_step(step, context)
             result.step_results.append(step_result)
             if on_step is not None:
                 payload = step_result.data if isinstance(step_result.data, dict) else {}
-                await on_step(tool_name, "done", payload)
+                await on_step(tool_name, "done", payload, "", "")
             tool = getattr(step, "tool", None)
             if not step_result.success:
                 logger.warning("step_failed", tool=tool, error=step_result.error)

--- a/backend/agents/pipeline.py
+++ b/backend/agents/pipeline.py
@@ -181,7 +181,8 @@ async def run_pipeline(
     model: Model | str | None = None,
     locale: str = "ja",
     context: dict[str, object] | None = None,
-    on_step: Callable[[str, str, dict[str, object]], Awaitable[None]] | None = None,
+    on_step: Callable[[str, str, dict[str, object], str, str], Awaitable[None]]
+    | None = None,
 ) -> PipelineResult:
     """Backward-compatible wrapper: runs ReAct loop and collects into PipelineResult."""
     planner = ReActPlannerAgent(model)
@@ -198,7 +199,9 @@ async def run_pipeline(
         context=context,
     ):
         if on_step is not None and event.type == "step":
-            await on_step(event.tool, event.status, event.data)
+            await on_step(
+                event.tool, event.status, event.data, event.thought, event.observation
+            )
 
         if event.step_result is not None:
             all_step_results.append(event.step_result)

--- a/backend/interfaces/fastapi_service.py
+++ b/backend/interfaces/fastapi_service.py
@@ -163,14 +163,20 @@ async def handle_runtime_stream(
         payload = json.dumps({"event": event, **data}, ensure_ascii=False)
         await queue.put(f"event: {event}\ndata: {payload}\n\n")
 
-    async def on_step(tool: str, status: str, data: dict[str, object]) -> None:
+    async def on_step(
+        tool: str,
+        status: str,
+        data: dict[str, object],
+        thought: str = "",
+        observation: str = "",
+    ) -> None:
         await emit(
             "step",
             {
                 "tool": tool,
                 "status": status,
-                "thought": "",
-                "observation": "",
+                "thought": thought,
+                "observation": observation,
                 "data": data,
             },
         )

--- a/backend/interfaces/public_api.py
+++ b/backend/interfaces/public_api.py
@@ -83,7 +83,8 @@ class RuntimeAPI:
         *,
         model: Model | str | None = None,
         user_id: str | None = None,
-        on_step: Callable[[str, str, dict[str, object]], Awaitable[None]] | None = None,
+        on_step: Callable[[str, str, dict[str, object], str, str], Awaitable[None]]
+        | None = None,
     ) -> PublicAPIResponse:
         """Execute the runtime pipeline and normalize its output."""
         session_id = request.session_id or None
@@ -482,7 +483,8 @@ async def handle_public_request(
     model: Model | str | None = None,
     session_store: SessionStore | None = None,
     user_id: str | None = None,
-    on_step: Callable[[str, str, dict[str, object]], Awaitable[None]] | None = None,
+    on_step: Callable[[str, str, dict[str, object], str, str], Awaitable[None]]
+    | None = None,
 ) -> PublicAPIResponse:
     """Convenience helper for one-off public API execution."""
     api = RuntimeAPI(db, session_store=session_store)

--- a/backend/tests/integration/test_sse_contract.py
+++ b/backend/tests/integration/test_sse_contract.py
@@ -87,8 +87,20 @@ def _build_runtime_api_mock(
         on_step: object = None,
     ) -> PublicAPIResponse:
         if emit_steps and on_step is not None and callable(on_step):
-            await on_step("search_bangumi", "running", {"bangumi_id": "12345"}, "Searching...", "")
-            await on_step("search_bangumi", "done", {"rows": [], "row_count": 0}, "", "Found 0 results")
+            await on_step(
+                "search_bangumi",
+                "running",
+                {"bangumi_id": "12345"},
+                "Searching...",
+                "",
+            )
+            await on_step(
+                "search_bangumi",
+                "done",
+                {"rows": [], "row_count": 0},
+                "",
+                "Found 0 results",
+            )
         return canned
 
     api.handle = AsyncMock(side_effect=handle_side_effect)

--- a/backend/tests/integration/test_sse_contract.py
+++ b/backend/tests/integration/test_sse_contract.py
@@ -87,8 +87,8 @@ def _build_runtime_api_mock(
         on_step: object = None,
     ) -> PublicAPIResponse:
         if emit_steps and on_step is not None and callable(on_step):
-            await on_step("search_bangumi", "running", {"bangumi_id": "12345"})
-            await on_step("search_bangumi", "done", {"rows": [], "row_count": 0})
+            await on_step("search_bangumi", "running", {"bangumi_id": "12345"}, "Searching...", "")
+            await on_step("search_bangumi", "done", {"rows": [], "row_count": 0}, "", "Found 0 results")
         return canned
 
     api.handle = AsyncMock(side_effect=handle_side_effect)

--- a/frontend/components/chat/ThinkingProcess.tsx
+++ b/frontend/components/chat/ThinkingProcess.tsx
@@ -20,6 +20,12 @@ const TOOL_ICONS: Record<string, string> = {
   clarify: "\u2753",
 };
 
+const STATUS_INDICATOR: Record<string, string> = {
+  running: "\u23F3",
+  done: "\u2713",
+  failed: "\u2717",
+};
+
 export default function ThinkingProcess({
   steps,
   isStreaming,
@@ -31,55 +37,85 @@ export default function ThinkingProcess({
     if (!isStreaming) return null;
     return (
       <div className="mb-2 flex items-center gap-1.5 text-xs text-[var(--color-muted-fg)]">
-        <span className="animate-pulse">🧠</span>
+        <span className="animate-pulse">{"\uD83E\uDDE0"}</span>
         <span>{t.chat?.thinking || "Thinking..."}</span>
       </div>
     );
   }
 
-  const summary = steps
-    .filter((s) => s.status === "done")
+  // Latest thought from the most recent step
+  const latestThought = [...steps].reverse().find((s) => s.thought)?.thought;
+
+  // Summary for collapsed state
+  const completedSteps = steps.filter((s) => s.status === "done");
+  const failedSteps = steps.filter((s) => s.status === "failed");
+  const summary = completedSteps
     .map((s) => s.observation || s.tool)
     .join(" \u2192 ");
 
   return (
     <div className="mb-2">
+      {/* Main thought line — natural language from planner */}
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-1.5 text-xs text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors"
+        className="flex items-center gap-1.5 text-xs text-[var(--color-muted-fg)] hover:text-[var(--color-fg)] transition-colors"
+        style={{ transitionDuration: "var(--duration-fast)" }}
       >
-        <span className={isStreaming ? "animate-pulse" : ""}>{"\uD83E\uDDE0"}</span>
+        <span className={isStreaming ? "animate-pulse" : ""}>
+          {"\uD83E\uDDE0"}
+        </span>
         <span>
           {isStreaming
-            ? t.chat?.thinking || "Thinking..."
+            ? latestThought || t.chat?.thinking || "Thinking..."
             : summary || t.chat?.thought_complete || "Done"}
         </span>
+        {failedSteps.length > 0 && !isStreaming && (
+          <span className="text-red-500 text-[10px]">
+            ({failedSteps.length} failed)
+          </span>
+        )}
         <span className="text-[10px]">{expanded ? "\u25BC" : "\u25B6"}</span>
       </button>
 
+      {/* Expanded: tool steps as compact sub-items */}
       {expanded && (
-        <div className="mt-1.5 ml-4 border-l-2 border-[var(--color-border)] pl-3 space-y-1.5">
+        <div className="mt-1.5 ml-4 border-l-2 border-[var(--color-border)] pl-3 space-y-1">
           {steps.map((step, i) => {
             const icon = TOOL_ICONS[step.tool] || "\u2699\uFE0F";
+            const isFailed = step.status === "failed";
             const isRunning = step.status === "running";
 
             return (
               <div key={`${step.tool}-${i}`} className="text-xs">
                 <div className="flex items-center gap-1.5">
-                  <span>{icon}</span>
+                  <span className="w-4 text-center">{icon}</span>
                   <span
                     className={
-                      isRunning ? "text-[var(--color-primary)] animate-pulse" : ""
+                      isFailed
+                        ? "text-red-500"
+                        : isRunning
+                          ? "text-[var(--color-primary)] animate-pulse"
+                          : "text-[var(--color-muted-fg)]"
                     }
                   >
                     {step.thought || step.tool}
                   </span>
-                  {!isRunning && (
-                    <span className="text-green-600">{"\u2713"}</span>
-                  )}
+                  <span
+                    className={
+                      isFailed
+                        ? "text-red-500"
+                        : isRunning
+                          ? "text-[var(--color-primary)]"
+                          : "text-green-600"
+                    }
+                  >
+                    {STATUS_INDICATOR[step.status] || ""}
+                  </span>
                 </div>
                 {step.observation && !isRunning && (
-                  <div className="ml-5 text-[var(--color-muted)]">
+                  <div
+                    className={`ml-5 ${isFailed ? "text-red-400" : "text-[var(--color-muted-fg)]"}`}
+                  >
                     {"\u2192"} {step.observation}
                   </div>
                 )}

--- a/frontend/components/chat/ThinkingProcess.tsx
+++ b/frontend/components/chat/ThinkingProcess.tsx
@@ -70,7 +70,10 @@ export default function ThinkingProcess({
             : summary || t.chat?.thought_complete || "Done"}
         </span>
         {failedSteps.length > 0 && !isStreaming && (
-          <span className="text-red-500 text-[10px]">
+          <span
+            className="text-[10px]"
+            style={{ color: "var(--color-error-fg)" }}
+          >
             ({failedSteps.length} failed)
           </span>
         )}
@@ -91,30 +94,39 @@ export default function ThinkingProcess({
                   <span className="w-4 text-center">{icon}</span>
                   <span
                     className={
+                      isRunning
+                        ? "text-[var(--color-primary)] animate-pulse"
+                        : "text-[var(--color-muted-fg)]"
+                    }
+                    style={
                       isFailed
-                        ? "text-red-500"
-                        : isRunning
-                          ? "text-[var(--color-primary)] animate-pulse"
-                          : "text-[var(--color-muted-fg)]"
+                        ? { color: "var(--color-error-fg)" }
+                        : undefined
                     }
                   >
                     {step.thought || step.tool}
                   </span>
                   <span
-                    className={
-                      isFailed
-                        ? "text-red-500"
+                    className={isRunning ? "text-[var(--color-primary)]" : ""}
+                    style={{
+                      color: isFailed
+                        ? "var(--color-error-fg)"
                         : isRunning
-                          ? "text-[var(--color-primary)]"
-                          : "text-green-600"
-                    }
+                          ? undefined
+                          : "var(--color-success-fg)",
+                    }}
                   >
                     {STATUS_INDICATOR[step.status] || ""}
                   </span>
                 </div>
                 {step.observation && !isRunning && (
                   <div
-                    className={`ml-5 ${isFailed ? "text-red-400" : "text-[var(--color-muted-fg)]"}`}
+                    className="ml-5 text-[var(--color-muted-fg)]"
+                    style={
+                      isFailed
+                        ? { color: "var(--color-error-fg)" }
+                        : undefined
+                    }
                   >
                     {"\u2192"} {step.observation}
                   </div>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -151,7 +151,7 @@ export interface PublicAPIError {
 
 export interface StepEvent {
   tool: string;
-  status: "running" | "done";
+  status: "running" | "done" | "failed";
   thought?: string;
   observation?: string;
 }


### PR DESCRIPTION
## Summary
- Rewrite ThinkingProcess.tsx: planner's thought as main text, tool steps as compact sub-items
- Failed steps show in red with ✗ indicator
- Add "failed" status to StepEvent type
- Thread thought + observation through full SSE chain (pipeline → on_step → SSE → frontend)
- Updated on_step callback from 3-arg to 5-arg across all layers

## Files changed (7)
- `frontend/components/chat/ThinkingProcess.tsx` — streaming-friendly rewrite
- `frontend/lib/types.ts` — add "failed" to StepEvent status
- `backend/agents/pipeline.py` — pass thought/observation to on_step
- `backend/agents/executor_agent.py` — updated callback signature
- `backend/interfaces/public_api.py` — updated callback type
- `backend/interfaces/fastapi_service.py` — SSE serializer threads thought/observation
- `backend/tests/integration/test_sse_contract.py` — updated mock calls

## Part of
Agent architecture v2 spec (Phase 4 — User Visibility)

## Test plan
- [ ] During streaming: shows planner's natural language thought
- [ ] Failed steps show in red with ✗
- [ ] SSE events include thought field
- [ ] `cd frontend && npm run build` passes
- [ ] `uv run pytest backend/tests/integration/ -x -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for "failed" step status in runtime events for improved error reporting.

* **UI/UX Improvements**
  * Enhanced thinking process display with per-step status indicators and a failed-step counter in collapsed view.
  * Streaming view uses most recent step thought for dynamic summaries and refined styling.

* **Bug Fixes**
  * Runtime stream events now include thought and observation text per step for richer client updates.

* **Tests**
  * Updated tests to validate expanded step event payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->