### PR TITLE
refactor(frontend): split types.ts into types/ module

### DIFF
--- a/frontend/lib/types/api.ts
+++ b/frontend/lib/types/api.ts
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------------
+// API types — request/response contracts for the public API layer.
+// ---------------------------------------------------------------------------
+
+import type {
+  Intent,
+  SearchResultData,
+  RouteData,
+  QAData,
+} from "./domain";
+
+export interface RouteHistoryRecord {
+  route_id: string | null;
+  bangumi_id: string;
+  origin_station: string | null;
+  point_count: number;
+  status: string;
+  created_at: string; // ISO 8601
+}
+
+export interface RuntimeRequest {
+  text: string;
+  session_id?: string | null;
+  locale?: "ja" | "zh" | "en";
+  model?: string | null;
+  include_debug?: boolean;
+  selected_point_ids?: string[];
+  origin?: string | null;
+}
+
+export interface PublicAPIError {
+  code: string;
+  message: string;
+  details: Record<string, unknown>;
+}
+
+export interface StepEvent {
+  tool: string;
+  status: "running" | "done" | "failed";
+  thought?: string;
+  observation?: string;
+}
+
+export interface ConversationRecord {
+  session_id: string;
+  title: string | null;
+  first_query: string;
+  created_at: string; // ISO 8601
+  updated_at: string; // ISO 8601
+}
+
+export interface UIDescriptor {
+  component: string;
+}
+
+export interface RuntimeResponse {
+  success: boolean;
+  status: string;
+  intent: Intent;
+  session_id: string | null;
+  message: string;
+  data: SearchResultData | RouteData | QAData;
+  session: {
+    interaction_count: number;
+    route_history_count: number;
+    last_intent?: string | null;
+    last_status?: string | null;
+    last_message?: string;
+  };
+  route_history: RouteHistoryRecord[];
+  errors: PublicAPIError[];
+  debug?: Record<string, unknown> | null;
+  ui?: UIDescriptor;
+}

