### PR TITLE
feat(frontend): add source badges + missing data handling

### DIFF
--- a/frontend/components/generative/PilgrimageGrid.tsx
+++ b/frontend/components/generative/PilgrimageGrid.tsx
@@ -7,6 +7,7 @@ import { usePointSelectionContext } from "../../contexts/PointSelectionContext";
 import { resolveUnknownName } from "../../lib/japanRegions";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
+import SourceBadge from "./SourceBadge";
 
 function PilgrimageCard({
   point,
@@ -22,6 +23,12 @@ function PilgrimageCard({
   onToggle: () => void;
 }) {
   const [imgError, setImgError] = useState(false);
+
+  // Treat empty string as absent — same as null for rendering purposes.
+  const hasImage = Boolean(point.screenshot_url) && !imgError;
+
+  // City display: fall back to "---" when origin is null or empty.
+  const cityLabel = point.origin || "---";
 
   return (
     <button
@@ -52,10 +59,10 @@ function PilgrimageCard({
           idx === 0 ? "aspect-video" : "aspect-[4/3]"
         }`}
       >
-        {point.screenshot_url && !imgError ? (
+        {hasImage ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
-            src={point.screenshot_url}
+            src={point.screenshot_url!}
             alt={point.name_cn || point.name}
             className="h-full w-full object-cover"
             loading="lazy"
@@ -73,21 +80,32 @@ function PilgrimageCard({
             </span>
           </div>
         )}
+
+        {/* Source badge overlaid on the image area */}
+        <SourceBadge
+          screenshotUrl={point.screenshot_url}
+          episode={point.episode}
+          episodeLabel={
+            point.episode != null && point.episode !== 0
+              ? episodeLabel.replace("{ep}", String(point.episode))
+              : undefined
+          }
+        />
       </div>
 
-      {point.episode != null && point.episode !== 0 && (
-        <span className="absolute bottom-2 left-2 rounded-sm bg-black/60 px-1.5 py-0.5 text-[10px] text-white/80">
-          {episodeLabel.replace("{ep}", String(point.episode))}
-        </span>
-      )}
-
-      <div className="pb-2 pt-1.5">
+      <div className="pb-2 pt-1.5 px-1">
         <p className="truncate text-xs font-light text-[var(--color-fg)]">
           {(point.name_cn && point.name_cn !== "不明" ? point.name_cn : null)
             || (point.name && point.name !== "不明" ? point.name : null)
             || resolveUnknownName(point.latitude, point.longitude)
             || point.name_cn
             || point.name}
+        </p>
+        <p
+          data-testid="city-label"
+          className="truncate text-[10px] font-light text-[var(--color-muted-fg)]"
+        >
+          {cityLabel}
         </p>
       </div>
     </button>

--- a/frontend/components/generative/PilgrimageGrid.tsx
+++ b/frontend/components/generative/PilgrimageGrid.tsx
@@ -86,7 +86,7 @@ function PilgrimageCard({
           screenshotUrl={point.screenshot_url}
           episode={point.episode}
           episodeLabel={
-            point.episode != null && point.episode !== 0
+            typeof point.episode === "number" && point.episode > 0
               ? episodeLabel.replace("{ep}", String(point.episode))
               : undefined
           }

--- a/frontend/components/generative/SourceBadge.tsx
+++ b/frontend/components/generative/SourceBadge.tsx
@@ -49,7 +49,7 @@ export default function SourceBadge({
 
   const sourceIcon = isUserPhoto(screenshotUrl) ? "📷" : "🎬";
 
-  const showEpisodeBadge = episode != null && episode !== 0;
+  const showEpisodeBadge = typeof episode === "number" && episode > 0;
 
   const episodeLabel =
     episodeLabelProp ??

--- a/frontend/components/generative/SourceBadge.tsx
+++ b/frontend/components/generative/SourceBadge.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useDict } from "../../lib/i18n-context";
+
+/**
+ * Determines whether a screenshot URL was uploaded by a user.
+ *
+ * Anitabi user-contributed photos have a `/user/` segment in their URL path.
+ * All other URLs (including null / empty) are treated as anime-screenshot stills.
+ */
+function isUserPhoto(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    // Use URL parsing when possible to extract only the pathname.
+    const parsed = new URL(url);
+    return parsed.pathname.includes("/user/");
+  } catch {
+    // Fallback for bare paths (e.g. "/user/avatar.jpg") or malformed URLs.
+    return url.includes("/user/");
+  }
+}
+
+interface SourceBadgeProps {
+  /** The screenshot URL for this pilgrimage point, or null if absent. */
+  screenshotUrl: string | null | undefined;
+  /** Episode number. Badge is omitted when null or 0. */
+  episode: number | null | undefined;
+  /**
+   * Pre-formatted episode label string, e.g. "第3話" or "Ep. 3".
+   * When omitted the component derives the label from the current locale dict.
+   */
+  episodeLabel?: string;
+}
+
+/**
+ * SourceBadge renders two optional overlays on a pilgrimage card:
+ *
+ * 1. **Source icon** — 📷 for user-contributed photos, 🎬 for anime stills.
+ * 2. **Episode badge** — shown only when episode > 0.
+ *
+ * All colours use CSS variables from the design system (no Tailwind colour classes).
+ */
+export default function SourceBadge({
+  screenshotUrl,
+  episode,
+  episodeLabel: episodeLabelProp,
+}: SourceBadgeProps) {
+  const dict = useDict();
+
+  const sourceIcon = isUserPhoto(screenshotUrl) ? "📷" : "🎬";
+
+  const showEpisodeBadge = episode != null && episode !== 0;
+
+  const episodeLabel =
+    episodeLabelProp ??
+    (showEpisodeBadge ? dict.grid.episode.replace("{ep}", String(episode)) : "");
+
+  return (
+    <>
+      {/* Source type icon — always rendered */}
+      <span
+        aria-label={sourceIcon === "📷" ? "user photo" : "screenshot"}
+        style={{
+          position: "absolute",
+          top: "6px",
+          left: "6px",
+          fontSize: "12px",
+          lineHeight: 1,
+          userSelect: "none",
+          pointerEvents: "none",
+        }}
+      >
+        {sourceIcon}
+      </span>
+
+      {/* Episode badge — rendered only when episode > 0 */}
+      {showEpisodeBadge && (
+        <span
+          data-testid="episode-badge"
+          style={{
+            position: "absolute",
+            bottom: "8px",
+            left: "8px",
+            borderRadius: "2px",
+            backgroundColor: "rgba(0,0,0,0.6)",
+            padding: "2px 6px",
+            fontSize: "10px",
+            color: "rgba(255,255,255,0.85)",
+            lineHeight: 1.4,
+            userSelect: "none",
+            pointerEvents: "none",
+          }}
+        >
+          {episodeLabel}
+        </span>
+      )}
+    </>
+  );
+}

--- a/frontend/tests/PilgrimageGrid.test.tsx
+++ b/frontend/tests/PilgrimageGrid.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * PilgrimageGrid missing-data handling unit tests (TDD).
+ *
+ * AC coverage:
+ * - Points with null/empty city display "---" -> unit
+ * - Points with null screenshot_url render placeholder background -> unit
+ * - Points with episode = 0 or null omit episode badge entirely -> unit
+ *   (episode-badge omission is also tested in SourceBadge.test.tsx; here we
+ *    verify the card renders at all without crashing and the badge is absent)
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { PilgrimagePoint } from "@/lib/types";
+import { PointSelectionContext } from "@/contexts/PointSelectionContext";
+import PilgrimageGrid from "@/components/generative/PilgrimageGrid";
+import defaultDict from "@/lib/dictionaries/ja.json";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/i18n-context", () => ({
+  useDict: () => defaultDict,
+}));
+
+vi.mock("@/lib/japanRegions", () => ({
+  resolveUnknownName: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_POINT: PilgrimagePoint = {
+  id: "pt-base",
+  name: "宇治駅",
+  name_cn: null,
+  episode: 1,
+  time_seconds: null,
+  screenshot_url: "https://example.com/img.jpg",
+  bangumi_id: "bg-001",
+  latitude: 34.88,
+  longitude: 135.8,
+  origin: "京都",
+};
+
+function makeGrid(rows: Partial<PilgrimagePoint>[], rowsAlt?: Partial<PilgrimagePoint>[]) {
+  const resolvedRows = rows.map((r, i) => ({ ...BASE_POINT, id: `pt-${i}`, ...r }));
+  return {
+    results: {
+      rows: rowsAlt
+        ? [...resolvedRows, ...rowsAlt.map((r, i) => ({ ...BASE_POINT, id: `pt-alt-${i}`, ...r }))]
+        : resolvedRows,
+      row_count: resolvedRows.length,
+      strategy: "sql" as const,
+      status: "ok" as const,
+    },
+    message: "ok",
+    status: "ok" as const,
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <PointSelectionContext.Provider
+      value={{ selectedIds: new Set<string>(), toggle: () => {}, clear: () => {} }}
+    >
+      {children}
+    </PointSelectionContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests: null screenshot_url → placeholder background
+// ---------------------------------------------------------------------------
+
+describe("PilgrimageGrid — null screenshot_url", () => {
+  it("renders the placeholder element (聖) when screenshot_url is null", () => {
+    const data = makeGrid([{ screenshot_url: null }]);
+    render(
+      <Wrapper>
+        <PilgrimageGrid data={data} />
+      </Wrapper>,
+    );
+    // Placeholder character rendered when there is no image
+    expect(screen.getByText("聖")).toBeInTheDocument();
+  });
+
+  it("does not render an <img> element when screenshot_url is null", () => {
+    const data = makeGrid([{ screenshot_url: null }]);
+    const { container } = render(
+      <Wrapper>
+        <PilgrimageGrid data={data} />
+      </Wrapper>,
+    );
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("renders placeholder when screenshot_url is an empty string", () => {
+    const data = makeGrid([{ screenshot_url: "" }]);
+    render(
+      <Wrapper>
+        <PilgrimageGrid data={data} />
+      </Wrapper>,
+    );
+    expect(screen.getByText("聖")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: null/empty city → "---" fallback
+// ---------------------------------------------------------------------------
+
+describe("PilgrimageGrid — city display fallback", () => {
+  it("displays '---' in the city field when origin is null", () => {
+    // We need a point whose name/name_cn are also null/unknown
+    // so that the city placeholder is visible; we rely on the card
+    // rendering a "city" element produced by PilgrimageGrid's city prop.
+    // The current PilgrimageGrid passes `origin` to PilgrimageCard as a
+    // new `city` prop. The card should render "---" when city is null/empty.
+    const data = makeGrid([{ origin: null, name: "不明", name_cn: null }]);
+    render(
+      <Wrapper>
+        <PilgrimageGrid data={data} />
+      </Wrapper>,
+    );
+    expect(screen.getByTestId("city-label")).toHaveTextContent("---");
+  });
+
+  it("displays '---' when origin is an empty string", () => {
+    const data = makeGrid([{ origin: "", name: "不明", name_cn: null }]);
+    render(
+      <Wrapper>
+        <PilgrimageGrid data={data} />
+      </Wrapper>,
+    );
+    expect(screen.getByTestId("city-label")).toHaveTextContent("---");
+  });
+
+  it("displays the city name when origin has a value", () => {
+    const data = makeGrid([{ origin: "京都", name: "不明", name_cn: null }]);
+    render(
+      <Wrapper>
+        <PilgrimageGrid data={data} />
+      </Wrapper>,
+    );
+    expect(screen.getByTestId("city-label")).toHaveTextContent("京都");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: episode badge omission in card
+// ---------------------------------------------------------------------------
+
+describe("PilgrimageGrid — episode badge omission", () => {
+  it("does not render episode badge when episode is 0", () => {
+    const data = makeGrid([{ episode: 0 }]);
+    render(
+      <Wrapper>
+        <PilgrimageGrid data={data} />
+      </Wrapper>,
+    );
+    expect(screen.queryByTestId("episode-badge")).toBeNull();
+  });
+
+  it("does not render episode badge when episode is null", () => {
+    const data = makeGrid([{ episode: null }]);
+    render(
+      <Wrapper>
+        <PilgrimageGrid data={data} />
+      </Wrapper>,
+    );
+    expect(screen.queryByTestId("episode-badge")).toBeNull();
+  });
+
+  it("renders episode badge when episode > 0", () => {
+    const data = makeGrid([{ episode: 3 }]);
+    render(
+      <Wrapper>
+        <PilgrimageGrid data={data} />
+      </Wrapper>,
+    );
+    // ja: 第3話
+    expect(screen.getByTestId("episode-badge")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: component does not crash on fully-null point
+// ---------------------------------------------------------------------------
+
+describe("PilgrimageGrid — graceful rendering", () => {
+  it("renders without crashing when point has all optional fields null", () => {
+    const data = makeGrid([
+      {
+        name_cn: null,
+        episode: null,
+        time_seconds: null,
+        screenshot_url: null,
+        origin: null,
+        title: null,
+        title_cn: null,
+        distance_m: null,
+        address: null,
+      },
+    ]);
+    expect(() => {
+      render(
+        <Wrapper>
+          <PilgrimageGrid data={data} />
+        </Wrapper>,
+      );
+    }).not.toThrow();
+  });
+});

--- a/frontend/tests/SourceBadge.test.tsx
+++ b/frontend/tests/SourceBadge.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * SourceBadge unit tests (TDD).
+ *
+ * AC coverage:
+ * - Image URL containing `/user/` renders user-photo badge (📷) -> unit
+ * - Other URLs render screenshot badge (🎬) -> unit
+ * - Points with episode > 0 show "EP {n}" badge -> unit
+ * - Points with episode = 0 or null omit episode badge entirely -> unit
+ * - Malformed image URL does not crash badge component -> unit
+ * - Episode badge label follows locale -> unit
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SourceBadge from "@/components/generative/SourceBadge";
+import defaultDict from "@/lib/dictionaries/ja.json";
+import enDict from "@/lib/dictionaries/en.json";
+import zhDict from "@/lib/dictionaries/zh.json";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/i18n-context", () => ({
+  useDict: () => defaultDict,
+}));
+
+// ---------------------------------------------------------------------------
+// Tests: source badge (URL type detection)
+// ---------------------------------------------------------------------------
+
+describe("SourceBadge — source icon", () => {
+  it("renders user-photo badge (📷) when screenshot_url contains /user/", () => {
+    render(
+      <SourceBadge
+        screenshotUrl="https://anitabi.cn/images/user/abc123.jpg"
+        episode={null}
+      />,
+    );
+    expect(screen.getByText("📷")).toBeInTheDocument();
+  });
+
+  it("renders screenshot badge (🎬) when screenshot_url does not contain /user/", () => {
+    render(
+      <SourceBadge
+        screenshotUrl="https://anitabi.cn/images/covers/show123.jpg"
+        episode={null}
+      />,
+    );
+    expect(screen.getByText("🎬")).toBeInTheDocument();
+  });
+
+  it("renders screenshot badge (🎬) for a plain HTTP URL without /user/", () => {
+    render(
+      <SourceBadge
+        screenshotUrl="https://example.com/screenshot.jpg"
+        episode={null}
+      />,
+    );
+    expect(screen.getByText("🎬")).toBeInTheDocument();
+  });
+
+  it("renders screenshot badge (🎬) when screenshotUrl is null", () => {
+    render(<SourceBadge screenshotUrl={null} episode={null} />);
+    expect(screen.getByText("🎬")).toBeInTheDocument();
+  });
+
+  it("does not render user-photo badge when /user/ appears only in domain, not path", () => {
+    // URL has 'user' in the domain itself, not in the path segment /user/
+    render(
+      <SourceBadge
+        screenshotUrl="https://user-content.cdn.com/images/ep1.jpg"
+        episode={null}
+      />,
+    );
+    // Should render screenshot badge because the path does not contain /user/
+    expect(screen.getByText("🎬")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: episode badge visibility
+// ---------------------------------------------------------------------------
+
+describe("SourceBadge — episode badge", () => {
+  it("shows EP badge when episode is a positive integer (e.g., 3)", () => {
+    render(
+      <SourceBadge screenshotUrl={null} episode={3} />,
+    );
+    // default locale is ja: "第3話"
+    expect(screen.getByText("第3話")).toBeInTheDocument();
+  });
+
+  it("shows EP badge when episode is 1", () => {
+    render(
+      <SourceBadge screenshotUrl={null} episode={1} />,
+    );
+    expect(screen.getByText("第1話")).toBeInTheDocument();
+  });
+
+  it("does not show episode badge when episode is 0", () => {
+    render(
+      <SourceBadge screenshotUrl={null} episode={0} />,
+    );
+    // "第0話" should NOT appear
+    expect(screen.queryByText("第0話")).toBeNull();
+    // More generally, no element containing "話" pattern for ep 0
+    const container = screen.queryByTestId("episode-badge");
+    expect(container).toBeNull();
+  });
+
+  it("does not show episode badge when episode is null", () => {
+    render(
+      <SourceBadge screenshotUrl={null} episode={null} />,
+    );
+    expect(screen.queryByTestId("episode-badge")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: malformed URL safety
+// ---------------------------------------------------------------------------
+
+describe("SourceBadge — malformed URL safety", () => {
+  it("does not crash when screenshotUrl is an empty string", () => {
+    expect(() => {
+      render(<SourceBadge screenshotUrl="" episode={null} />);
+    }).not.toThrow();
+    // Should still render screenshot badge fallback
+    expect(screen.getByText("🎬")).toBeInTheDocument();
+  });
+
+  it("does not crash when screenshotUrl contains unusual characters", () => {
+    expect(() => {
+      render(
+        <SourceBadge
+          screenshotUrl="not-a-url://[malformed]/user/file?q=1&r=2"
+          episode={null}
+        />,
+      );
+    }).not.toThrow();
+  });
+
+  it("does not crash when screenshotUrl is a bare path (no scheme)", () => {
+    expect(() => {
+      render(<SourceBadge screenshotUrl="/user/avatar.jpg" episode={5} />);
+    }).not.toThrow();
+    // bare path /user/ → should render user-photo badge
+    expect(screen.getByText("📷")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: locale-aware episode label
+// ---------------------------------------------------------------------------
+
+describe("SourceBadge — locale episode label", () => {
+  it("uses Japanese episode template (第{ep}話) for ja locale", () => {
+    // useDict mock returns ja dict
+    render(<SourceBadge screenshotUrl={null} episode={2} />);
+    expect(screen.getByText("第2話")).toBeInTheDocument();
+  });
+
+  it("formats English episode template (Ep. {ep}) correctly", () => {
+    const episodeLabel = enDict.grid.episode.replace("{ep}", "4");
+    render(
+      <SourceBadge
+        screenshotUrl={null}
+        episode={4}
+        episodeLabel={episodeLabel}
+      />,
+    );
+    expect(screen.getByText(episodeLabel)).toBeInTheDocument();
+  });
+
+  it("formats Chinese episode template correctly", () => {
+    const episodeLabel = zhDict.grid.episode.replace("{ep}", "7");
+    render(
+      <SourceBadge
+        screenshotUrl={null}
+        episode={7}
+        episodeLabel={episodeLabel}
+      />,
+    );
+    expect(screen.getByText(episodeLabel)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Add SourceBadge: renders 📷 for /user/ photo URLs, 🎬 for screenshots;
  episode badge shown only when episode > 0; locale-aware via dict.grid.episode
- Update PilgrimageGrid/PilgrimageCard: use SourceBadge, guard empty
  screenshot_url, add city-label with "---" fallback for null/empty origin
- 25 unit tests covering all 7 ACs (SourceBadge URL detection, episode
  badge omission, malformed URL safety, locale labels, null data handling)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual source indicators to grid items: camera icon for user-contributed photos, film reel icon for other sources.
  * Introduced city/location labels displayed in grid items with fallback display for missing data.
  * Enhanced episode badge display with improved layout and visibility handling.

* **Tests**
  * Added comprehensive test coverage for grid rendering and source badge components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->