### PR TITLE
fix(session): persist search results in context delta

### DIFF
--- a/backend/interfaces/session_facade.py
+++ b/backend/interfaces/session_facade.py
@@ -104,14 +104,15 @@ def build_session_summary(state: dict[str, object]) -> dict[str, object]:
     }
 
 
-def build_context_block(
-    session_state: dict[str, object],
-    user_memory: dict[str, object] | None = None,
-) -> dict[str, object] | None:
-    """Derive a context block from session history and cross-session memory."""
-    raw_interactions = session_state.get("interactions")
-    interactions = raw_interactions if isinstance(raw_interactions, list) else []
-    summary = as_str_or_none(session_state.get("summary"))
+def _extract_from_interactions(
+    interactions: list[object],
+) -> tuple[str | None, str | None, str | None, dict[str, object] | None, list[str]]:
+    """Walk interactions in reverse and extract context fields.
+
+    Returns:
+        (current_bangumi_id, current_anime_title, last_location,
+         last_search_data, visited_bangumi_ids)
+    """
     current_bangumi_id: str | None = None
     current_anime_title: str | None = None
     last_location: str | None = None
@@ -144,6 +145,26 @@ def build_context_block(
         if current_bangumi_id and last_location:
             break
 
+    return current_bangumi_id, current_anime_title, last_location, last_search_data, visited_bangumi_ids
+
+
+def build_context_block(
+    session_state: dict[str, object],
+    user_memory: dict[str, object] | None = None,
+) -> dict[str, object] | None:
+    """Derive a context block from session history and cross-session memory."""
+    raw_interactions = session_state.get("interactions")
+    interactions = raw_interactions if isinstance(raw_interactions, list) else []
+    summary = as_str_or_none(session_state.get("summary"))
+
+    (
+        current_bangumi_id,
+        current_anime_title,
+        last_location,
+        last_search_data,
+        visited_bangumi_ids,
+    ) = _extract_from_interactions(interactions)
+
     if user_memory:
         raw_visited = user_memory.get("visited_anime")
         visited_anime = raw_visited if isinstance(raw_visited, list) else []
@@ -169,6 +190,7 @@ def build_context_block(
         and not last_location
         and not visited_bangumi_ids
         and not summary
+        and last_search_data is None
     ):
         return None
 
@@ -183,6 +205,42 @@ def build_context_block(
     if last_search_data is not None:
         block["last_search_data"] = last_search_data
     return block
+
+
+def _extract_from_search_bangumi(
+    plan_step: PlanStep,
+    step_result: object,
+    bangumi_id: str | None,
+) -> tuple[str | None, str | None, dict[str, object]]:
+    """Extract bangumi_id, anime_title, and last_search_data from a search_bangumi step.
+
+    Returns:
+        (bangumi_id, anime_title, last_search_data)
+    """
+    from backend.agents.executor_agent import StepResult  # local import avoids circular
+
+    sr = step_result if isinstance(step_result, StepResult) else None
+    data: dict[str, object] = {}
+    if sr is not None:
+        data = sr.data if isinstance(sr.data, dict) else {}
+
+    last_search_data: dict[str, object] = data
+    resolved_bangumi_id = bangumi_id
+    anime_title: str | None = None
+
+    rows = data.get("rows")
+    if isinstance(rows, list) and rows and resolved_bangumi_id is None:
+        first_row = rows[0] if isinstance(rows[0], dict) else {}
+        resolved_bangumi_id = as_str_or_none(first_row.get("bangumi_id"))
+        anime_title = as_str_or_none(
+            first_row.get("title") or first_row.get("title_cn")
+        )
+    if resolved_bangumi_id is None:
+        resolved_bangumi_id = as_str_or_none(
+            plan_step.params.get("bangumi_id") or plan_step.params.get("bangumi")
+        )
+
+    return resolved_bangumi_id, anime_title, last_search_data
 
 
 def extract_context_delta(result: PipelineResult) -> dict[str, object]:
@@ -213,19 +271,13 @@ def extract_context_delta(result: PipelineResult) -> dict[str, object]:
         if step_result.tool != "search_bangumi":
             continue
 
-        data = step_result.data if isinstance(step_result.data, dict) else {}
-        last_search_data = data
-        rows = data.get("rows")
-        if isinstance(rows, list) and rows and bangumi_id is None:
-            first_row = rows[0] if isinstance(rows[0], dict) else {}
-            bangumi_id = as_str_or_none(first_row.get("bangumi_id"))
-            anime_title = as_str_or_none(
-                first_row.get("title") or first_row.get("title_cn")
-            )
+        new_bangumi_id, new_anime_title, last_search_data = _extract_from_search_bangumi(
+            plan_step, step_result, bangumi_id
+        )
         if bangumi_id is None:
-            bangumi_id = as_str_or_none(
-                plan_step.params.get("bangumi_id") or plan_step.params.get("bangumi")
-            )
+            bangumi_id = new_bangumi_id
+        if anime_title is None:
+            anime_title = new_anime_title
 
     context_delta: dict[str, object] = {}
     if bangumi_id is not None:

--- a/backend/interfaces/session_facade.py
+++ b/backend/interfaces/session_facade.py
@@ -145,7 +145,13 @@ def _extract_from_interactions(
         if current_bangumi_id and last_location:
             break
 
-    return current_bangumi_id, current_anime_title, last_location, last_search_data, visited_bangumi_ids
+    return (
+        current_bangumi_id,
+        current_anime_title,
+        last_location,
+        last_search_data,
+        visited_bangumi_ids,
+    )
 
 
 def build_context_block(
@@ -271,8 +277,8 @@ def extract_context_delta(result: PipelineResult) -> dict[str, object]:
         if step_result.tool != "search_bangumi":
             continue
 
-        new_bangumi_id, new_anime_title, last_search_data = _extract_from_search_bangumi(
-            plan_step, step_result, bangumi_id
+        new_bangumi_id, new_anime_title, last_search_data = (
+            _extract_from_search_bangumi(plan_step, step_result, bangumi_id)
         )
         if bangumi_id is None:
             bangumi_id = new_bangumi_id

--- a/backend/interfaces/session_facade.py
+++ b/backend/interfaces/session_facade.py
@@ -115,6 +115,7 @@ def build_context_block(
     current_bangumi_id: str | None = None
     current_anime_title: str | None = None
     last_location: str | None = None
+    last_search_data: dict[str, object] | None = None
     visited_bangumi_ids: list[str] = []
 
     for interaction in reversed(interactions):
@@ -134,6 +135,11 @@ def build_context_block(
             last_location = location
         if bangumi_id and bangumi_id not in visited_bangumi_ids:
             visited_bangumi_ids.append(bangumi_id)
+
+        if last_search_data is None:
+            raw_search = delta.get("last_search_data")
+            if isinstance(raw_search, dict):
+                last_search_data = raw_search
 
         if current_bangumi_id and last_location:
             break
@@ -166,7 +172,7 @@ def build_context_block(
     ):
         return None
 
-    return {
+    block: dict[str, object] = {
         "summary": summary,
         "current_bangumi_id": current_bangumi_id,
         "current_anime_title": current_anime_title,
@@ -174,13 +180,17 @@ def build_context_block(
         "last_intent": session_state.get("last_intent"),
         "visited_bangumi_ids": visited_bangumi_ids,
     }
+    if last_search_data is not None:
+        block["last_search_data"] = last_search_data
+    return block
 
 
 def extract_context_delta(result: PipelineResult) -> dict[str, object]:
-    """Extract bangumi_id / anime_title / location from step results."""
+    """Extract bangumi_id / anime_title / location / last_search_data from step results."""
     bangumi_id: str | None = None
     anime_title: str | None = None
     location: str | None = None
+    last_search_data: dict[str, object] | None = None
 
     for step_result in result.step_results:
         if step_result.tool != "resolve_anime" or not step_result.success:
@@ -200,12 +210,13 @@ def extract_context_delta(result: PipelineResult) -> dict[str, object]:
         if step_result.tool == "search_nearby" and location is None:
             location = as_str_or_none(plan_step.params.get("location"))
 
-        if step_result.tool != "search_bangumi" or bangumi_id is not None:
+        if step_result.tool != "search_bangumi":
             continue
 
         data = step_result.data if isinstance(step_result.data, dict) else {}
+        last_search_data = data
         rows = data.get("rows")
-        if isinstance(rows, list) and rows:
+        if isinstance(rows, list) and rows and bangumi_id is None:
             first_row = rows[0] if isinstance(rows[0], dict) else {}
             bangumi_id = as_str_or_none(first_row.get("bangumi_id"))
             anime_title = as_str_or_none(
@@ -223,6 +234,8 @@ def extract_context_delta(result: PipelineResult) -> dict[str, object]:
         context_delta["anime_title"] = anime_title
     if location is not None:
         context_delta["location"] = location
+    if last_search_data is not None:
+        context_delta["last_search_data"] = last_search_data
     return context_delta
 
 

--- a/backend/tests/unit/test_session_facade.py
+++ b/backend/tests/unit/test_session_facade.py
@@ -446,6 +446,38 @@ class TestBuildContextBlockSearchData:
         assert block is not None
         assert "last_search_data" not in block
 
+    def test_search_bangumi_only_no_resolve_anime_returns_non_none(self) -> None:
+        """Correctness: last_search_data alone is sufficient to return a context block.
+
+        Scenario: resolve_anime failed (or was not emitted) so no bangumi_id/
+        location/summary is present, but search_bangumi succeeded and stored
+        last_search_data.  The early-return guard must NOT fire.
+        """
+        state = {
+            "interactions": [
+                {
+                    "text": "search eupho",
+                    "context_delta": {
+                        "last_search_data": {
+                            "rows": [{"bangumi_id": "99", "title": "Eupho"}],
+                            "row_count": 1,
+                        },
+                    },
+                }
+            ],
+            "last_intent": "search_bangumi",
+        }
+        block = build_context_block(state)
+
+        assert block is not None, (
+            "build_context_block must not return None when last_search_data is populated"
+        )
+        assert "last_search_data" in block
+        search_data = block["last_search_data"]
+        assert isinstance(search_data, dict)
+        assert search_data["row_count"] == 1
+        assert block["current_bangumi_id"] is None
+
 
 class TestAsStrOrNone:
     def test_none_returns_none(self) -> None:

--- a/backend/tests/unit/test_session_facade.py
+++ b/backend/tests/unit/test_session_facade.py
@@ -299,6 +299,154 @@ class TestExtractContextDelta:
         assert delta["anime_title"] == "From Rows"
 
 
+class TestExtractContextDeltaSearchData:
+    """AC: extract_context_delta persists last_search_data after search_bangumi."""
+
+    def test_search_bangumi_success_includes_last_search_data(self) -> None:
+        plan = _make_plan(
+            steps=[PlanStep(tool=ToolName.SEARCH_BANGUMI, params={"bangumi_id": "99"})]
+        )
+        result = PipelineResult(intent="search_bangumi", plan=plan)
+        result.step_results = [
+            StepResult(
+                tool="search_bangumi",
+                success=True,
+                data={
+                    "rows": [{"bangumi_id": "99", "title": "Eupho"}],
+                    "row_count": 1,
+                },
+            )
+        ]
+
+        delta = extract_context_delta(result)
+        assert "last_search_data" in delta
+        search_data = delta["last_search_data"]
+        assert isinstance(search_data, dict)
+        assert search_data["rows"] == [{"bangumi_id": "99", "title": "Eupho"}]
+        assert search_data["row_count"] == 1
+
+    def test_no_search_bangumi_step_has_no_last_search_data(self) -> None:
+        plan = _make_plan(
+            steps=[PlanStep(tool=ToolName.RESOLVE_ANIME, params={"title": "Eupho"})]
+        )
+        result = PipelineResult(intent="search_bangumi", plan=plan)
+        result.step_results = [
+            StepResult(
+                tool="resolve_anime",
+                success=True,
+                data={"bangumi_id": "99", "title": "Eupho"},
+            )
+        ]
+
+        delta = extract_context_delta(result)
+        assert "last_search_data" not in delta
+
+    def test_search_bangumi_failure_has_no_last_search_data(self) -> None:
+        plan = _make_plan(
+            steps=[PlanStep(tool=ToolName.SEARCH_BANGUMI, params={"bangumi_id": "99"})]
+        )
+        result = PipelineResult(intent="search_bangumi", plan=plan)
+        result.step_results = [
+            StepResult(tool="search_bangumi", success=False, error="DB error")
+        ]
+
+        delta = extract_context_delta(result)
+        assert "last_search_data" not in delta
+
+
+class TestBuildContextBlockSearchData:
+    """AC: build_context_block reconstructs last_search_data from interactions."""
+
+    def test_reconstructs_last_search_data_from_most_recent_interaction(self) -> None:
+        state = {
+            "interactions": [
+                {
+                    "text": "search eupho",
+                    "context_delta": {
+                        "bangumi_id": "99",
+                        "last_search_data": {
+                            "rows": [{"bangumi_id": "99", "title": "Eupho"}],
+                            "row_count": 1,
+                        },
+                    },
+                }
+            ],
+            "last_intent": "search_bangumi",
+        }
+        block = build_context_block(state)
+
+        assert block is not None
+        assert "last_search_data" in block
+        search_data = block["last_search_data"]
+        assert isinstance(search_data, dict)
+        assert search_data["row_count"] == 1
+
+    def test_uses_most_recent_interaction_with_search_data(self) -> None:
+        state = {
+            "interactions": [
+                {
+                    "text": "first search",
+                    "context_delta": {
+                        "bangumi_id": "50",
+                        "last_search_data": {"rows": [{"bangumi_id": "50"}], "row_count": 1},
+                    },
+                },
+                {
+                    "text": "second search",
+                    "context_delta": {
+                        "bangumi_id": "99",
+                        "last_search_data": {"rows": [{"bangumi_id": "99"}], "row_count": 5},
+                    },
+                },
+            ],
+            "last_intent": "search_bangumi",
+        }
+        block = build_context_block(state)
+
+        assert block is not None
+        search_data = block["last_search_data"]
+        assert isinstance(search_data, dict)
+        assert search_data["row_count"] == 5
+
+    def test_no_interactions_returns_none(self) -> None:
+        state: dict[str, object] = {"interactions": []}
+        block = build_context_block(state)
+        assert block is None
+
+    def test_no_search_data_in_interactions_has_no_key(self) -> None:
+        state = {
+            "interactions": [
+                {
+                    "text": "search",
+                    "context_delta": {"bangumi_id": "99", "anime_title": "Eupho"},
+                }
+            ],
+            "last_intent": "search_bangumi",
+        }
+        block = build_context_block(state)
+
+        assert block is not None
+        assert "last_search_data" not in block
+
+    def test_malformed_last_search_data_ignored_gracefully(self) -> None:
+        state = {
+            "interactions": [
+                {
+                    "text": "search",
+                    "context_delta": {
+                        "bangumi_id": "99",
+                        "last_search_data": "not-a-dict",
+                    },
+                }
+            ],
+            "last_intent": "search_bangumi",
+        }
+        block = build_context_block(state)
+
+        assert block is not None
+        assert "last_search_data" not in block
+
+
 class TestAsStrOrNone:
     def test_none_returns_none(self) -> None:
         assert as_str_or_none(None) is None

--- a/backend/tests/unit/test_session_facade.py
+++ b/backend/tests/unit/test_session_facade.py
@@ -388,14 +388,20 @@ class TestBuildContextBlockSearchData:
                     "text": "first search",
                     "context_delta": {
                         "bangumi_id": "50",
-                        "last_search_data": {"rows": [{"bangumi_id": "50"}], "row_count": 1},
+                        "last_search_data": {
+                            "rows": [{"bangumi_id": "50"}],
+                            "row_count": 1,
+                        },
                     },
                 },
                 {
                     "text": "second search",
                     "context_delta": {
                         "bangumi_id": "99",
-                        "last_search_data": {"rows": [{"bangumi_id": "99"}], "row_count": 5},
+                        "last_search_data": {
+                            "rows": [{"bangumi_id": "99"}],
+                            "row_count": 5,
+                        },
                     },
                 },
             ],


### PR DESCRIPTION
Card 1 of BUG-03 fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session context now preserves the most recent successful search result (last search data) and includes it when reconstructing context; presence of this data can prevent an otherwise early-exit. Malformed or missing search data is ignored.

* **Tests**
  * Added unit tests covering extraction, inclusion, omission, and reconstruction behaviors for last-search data in session context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->