### PR TITLE
fix(api): PATCH conversation returns 404 for non-existent session

### DIFF
--- a/backend/interfaces/fastapi_service.py
+++ b/backend/interfaces/fastapi_service.py
@@ -255,6 +255,15 @@ async def handle_patch_conversation(
 ) -> JSONResponse:
     assert auth.user_id is not None
     db = _get_db_from_request(request)
+    get_conversation = _require_db_method(db, "get_conversation")
+    conversation_obj: object = await get_conversation(session_id)
+    conversation = conversation_obj if isinstance(conversation_obj, dict) else None
+    if conversation is None or conversation.get("user_id") != auth.user_id:
+        return _error_response(
+            "not_found",
+            "Conversation not found.",
+            status_code=404,
+        )
     update_conversation_title = _require_db_method(db, "update_conversation_title")
     await update_conversation_title(session_id, payload.title, user_id=auth.user_id)
     return _json_response({"ok": True})

--- a/backend/tests/unit/test_fastapi_service.py
+++ b/backend/tests/unit/test_fastapi_service.py
@@ -25,6 +25,7 @@ def _build_stub_db() -> MagicMock:
     db.get_messages = AsyncMock(return_value=[])
     db.get_user_routes = AsyncMock(return_value=[])
     db.save_feedback = AsyncMock(return_value="fb-001")
+    db.update_conversation_title = AsyncMock(return_value=None)
     return db
 
 
@@ -252,3 +253,73 @@ async def test_app_state_accessible_when_injected() -> None:
     assert app.state.runtime_api is runtime_api
     assert app.state.settings is settings
     assert app.state.db_client is mock_db
+
+
+# ---------------------------------------------------------------------------
+# AC 10: PATCH /v1/conversations/{session_id} returns 404 for nonexistent
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_conversation_nonexistent_returns_404() -> None:
+    db = _build_stub_db()
+    db.get_conversation = AsyncMock(return_value=None)
+    app, _ = _build_app(db=db)
+
+    async with _async_client(app) as client:
+        resp = await client.patch(
+            "/v1/conversations/nonexistent-session",
+            json={"title": "New Title"},
+            headers={"X-User-Id": "user-1"},
+        )
+
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["code"] == "not_found"
+    assert body["error"]["message"] == "Conversation not found."
+
+
+# ---------------------------------------------------------------------------
+# AC 11: PATCH /v1/conversations/{session_id} returns 404 for wrong user
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_conversation_wrong_user_returns_404() -> None:
+    db = _build_stub_db()
+    db.get_conversation = AsyncMock(return_value={"user_id": "other-user"})
+    app, _ = _build_app(db=db)
+
+    async with _async_client(app) as client:
+        resp = await client.patch(
+            "/v1/conversations/some-session",
+            json={"title": "New Title"},
+            headers={"X-User-Id": "user-1"},
+        )
+
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["code"] == "not_found"
+    assert body["error"]["message"] == "Conversation not found."
+
+
+# ---------------------------------------------------------------------------
+# AC 12: PATCH /v1/conversations/{session_id} returns 200 for valid update
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_conversation_valid_returns_200() -> None:
+    db = _build_stub_db()
+    db.get_conversation = AsyncMock(return_value={"user_id": "user-1"})
+    db.update_conversation_title = AsyncMock(return_value=None)
+    app, _ = _build_app(db=db)
+
+    async with _async_client(app) as client:
+        resp = await client.patch(
+            "/v1/conversations/existing-session",
+            json={"title": "New Title"},
+            headers={"X-User-Id": "user-1"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    db.update_conversation_title.assert_awaited_once()

--- a/backend/tests/unit/test_fastapi_service.py
+++ b/backend/tests/unit/test_fastapi_service.py
@@ -276,6 +276,7 @@ async def test_patch_conversation_nonexistent_returns_404() -> None:
     body = resp.json()
     assert body["error"]["code"] == "not_found"
     assert body["error"]["message"] == "Conversation not found."
+    db.update_conversation_title.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -299,6 +300,7 @@ async def test_patch_conversation_wrong_user_returns_404() -> None:
     body = resp.json()
     assert body["error"]["code"] == "not_found"
     assert body["error"]["message"] == "Conversation not found."
+    db.update_conversation_title.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Check conversation existence and ownership before updating title
- Return 404 instead of silent 200 for non-existent conversations
- Found by sandbox-tester during Wave 1 API testing

## AC
- [x] PATCH nonexistent conversation returns 404
- [x] PATCH conversation owned by different user returns 404
- [x] PATCH valid conversation returns 200

3 new tests added. 486/486 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved security by adding validation to prevent users from modifying conversations that don't belong to them.

* **Tests**
  * Added comprehensive unit test coverage for API endpoints and request validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->