### PR TITLE
feat(pipeline): inject session search data into executor context

### DIFF
--- a/backend/agents/pipeline.py
+++ b/backend/agents/pipeline.py
@@ -46,6 +46,31 @@ def _infer_intent(step_results: list[StepResult], priority_map: dict[str, int]) 
     return intent
 
 
+_SEARCH_TOOLS = ("search_bangumi", "search_nearby")
+
+
+def _seed_executor_context(
+    executor_context: dict[str, object],
+    context: dict[str, object] | None,
+) -> None:
+    """Pre-populate executor_context with cached search results from the session.
+
+    When the session's context block carries ``last_search_data``, its
+    ``search_bangumi`` and/or ``search_nearby`` entries are copied into
+    *executor_context* so downstream steps can reuse previous results
+    without re-executing the search.
+    """
+    if context is None:
+        return
+    raw = context.get("last_search_data")
+    if not isinstance(raw, dict):
+        return
+    for key in _SEARCH_TOOLS:
+        value = raw.get(key)
+        if isinstance(value, dict):
+            executor_context[key] = value
+
+
 @dataclass
 class ReactStepEvent:
     """One event yielded by the ReAct loop for SSE streaming."""
@@ -81,6 +106,7 @@ async def react_loop(
     executor_context: dict[str, object] = {"locale": locale}
     if context and context.get("last_location"):
         executor_context["last_location"] = context["last_location"]
+    _seed_executor_context(executor_context, context)
 
     # Classify intent once for the entire loop
     classified_intent, _confidence = classify_intent(text, locale)

--- a/backend/tests/unit/test_pipeline_context_inject.py
+++ b/backend/tests/unit/test_pipeline_context_inject.py
@@ -1,0 +1,84 @@
+"""Tests for Card B2: inject session search data into executor context."""
+
+from __future__ import annotations
+
+from backend.agents.pipeline import _seed_executor_context
+
+
+class TestSeedExecutorContextSearchBangumi:
+    """AC1: context has last_search_data with search_bangumi -> executor_context["search_bangumi"] pre-populated."""
+
+    def test_search_bangumi_pre_populated(self) -> None:
+        search_data: dict[str, object] = {
+            "rows": [{"bangumi_id": "99", "title": "Eupho"}],
+            "row_count": 1,
+            "status": "ok",
+        }
+        context: dict[str, object] = {
+            "last_search_data": {"search_bangumi": search_data},
+        }
+        executor_context: dict[str, object] = {"locale": "ja"}
+
+        _seed_executor_context(executor_context, context)
+
+        assert "search_bangumi" in executor_context
+        assert executor_context["search_bangumi"] is search_data
+
+
+class TestSeedExecutorContextSearchNearby:
+    """AC2: context has last_search_data with search_nearby -> executor_context["search_nearby"] pre-populated."""
+
+    def test_search_nearby_pre_populated(self) -> None:
+        nearby_data: dict[str, object] = {
+            "rows": [{"point_id": "p1", "name": "Uji Bridge"}],
+            "row_count": 1,
+            "status": "ok",
+        }
+        context: dict[str, object] = {
+            "last_search_data": {"search_nearby": nearby_data},
+        }
+        executor_context: dict[str, object] = {"locale": "ja"}
+
+        _seed_executor_context(executor_context, context)
+
+        assert "search_nearby" in executor_context
+        assert executor_context["search_nearby"] is nearby_data
+
+
+class TestSeedExecutorContextNoData:
+    """AC3: context is None or no last_search_data -> executor_context only has locale."""
+
+    def test_context_none(self) -> None:
+        executor_context: dict[str, object] = {"locale": "ja"}
+
+        _seed_executor_context(executor_context, None)
+
+        assert executor_context == {"locale": "ja"}
+
+    def test_context_without_last_search_data(self) -> None:
+        context: dict[str, object] = {"summary": "some summary"}
+        executor_context: dict[str, object] = {"locale": "ja"}
+
+        _seed_executor_context(executor_context, context)
+
+        assert executor_context == {"locale": "ja"}
+
+
+class TestSeedExecutorContextEmptyRows:
+    """AC4: last_search_data present but rows is empty -> executor_context still seeded."""
+
+    def test_empty_rows_still_seeded(self) -> None:
+        search_data: dict[str, object] = {
+            "rows": [],
+            "row_count": 0,
+            "status": "empty",
+        }
+        context: dict[str, object] = {
+            "last_search_data": {"search_bangumi": search_data},
+        }
+        executor_context: dict[str, object] = {"locale": "ja"}
+
+        _seed_executor_context(executor_context, context)
+
+        assert "search_bangumi" in executor_context
+        assert executor_context["search_bangumi"] is search_data


### PR DESCRIPTION
## Summary
- Seed executor_context with session's last search results at pipeline startup
- Card B2 — Iteration 10 Wave 1 (BUG-03 fix)

## AC
- [x] context has search_bangumi -> executor_context pre-populated
- [x] context has search_nearby -> executor_context pre-populated
- [x] context is None -> executor_context only has locale
- [x] rows empty -> executor_context still seeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)