### PR TITLE
test(backend): add repository unit tests

### DIFF
--- a/backend/tests/unit/repositories/test_bangumi_repo.py
+++ b/backend/tests/unit/repositories/test_bangumi_repo.py
@@ -1,0 +1,98 @@
+"""Unit tests for BangumiRepository."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.infrastructure.supabase.repositories.bangumi import BangumiRepository
+
+
+@pytest.fixture
+def pool() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def repo(pool: AsyncMock) -> BangumiRepository:
+    return BangumiRepository(pool)
+
+
+async def test_get_bangumi_returns_row_when_exists(
+    repo: BangumiRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = {"id": "115908", "title": "Liz and the Blue Bird"}
+    result = await repo.get_bangumi("115908")
+    assert result is not None
+    assert result["id"] == "115908"
+    assert result["title"] == "Liz and the Blue Bird"
+    pool.fetchrow.assert_awaited_once_with(
+        "SELECT * FROM bangumi WHERE id = $1", "115908"
+    )
+
+
+async def test_get_bangumi_returns_none_when_not_found(
+    repo: BangumiRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = None
+    result = await repo.get_bangumi("nonexistent")
+    assert result is None
+
+
+async def test_get_bangumi_raises_on_pool_error(
+    repo: BangumiRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.side_effect = RuntimeError("connection lost")
+    with pytest.raises(RuntimeError, match="connection lost"):
+        await repo.get_bangumi("115908")
+
+
+async def test_list_bangumi_returns_list(
+    repo: BangumiRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = [
+        {"id": "1", "title": "A", "rating": 9.0},
+        {"id": "2", "title": "B", "rating": 8.0},
+    ]
+    result = await repo.list_bangumi(limit=10)
+    assert len(result) == 2
+    pool.fetch.assert_awaited_once()
+
+
+async def test_upsert_bangumi_calls_execute(
+    repo: BangumiRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = None
+    await repo.upsert_bangumi("115908", title="Liz")
+    pool.execute.assert_awaited_once()
+    sql = pool.execute.await_args.args[0]
+    assert "INSERT INTO bangumi" in sql
+    assert "ON CONFLICT (id)" in sql
+
+
+async def test_find_bangumi_by_title_returns_id(
+    repo: BangumiRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = {"id": "115908"}
+    result = await repo.find_bangumi_by_title("Liz")
+    assert result == "115908"
+
+
+async def test_find_bangumi_by_title_returns_none(
+    repo: BangumiRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = None
+    result = await repo.find_bangumi_by_title("nonexistent")
+    assert result is None
+
+
+async def test_get_bangumi_by_area_returns_dicts(
+    repo: BangumiRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = [
+        {"bangumi_id": "1", "bangumi_title": "A", "city": "Kyoto"}
+    ]
+    result = await repo.get_bangumi_by_area(34.88, 135.80)
+    assert len(result) == 1
+    assert result[0]["city"] == "Kyoto"

--- a/backend/tests/unit/repositories/test_feedback_repo.py
+++ b/backend/tests/unit/repositories/test_feedback_repo.py
@@ -1,0 +1,95 @@
+"""Unit tests for FeedbackRepository."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.infrastructure.supabase.repositories.feedback import FeedbackRepository
+
+
+@pytest.fixture
+def pool() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def repo(pool: AsyncMock) -> FeedbackRepository:
+    return FeedbackRepository(pool)
+
+
+async def test_save_feedback_returns_feedback_id(
+    repo: FeedbackRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = {"id": "fb-uuid-123"}
+    result = await repo.save_feedback(
+        session_id="sess-1",
+        query_text="Where is Liz filmed?",
+        intent="search_anime",
+        rating="good",
+        comment="Helpful!",
+    )
+    assert result == "fb-uuid-123"
+    pool.fetchrow.assert_awaited_once()
+    sql = pool.fetchrow.await_args.args[0]
+    assert "INSERT INTO feedback" in sql
+    assert "RETURNING id" in sql
+
+
+async def test_save_feedback_raises_when_no_row_returned(
+    repo: FeedbackRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = None
+    with pytest.raises(RuntimeError, match="save_feedback"):
+        await repo.save_feedback(
+            session_id="sess-1",
+            query_text="test",
+            intent=None,
+            rating="bad",
+        )
+
+
+async def test_insert_request_log_returns_id(
+    repo: FeedbackRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = {"id": "log-uuid-456"}
+    result = await repo.insert_request_log(
+        session_id="sess-1",
+        query_text="test query",
+        locale="ja",
+        plan_steps=["resolve_anime", "search_bangumi"],
+        intent="search",
+        status="ok",
+        latency_ms=120,
+    )
+    assert result == "log-uuid-456"
+
+
+async def test_fetch_bad_feedback_returns_list(
+    repo: FeedbackRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = [
+        {
+            "id": "1",
+            "query_text": "bad result",
+            "intent": None,
+            "comment": "wrong",
+            "created_at": "2026-01-01",
+        }
+    ]
+    result = await repo.fetch_bad_feedback(limit=10)
+    assert len(result) == 1
+    assert result[0]["query_text"] == "bad result"
+
+
+async def test_update_request_log_score_calls_execute(
+    repo: FeedbackRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = None
+    await repo.update_request_log_score(log_id="log-1", score=0.85)
+    pool.execute.assert_awaited_once()
+    call_args = pool.execute.await_args.args
+    assert "UPDATE request_log" in call_args[0]
+    assert call_args[1] == 0.85
+    assert call_args[2] == "log-1"

--- a/backend/tests/unit/repositories/test_messages_repo.py
+++ b/backend/tests/unit/repositories/test_messages_repo.py
@@ -1,0 +1,75 @@
+"""Unit tests for MessagesRepository."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.infrastructure.supabase.repositories.messages import MessagesRepository
+
+
+@pytest.fixture
+def pool() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def repo(pool: AsyncMock) -> MessagesRepository:
+    return MessagesRepository(pool)
+
+
+async def test_insert_message_calls_execute(
+    repo: MessagesRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = None
+    await repo.insert_message("sess-1", "user", "Hello")
+    pool.execute.assert_awaited_once()
+    sql = pool.execute.await_args.args[0]
+    assert "INSERT INTO conversation_messages" in sql
+    assert pool.execute.await_args.args[1] == "sess-1"
+    assert pool.execute.await_args.args[2] == "user"
+    assert pool.execute.await_args.args[3] == "Hello"
+    assert pool.execute.await_args.args[4] is None
+
+
+async def test_insert_message_with_response_data(
+    repo: MessagesRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = None
+    data = {"ui": {"type": "search_results"}}
+    await repo.insert_message("sess-1", "assistant", "Found results", data)
+    call_args = pool.execute.await_args.args
+    assert call_args[4] == json.dumps(data)
+
+
+async def test_get_messages_returns_list(
+    repo: MessagesRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = [
+        {
+            "role": "user",
+            "content": "Hi",
+            "response_data": None,
+            "created_at": "2026-01-01",
+        },
+        {
+            "role": "assistant",
+            "content": "Hello",
+            "response_data": None,
+            "created_at": "2026-01-01",
+        },
+    ]
+    result = await repo.get_messages("sess-1", limit=50)
+    assert len(result) == 2
+    assert result[0]["role"] == "user"
+    assert result[1]["role"] == "assistant"
+
+
+async def test_get_messages_empty_conversation(
+    repo: MessagesRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = []
+    result = await repo.get_messages("empty-sess")
+    assert result == []

--- a/backend/tests/unit/repositories/test_points_repo.py
+++ b/backend/tests/unit/repositories/test_points_repo.py
@@ -1,0 +1,80 @@
+"""Unit tests for PointsRepository."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.infrastructure.supabase.repositories.points import PointsRepository
+
+
+@pytest.fixture
+def pool() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def repo(pool: AsyncMock) -> PointsRepository:
+    return PointsRepository(pool)
+
+
+async def test_get_points_by_bangumi_returns_list(
+    repo: PointsRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = [
+        {"id": "p1", "bangumi_id": "115908", "name": "Uji Bridge"},
+        {"id": "p2", "bangumi_id": "115908", "name": "Station"},
+    ]
+    result = await repo.get_points_by_bangumi("115908")
+    assert isinstance(result, list)
+    assert len(result) == 2
+    pool.fetch.assert_awaited_once()
+
+
+async def test_get_points_by_bangumi_returns_empty_list(
+    repo: PointsRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = []
+    result = await repo.get_points_by_bangumi("nonexistent")
+    assert result == []
+
+
+async def test_get_points_by_ids_returns_ordered_dicts(
+    repo: PointsRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = [
+        {"id": "p1", "name": "A"},
+        {"id": "p2", "name": "B"},
+    ]
+    result = await repo.get_points_by_ids(["p1", "p2"])
+    assert len(result) == 2
+    assert result[0]["id"] == "p1"
+
+
+async def test_get_points_by_ids_empty_input(
+    repo: PointsRepository, pool: AsyncMock
+) -> None:
+    result = await repo.get_points_by_ids([])
+    assert result == []
+    pool.fetch.assert_not_awaited()
+
+
+async def test_search_points_by_location_returns_rows(
+    repo: PointsRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = [{"id": "p1", "distance_m": 100.0}]
+    result = await repo.search_points_by_location(34.88, 135.80, 5000)
+    assert len(result) == 1
+    pool.fetch.assert_awaited_once()
+
+
+async def test_upsert_point_calls_execute(
+    repo: PointsRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = None
+    await repo.upsert_point("p1", bangumi_id="115908", name="Uji")
+    pool.execute.assert_awaited_once()
+    sql = pool.execute.await_args.args[0]
+    assert "INSERT INTO points" in sql
+    assert "ON CONFLICT (id)" in sql

--- a/backend/tests/unit/repositories/test_routes_repo.py
+++ b/backend/tests/unit/repositories/test_routes_repo.py
@@ -1,0 +1,87 @@
+"""Unit tests for RoutesRepository."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.infrastructure.supabase.repositories.routes import RoutesRepository
+
+
+@pytest.fixture
+def pool() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def repo(pool: AsyncMock) -> RoutesRepository:
+    return RoutesRepository(pool)
+
+
+async def test_save_route_returns_route_id(
+    repo: RoutesRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = {"id": "route-uuid-789"}
+    result = await repo.save_route(
+        session_id="sess-1",
+        bangumi_id="115908",
+        point_ids=["p1", "p2", "p3"],
+        route_data={"steps": [{"from": "p1", "to": "p2"}]},
+        origin_station="Uji Station",
+        origin_lat=34.88,
+        origin_lon=135.80,
+        total_distance=5200.0,
+        total_duration=3600,
+    )
+    assert result == "route-uuid-789"
+    pool.fetchrow.assert_awaited_once()
+    sql = pool.fetchrow.await_args.args[0]
+    assert "INSERT INTO routes" in sql
+    assert "RETURNING id" in sql
+
+
+async def test_save_route_without_origin(
+    repo: RoutesRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = {"id": "route-uuid-abc"}
+    result = await repo.save_route(
+        session_id="sess-1",
+        bangumi_id="115908",
+        point_ids=["p1"],
+        route_data={},
+    )
+    assert result == "route-uuid-abc"
+    call_args = pool.fetchrow.await_args.args
+    assert call_args[4] is None  # origin_location param
+
+
+async def test_save_route_raises_when_no_row(
+    repo: RoutesRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = None
+    with pytest.raises(RuntimeError, match="save_route"):
+        await repo.save_route(
+            session_id="sess-1",
+            bangumi_id="115908",
+            point_ids=["p1"],
+            route_data={},
+        )
+
+
+async def test_get_user_routes_returns_list(
+    repo: RoutesRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = [
+        {
+            "id": "r1",
+            "bangumi_id": "115908",
+            "bangumi_title": "Liz",
+            "point_count": 3,
+            "created_at": "2026-01-01",
+            "origin_station": None,
+        }
+    ]
+    result = await repo.get_user_routes("user-1", limit=5)
+    assert len(result) == 1
+    assert result[0]["bangumi_id"] == "115908"

--- a/backend/tests/unit/repositories/test_session_repo.py
+++ b/backend/tests/unit/repositories/test_session_repo.py
@@ -1,0 +1,97 @@
+"""Unit tests for SessionRepository."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.infrastructure.supabase.repositories.session import SessionRepository
+
+
+@pytest.fixture
+def pool() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def repo(pool: AsyncMock) -> SessionRepository:
+    return SessionRepository(pool)
+
+
+async def test_upsert_session_calls_execute_with_correct_params(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = None
+    state = {"context": {"bangumi_id": "115908"}}
+    metadata = {"locale": "ja"}
+    await repo.upsert_session("sess-1", state, metadata)
+    pool.execute.assert_awaited_once()
+    call_args = pool.execute.await_args.args
+    assert "INSERT INTO sessions" in call_args[0]
+    assert call_args[1] == "sess-1"
+    assert call_args[2] == json.dumps(state)
+    assert call_args[3] == json.dumps(metadata)
+
+
+async def test_upsert_session_defaults_metadata_to_empty(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = None
+    await repo.upsert_session("sess-1", {"key": "val"})
+    call_args = pool.execute.await_args.args
+    assert call_args[3] == json.dumps({})
+
+
+async def test_get_session_returns_row(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = {"id": "sess-1", "state": "{}"}
+    result = await repo.get_session("sess-1")
+    assert result is not None
+    assert result["id"] == "sess-1"
+
+
+async def test_get_session_returns_none(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = None
+    result = await repo.get_session("missing")
+    assert result is None
+
+
+async def test_upsert_conversation_calls_execute(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = None
+    await repo.upsert_conversation("sess-1", "user-1", "Where is Liz filmed?")
+    pool.execute.assert_awaited_once()
+    sql = pool.execute.await_args.args[0]
+    assert "INSERT INTO conversations" in sql
+
+
+async def test_get_session_state_returns_dict(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = {"state": json.dumps({"bangumi_id": "1"})}
+    result = await repo.get_session_state("sess-1")
+    assert result == {"bangumi_id": "1"}
+
+
+async def test_get_session_state_returns_none_when_missing(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = None
+    result = await repo.get_session_state("missing")
+    assert result is None
+
+
+async def test_delete_session_state_calls_execute(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = None
+    await repo.delete_session_state("sess-1")
+    pool.execute.assert_awaited_once()
+    sql = pool.execute.await_args.args[0]
+    assert "DELETE FROM sessions" in sql

--- a/backend/tests/unit/repositories/test_user_memory_repo.py
+++ b/backend/tests/unit/repositories/test_user_memory_repo.py
@@ -1,0 +1,72 @@
+"""Unit tests for UserMemoryRepository."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.infrastructure.supabase.repositories.user_memory import (
+    UserMemoryRepository,
+)
+
+
+@pytest.fixture
+def pool() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def repo(pool: AsyncMock) -> UserMemoryRepository:
+    return UserMemoryRepository(pool)
+
+
+async def test_upsert_user_memory_inserts_new_anime(
+    repo: UserMemoryRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = None
+    pool.execute.return_value = None
+    await repo.upsert_user_memory("user-1", bangumi_id="115908", anime_title="Liz")
+    pool.execute.assert_awaited_once()
+    sql = pool.execute.await_args.args[0]
+    assert "INSERT INTO user_memory" in sql
+    saved_json = json.loads(pool.execute.await_args.args[2])
+    assert len(saved_json) == 1
+    assert saved_json[0]["bangumi_id"] == "115908"
+    assert saved_json[0]["title"] == "Liz"
+
+
+async def test_upsert_user_memory_updates_existing_anime(
+    repo: UserMemoryRepository, pool: AsyncMock
+) -> None:
+    existing = [{"bangumi_id": "115908", "title": "Old Title", "last_at": "2026-01-01"}]
+    pool.fetchrow.return_value = {"visited_anime": json.dumps(existing)}
+    pool.execute.return_value = None
+    await repo.upsert_user_memory(
+        "user-1", bangumi_id="115908", anime_title="New Title"
+    )
+    saved_json = json.loads(pool.execute.await_args.args[2])
+    assert len(saved_json) == 1
+    assert saved_json[0]["title"] == "New Title"
+
+
+async def test_get_user_memory_returns_parsed_data(
+    repo: UserMemoryRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = {
+        "visited_anime": json.dumps([{"bangumi_id": "1", "title": "A"}]),
+        "visited_points": json.dumps([]),
+    }
+    result = await repo.get_user_memory("user-1")
+    assert result is not None
+    assert len(result["visited_anime"]) == 1
+    assert result["visited_points"] == []
+
+
+async def test_get_user_memory_returns_none_when_missing(
+    repo: UserMemoryRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = None
+    result = await repo.get_user_memory("nonexistent")
+    assert result is None


### PR DESCRIPTION
Add 39 unit tests for all 7 repository classes using AsyncMock. Covers Card R4 ACs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Added comprehensive unit test coverage for core database repository modules to enhance system stability and code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->