### PR TITLE
refactor(frontend): split types.ts into types/ module

### DIFF
--- a/frontend/lib/types/api.ts
+++ b/frontend/lib/types/api.ts
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------------
+// API types — request/response contracts for the public API layer.
+// ---------------------------------------------------------------------------
+
+import type {
+  Intent,
+  SearchResultData,
+  RouteData,
+  QAData,
+} from "./domain";
+
+export interface RouteHistoryRecord {
+  route_id: string | null;
+  bangumi_id: string;
+  origin_station: string | null;
+  point_count: number;
+  status: string;
+  created_at: string; // ISO 8601
+}
+
+export interface RuntimeRequest {
+  text: string;
+  session_id?: string | null;
+  locale?: "ja" | "zh" | "en";
+  model?: string | null;
+  include_debug?: boolean;
+  selected_point_ids?: string[];
+  origin?: string | null;
+}
+
+export interface PublicAPIError {
+  code: string;
+  message: string;
+  details: Record<string, unknown>;
+}
+
+export interface StepEvent {
+  tool: string;
+  status: "running" | "done" | "failed";
+  thought?: string;
+  observation?: string;
+}
+
+export interface ConversationRecord {
+  session_id: string;
+  title: string | null;
+  first_query: string;
+  created_at: string; // ISO 8601
+  updated_at: string; // ISO 8601
+}
+
+export interface UIDescriptor {
+  component: string;
+}
+
+export interface RuntimeResponse {
+  success: boolean;
+  status: string;
+  intent: Intent;
+  session_id: string | null;
+  message: string;
+  data: SearchResultData | RouteData | QAData;
+  session: {
+    interaction_count: number;
+    route_history_count: number;
+    last_intent?: string | null;
+    last_status?: string | null;
+    last_message?: string;
+  };
+  route_history: RouteHistoryRecord[];
+  errors: PublicAPIError[];
+  debug?: Record<string, unknown> | null;
+  ui?: UIDescriptor;
+}

--- a/frontend/lib/types/components.ts
+++ b/frontend/lib/types/components.ts
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------------------
+// Component types — frontend-only types for React component props and state.
+// ---------------------------------------------------------------------------
+
+import type { RuntimeResponse, StepEvent } from "./api";
+
+export type ErrorCode = "stream_error" | "timeout" | "rate_limit" | "generic";
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  response?: RuntimeResponse;
+  loading?: boolean;
+  timestamp: number;
+  steps?: StepEvent[];
+  errorCode?: ErrorCode;
+}

--- a/frontend/lib/types/domain.ts
+++ b/frontend/lib/types/domain.ts
@@ -1,7 +1,5 @@
 // ---------------------------------------------------------------------------
-// TypeScript contract mirroring the Python backend (interfaces/public_api.py,
-// agents/intent_agent.py, domain/entities.py).  Every field matches the
-// backend exactly — consult those files for the source of truth.
+// Domain types — entities and value objects from the backend domain layer.
 // ---------------------------------------------------------------------------
 
 // ── Intent values ──────────────────────────────────────────────────────────
@@ -131,105 +129,6 @@ export interface QAData {
   message: string;
 }
 
-// ── Top-level request / response ───────────────────────────────────────────
-
-export interface RuntimeRequest {
-  text: string;
-  session_id?: string | null;
-  locale?: "ja" | "zh" | "en";
-  model?: string | null;
-  include_debug?: boolean;
-  selected_point_ids?: string[];
-  origin?: string | null;
-}
-
-export interface PublicAPIError {
-  code: string;
-  message: string;
-  details: Record<string, unknown>;
-}
-
-export interface StepEvent {
-  tool: string;
-  status: "running" | "done" | "failed";
-  thought?: string;
-  observation?: string;
-}
-
-export interface RouteHistoryRecord {
-  route_id: string | null;
-  bangumi_id: string;
-  origin_station: string | null;
-  point_count: number;
-  status: string;
-  created_at: string; // ISO 8601
-}
-
-export interface ConversationRecord {
-  session_id: string;
-  title: string | null;
-  first_query: string;
-  created_at: string; // ISO 8601
-  updated_at: string; // ISO 8601
-}
-
-export interface UIDescriptor {
-  component: string;
-}
-
-export interface RuntimeResponse {
-  success: boolean;
-  status: string;
-  intent: Intent;
-  session_id: string | null;
-  message: string;
-  data: SearchResultData | RouteData | QAData;
-  session: {
-    interaction_count: number;
-    route_history_count: number;
-    last_intent?: string | null;
-    last_status?: string | null;
-    last_message?: string;
-  };
-  route_history: RouteHistoryRecord[];
-  errors: PublicAPIError[];
-  debug?: Record<string, unknown> | null;
-  ui?: UIDescriptor;
-}
-
-// ── Frontend-only types ────────────────────────────────────────────────────
-
-export type ErrorCode = "stream_error" | "timeout" | "rate_limit" | "generic";
-
-export interface ChatMessage {
-  id: string;
-  role: "user" | "assistant";
-  text: string;
-  response?: RuntimeResponse;
-  loading?: boolean;
-  timestamp: number;
-  steps?: StepEvent[];
-  errorCode?: ErrorCode;
-}
-
-// ── Type guards ────────────────────────────────────────────────────────────
-
-export function isSearchData(data: RuntimeResponse["data"]): data is SearchResultData {
-  return data != null && "results" in data && !("route" in data);
-}
-
-export function isRouteData(data: RuntimeResponse["data"]): data is RouteData {
-  return data != null && "route" in data;
-}
-
-export function isQAData(data: RuntimeResponse["data"]): data is QAData {
-  return data != null && (data.status === "info" || data.status === "needs_clarification");
-}
-
 export type TimedRouteData = RouteData & {
   route: { timed_itinerary: TimedItinerary };
 };
