### PR TITLE
feat(frontend): rewrite ResultPanel with grid/map toggle

### DIFF
--- a/frontend/components/generative/PhotoCard.tsx
+++ b/frontend/components/generative/PhotoCard.tsx
@@ -12,8 +12,12 @@ export function EpisodeBadge({ episode }: { episode: number | null }) {
   if (episode == null) return null;
   return (
     <span
-      className="absolute left-2 top-2 rounded-[5px] px-2 py-0.5 text-[10px] font-semibold tracking-wide text-white"
-      style={{ background: "rgba(0,0,0,0.55)", backdropFilter: "blur(4px)" }}
+      className="absolute left-2 top-2 rounded-[5px] px-2 py-0.5 text-[10px] font-semibold tracking-wide"
+      style={{
+        background: "rgba(0,0,0,0.55)",
+        backdropFilter: "blur(4px)",
+        color: "var(--color-bg)",
+      }}
     >
       {t.episode.replace("{ep}", String(episode))}
     </span>
@@ -59,7 +63,10 @@ export function PhotoCard({ point, selected, onToggle }: PhotoCardProps) {
         )}
         <EpisodeBadge episode={point.episode} />
         {selected && (
-          <div className="absolute right-2 top-2 flex h-[22px] w-[22px] items-center justify-center rounded-full bg-[var(--color-primary)] text-[11px] font-bold text-white">
+          <div
+            className="absolute right-2 top-2 flex h-[22px] w-[22px] items-center justify-center rounded-full bg-[var(--color-primary)] text-[11px] font-bold"
+            style={{ color: "var(--color-bg)" }}
+          >
             ✓
           </div>
         )}

--- a/frontend/components/generative/PhotoCard.tsx
+++ b/frontend/components/generative/PhotoCard.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { PilgrimagePoint } from "../../lib/types";
+import { useDict } from "../../lib/i18n-context";
+
+// ---------------------------------------------------------------------------
+// EpisodeBadge
+// ---------------------------------------------------------------------------
+
+export function EpisodeBadge({ episode }: { episode: number | null }) {
+  const { grid: t } = useDict();
+  if (episode == null) return null;
+  return (
+    <span
+      className="absolute left-2 top-2 rounded-[5px] px-2 py-0.5 text-[10px] font-semibold tracking-wide text-white"
+      style={{ background: "rgba(0,0,0,0.55)", backdropFilter: "blur(4px)" }}
+    >
+      {t.episode.replace("{ep}", String(episode))}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PhotoCard
+// ---------------------------------------------------------------------------
+
+interface PhotoCardProps {
+  point: PilgrimagePoint;
+  selected: boolean;
+  onToggle: (id: string) => void;
+}
+
+export function PhotoCard({ point, selected, onToggle }: PhotoCardProps) {
+  return (
+    <div
+      className="group relative cursor-pointer overflow-hidden rounded-[10px] bg-[var(--color-card)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg"
+      style={{ border: `2px solid ${selected ? "var(--color-primary)" : "transparent"}` }}
+      onClick={() => onToggle(point.id)}
+      role="button"
+      tabIndex={0}
+      aria-pressed={selected}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onToggle(point.id);
+        }
+      }}
+    >
+      {/* Image — 16/10 aspect ratio */}
+      <div className="relative overflow-hidden" style={{ aspectRatio: "16/10" }}>
+        {point.screenshot_url ? (
+          <img
+            src={point.screenshot_url}
+            alt={point.name}
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.04]"
+          />
+        ) : (
+          <div className="h-full w-full bg-[var(--color-muted)]" />
+        )}
+        <EpisodeBadge episode={point.episode} />
+        {selected && (
+          <div className="absolute right-2 top-2 flex h-[22px] w-[22px] items-center justify-center rounded-full bg-[var(--color-primary)] text-[11px] font-bold text-white">
+            ✓
+          </div>
+        )}
+      </div>
+      {/* Info */}
+      <div className="px-3 py-2.5">
+        <p className="truncate text-[13px] font-medium text-[var(--color-fg)]">
+          {point.name}
+        </p>
+        {point.title && (
+          <p className="mt-0.5 truncate text-[11px] text-[var(--color-muted-fg)]">
+            {point.title}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/layout/LeafletResultMap.tsx
+++ b/frontend/components/layout/LeafletResultMap.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+ * LeafletResultMap — loaded lazily via dynamic() from ResultPanel.
+ *
+ * This file MUST NOT be imported at the top level of any server-rendered module.
+ * Leaflet requires `window` and will throw in SSR contexts.
+ */
+
+import { useEffect, useRef } from "react";
+import type { Map as LeafletMap } from "leaflet";
+import type { PilgrimagePoint } from "../../lib/types";
+
+interface LeafletResultMapProps {
+  points: PilgrimagePoint[];
+  selectedIds: Set<string>;
+  onToggle: (id: string) => void;
+}
+
+export default function LeafletResultMap({
+  points,
+  selectedIds,
+  onToggle,
+}: LeafletResultMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<LeafletMap | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current) return;
+
+    // Dynamic import inside effect so SSR never touches Leaflet.
+    import("leaflet").then((L) => {
+      if (!containerRef.current || mapRef.current) return;
+
+      // Default marker icon fix for bundled environments.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const iconDefault = L.Icon.Default as unknown as { _getIconUrl?: unknown };
+      delete iconDefault._getIconUrl;
+      L.Icon.Default.mergeOptions({
+        iconRetinaUrl: "/leaflet/marker-icon-2x.png",
+        iconUrl: "/leaflet/marker-icon.png",
+        shadowUrl: "/leaflet/marker-shadow.png",
+      });
+
+      const validPoints = points.filter(
+        (p) => p.latitude !== 0 && p.longitude !== 0,
+      );
+
+      const center: [number, number] =
+        validPoints.length > 0
+          ? [validPoints[0].latitude, validPoints[0].longitude]
+          : [35.6895, 139.6917]; // Tokyo fallback
+
+      const map = L.map(containerRef.current!, {
+        center,
+        zoom: 13,
+        zoomControl: true,
+      });
+
+      mapRef.current = map;
+
+      L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        attribution:
+          '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        maxZoom: 19,
+      }).addTo(map);
+
+      for (const point of validPoints) {
+        const marker = L.marker([point.latitude, point.longitude]);
+        marker.bindPopup(`<div style="padding:4px 2px"><strong style="font-size:13px">${point.name}</strong></div>`);
+        marker.on("click", () => onToggle(point.id));
+        marker.addTo(map);
+      }
+
+      if (validPoints.length > 1) {
+        const bounds = L.latLngBounds(
+          validPoints.map((p) => [p.latitude, p.longitude] as [number, number]),
+        );
+        map.fitBounds(bounds, { padding: [32, 32] });
+      }
+    });
+
+    return () => {
+      mapRef.current?.remove();
+      mapRef.current = null;
+    };
+    // onToggle is intentionally excluded — adding it would re-create the map on
+    // every selection change. Markers capture a stable reference via closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [points]);
+
+  // Keep selected state visually in sync without re-building the map.
+  // For a simple implementation we just rely on the tile layer remaining functional.
+  void selectedIds; // consumed by parent via onToggle callback
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: "100%", height: "100%" }}
+      data-testid="leaflet-map-container"
+    />
+  );
+}

--- a/frontend/components/layout/LeafletResultMap.tsx
+++ b/frontend/components/layout/LeafletResultMap.tsx
@@ -17,6 +17,67 @@ interface LeafletResultMapProps {
   onToggle: (id: string) => void;
 }
 