--- a/frontend/lib/types/api.ts
+++ b/frontend/lib/types/api.ts
@@ -7,6 +7,7 @@ import type {
   SearchResultData,
   RouteData,
   QAData,
+  ClarifyData,
 } from "./domain";
 
 export interface RouteHistoryRecord {
@@ -59,7 +60,7 @@ export interface RuntimeResponse {
   intent: Intent;
   session_id: string | null;
   message: string;
-  data: SearchResultData | RouteData | QAData;
+  data: SearchResultData | RouteData | QAData | ClarifyData;
   session: {
     interaction_count: number;
     route_history_count: number;

--- a/frontend/lib/types/components.ts
+++ b/frontend/lib/types/components.ts
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------------------
+// Component types — frontend-only types for React component props and state.
+// ---------------------------------------------------------------------------
+
+import type { RuntimeResponse, StepEvent } from "./api";
+
+export type ErrorCode = "stream_error" | "timeout" | "rate_limit" | "generic";
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  response?: RuntimeResponse;
+  loading?: boolean;
+  timestamp: number;
+  steps?: StepEvent[];
+  errorCode?: ErrorCode;
+}

--- a/frontend/lib/types/domain.ts
+++ b/frontend/lib/types/domain.ts
@@ -1,7 +1,5 @@
 // ---------------------------------------------------------------------------
-// TypeScript contract mirroring the Python backend (interfaces/public_api.py,
-// agents/intent_agent.py, domain/entities.py).  Every field matches the
-// backend exactly — consult those files for the source of truth.
+// Domain types — entities and value objects from the backend domain layer.
 // ---------------------------------------------------------------------------
 
 // ── Intent values ──────────────────────────────────────────────────────────
@@ -131,119 +129,6 @@ export interface QAData {
   message: string;
 }
 
-/** data shape when intent = clarify (SSE clarify event merged into response) */
-export interface ClarifyData {
-  intent: string;
-  confidence: number;
-  status: "needs_clarification";
-  message: string;
-  question: string;
-  options: string[];
-}
-
-// ── Top-level request / response ───────────────────────────────────────────
-
-export interface RuntimeRequest {
-  text: string;
-  session_id?: string | null;
-  locale?: "ja" | "zh" | "en";
-  model?: string | null;
-  include_debug?: boolean;
-  selected_point_ids?: string[];
-  origin?: string | null;
-}
-
-export interface PublicAPIError {
-  code: string;
-  message: string;
-  details: Record<string, unknown>;
-}
-
-export interface StepEvent {
-  tool: string;
-  status: "running" | "done" | "failed";
-  thought?: string;
-  observation?: string;
-}
-
-export interface RouteHistoryRecord {
-  route_id: string | null;
-  bangumi_id: string;
-  origin_station: string | null;
-  point_count: number;
-  status: string;
-  created_at: string; // ISO 8601
-}
-
-export interface ConversationRecord {
-  session_id: string;
-  title: string | null;
-  first_query: string;
-  created_at: string; // ISO 8601
-  updated_at: string; // ISO 8601
-}
-
-export interface UIDescriptor {
-  component: string;
-}
-
-export interface RuntimeResponse {
-  success: boolean;
-  status: string;
-  intent: Intent;
-  session_id: string | null;
-  message: string;
-  data: SearchResultData | RouteData | QAData | ClarifyData;
-  session: {
-    interaction_count: number;
-    route_history_count: number;
-    last_intent?: string | null;
-    last_status?: string | null;
-    last_message?: string;
-  };
-  route_history: RouteHistoryRecord[];
-  errors: PublicAPIError[];
-  debug?: Record<string, unknown> | null;
-  ui?: UIDescriptor;
-}
-
-// ── Frontend-only types ────────────────────────────────────────────────────
-
-export type ErrorCode = "stream_error" | "timeout" | "rate_limit" | "generic";
-
-export interface ChatMessage {
-  id: string;
-  role: "user" | "assistant";
-  text: string;
-  response?: RuntimeResponse;
-  loading?: boolean;
-  timestamp: number;
-  steps?: StepEvent[];
-  errorCode?: ErrorCode;
-}
-
-// ── Type guards ────────────────────────────────────────────────────────────
-
-export function isSearchData(data: RuntimeResponse["data"]): data is SearchResultData {
-  return data != null && "results" in data && !("route" in data);
-}
-
-export function isRouteData(data: RuntimeResponse["data"]): data is RouteData {
-  return data != null && "route" in data;
-}
-
-export function isQAData(data: RuntimeResponse["data"]): data is QAData {
-  return data != null && !("question" in data) && (data.status === "info" || data.status === "needs_clarification");
-}
-
-export function isClarifyData(data: RuntimeResponse["data"]): data is ClarifyData {
-  return data != null && "question" in data && "options" in data;
-}
-
 export type TimedRouteData = RouteData & {
   route: { timed_itinerary: TimedItinerary };
 };
-
-export function isTimedRouteData(data: RuntimeResponse["data"]): data is TimedRouteData {
-  return data != null && "route" in data && "timed_itinerary" in (data as RouteData).route;
-}

--- a/frontend/lib/types/domain.ts
+++ b/frontend/lib/types/domain.ts
@@ -129,6 +129,16 @@ export interface QAData {
   message: string;
 }
 
+/** data shape when intent = clarify (SSE clarify event merged into response) */
+export interface ClarifyData {
+  intent: string;
+  confidence: number;
+  status: "needs_clarification";
+  message: string;
+  question: string;
+  options: string[];
+}
+
 export type TimedRouteData = RouteData & {
   route: { timed_itinerary: TimedItinerary };
 };

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -13,6 +13,7 @@ export type {
   TransitLeg,
   TimedItinerary,
   QAData,
+  ClarifyData,
   TimedRouteData,
 } from "./domain";
 
@@ -31,7 +32,7 @@ export type { ErrorCode, ChatMessage } from "./components";
 // ── Type guards ────────────────────────────────────────────────────────────
 
 import type { RuntimeResponse } from "./api";
-import type { SearchResultData, RouteData, QAData, TimedRouteData } from "./domain";
+import type { SearchResultData, RouteData, QAData, ClarifyData, TimedRouteData } from "./domain";
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -46,6 +47,10 @@ export function isRouteData(data: RuntimeResponse["data"]): data is RouteData {
 
 export function isQAData(data: RuntimeResponse["data"]): data is QAData {
   return isObjectRecord(data) && (data.status === "info" || data.status === "needs_clarification");
+}
+
+export function isClarifyData(data: RuntimeResponse["data"]): data is ClarifyData {
+  return isObjectRecord(data) && data.status === "needs_clarification" && "question" in data;
 }
 
 export function isTimedRouteData(data: RuntimeResponse["data"]): data is TimedRouteData {

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -45,6 +45,11 @@ export function isQAData(data: RuntimeResponse["data"]): data is QAData {
   return data != null && (data.status === "info" || data.status === "needs_clarification");
 }
 
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
 export function isTimedRouteData(data: RuntimeResponse["data"]): data is TimedRouteData {
-  return data != null && "route" in data && "timed_itinerary" in (data as RouteData).route;
+  if (!isObjectRecord(data) || !("route" in data)) return false;
+  const route = (data as { route?: unknown }).route;
+  return isObjectRecord(route) && "timed_itinerary" in route;
 }

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -33,20 +33,20 @@ export type { ErrorCode, ChatMessage } from "./components";
 import type { RuntimeResponse } from "./api";
 import type { SearchResultData, RouteData, QAData, TimedRouteData } from "./domain";
 
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
 export function isSearchData(data: RuntimeResponse["data"]): data is SearchResultData {
-  return data != null && "results" in data && !("route" in data);
+  return isObjectRecord(data) && "results" in data && !("route" in data);
 }
 
 export function isRouteData(data: RuntimeResponse["data"]): data is RouteData {
-  return data != null && "route" in data;
+  return isObjectRecord(data) && "route" in data;
 }
 
 export function isQAData(data: RuntimeResponse["data"]): data is QAData {
-  return data != null && (data.status === "info" || data.status === "needs_clarification");
+  return isObjectRecord(data) && (data.status === "info" || data.status === "needs_clarification");
 }
-
-const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
 
 export function isTimedRouteData(data: RuntimeResponse["data"]): data is TimedRouteData {
   if (!isObjectRecord(data) || !("route" in data)) return false;

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------
+// Barrel export — all types available from @/lib/types
+// ---------------------------------------------------------------------------
+
+export type {
+  Intent,
+  PilgrimagePoint,
+  ResultsMeta,
+  SearchResultData,
+  RouteData,
+  LocationCluster,
+  TimedStop,
+  TransitLeg,
+  TimedItinerary,
+  QAData,
+  TimedRouteData,
+} from "./domain";
+
+export type {
+  RuntimeRequest,
+  PublicAPIError,
+  StepEvent,
+  RouteHistoryRecord,
+  ConversationRecord,
+  UIDescriptor,
+  RuntimeResponse,
+} from "./api";
+
+export type { ErrorCode, ChatMessage } from "./components";
+
+// ── Type guards ────────────────────────────────────────────────────────────
+
+import type { RuntimeResponse } from "./api";
+import type { SearchResultData, RouteData, QAData, TimedRouteData } from "./domain";
+
+export function isSearchData(data: RuntimeResponse["data"]): data is SearchResultData {
+  return data != null && "results" in data && !("route" in data);
+}
+
+export function isRouteData(data: RuntimeResponse["data"]): data is RouteData {
+  return data != null && "route" in data;
+}
+
+export function isQAData(data: RuntimeResponse["data"]): data is QAData {
+  return data != null && (data.status === "info" || data.status === "needs_clarification");
+}
+
+export function isTimedRouteData(data: RuntimeResponse["data"]): data is TimedRouteData {
+  return data != null && "route" in data && "timed_itinerary" in (data as RouteData).route;
+}

--- a/frontend/tests/type-guards.test.ts
+++ b/frontend/tests/type-guards.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isSearchData, isRouteData, isQAData, isTimedRouteData } from "../lib/types";
+
+// AC: isSearchData(null) returns false
+test("isSearchData returns false for null", () => {
+  assert.equal(isSearchData(null as never), false);
+});
+
+// AC: isRouteData(undefined) returns false
+test("isRouteData returns false for undefined", () => {
+  assert.equal(isRouteData(undefined as never), false);
+});
+
+test("isQAData returns false for null", () => {
+  assert.equal(isQAData(null as never), false);
+});
+
+test("isTimedRouteData returns false for null", () => {
+  assert.equal(isTimedRouteData(null as never), false);
+});
+
+test("isSearchData returns true for valid search data", () => {
+  const data = {
+    results: { rows: [], row_count: 0, strategy: "sql", status: "ok" },
+    message: "Found 0 results",
+    status: "ok",
+  };
+  assert.equal(isSearchData(data as never), true);
+});
+
+test("isRouteData returns true for valid route data", () => {
+  const data = {
+    results: { rows: [], row_count: 0, strategy: "sql", status: "ok" },
+    route: { ordered_points: [], point_count: 0, status: "ok" },
+    message: "Route planned",
+    status: "ok",
+  };
+  assert.equal(isRouteData(data as never), true);
+});
+
+test("isSearchData returns false for route data (has route key)", () => {
+  const data = {
+    results: { rows: [], row_count: 0, strategy: "sql", status: "ok" },
+    route: { ordered_points: [], point_count: 0, status: "ok" },
+    message: "Route planned",
+    status: "ok",
+  };
+  assert.equal(isSearchData(data as never), false);
+});
+
+test("isQAData returns true for info status", () => {
+  const data = {
+    intent: "general_qa",
+    confidence: 0.9,
+    status: "info",
+    message: "Hello!",
+  };
+  assert.equal(isQAData(data as never), true);
+});
+
+test("isTimedRouteData returns true for route with timed_itinerary", () => {
+  const data = {
+    results: { rows: [], row_count: 0, strategy: "sql", status: "ok" },
+    route: {
+      ordered_points: [],
+      point_count: 0,
+      status: "ok",
+      timed_itinerary: {
+        stops: [],
+        legs: [],
+        total_minutes: 0,
+        total_distance_m: 0,
+        spot_count: 0,
+        pacing: "normal",
+        start_time: "09:00",
+        export_google_maps_url: [],
+        export_ics: "",
+      },
+    },
+    message: "Timed route",
+    status: "ok",
+  };
+  assert.equal(isTimedRouteData(data as never), true);
+});

--- a/frontend/tests/type-guards.test.ts
+++ b/frontend/tests/type-guards.test.ts
@@ -60,6 +60,14 @@ test("isQAData returns true for info status", () => {
   assert.equal(isQAData(data as never), true);
 });
 
+test("isTimedRouteData returns false when route is null", () => {
+  assert.equal(isTimedRouteData({ route: null } as never), false);
+});
+
+test("isTimedRouteData returns false when route is undefined", () => {
+  assert.equal(isTimedRouteData({ route: undefined } as never), false);
+});
+
 test("isTimedRouteData returns true for route with timed_itinerary", () => {
   const data = {
     results: { rows: [], row_count: 0, strategy: "sql", status: "ok" },


### PR DESCRIPTION
Card R2 — Wave 1. Split into types/{api,domain,components,index}.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and clarified the app's public API and chat message contracts to stabilize how responses, errors, and conversation metadata are handled by the UI.
* **Tests**
  * Added runtime validation tests for response data shapes to reduce regressions when processing replies and rendering conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->