-
-export function isTimedRouteData(data: RuntimeResponse["data"]): data is TimedRouteData {
-  return data != null && "route" in data && "timed_itinerary" in (data as RouteData).route;
-}

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------
+// Barrel export — all types available from @/lib/types
+// ---------------------------------------------------------------------------
+
+export type {
+  Intent,
+  PilgrimagePoint,
+  ResultsMeta,
+  SearchResultData,
+  RouteData,
+  LocationCluster,
+  TimedStop,
+  TransitLeg,
+  TimedItinerary,
+  QAData,
+  TimedRouteData,
+} from "./domain";
+
+export type {
+  RuntimeRequest,
+  PublicAPIError,
+  StepEvent,
+  RouteHistoryRecord,
+  ConversationRecord,
+  UIDescriptor,
+  RuntimeResponse,
+} from "./api";
+
+export type { ErrorCode, ChatMessage } from "./components";
+
+// ── Type guards ────────────────────────────────────────────────────────────
+
+import type { RuntimeResponse } from "./api";
+import type { SearchResultData, RouteData, QAData, TimedRouteData } from "./domain";
+
+export function isSearchData(data: RuntimeResponse["data"]): data is SearchResultData {
+  return data != null && "results" in data && !("route" in data);
+}
+
+export function isRouteData(data: RuntimeResponse["data"]): data is RouteData {
+  return data != null && "route" in data;
+}
+
+export function isQAData(data: RuntimeResponse["data"]): data is QAData {
+  return data != null && (data.status === "info" || data.status === "needs_clarification");
+}
+
+export function isTimedRouteData(data: RuntimeResponse["data"]): data is TimedRouteData {
+  return data != null && "route" in data && "timed_itinerary" in (data as RouteData).route;
+}

--- a/frontend/tests/type-guards.test.ts
+++ b/frontend/tests/type-guards.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isSearchData, isRouteData, isQAData, isTimedRouteData } from "../lib/types";
+
+// AC: isSearchData(null) returns false
+test("isSearchData returns false for null", () => {
+  assert.equal(isSearchData(null as never), false);
+});
+
+// AC: isRouteData(undefined) returns false
+test("isRouteData returns false for undefined", () => {
+  assert.equal(isRouteData(undefined as never), false);
+});
+
+test("isQAData returns false for null", () => {
+  assert.equal(isQAData(null as never), false);
+});
+
+test("isTimedRouteData returns false for null", () => {
+  assert.equal(isTimedRouteData(null as never), false);
+});
+
+test("isSearchData returns true for valid search data", () => {
+  const data = {
+    results: { rows: [], row_count: 0, strategy: "sql", status: "ok" },
+    message: "Found 0 results",
+    status: "ok",
+  };
+  assert.equal(isSearchData(data as never), true);
+});
+
+test("isRouteData returns true for valid route data", () => {
+  const data = {
+    results: { rows: [], row_count: 0, strategy: "sql", status: "ok" },
+    route: { ordered_points: [], point_count: 0, status: "ok" },
+    message: "Route planned",
+    status: "ok",
+  };
+  assert.equal(isRouteData(data as never), true);
+});
+
+test("isSearchData returns false for route data (has route key)", () => {
+  const data = {
+    results: { rows: [], row_count: 0, strategy: "sql", status: "ok" },
+    route: { ordered_points: [], point_count: 0, status: "ok" },
+    message: "Route planned",
+    status: "ok",
+  };
+  assert.equal(isSearchData(data as never), false);
+});
+
+test("isQAData returns true for info status", () => {
+  const data = {
+    intent: "general_qa",
+    confidence: 0.9,
+    status: "info",
+    message: "Hello!",
+  };
+  assert.equal(isQAData(data as never), true);
+});
+
+test("isTimedRouteData returns true for route with timed_itinerary", () => {
+  const data = {
+    results: { rows: [], row_count: 0, strategy: "sql", status: "ok" },
+    route: {
+      ordered_points: [],
+      point_count: 0,
+      status: "ok",
+      timed_itinerary: {
+        stops: [],
+        legs: [],
+        total_minutes: 0,
+        total_distance_m: 0,
+        spot_count: 0,
+        pacing: "normal",
+        start_time: "09:00",
+        export_google_maps_url: [],
+        export_ics: "",
+      },
+    },
+    message: "Timed route",
+    status: "ok",
+  };
+  assert.equal(isTimedRouteData(data as never), true);
+});


### PR DESCRIPTION
Split monolithic frontend/lib/types.ts into types/ directory with domain.ts, api.ts, components.ts, and barrel index.ts. All importers unchanged. Added 9 type guard unit tests. tsc, build, and lint all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Reorganized internal TypeScript type definitions for improved code structure and maintainability across API contracts, component interfaces, and domain models.
  * Enhanced internal type validation with comprehensive test coverage for data type verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->