+type LeafletModule = typeof import("leaflet");
+
+function buildPopupEl(name: string): HTMLElement {
+  const strong = document.createElement("strong");
+  strong.textContent = name; // textContent auto-escapes — no XSS risk
+  strong.style.fontSize = "13px";
+  const wrap = document.createElement("div");
+  wrap.style.padding = "4px 2px";
+  wrap.appendChild(strong);
+  return wrap;
+}
+
+function initLeafletMap(
+  container: HTMLElement,
+  points: PilgrimagePoint[],
+  L: LeafletModule,
+  onToggle: (id: string) => void,
+): LeafletMap {
+  // Default marker icon fix for bundled environments.
+  const iconDefault = L.Icon.Default as unknown as { _getIconUrl?: unknown };
+  delete iconDefault._getIconUrl;
+  L.Icon.Default.mergeOptions({
+    iconRetinaUrl: "/leaflet/marker-icon-2x.png",
+    iconUrl: "/leaflet/marker-icon.png",
+    shadowUrl: "/leaflet/marker-shadow.png",
+  });
+
+  const validPoints = points.filter(
+    (p) => p.latitude !== 0 && p.longitude !== 0,
+  );
+
+  const center: [number, number] =
+    validPoints.length > 0
+      ? [validPoints[0].latitude, validPoints[0].longitude]
+      : [35.6895, 139.6917]; // Tokyo fallback
+
+  const map = L.map(container, { center, zoom: 13, zoomControl: true });
+
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution:
+      '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    maxZoom: 19,
+  }).addTo(map);
+
+  for (const point of validPoints) {
+    const marker = L.marker([point.latitude, point.longitude]);
+    marker.bindPopup(buildPopupEl(point.name));
+    marker.on("click", () => onToggle(point.id));
+    marker.addTo(map);
+  }
+
+  if (validPoints.length > 1) {
+    const bounds = L.latLngBounds(
+      validPoints.map((p) => [p.latitude, p.longitude] as [number, number]),
+    );
+    map.fitBounds(bounds, { padding: [32, 32] });
+  }
+
+  return map;
+}
+
 export default function LeafletResultMap({
   points,
   selectedIds,
@@ -31,53 +92,7 @@ export default function LeafletResultMap({
     // Dynamic import inside effect so SSR never touches Leaflet.
     import("leaflet").then((L) => {
       if (!containerRef.current || mapRef.current) return;
-
-      // Default marker icon fix for bundled environments.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const iconDefault = L.Icon.Default as unknown as { _getIconUrl?: unknown };
-      delete iconDefault._getIconUrl;
-      L.Icon.Default.mergeOptions({
-        iconRetinaUrl: "/leaflet/marker-icon-2x.png",
-        iconUrl: "/leaflet/marker-icon.png",
-        shadowUrl: "/leaflet/marker-shadow.png",
-      });
-
-      const validPoints = points.filter(
-        (p) => p.latitude !== 0 && p.longitude !== 0,
-      );
-
-      const center: [number, number] =
-        validPoints.length > 0
-          ? [validPoints[0].latitude, validPoints[0].longitude]
-          : [35.6895, 139.6917]; // Tokyo fallback
-
-      const map = L.map(containerRef.current!, {
-        center,
-        zoom: 13,
-        zoomControl: true,
-      });
-
-      mapRef.current = map;
-
-      L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-        attribution:
-          '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-        maxZoom: 19,
-      }).addTo(map);
-
-      for (const point of validPoints) {
-        const marker = L.marker([point.latitude, point.longitude]);
-        marker.bindPopup(`<div style="padding:4px 2px"><strong style="font-size:13px">${point.name}</strong></div>`);
-        marker.on("click", () => onToggle(point.id));
-        marker.addTo(map);
-      }
-
-      if (validPoints.length > 1) {
-        const bounds = L.latLngBounds(
-          validPoints.map((p) => [p.latitude, p.longitude] as [number, number]),
-        );
-        map.fitBounds(bounds, { padding: [32, 32] });
-      }
+      mapRef.current = initLeafletMap(containerRef.current, points, L, onToggle);
     });
 
     return () => {

--- a/frontend/components/layout/ResultPanel.tsx
+++ b/frontend/components/layout/ResultPanel.tsx
@@ -1,10 +1,29 @@
 "use client";
 
-import type { RuntimeResponse } from "../../lib/types";
+import { useState, useMemo } from "react";
+import dynamic from "next/dynamic";
+import type { RuntimeResponse, PilgrimagePoint, SearchResultData } from "../../lib/types";
+import { isSearchData } from "../../lib/types";
 import { useDict } from "../../lib/i18n-context";
 import { usePointSelectionContext } from "../../contexts/PointSelectionContext";
-import GenerativeUIRenderer from "../generative/GenerativeUIRenderer";
 import SelectionBar from "../generative/SelectionBar";
+import GenerativeUIRenderer from "../generative/GenerativeUIRenderer";
+
+// ---------------------------------------------------------------------------
+// Leaflet map — lazy-loaded with ssr:false so Leaflet's window accesses do not
+// break the static-export build.
+// ---------------------------------------------------------------------------
+
+const LazyLeafletMap = dynamic(
+  () => import("./LeafletResultMap"),
+  { ssr: false },
+);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ViewMode = "grid" | "map";
 
 interface ResultPanelProps {
   activeResponse: RuntimeResponse | null;
@@ -14,6 +33,367 @@ interface ResultPanelProps {
   loading?: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Episode-range helpers
+// ---------------------------------------------------------------------------
+
+const EP_RANGE = 4; // episodes per bucket
+
+function epRangeLabel(ep: number): string {
+  const start = Math.floor((ep - 1) / EP_RANGE) * EP_RANGE + 1;
+  const end = start + EP_RANGE - 1;
+  return `EP ${start}-${end}`;
+}
+
+function buildEpRanges(points: PilgrimagePoint[]): string[] {
+  const ranges = new Set<string>();
+  for (const p of points) {
+    if (p.episode != null) {
+      ranges.add(epRangeLabel(p.episode));
+    }
+  }
+  // Sort ranges numerically by their start episode.
+  return Array.from(ranges).sort((a, b) => {
+    const numA = parseInt(a.replace(/\D.*/, ""), 10);
+    const numB = parseInt(b.replace(/\D.*/, ""), 10);
+    return numA - numB;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function EpisodeBadge({ episode }: { episode: number | null }) {
+  const { grid: t } = useDict();
+  if (episode == null) return null;
+  return (
+    <span
+      className="absolute left-2 top-2 rounded-[5px] px-2 py-0.5 text-[10px] font-semibold tracking-wide text-white"
+      style={{ background: "rgba(0,0,0,0.55)", backdropFilter: "blur(4px)" }}
+    >
+      {t.episode.replace("{ep}", String(episode))}
+    </span>
+  );
+}
+
+interface PhotoCardProps {
+  point: PilgrimagePoint;
+  selected: boolean;
+  onToggle: (id: string) => void;
+}
+
+function PhotoCard({ point, selected, onToggle }: PhotoCardProps) {
+  return (
+    <div
+      className="group relative cursor-pointer overflow-hidden rounded-[10px] bg-[var(--color-card)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg"
+      style={{ border: `2px solid ${selected ? "var(--color-primary)" : "transparent"}` }}
+      onClick={() => onToggle(point.id)}
+      role="button"
+      tabIndex={0}
+      aria-pressed={selected}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onToggle(point.id);
+        }
+      }}
+    >
+      {/* Image — 16/10 aspect ratio */}
+      <div className="relative overflow-hidden" style={{ aspectRatio: "16/10" }}>
+        {point.screenshot_url ? (
+          <img
+            src={point.screenshot_url}
+            alt={point.name}
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.04]"
+          />
+        ) : (
+          <div className="h-full w-full bg-[var(--color-muted)]" />
+        )}
+        <EpisodeBadge episode={point.episode} />
+        {selected && (
+          <div className="absolute right-2 top-2 flex h-[22px] w-[22px] items-center justify-center rounded-full bg-[var(--color-primary)] text-[11px] font-bold text-white">
+            ✓
+          </div>
+        )}
+      </div>
+      {/* Info */}
+      <div className="px-3 py-2.5">
+        <p className="truncate text-[13px] font-medium text-[var(--color-fg)]">
+          {point.name}
+        </p>
+        {point.title && (
+          <p className="mt-0.5 truncate text-[11px] text-[var(--color-muted-fg)]">
+            {point.title}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function LoadingSkeleton() {
+  return (
+    <div className="flex w-full flex-1 flex-col gap-4 p-6">
+      {[80, 55, 65].map((w) => (
+        <div
+          key={w}
+          className="h-3 rounded-sm bg-[var(--color-muted)]"
+          style={{
+            width: `${w}%`,
+            animation: "pulse-skeleton 1.6s ease-in-out infinite",
+          }}
+        />
+      ))}
+      <div
+        className="mt-2 h-32 w-full rounded-sm bg-[var(--color-muted)]"
+        style={{ animation: "pulse-skeleton 1.6s ease-in-out infinite 0.2s" }}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+function EmptyState({
+  onSuggest,
+}: {
+  onSuggest?: (text: string) => void;
+}) {
+  const { chat, clarification } = useDict();
+
+  return (
+    <div className="relative flex min-h-0 flex-1 overflow-hidden">
+      {/* Radial gradient background */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(ellipse 70% 60% at 60% 70%, oklch(93% 0.025 240 / 0.18), transparent 70%)",
+        }}
+      />
+      {/* Map watermark */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.05]"
+        style={{
+          backgroundImage: "url(/empty-map.svg)",
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      <div className="relative flex flex-1 flex-col justify-end pb-16 pl-10 pr-8">
+        <div className="relative mb-6 select-none leading-[0.85]">
+          <div
+            className="font-[family-name:var(--app-font-display)] font-bold"
+            style={{
+              fontSize: "clamp(5rem, 12vw, 9rem)",
+              color: "color-mix(in oklch, var(--color-fg) 9%, transparent)",
+            }}
+          >
+            <div>聖地</div>
+            <div>巡礼</div>
+          </div>
+          <div
+            className="absolute left-0 top-0 font-[family-name:var(--app-font-display)] font-bold text-[var(--color-primary)]"
+            style={{ fontSize: "clamp(5rem, 12vw, 9rem)", lineHeight: "0.85" }}
+          >
+            聖
+          </div>
+        </div>
+
+        <div className="mb-5 w-12 border-t border-[var(--color-border)]" />
+
+        <p className="mb-8 max-w-xs text-sm font-light leading-relaxed text-[var(--color-muted-fg)]">
+          {chat.welcome_subtitle}
+        </p>
+
+        <div className="flex flex-col gap-1.5">
+          {clarification.suggestions.map((s) => (
+            <button
+              key={s.label}
+              onClick={() => onSuggest?.(s.query)}
+              className="w-fit text-left text-xs font-light text-[var(--color-muted-fg)] transition-colors hover:text-[var(--color-primary)]"
+              style={{ transitionDuration: "var(--duration-fast)" }}
+            >
+              {s.label} →
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Toolbar: view toggle + filter chips
+// ---------------------------------------------------------------------------
+
+interface ToolbarProps {
+  view: ViewMode;
+  onViewChange: (v: ViewMode) => void;
+  epRanges: string[];
+  activeEpRange: string | null;
+  onEpRangeChange: (range: string | null) => void;
+}
+
+function Toolbar({
+  view,
+  onViewChange,
+  epRanges,
+  activeEpRange,
+  onEpRangeChange,
+}: ToolbarProps) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-[var(--color-border)] bg-white px-4 py-1.5">
+      {/* Episode filter chips */}
+      {epRanges.length > 0 && (
+        <div className="flex items-center gap-1.5 overflow-x-auto">
+          <button
+            onClick={() => onEpRangeChange(null)}
+            className="shrink-0 rounded-[18px] border px-3 py-1 text-[11px] font-medium transition-all duration-150"
+            style={
+              activeEpRange === null
+                ? {
+                    background: "var(--color-primary)",
+                    color: "white",
+                    borderColor: "var(--color-primary)",
+                  }
+                : {
+                    background: "white",
+                    color: "var(--color-muted-fg)",
+                    borderColor: "var(--color-border)",
+                  }
+            }
+          >
+            すべて
+          </button>
+          {epRanges.map((range) => (
+            <button
+              key={range}
+              onClick={() => onEpRangeChange(range)}
+              className="shrink-0 rounded-[18px] border px-3 py-1 text-[11px] font-medium transition-all duration-150"
+              style={
+                activeEpRange === range
+                  ? {
+                      background: "var(--color-primary)",
+                      color: "white",
+                      borderColor: "var(--color-primary)",
+                    }
+                  : {
+                      background: "white",
+                      color: "var(--color-muted-fg)",
+                      borderColor: "var(--color-border)",
+                    }
+              }
+            >
+              {range}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Grid / map pill toggle */}
+      <div
+        className="flex shrink-0 gap-0.5 rounded-lg p-0.5"
+        style={{ background: "var(--color-card)" }}
+      >
+        <button
+          onClick={() => onViewChange("grid")}
+          className="flex items-center gap-1.5 rounded-md px-3.5 py-1.5 text-[12px] font-medium transition-all duration-150"
+          style={
+            view === "grid"
+              ? {
+                  background: "white",
+                  color: "var(--color-fg)",
+                  boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
+                }
+              : { background: "transparent", color: "var(--color-muted-fg)" }
+          }
+        >
+          <span>📷</span>
+          グリッド
+        </button>
+        <button
+          onClick={() => onViewChange("map")}
+          className="flex items-center gap-1.5 rounded-md px-3.5 py-1.5 text-[12px] font-medium transition-all duration-150"
+          style={
+            view === "map"
+              ? {
+                  background: "white",
+                  color: "var(--color-fg)",
+                  boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
+                }
+              : { background: "transparent", color: "var(--color-muted-fg)" }
+          }
+        >
+          <span>🗺</span>
+          マップ
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// No-results state
+// ---------------------------------------------------------------------------
+
+function NoResults() {
+  const { grid: t } = useDict();
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
+      <p className="text-[13px] text-[var(--color-muted-fg)]">{t.no_results}</p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Grid content
+// ---------------------------------------------------------------------------
+
+interface GridContentProps {
+  points: PilgrimagePoint[];
+  selectedIds: Set<string>;
+  onToggle: (id: string) => void;
+}
+
+function GridContent({ points, selectedIds, onToggle }: GridContentProps) {
+  return (
+    <div className="flex-1 overflow-y-auto p-4">
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+          gap: "12px",
+        }}
+      >
+        {points.map((point) => (
+          <PhotoCard
+            key={point.id}
+            point={point}
+            selected={selectedIds.has(point.id)}
+            onToggle={onToggle}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ResultPanel
+// ---------------------------------------------------------------------------
+
 export default function ResultPanel({
   activeResponse,
   onSuggest,
@@ -21,101 +401,98 @@ export default function ResultPanel({
   defaultOrigin,
   loading,
 }: ResultPanelProps) {
-  const { chat, clarification } = useDict();
-  const { selectedIds, clear } = usePointSelectionContext();
+  const { selectedIds, toggle, clear } = usePointSelectionContext();
+  const [view, setView] = useState<ViewMode>("grid");
+  const [activeEpRange, setActiveEpRange] = useState<string | null>(null);
 
-  const selectionBar = selectedIds.size > 0 ? (
-    <SelectionBar
-      count={selectedIds.size}
-      defaultOrigin={defaultOrigin ?? ""}
-      onRoute={(origin) => onRouteSelected?.(origin)}
-      onClear={clear}
-      disabled={loading}
-    />
-  ) : null;
+  // Extract search points from the response (when available).
+  const searchPoints = useMemo<PilgrimagePoint[]>(() => {
+    if (!activeResponse || !isSearchData(activeResponse.data)) return [];
+    return (activeResponse.data as SearchResultData).results.rows;
+  }, [activeResponse]);
 
-  if (!activeResponse) {
-    if (loading) {
-      return (
-        <section className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-[var(--color-bg)]">
-          {selectionBar}
-          <div className="flex w-full flex-1 flex-col gap-4 p-6">
-            {[80, 55, 65].map((w) => (
-              <div
-                key={w}
-                className="h-3 rounded-sm bg-[var(--color-muted)]"
-                style={{
-                  width: `${w}%`,
-                  animation: "pulse-skeleton 1.6s ease-in-out infinite",
-                }}
-              />
-            ))}
-            <div
-              className="mt-2 h-32 w-full rounded-sm bg-[var(--color-muted)]"
-              style={{ animation: "pulse-skeleton 1.6s ease-in-out infinite 0.2s" }}
-            />
-          </div>
-        </section>
-      );
-    }
+  // Episode range filter chips — only built when episode data exists.
+  const epRanges = useMemo(() => buildEpRanges(searchPoints), [searchPoints]);
 
+  // Filtered points based on active episode range.
+  const visiblePoints = useMemo<PilgrimagePoint[]>(() => {
+    if (activeEpRange === null) return searchPoints;
+    return searchPoints.filter(
+      (p) => p.episode != null && epRangeLabel(p.episode) === activeEpRange,
+    );
+  }, [searchPoints, activeEpRange]);
+
+  const selectionBar =
+    selectedIds.size > 0 ? (
+      <SelectionBar
+        count={selectedIds.size}
+        defaultOrigin={defaultOrigin ?? ""}
+        onRoute={(origin) => onRouteSelected?.(origin)}
+        onClear={clear}
+        disabled={loading}
+      />
+    ) : null;
+
+  // ── Loading state ─────────────────────────────────────────────────────────
+  if (!activeResponse && loading) {
     return (
       <section className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-[var(--color-bg)]">
         {selectionBar}
-        <div className="relative flex min-h-0 flex-1 overflow-hidden">
-          <div
-            className="pointer-events-none absolute inset-0 opacity-[0.05]"
-            style={{
-              backgroundImage: "url(/empty-map.svg)",
-              backgroundSize: "cover",
-              backgroundPosition: "center",
-            }}
-          />
-
-          <div className="relative flex flex-1 flex-col justify-end pb-16 pl-10 pr-8">
-            <div className="relative mb-6 select-none leading-[0.85]">
-              <div
-                className="font-[family-name:var(--app-font-display)] font-bold"
-                style={{
-                  fontSize: "clamp(5rem, 12vw, 9rem)",
-                  color: "color-mix(in oklch, var(--color-fg) 9%, transparent)",
-                }}
-              >
-                <div>聖地</div>
-                <div>巡礼</div>
-              </div>
-              <div
-                className="absolute left-0 top-0 font-[family-name:var(--app-font-display)] font-bold text-[var(--color-primary)]"
-                style={{ fontSize: "clamp(5rem, 12vw, 9rem)", lineHeight: "0.85" }}
-              >
-                聖
-              </div>
-            </div>
-
-            <div className="mb-5 w-12 border-t border-[var(--color-border)]" />
-
-            <p className="mb-8 max-w-xs text-sm font-light leading-relaxed text-[var(--color-muted-fg)]">
-              {chat.welcome_subtitle}
-            </p>
-
-            <div className="flex flex-col gap-1.5">
-              {clarification.suggestions.map((s) => (
-                <button
-                  key={s.label}
-                  onClick={() => onSuggest?.(s.query)}
-                  className="w-fit text-left text-xs font-light text-[var(--color-muted-fg)] transition-colors hover:text-[var(--color-primary)]"
-                  style={{ transitionDuration: "var(--duration-fast)" }}
-                >
-                  {s.label} →
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
+        <LoadingSkeleton />
       </section>
     );
   }
 
+  // ── No active response (empty / welcome state) ────────────────────────────
+  if (!activeResponse) {
+    return (
+      <section className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-[var(--color-bg)]">
+        {selectionBar}
+        <EmptyState onSuggest={onSuggest} />
+      </section>
+    );
+  }
+
+  // ── Active response with search results ───────────────────────────────────
+  if (isSearchData(activeResponse.data)) {
+    const isEmpty = searchPoints.length === 0;
+
+    return (
+      <section
+        className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-[var(--color-bg)]"
+        style={{ animation: "slide-in-right 0.3s ease-out" }}
+      >
+        {selectionBar}
+
+        {/* Toolbar: filter chips + view toggle */}
+        <Toolbar
+          view={view}
+          onViewChange={setView}
+          epRanges={epRanges}
+          activeEpRange={activeEpRange}
+          onEpRangeChange={setActiveEpRange}
+        />
+
+        {/* Content area */}
+        {isEmpty ? (
+          <NoResults />
+        ) : view === "grid" ? (
+          <GridContent
+            points={visiblePoints}
+            selectedIds={selectedIds}
+            onToggle={toggle}
+          />
+        ) : (
+          <div className="relative flex-1 overflow-hidden">
+            <LazyLeafletMap points={visiblePoints} selectedIds={selectedIds} onToggle={toggle} />
+          </div>
+        )}
+      </section>
+    );
+  }
+
+  // ── Other response types: fall through to GenerativeUIRenderer ────────────
+  // (route results, QA, greet, etc.) — keep existing GenerativeUI path.
   return (
     <section
       className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-[var(--color-bg)]"

--- a/frontend/components/layout/ResultPanel.tsx
+++ b/frontend/components/layout/ResultPanel.tsx
@@ -53,9 +53,10 @@ function buildEpRanges(points: PilgrimagePoint[]): string[] {
     }
   }
   // Sort ranges numerically by their start episode.
+  // Extract the first run of digits (e.g. "EP 5-8" → "5") for comparison.
   return Array.from(ranges).sort((a, b) => {
-    const numA = parseInt(a.replace(/\D.*/, ""), 10);
-    const numB = parseInt(b.replace(/\D.*/, ""), 10);
+    const numA = parseInt(a.match(/\d+/)?.[0] ?? "0", 10);
+    const numB = parseInt(b.match(/\d+/)?.[0] ?? "0", 10);
     return numA - numB;
   });
 }

--- a/frontend/components/layout/ResultPanel.tsx
+++ b/frontend/components/layout/ResultPanel.tsx
@@ -4,10 +4,13 @@ import { useState, useMemo } from "react";
 import dynamic from "next/dynamic";
 import type { RuntimeResponse, PilgrimagePoint, SearchResultData } from "../../lib/types";
 import { isSearchData } from "../../lib/types";
-import { useDict } from "../../lib/i18n-context";
 import { usePointSelectionContext } from "../../contexts/PointSelectionContext";
+import { useDict } from "../../lib/i18n-context";
 import SelectionBar from "../generative/SelectionBar";
 import GenerativeUIRenderer from "../generative/GenerativeUIRenderer";
+import { PhotoCard } from "../generative/PhotoCard";
+import { ResultPanelToolbar } from "./ResultPanelToolbar";
+import { ResultPanelEmptyState } from "./ResultPanelEmptyState";
 
 // ---------------------------------------------------------------------------
 // Leaflet map — lazy-loaded with ssr:false so Leaflet's window accesses do not
@@ -62,78 +65,6 @@ function buildEpRanges(points: PilgrimagePoint[]): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
-
-function EpisodeBadge({ episode }: { episode: number | null }) {
-  const { grid: t } = useDict();
-  if (episode == null) return null;
-  return (
-    <span
-      className="absolute left-2 top-2 rounded-[5px] px-2 py-0.5 text-[10px] font-semibold tracking-wide text-white"
-      style={{ background: "rgba(0,0,0,0.55)", backdropFilter: "blur(4px)" }}
-    >
-      {t.episode.replace("{ep}", String(episode))}
-    </span>
-  );
-}
-
-interface PhotoCardProps {
-  point: PilgrimagePoint;
-  selected: boolean;
-  onToggle: (id: string) => void;
-}
-
-function PhotoCard({ point, selected, onToggle }: PhotoCardProps) {
-  return (
-    <div
-      className="group relative cursor-pointer overflow-hidden rounded-[10px] bg-[var(--color-card)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg"
-      style={{ border: `2px solid ${selected ? "var(--color-primary)" : "transparent"}` }}
-      onClick={() => onToggle(point.id)}
-      role="button"
-      tabIndex={0}
-      aria-pressed={selected}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onToggle(point.id);
-        }
-      }}
-    >
-      {/* Image — 16/10 aspect ratio */}
-      <div className="relative overflow-hidden" style={{ aspectRatio: "16/10" }}>
-        {point.screenshot_url ? (
-          <img
-            src={point.screenshot_url}
-            alt={point.name}
-            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.04]"
-          />
-        ) : (
-          <div className="h-full w-full bg-[var(--color-muted)]" />
-        )}
-        <EpisodeBadge episode={point.episode} />
-        {selected && (
-          <div className="absolute right-2 top-2 flex h-[22px] w-[22px] items-center justify-center rounded-full bg-[var(--color-primary)] text-[11px] font-bold text-white">
-            ✓
-          </div>
-        )}
-      </div>
-      {/* Info */}
-      <div className="px-3 py-2.5">
-        <p className="truncate text-[13px] font-medium text-[var(--color-fg)]">
-          {point.name}
-        </p>
-        {point.title && (
-          <p className="mt-0.5 truncate text-[11px] text-[var(--color-muted-fg)]">
-            {point.title}
-          </p>
-        )}
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Loading skeleton
 // ---------------------------------------------------------------------------
 
@@ -154,193 +85,6 @@ function LoadingSkeleton() {
         className="mt-2 h-32 w-full rounded-sm bg-[var(--color-muted)]"
         style={{ animation: "pulse-skeleton 1.6s ease-in-out infinite 0.2s" }}
       />
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Empty state
-// ---------------------------------------------------------------------------
-
-function EmptyState({
-  onSuggest,
-}: {
-  onSuggest?: (text: string) => void;
-}) {
-  const { chat, clarification } = useDict();
-
-  return (
-    <div className="relative flex min-h-0 flex-1 overflow-hidden">
-      {/* Radial gradient background */}
-      <div
-        className="pointer-events-none absolute inset-0"
-        style={{
-          background:
-            "radial-gradient(ellipse 70% 60% at 60% 70%, oklch(93% 0.025 240 / 0.18), transparent 70%)",
-        }}
-      />
-      {/* Map watermark */}
-      <div
-        className="pointer-events-none absolute inset-0 opacity-[0.05]"
-        style={{
-          backgroundImage: "url(/empty-map.svg)",
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-        }}
-      />
-
-      <div className="relative flex flex-1 flex-col justify-end pb-16 pl-10 pr-8">
-        <div className="relative mb-6 select-none leading-[0.85]">
-          <div
-            className="font-[family-name:var(--app-font-display)] font-bold"
-            style={{
-              fontSize: "clamp(5rem, 12vw, 9rem)",
-              color: "color-mix(in oklch, var(--color-fg) 9%, transparent)",
-            }}
-          >
-            <div>聖地</div>
-            <div>巡礼</div>
-          </div>
-          <div
-            className="absolute left-0 top-0 font-[family-name:var(--app-font-display)] font-bold text-[var(--color-primary)]"
-            style={{ fontSize: "clamp(5rem, 12vw, 9rem)", lineHeight: "0.85" }}
-          >
-            聖
-          </div>
-        </div>
-
-        <div className="mb-5 w-12 border-t border-[var(--color-border)]" />
-
-        <p className="mb-8 max-w-xs text-sm font-light leading-relaxed text-[var(--color-muted-fg)]">
-          {chat.welcome_subtitle}
-        </p>
-
-        <div className="flex flex-col gap-1.5">
-          {clarification.suggestions.map((s) => (
-            <button
-              key={s.label}
-              onClick={() => onSuggest?.(s.query)}
-              className="w-fit text-left text-xs font-light text-[var(--color-muted-fg)] transition-colors hover:text-[var(--color-primary)]"
-              style={{ transitionDuration: "var(--duration-fast)" }}
-            >
-              {s.label} →
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Toolbar: view toggle + filter chips
-// ---------------------------------------------------------------------------
-
-interface ToolbarProps {
-  view: ViewMode;
-  onViewChange: (v: ViewMode) => void;
-  epRanges: string[];
-  activeEpRange: string | null;
-  onEpRangeChange: (range: string | null) => void;
-}
-
-function Toolbar({
-  view,
-  onViewChange,
-  epRanges,
-  activeEpRange,
-  onEpRangeChange,
-}: ToolbarProps) {
-  return (
-    <div className="flex shrink-0 items-center gap-2 border-b border-[var(--color-border)] bg-white px-4 py-1.5">
-      {/* Episode filter chips */}
-      {epRanges.length > 0 && (
-        <div className="flex items-center gap-1.5 overflow-x-auto">
-          <button
-            onClick={() => onEpRangeChange(null)}
-            className="shrink-0 rounded-[18px] border px-3 py-1 text-[11px] font-medium transition-all duration-150"
-            style={
-              activeEpRange === null
-                ? {
-                    background: "var(--color-primary)",
-                    color: "white",
-                    borderColor: "var(--color-primary)",
-                  }
-                : {
-                    background: "white",
-                    color: "var(--color-muted-fg)",
-                    borderColor: "var(--color-border)",
-                  }
-            }
-          >
-            すべて
-          </button>
-          {epRanges.map((range) => (
-            <button
-              key={range}
-              onClick={() => onEpRangeChange(range)}
-              className="shrink-0 rounded-[18px] border px-3 py-1 text-[11px] font-medium transition-all duration-150"
-              style={
-                activeEpRange === range
-                  ? {
-                      background: "var(--color-primary)",
-                      color: "white",
-                      borderColor: "var(--color-primary)",
-                    }
-                  : {
-                      background: "white",
-                      color: "var(--color-muted-fg)",
-                      borderColor: "var(--color-border)",
-                    }
-              }
-            >
-              {range}
-            </button>
-          ))}
-        </div>
-      )}
-
-      {/* Spacer */}
-      <div className="flex-1" />
-
-      {/* Grid / map pill toggle */}
-      <div
-        className="flex shrink-0 gap-0.5 rounded-lg p-0.5"
-        style={{ background: "var(--color-card)" }}
-      >
-        <button
-          onClick={() => onViewChange("grid")}
-          className="flex items-center gap-1.5 rounded-md px-3.5 py-1.5 text-[12px] font-medium transition-all duration-150"
-          style={
-            view === "grid"
-              ? {
-                  background: "white",
-                  color: "var(--color-fg)",
-                  boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
-                }
-              : { background: "transparent", color: "var(--color-muted-fg)" }
-          }
-        >
-          <span>📷</span>
-          グリッド
-        </button>
-        <button
-          onClick={() => onViewChange("map")}
-          className="flex items-center gap-1.5 rounded-md px-3.5 py-1.5 text-[12px] font-medium transition-all duration-150"
-          style={
-            view === "map"
-              ? {
-                  background: "white",
-                  color: "var(--color-fg)",
-                  boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
-                }
-              : { background: "transparent", color: "var(--color-muted-fg)" }
-          }
-        >
-          <span>🗺</span>
-          マップ
-        </button>
-      </div>
     </div>
   );
 }
@@ -449,7 +193,7 @@ export default function ResultPanel({
     return (
       <section className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-[var(--color-bg)]">
         {selectionBar}
-        <EmptyState onSuggest={onSuggest} />
+        <ResultPanelEmptyState onSuggest={onSuggest} />
       </section>
     );
   }
@@ -466,7 +210,7 @@ export default function ResultPanel({
         {selectionBar}
 
         {/* Toolbar: filter chips + view toggle */}
-        <Toolbar
+        <ResultPanelToolbar
           view={view}
           onViewChange={setView}
           epRanges={epRanges}

--- a/frontend/components/layout/ResultPanelEmptyState.tsx
+++ b/frontend/components/layout/ResultPanelEmptyState.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useDict } from "../../lib/i18n-context";
+
+interface ResultPanelEmptyStateProps {
+  onSuggest?: (text: string) => void;
+}
+
+export function ResultPanelEmptyState({ onSuggest }: ResultPanelEmptyStateProps) {
+  const { chat, clarification } = useDict();
+
+  return (
+    <div className="relative flex min-h-0 flex-1 overflow-hidden">
+      {/* Radial gradient background */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(ellipse 70% 60% at 60% 70%, oklch(93% 0.025 240 / 0.18), transparent 70%)",
+        }}
+      />
+      {/* Map watermark */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.05]"
+        style={{
+          backgroundImage: "url(/empty-map.svg)",
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      <div className="relative flex flex-1 flex-col justify-end pb-16 pl-10 pr-8">
+        <div className="relative mb-6 select-none leading-[0.85]">
+          <div
+            className="font-[family-name:var(--app-font-display)] font-bold"
+            style={{
+              fontSize: "clamp(5rem, 12vw, 9rem)",
+              color: "color-mix(in oklch, var(--color-fg) 9%, transparent)",
+            }}
+          >
+            <div>聖地</div>
+            <div>巡礼</div>
+          </div>
+          <div
+            className="absolute left-0 top-0 font-[family-name:var(--app-font-display)] font-bold text-[var(--color-primary)]"
+            style={{ fontSize: "clamp(5rem, 12vw, 9rem)", lineHeight: "0.85" }}
+          >
+            聖
+          </div>
+        </div>
+
+        <div className="mb-5 w-12 border-t border-[var(--color-border)]" />
+
+        <p className="mb-8 max-w-xs text-sm font-light leading-relaxed text-[var(--color-muted-fg)]">
+          {chat.welcome_subtitle}
+        </p>
+
+        <div className="flex flex-col gap-1.5">
+          {clarification.suggestions.map((s) => (
+            <button
+              key={s.label}
+              onClick={() => onSuggest?.(s.query)}
+              className="w-fit text-left text-xs font-light text-[var(--color-muted-fg)] transition-colors hover:text-[var(--color-primary)]"
+              style={{ transitionDuration: "var(--duration-fast)" }}
+            >
+              {s.label} →
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/layout/ResultPanelToolbar.tsx
+++ b/frontend/components/layout/ResultPanelToolbar.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import type { CSSProperties } from "react";
+
+type ViewMode = "grid" | "map";
+
+interface ResultPanelToolbarProps {
+  view: ViewMode;
+  onViewChange: (v: ViewMode) => void;
+  epRanges: string[];
+  activeEpRange: string | null;
+  onEpRangeChange: (range: string | null) => void;
+}
+
+function chipStyle(active: boolean): CSSProperties {
+  return active
+    ? {
+        background: "var(--color-primary)",
+        color: "var(--color-bg)",
+        borderColor: "var(--color-primary)",
+      }
+    : {
+        background: "var(--color-bg)",
+        color: "var(--color-muted-fg)",
+        borderColor: "var(--color-border)",
+      };
+}
+
+export function ResultPanelToolbar({
+  view,
+  onViewChange,
+  epRanges,
+  activeEpRange,
+  onEpRangeChange,
+}: ResultPanelToolbarProps) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-1.5">
+      {/* Episode filter chips */}
+      {epRanges.length > 0 && (
+        <div className="flex items-center gap-1.5 overflow-x-auto">
+          <button
+            onClick={() => onEpRangeChange(null)}
+            className="shrink-0 rounded-[18px] border px-3 py-1 text-[11px] font-medium transition-all duration-150"
+            style={chipStyle(activeEpRange === null)}
+          >
+            すべて
+          </button>
+          {epRanges.map((range) => (
+            <button
+              key={range}
+              onClick={() => onEpRangeChange(range)}
+              className="shrink-0 rounded-[18px] border px-3 py-1 text-[11px] font-medium transition-all duration-150"
+              style={chipStyle(activeEpRange === range)}
+            >
+              {range}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Grid / map pill toggle */}
+      <div
+        className="flex shrink-0 gap-0.5 rounded-lg p-0.5"
+        style={{ background: "var(--color-card)" }}
+      >
+        <button
+          onClick={() => onViewChange("grid")}
+          className="flex items-center gap-1.5 rounded-md px-3.5 py-1.5 text-[12px] font-medium transition-all duration-150"
+          style={
+            view === "grid"
+              ? {
+                  background: "var(--color-bg)",
+                  color: "var(--color-fg)",
+                  boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
+                }
+              : { background: "transparent", color: "var(--color-muted-fg)" }
+          }
+        >
+          <span>📷</span>
+          グリッド
+        </button>
+        <button
+          onClick={() => onViewChange("map")}
+          className="flex items-center gap-1.5 rounded-md px-3.5 py-1.5 text-[12px] font-medium transition-all duration-150"
+          style={
+            view === "map"
+              ? {
+                  background: "var(--color-bg)",
+                  color: "var(--color-fg)",
+                  boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
+                }
+              : { background: "transparent", color: "var(--color-muted-fg)" }
+          }
+        >
+          <span>🗺</span>
+          マップ
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/tests/result-panel.test.tsx
+++ b/frontend/tests/result-panel.test.tsx
@@ -1,0 +1,444 @@
+/**
+ * ResultPanel unit tests (TDD).
+ *
+ * AC coverage:
+ * - Filter chips appear for episode ranges when results have episode data -> unit
+ * - No active response — result panel shows empty state with gradient bg and hint -> unit
+ * - Zero results returned — result panel shows "no results" message -> unit
+ * - Leaflet map is lazy-loaded via dynamic(() => import(...), { ssr: false }) -> unit
+ * - Grid/map toggle switches view, selection state persists across switches -> unit (toggle part)
+ * - Selection bar slides up when 1+ points selected, shows count and route button -> unit
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+import ResultPanel from "@/components/layout/ResultPanel";
+import type { RuntimeResponse } from "@/lib/types";
+import { PointSelectionContext } from "@/contexts/PointSelectionContext";
+import defaultDict from "@/lib/dictionaries/ja.json";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock i18n — useDict returns the Japanese dictionary so we can assert on real strings.
+vi.mock("@/lib/i18n-context", () => ({
+  useDict: () => defaultDict,
+}));
+
+// Mock GenerativeUIRenderer — irrelevant for ResultPanel layout tests.
+vi.mock("@/components/generative/GenerativeUIRenderer", () => ({
+  default: ({ response }: { response: RuntimeResponse }) => (
+    <div data-testid="generative-ui">{response.intent}</div>
+  ),
+}));
+
+// Mock SelectionBar — we test integration via PointSelectionContext below.
+vi.mock("@/components/generative/SelectionBar", () => ({
+  default: ({
+    count,
+    onRoute,
+    onClear,
+  }: {
+    count: number;
+    defaultOrigin: string;
+    onRoute: (o: string) => void;
+    onClear: () => void;
+    disabled?: boolean;
+  }) => (
+    <div data-testid="selection-bar">
+      <span data-testid="selection-count">{count}件選択</span>
+      <button onClick={() => onRoute("")} data-testid="route-btn">
+        ルートを作成
+      </button>
+      <button onClick={onClear} data-testid="clear-btn">
+        クリア
+      </button>
+    </div>
+  ),
+}));
+
+// Mock next/dynamic — when used with ssr:false, return a placeholder so we can
+// verify the Leaflet map is NOT rendered until the map view is activated.
+vi.mock("next/dynamic", () => ({
+  default: (loader: () => Promise<{ default: () => ReactNode }>, opts?: { ssr?: boolean }) => {
+    // Capture ssr option to verify it is false.
+    if (opts?.ssr !== false) {
+      throw new Error("Leaflet dynamic import must have ssr: false");
+    }
+    // Return a lazy component that renders a sentinel element.
+    const LazyMap = () => <div data-testid="lazy-map-placeholder" />;
+    LazyMap.displayName = "LazyMap";
+    return LazyMap;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSearchResponse(rows: Partial<typeof POINT>[] = [POINT]): RuntimeResponse {
+  return {
+    success: true,
+    status: "ok",
+    intent: "search_bangumi",
+    session_id: "s-001",
+    message: "ok",
+    data: {
+      results: {
+        rows: rows.map((r) => ({ ...POINT, ...r })),
+        row_count: rows.length,
+        strategy: "sql",
+        status: rows.length > 0 ? "ok" : "empty",
+      },
+      message: "ok",
+      status: rows.length > 0 ? "ok" : "empty",
+    },
+    session: { interaction_count: 1, route_history_count: 0 },
+    route_history: [],
+    errors: [],
+  };
+}
+
+const POINT = {
+  id: "pt-001",
+  name: "宇治駅",
+  name_cn: null,
+  episode: 1,
+  time_seconds: null,
+  screenshot_url: "https://example.com/img.jpg",
+  bangumi_id: "bg-001",
+  latitude: 34.88,
+  longitude: 135.8,
+};
+
+interface WrapperProps {
+  selectedIds?: Set<string>;
+  toggle?: (id: string) => void;
+  clear?: () => void;
+  children: ReactNode;
+}
+
+function SelectionWrapper({
+  selectedIds = new Set<string>(),
+  toggle = () => {},
+  clear = () => {},
+  children,
+}: WrapperProps) {
+  return (
+    <PointSelectionContext.Provider value={{ selectedIds, toggle, clear }}>
+      {children}
+    </PointSelectionContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ResultPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Empty state ───────────────────────────────────────────────────────────
+
+  describe("empty state (no active response)", () => {
+    it("renders without crashing when activeResponse is null", () => {
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={null} />
+        </SelectionWrapper>,
+      );
+      // The panel should mount without throwing.
+    });
+
+    it("shows the hint text from the dictionary", () => {
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={null} />
+        </SelectionWrapper>,
+      );
+      // "聖地を探してみよう" or the welcome_subtitle — panel must display guide text
+      // We assert that some landmark hint copy appears (welcome_subtitle or chat.empty_hint).
+      const hint = screen.queryByText(defaultDict.chat.welcome_subtitle);
+      if (!hint) {
+        // Also acceptable: the empty_hint text
+        expect(screen.queryByText(defaultDict.chat.empty_hint)).not.toBeNull();
+      } else {
+        expect(hint).toBeInTheDocument();
+      }
+    });
+
+    it("does not show selection bar when no points are selected", () => {
+      render(
+        <SelectionWrapper selectedIds={new Set<string>()}>
+          <ResultPanel activeResponse={null} />
+        </SelectionWrapper>,
+      );
+      expect(screen.queryByTestId("selection-bar")).toBeNull();
+    });
+  });
+
+  // ── Zero results ──────────────────────────────────────────────────────────
+
+  describe("zero results response", () => {
+    it("shows no-results message when result rows are empty", () => {
+      const emptyResponse = makeSearchResponse([]);
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={emptyResponse} />
+        </SelectionWrapper>,
+      );
+      expect(screen.getByText(defaultDict.grid.no_results)).toBeInTheDocument();
+    });
+  });
+
+  // ── Grid view (default) ───────────────────────────────────────────────────
+
+  describe("grid view (default)", () => {
+    it("renders grid by default when activeResponse has results", () => {
+      const response = makeSearchResponse();
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={response} />
+        </SelectionWrapper>,
+      );
+      // Grid toggle button must be present and initially active.
+      const gridToggle = screen.getByRole("button", { name: /グリッド/i });
+      expect(gridToggle).toBeInTheDocument();
+    });
+
+    it("renders photo card for each result point", () => {
+      const response = makeSearchResponse();
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={response} />
+        </SelectionWrapper>,
+      );
+      // Point name should appear in the card.
+      expect(screen.getByText("宇治駅")).toBeInTheDocument();
+    });
+  });
+
+  // ── Toggle: grid ↔ map ────────────────────────────────────────────────────
+
+  describe("grid/map view toggle", () => {
+    it("shows map toggle button", () => {
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      expect(screen.getByRole("button", { name: /マップ/i })).toBeInTheDocument();
+    });
+
+    it("switches to map view when map toggle is clicked", () => {
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      const mapBtn = screen.getByRole("button", { name: /マップ/i });
+      fireEvent.click(mapBtn);
+      // The lazy-loaded map placeholder should now be present.
+      expect(screen.getByTestId("lazy-map-placeholder")).toBeInTheDocument();
+    });
+
+    it("switches back to grid view when grid toggle is clicked after switching to map", () => {
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      // Switch to map
+      fireEvent.click(screen.getByRole("button", { name: /マップ/i }));
+      // Switch back to grid
+      fireEvent.click(screen.getByRole("button", { name: /グリッド/i }));
+      // Point card should be visible again.
+      expect(screen.getByText("宇治駅")).toBeInTheDocument();
+    });
+
+    it("hides the point cards when in map view", () => {
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /マップ/i }));
+      expect(screen.queryByText("宇治駅")).toBeNull();
+    });
+  });
+
+  // ── Filter chips ──────────────────────────────────────────────────────────
+
+  describe("filter chips for episode ranges", () => {
+    it("renders a 'すべて' chip when results have episode data", () => {
+      const response = makeSearchResponse([
+        { ...POINT, id: "pt-001", episode: 1 },
+        { ...POINT, id: "pt-002", episode: 3 },
+        { ...POINT, id: "pt-003", episode: 7 },
+      ]);
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={response} />
+        </SelectionWrapper>,
+      );
+      expect(screen.getByRole("button", { name: /すべて/i })).toBeInTheDocument();
+    });
+
+    it("renders episode range chips based on available episodes", () => {
+      const response = makeSearchResponse([
+        { ...POINT, id: "pt-001", episode: 1 },
+        { ...POINT, id: "pt-002", episode: 3 },
+        { ...POINT, id: "pt-003", episode: 7 },
+      ]);
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={response} />
+        </SelectionWrapper>,
+      );
+      // At least one EP range chip should appear (EP 1-4 or similar).
+      const epChips = screen.getAllByRole("button").filter((btn) =>
+        /EP\s?\d/.test(btn.textContent ?? ""),
+      );
+      expect(epChips.length).toBeGreaterThan(0);
+    });
+
+    it("does not render episode filter chips when no episode data exists", () => {
+      const response = makeSearchResponse([{ ...POINT, id: "pt-001", episode: null }]);
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={response} />
+        </SelectionWrapper>,
+      );
+      const epChips = screen.getAllByRole("button").filter((btn) =>
+        /EP\s?\d/.test(btn.textContent ?? ""),
+      );
+      expect(epChips).toHaveLength(0);
+    });
+
+    it("filters visible cards to matching episode range when chip is clicked", () => {
+      const response = makeSearchResponse([
+        { ...POINT, id: "pt-001", name: "宇治駅", episode: 1 },
+        { ...POINT, id: "pt-002", name: "京アニスタジオ", episode: 7 },
+      ]);
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={response} />
+        </SelectionWrapper>,
+      );
+      // Both initially visible
+      expect(screen.getByText("宇治駅")).toBeInTheDocument();
+      expect(screen.getByText("京アニスタジオ")).toBeInTheDocument();
+
+      // Click EP 1-4 chip to filter
+      const ep1Chip = screen.getAllByRole("button").find((b) =>
+        /EP\s?1/.test(b.textContent ?? ""),
+      );
+      if (ep1Chip) {
+        fireEvent.click(ep1Chip);
+        // EP-1 point should remain; EP-7 point should be hidden.
+        expect(screen.getByText("宇治駅")).toBeInTheDocument();
+        expect(screen.queryByText("京アニスタジオ")).toBeNull();
+      }
+    });
+  });
+
+  // ── Selection bar ─────────────────────────────────────────────────────────
+
+  describe("selection bar", () => {
+    it("shows selection bar when one or more points are selected", () => {
+      render(
+        <SelectionWrapper selectedIds={new Set(["pt-001"])}>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      expect(screen.getByTestId("selection-bar")).toBeInTheDocument();
+    });
+
+    it("shows correct count in selection bar", () => {
+      render(
+        <SelectionWrapper selectedIds={new Set(["pt-001", "pt-002"])}>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      expect(screen.getByTestId("selection-count")).toHaveTextContent("2件選択");
+    });
+
+    it("does not show selection bar when no points are selected", () => {
+      render(
+        <SelectionWrapper selectedIds={new Set()}>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      expect(screen.queryByTestId("selection-bar")).toBeNull();
+    });
+
+    it("calls onRouteSelected when route button is clicked", () => {
+      const onRouteSelected = vi.fn();
+      render(
+        <SelectionWrapper selectedIds={new Set(["pt-001"])}>
+          <ResultPanel
+            activeResponse={makeSearchResponse()}
+            onRouteSelected={onRouteSelected}
+          />
+        </SelectionWrapper>,
+      );
+      fireEvent.click(screen.getByTestId("route-btn"));
+      expect(onRouteSelected).toHaveBeenCalledOnce();
+    });
+
+    it("calls clear on PointSelectionContext when clear button is clicked", () => {
+      const clear = vi.fn();
+      render(
+        <SelectionWrapper selectedIds={new Set(["pt-001"])} clear={clear}>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      fireEvent.click(screen.getByTestId("clear-btn"));
+      expect(clear).toHaveBeenCalledOnce();
+    });
+
+    it("selection bar persists when toggling between grid and map views", () => {
+      render(
+        <SelectionWrapper selectedIds={new Set(["pt-001"])}>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      // Switch to map
+      fireEvent.click(screen.getByRole("button", { name: /マップ/i }));
+      expect(screen.getByTestId("selection-bar")).toBeInTheDocument();
+      // Switch back to grid
+      fireEvent.click(screen.getByRole("button", { name: /グリッド/i }));
+      expect(screen.getByTestId("selection-bar")).toBeInTheDocument();
+    });
+  });
+
+  // ── Leaflet lazy-load ─────────────────────────────────────────────────────
+
+  describe("Leaflet lazy loading", () => {
+    it("does not render map content until map view is activated", () => {
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      // In grid (default) view, the lazy map placeholder should not be present.
+      expect(screen.queryByTestId("lazy-map-placeholder")).toBeNull();
+    });
+
+    it("renders lazy map placeholder (ssr:false enforced) when map view is active", () => {
+      // The vi.mock for next/dynamic throws if ssr !== false, so this test
+      // also validates the ssr:false requirement at mock time.
+      render(
+        <SelectionWrapper>
+          <ResultPanel activeResponse={makeSearchResponse()} />
+        </SelectionWrapper>,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /マップ/i }));
+      expect(screen.getByTestId("lazy-map-placeholder")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/tests/result-panel.test.tsx
+++ b/frontend/tests/result-panel.test.tsx
@@ -14,7 +14,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { ReactNode } from "react";
 import ResultPanel from "@/components/layout/ResultPanel";
-import type { RuntimeResponse } from "@/lib/types";
+import type { RuntimeResponse, PilgrimagePoint } from "@/lib/types";
 import { PointSelectionContext } from "@/contexts/PointSelectionContext";
 import defaultDict from "@/lib/dictionaries/ja.json";
 
@@ -78,7 +78,7 @@ vi.mock("next/dynamic", () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeSearchResponse(rows: Partial<typeof POINT>[] = [POINT]): RuntimeResponse {
+function makeSearchResponse(rows: Partial<PilgrimagePoint>[] = [POINT]): RuntimeResponse {
   return {
     success: true,
     status: "ok",
@@ -101,7 +101,7 @@ function makeSearchResponse(rows: Partial<typeof POINT>[] = [POINT]): RuntimeRes
   };
 }
 
-const POINT = {
+const POINT: PilgrimagePoint = {
   id: "pt-001",
   name: "宇治駅",
   name_cn: null,


### PR DESCRIPTION
## Summary

**Grid/Map View Toggle**
- Pill-button toggle (📷 グリッド | 🗺 マップ) in toolbar above results
- View state lives in ResultPanel; selection state (PointSelectionContext) persists across switches
- Leaflet map lazy-loaded via `dynamic(() => import('./LeafletResultMap'), { ssr: false })` — keeps Leaflet's window accesses out of the SSR/static-export build path

**Episode Filter Chips**
- Auto-generated EP range chips (すべて, EP 1-4, EP 5-8, …) from available episode data
- Chips only appear when results have non-null episode values
- Clicking a chip filters the visible photo cards to that range

**Photo Card Grid**
- `grid-template-columns: repeat(auto-fill, minmax(200px, 1fr))`, gap 12px
- 16/10 aspect ratio images, ep badge top-left, selected state with primary border + checkmark
- Hover: `translateY(-2px)` + shadow
- Keyboard accessible (Enter/Space toggles selection)

**SelectionBar Integration**
- Bar renders above content when 1+ points selected (slides up via existing SelectionBar component)
- Persists across grid ↔ map view switches
- Shows count, origin input, route button, clear button

**Empty / Zero-result States**
- Empty state: radial gradient bg + watermark + 聖地/巡礼 display type + suggestion links
- Zero-results state: `grid.no_results` message centered in panel

## Test Coverage

```
CODE PATH COVERAGE (unit-testable paths)
===========================
EmptyState: 3/3 paths tested (★★★)
Loading: 1/1 (★)
Search results - Toolbar: 6/6 (★★★)
Search results - GridContent: 2/3 (missing: keyboard nav)
NoResults: 1/1 (★★★)
Map view (lazy): 3/3 (★★★)
SelectionBar integration: 5/5 (★★★)
─────────────────────────────────
Unit-testable coverage: 21/23 (91%)
Browser-only (pending browser ACs): 3 paths
─────────────────────────────────
```

Tests: 7 → 8 test files (+1 new: result-panel.test.tsx with 22 tests)

## Pre-Landing Review

1 issue found, 1 AUTO-FIXED:
- [AUTO-FIXED] `ResultPanel.tsx:buildEpRanges` — sort key regex `\D.*` matched from first non-digit, returning `NaN` for labels like "EP 5-8". Fixed to use `a.match(/\d+/)?.[0]`.

Design Review (lite): Clean — no `outline: none`, no `!important`, no body text under 16px.

## Eval Results

No prompt-related files changed — evals skipped.

## Greptile Review

No PR existed during pre-review.

## Scope Drift

Scope Check: CLEAN
Intent: Rewrite ResultPanel with grid/map toggle + SelectionBar integration (card W1-3)
Delivered: Exactly that — ResultPanel.tsx, LeafletResultMap.tsx, tests, setup.ts cleanup

## Plan Completion

| Item | Status |
|---|---|
| Grid/map toggle | DONE |
| Episode filter chips | DONE |
| SelectionBar slides up | DONE |
| Empty state (gradient + hint) | DONE |
| Zero-results message | DONE |
| Leaflet dynamic import ssr:false | DONE |
| Unit tests — all unit ACs | DONE |
| Grid/map selection persists (browser AC) | DEFERRED → browser |
| Map tile failure fallback (browser AC) | DEFERRED → browser |
| Grid column responsiveness (browser AC) | DEFERRED → browser |

## TODOS

No TODOS.md in repo.

## Test plan

- [x] 22/22 Vitest unit tests pass (`tests/result-panel.test.tsx`)
- [x] Full suite: 29/29 tests pass
- [x] `npm run build` — compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now support grid and map view modes with easy toggle switching
  * Filter search results by episode ranges using episode chips
  * Empty state displays helpful search suggestions
  * Interactive photo cards with selection capability and episode badges
  * Map visualization of pilgrimage points with clickable markers and popups
<!-- end of auto-generated comment: release notes by coderabbit.ai -->