### PR TITLE
feat(frontend): rewrite landing page with hero and 3-step layout

### DIFF
--- a/frontend/components/auth/AuthGate.tsx
+++ b/frontend/components/auth/AuthGate.tsx
@@ -252,7 +252,7 @@ export default function AuthGate() {
           data-testid="floating-cards"
           className="pointer-events-none absolute inset-0 overflow-hidden"
         >
-          {FLOAT_CARDS.map((card, i) => (
+          {FLOAT_CARDS.map((card) => (
             <div
               key={card.cls}
               className="absolute overflow-hidden rounded-xl"

--- a/frontend/components/auth/AuthGate.tsx
+++ b/frontend/components/auth/AuthGate.tsx
@@ -2,31 +2,103 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
-import { useDict, useLocale, useSetLocale } from "../../lib/i18n-context";
-import { LOCALES, type Locale } from "../../lib/i18n";
+import { useDict, useLocale } from "../../lib/i18n-context";
 import { getSupabaseClient } from "../../lib/supabase";
 import AppShell from "../layout/AppShell";
 
-/* ── Pin positions (labels come from i18n dictionaries) ── */
-const PIN_POSITIONS: { top: string; left: string; labelKey?: string }[] = [
-  { top: "30%", left: "46%", labelKey: "pin_yourname" },
-  { top: "42%", left: "56%", labelKey: "pin_euphonium" },
-  { top: "52%", left: "44%", labelKey: "pin_violet" },
-  { top: "36%", left: "38%" },
-  { top: "48%", left: "60%" },
-  { top: "26%", left: "52%" },
-  { top: "58%", left: "50%" },
-  { top: "40%", left: "48%" },
+/* ── Anitabi floating photo cards ── */
+const FLOAT_CARDS: {
+  src: string;
+  label: string;
+  ep: string;
+  cls: string;
+  rotate: string;
+}[] = [
+  {
+    src: "https://image.anitabi.cn/points/115908/qys7fu.jpg?plan=h160",
+    label: "京都コンサートホール",
+    ep: "EP1",
+    cls: "fc-1",
+    rotate: "-3deg",
+  },
+  {
+    src: "https://image.anitabi.cn/points/160209/al3yeri_1770054618536.jpg?plan=h160",
+    label: "マンション桂",
+    ep: "君の名は。",
+    cls: "fc-2",
+    rotate: "2deg",
+  },
+  {
+    src: "https://image.anitabi.cn/points/115908/7evkbmy2.jpg?plan=h160",
+    label: "あじろぎの道",
+    ep: "EP1",
+    cls: "fc-3",
+    rotate: "-1deg",
+  },
+  {
+    src: "https://image.anitabi.cn/points/160209/3ik9kj0e.jpg?plan=h160",
+    label: "信濃町歩道橋",
+    ep: "君の名は。",
+    cls: "fc-4",
+    rotate: "3deg",
+  },
+  {
+    src: "https://image.anitabi.cn/points/115908/7eyih3xg.jpg?plan=h160",
+    label: "莵道高",
+    ep: "EP1",
+    cls: "fc-5",
+    rotate: "-2deg",
+  },
+  {
+    src: "https://image.anitabi.cn/points/160209/3ik9kjew.jpg?plan=h160",
+    label: "LABI新宿東口館前",
+    ep: "君の名は。",
+    cls: "fc-6",
+    rotate: "1deg",
+  },
 ];
 
-const LOCALE_LABELS: Record<Locale, string> = { ja: "日本語", zh: "中文", en: "EN" };
+/* ── Anime gallery ── */
+const ANIME_GALLERY: {
+  bangumiId: string;
+  title: string;
+  count: string;
+}[] = [
+  { bangumiId: "115908", title: "響け！ユーフォニアム", count: "156 スポット · 宇治市" },
+  { bangumiId: "160209", title: "君の名は。", count: "89 スポット · 新宿/飛騨" },
+  { bangumiId: "269235", title: "天気の子", count: "72 スポット · 東京" },
+  { bangumiId: "485", title: "涼宮ハルヒの憂鬱", count: "134 スポット · 西宮市" },
+  { bangumiId: "1424", title: "けいおん！", count: "98 スポット · 京都/豊郷" },
+  { bangumiId: "362577", title: "すずめの戸締まり", count: "65 スポット · 九州〜東北" },
+  { bangumiId: "55113", title: "たまこまーけっと", count: "47 スポット · 出町柳" },
+  { bangumiId: "27364", title: "氷菓", count: "82 スポット · 高山市" },
+];
+
+/* ── Float card position styles ── */
+const FLOAT_CARD_STYLES: Record<string, React.CSSProperties> = {
+  "fc-1": { top: "18%", left: "8%", width: 140, height: 95 },
+  "fc-2": { top: "28%", right: "12%", width: 160, height: 108 },
+  "fc-3": { bottom: "30%", left: "6%", width: 130, height: 88 },
+  "fc-4": { bottom: "22%", right: "8%", width: 150, height: 100 },
+  "fc-5": { top: "50%", left: "18%", width: 120, height: 80 },
+  "fc-6": { top: "14%", left: "35%", width: 110, height: 75 },
+};
+
+const FLOAT_DELAYS: Record<string, string> = {
+  "fc-1": "0.2s",
+  "fc-2": "0.4s",
+  "fc-3": "0.6s",
+  "fc-4": "0.8s",
+  "fc-5": "1.0s",
+  "fc-6": "0.3s",
+};
 
 export default function AuthGate() {
   const dict = useDict();
   const t = dict.auth;
   const lh = dict.landing_hero;
+  const landing = lh.landing;
   const locale = useLocale();
-  const setLocale = useSetLocale();
   const authClient = getSupabaseClient();
   const authConfigured = !!authClient;
 
@@ -37,6 +109,7 @@ export default function AuthGate() {
   const [submitting, setSubmitting] = useState(false);
   const [sent, setSent] = useState(false);
   const [showAuthModal, setShowAuthModal] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const effectiveStatus = status ?? (!authConfigured ? t.not_configured : null);
 
   /* ── Scroll-reveal ── */
@@ -95,18 +168,10 @@ export default function AuthGate() {
     setSubmitting(false);
   }
 
-  /* ── Render hint text with safe HTML (only bold tags from static i18n) ── */
-  function renderHint(html: string): React.ReactNode {
-    // The hint strings contain only <strong> tags from our own dictionary files.
-    // Parse them safely instead of using dangerouslySetInnerHTML.
-    const parts = html.split(/(<strong>.*?<\/strong>)/g);
-    return parts.map((part, i) => {
-      const match = part.match(/^<strong>(.*)<\/strong>$/);
-      if (match) {
-        return <strong key={i} className="font-medium text-[var(--color-fg)]">{match[1]}</strong>;
-      }
-      return part;
-    });
+  function handleSearchSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    // On landing, search opens auth modal to transition to the app
+    setShowAuthModal(true);
   }
 
   /* ── Loading state ── */
@@ -123,7 +188,11 @@ export default function AuthGate() {
 
   /* ── Landing page ── */
   return (
-    <div className="min-h-screen overflow-x-hidden bg-[var(--color-bg)]" style={{ fontFamily: "var(--app-font-body)" }}>
+    <div
+      className="min-h-screen overflow-x-hidden bg-[var(--color-bg)]"
+      style={{ fontFamily: "var(--app-font-body)" }}
+      lang={locale}
+    >
 
       {/* ── Sticky Header ── */}
       <header
@@ -132,247 +201,335 @@ export default function AuthGate() {
           background: "color-mix(in oklch, var(--color-bg) 85%, transparent)",
           backdropFilter: "blur(16px)",
           borderColor: "color-mix(in oklch, var(--color-border) 30%, transparent)",
-          animation: "seichi-fade-up 0.6s ease-out",
+          animation: "seichi-fade-down 0.5s ease-out",
         }}
       >
-        <div style={{ fontFamily: "var(--app-font-display)", fontSize: 18, lineHeight: 1.2 }}>
+        <div
+          style={{
+            fontFamily: "var(--app-font-display)",
+            fontSize: 20,
+            fontWeight: 600,
+            letterSpacing: "0.03em",
+            lineHeight: 1.2,
+          }}
+        >
           聖地巡礼
-          <span className="block text-[10px] font-light tracking-[2.5px] text-[var(--color-muted-fg)]" style={{ fontFamily: "var(--app-font-body)" }}>
+          <span
+            className="block text-[10px] font-light tracking-[2.5px] text-[var(--color-muted-fg)]"
+            style={{ fontFamily: "var(--app-font-body)" }}
+          >
             seichijunrei
           </span>
         </div>
         <div className="flex items-center gap-2">
-          {/* Language switcher */}
-          <div className="flex gap-0.5 rounded-md border border-[var(--color-border)] bg-[var(--color-card)] p-0.5">
-            {LOCALES.map((l) => (
-              <button
-                key={l}
-                type="button"
-                onClick={() => setLocale(l)}
-                className="min-h-[44px] min-w-[44px] rounded px-2.5 py-1 text-xs font-medium transition-all"
-                style={{
-                  transitionDuration: "var(--duration-fast)",
-                  background: locale === l ? "var(--color-bg)" : "transparent",
-                  color: locale === l ? "var(--color-fg)" : "var(--color-muted-fg)",
-                  boxShadow: locale === l ? "0 1px 3px rgba(0,0,0,0.08)" : "none",
-                  fontFamily: "var(--app-font-body)",
-                }}
-              >
-                {LOCALE_LABELS[l]}
-              </button>
-            ))}
-          </div>
-          {/* Login link (hidden on mobile) */}
           <button
             type="button"
             onClick={() => setShowAuthModal(true)}
-            className="min-h-[44px] px-3 text-[13px] text-[var(--color-muted-fg)]"
+            className="min-h-[44px] rounded-md px-4 py-1.5 text-[13px] text-[var(--color-muted-fg)] transition-colors hover:bg-[var(--color-muted)]"
+            style={{ fontFamily: "var(--app-font-body)" }}
           >
-            {lh.login}
-          </button>
-          {/* Join beta CTA */}
-          <button
-            type="button"
-            onClick={() => setShowAuthModal(true)}
-            className="min-h-[44px] rounded-md bg-[var(--color-primary)] px-4 py-1.5 text-[13px] font-semibold text-[var(--color-primary-fg)]"
-          >
-            {lh.join_beta}
+            {landing.login}
           </button>
         </div>
       </header>
 
-      {/* ── Section 1: MAP HERO ── */}
-      <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden pt-[60px]">
-        {/* Radial gradient bg */}
+      {/* ── Section 1: HERO ── */}
+      <section
+        data-testid="hero-section"
+        className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden pt-[60px]"
+      >
+        {/* Radial gradient background */}
         <div
           className="pointer-events-none absolute inset-0"
-          style={{ background: "radial-gradient(ellipse 800px 800px at 50% 50%, oklch(94% 0.016 220), var(--color-bg))" }}
-        />
-        {/* Abstract Japan shape */}
-        <div
-          className="pointer-events-none absolute opacity-50"
           style={{
-            width: 200, height: 480, top: "48%", left: "50%",
-            transform: "translate(-50%, -50%) rotate(-15deg)",
-            background: "oklch(91% 0.022 218)",
-            borderRadius: "35% 65% 45% 55% / 55% 45% 55% 45%",
+            background:
+              "radial-gradient(ellipse 900px 900px at 50% 45%, oklch(93% 0.020 220), var(--color-bg))",
           }}
         />
 
-        {/* Pins */}
-        {PIN_POSITIONS.map((pin, i) => {
-          const pinLabel = pin.labelKey
-            ? (lh as Record<string, string>)[pin.labelKey] ?? ""
-            : "";
-          return (
-            <div key={i} className="group absolute z-[3]" style={{ top: pin.top, left: pin.left }}>
-              <div
-                className="h-2.5 w-2.5 cursor-pointer rounded-full bg-[var(--color-primary)]"
-                style={{ animation: `seichi-pin-pulse 2.5s ease-in-out infinite ${i % 2 === 0 ? "0s" : "0.8s"}` }}
-              />
-              {pinLabel && (
-                <div
-                  className="pointer-events-none absolute bottom-[18px] left-1/2 hidden -translate-x-1/2 translate-y-1 whitespace-nowrap rounded-lg bg-[var(--color-bg)] p-1 opacity-0 shadow-lg transition-all group-hover:translate-y-0 group-hover:opacity-100 sm:block"
-                  style={{ transitionDuration: "250ms" }}
-                >
-                  <div
-                    className="h-[60px] w-[88px] rounded-md"
-                    style={{ background: "var(--color-card)" }}
-                  />
-                  <div className="px-1 pb-0.5 pt-1 text-center text-[9px] font-medium text-[var(--color-muted-fg)]">
-                    {pinLabel}
-                  </div>
-                </div>
-              )}
-            </div>
-          );
-        })}
-
-        {/* Hero center content */}
-        <div className="relative z-[5] max-w-[540px] px-6 text-center">
-          <h1
-            className="font-[family-name:var(--app-font-display)] text-[clamp(52px,9vw,80px)] font-extrabold tracking-[0.04em] text-[var(--color-fg)]"
-            style={{ animation: "seichi-fade-up 0.8s ease-out" }}
-          >
-            聖地巡礼
-          </h1>
-          <p
-            className="mt-2.5 text-[17px] font-light leading-relaxed text-[var(--color-muted-fg)]"
-            style={{ animation: "seichi-fade-up 0.8s ease-out 0.1s backwards" }}
-          >
-            {lh.tagline}
-          </p>
-
-          {/* Chat input */}
-          <div
-            className="mt-7 flex overflow-hidden rounded-[10px] border border-[var(--color-border)] bg-[var(--color-bg)] shadow-[0_4px_20px_rgba(0,0,0,0.05)] transition-shadow focus-within:border-[var(--color-primary)] focus-within:shadow-[0_4px_24px_rgba(74,130,220,0.15)]"
-            style={{ animation: "seichi-fade-up 0.8s ease-out 0.2s backwards", transitionDuration: "300ms" }}
-          >
-            <input
-              type="text"
-              placeholder={lh.chat_placeholder}
-              onFocus={() => setShowAuthModal(true)}
-              className="min-h-[52px] flex-1 border-none bg-transparent px-5 text-[15px] text-[var(--color-fg)] outline-none placeholder:text-[var(--color-border)]"
-              style={{ fontFamily: "var(--app-font-body)" }}
-              readOnly
-            />
-            <button
-              type="button"
-              onClick={() => setShowAuthModal(true)}
-              className="min-h-[52px] min-w-[44px] bg-[var(--color-primary)] px-6 text-sm font-semibold text-[var(--color-primary-fg)] transition-opacity hover:opacity-90"
-              style={{ fontFamily: "var(--app-font-body)" }}
-            >
-              {lh.chat_submit}
-            </button>
-          </div>
-
-          {/* Search hint */}
-          <p
-            className="mt-3 text-xs text-[var(--color-muted-fg)]"
-            style={{ animation: "seichi-fade-up 0.8s ease-out 0.4s backwards" }}
-          >
-            {renderHint(lh.hint)}
-          </p>
-        </div>
-
-        {/* Stats row */}
+        {/* ── Floating photo cards ── */}
         <div
-          className="relative z-[5] mt-12 flex gap-6 sm:gap-11"
-          style={{ animation: "seichi-fade-up 0.8s ease-out 0.35s backwards" }}
+          data-testid="floating-cards"
+          className="pointer-events-none absolute inset-0 overflow-hidden"
         >
-          {([
-            ["2,400+", lh.stat_locations],
-            ["180+", lh.stat_anime],
-            ["47", lh.stat_prefectures],
-          ] as const).map(([num, label]) => (
-            <div key={num} className="text-center">
-              <div className="font-[family-name:var(--app-font-display)] text-[28px] font-bold text-[var(--color-primary)]">
-                {num}
+          {FLOAT_CARDS.map((card, i) => (
+            <div
+              key={card.cls}
+              className="absolute overflow-hidden rounded-xl"
+              style={{
+                ...FLOAT_CARD_STYLES[card.cls],
+                boxShadow: "0 8px 32px rgba(0,0,0,0.08)",
+                opacity: 0,
+                transform: `rotate(${card.rotate})`,
+                animation: `seichi-float-in 0.8s ease-out ${FLOAT_DELAYS[card.cls]} forwards`,
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={card.src}
+                alt={card.label}
+                width={160}
+                height={108}
+                loading="lazy"
+                className="h-full w-full object-cover"
+                onError={(e) => {
+                  const target = e.currentTarget;
+                  target.style.display = "none";
+                  const parent = target.parentElement;
+                  if (parent) {
+                    parent.style.background =
+                      "linear-gradient(135deg, oklch(88% 0.04 240), oklch(82% 0.06 260))";
+                  }
+                }}
+              />
+              <div
+                className="absolute inset-x-0 bottom-0 px-2.5 py-1.5 text-[10px] font-medium text-white"
+                style={{
+                  background: "linear-gradient(transparent, rgba(0,0,0,0.6))",
+                  letterSpacing: "0.3px",
+                }}
+              >
+                {card.label}
+                <span className="ml-1 opacity-70" style={{ fontSize: 9 }}>
+                  {card.ep}
+                </span>
               </div>
-              <div className="mt-0.5 text-[11px] text-[var(--color-muted-fg)]">{label}</div>
             </div>
           ))}
         </div>
 
-        {/* Scroll cue */}
+        {/* ── Hero center content ── */}
+        <div className="relative z-[5] max-w-[560px] px-6 text-center">
+          <h1
+            className="font-[family-name:var(--app-font-display)] text-[clamp(56px,10vw,88px)] font-extrabold tracking-[0.04em] leading-[1.1] text-[var(--color-fg)]"
+            style={{ animation: "seichi-fade-up 0.8s ease-out" }}
+          >
+            {landing.hero_title}
+          </h1>
+          <p
+            className="mt-3 text-[18px] font-light leading-relaxed text-[var(--color-muted-fg)]"
+            style={{ animation: "seichi-fade-up 0.8s ease-out 0.1s backwards" }}
+          >
+            {landing.hero_subtitle}
+          </p>
+
+          {/* Search bar */}
+          <form
+            onSubmit={handleSearchSubmit}
+            className="mt-8 flex overflow-hidden rounded-[12px] border border-[var(--color-border)] bg-white shadow-[0_4px_24px_rgba(0,0,0,0.05)] transition-shadow focus-within:border-[var(--color-primary)] focus-within:shadow-[0_4px_28px_rgba(74,130,220,0.15)]"
+            style={{
+              animation: "seichi-fade-up 0.8s ease-out 0.2s backwards",
+              transitionDuration: "300ms",
+            }}
+          >
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={landing.search_placeholder}
+              className="min-h-[52px] flex-1 border-none bg-transparent px-5 text-[15px] text-[var(--color-fg)] outline-none placeholder:text-[var(--color-border)]"
+              style={{ fontFamily: "var(--app-font-body)" }}
+            />
+            <button
+              type="submit"
+              className="min-h-[52px] min-w-[44px] bg-[var(--color-primary)] px-6 text-[14px] font-semibold text-[var(--color-primary-fg)] transition-opacity hover:opacity-90"
+              style={{ fontFamily: "var(--app-font-body)" }}
+            >
+              検索
+            </button>
+          </form>
+        </div>
+
+        {/* ── Stats ── */}
+        <div
+          className="relative z-[5] mt-12 flex gap-12 sm:gap-12"
+          style={{ animation: "seichi-fade-up 0.8s ease-out 0.4s backwards" }}
+        >
+          {(
+            [
+              ["2,400+", landing.stats_spots],
+              ["180+", landing.stats_anime],
+              ["47", landing.stats_prefectures],
+            ] as const
+          ).map(([num, label]) => (
+            <div key={num} className="text-center">
+              <div
+                className="font-[family-name:var(--app-font-display)] text-[32px] font-semibold text-[var(--color-primary)]"
+              >
+                {num}
+              </div>
+              <div className="mt-0.5 text-[11px] text-[var(--color-muted-fg)]">
+                {label}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* ── Scroll cue ── */}
         <div
           className="absolute bottom-7 z-[5] flex flex-col items-center gap-1 text-[11px] text-[var(--color-muted-fg)]"
           style={{ animation: "seichi-fade-up 1s ease-out 0.8s backwards" }}
         >
-          <span>{lh.scroll_hint}</span>
-          <span className="text-base" style={{ animation: "float-arrow 2.5s ease-in-out infinite" }}>↓</span>
+          <span>{landing.scroll_hint}</span>
+          <span
+            className="text-base"
+            style={{ animation: "seichi-bounce 2.5s ease-in-out infinite" }}
+          >
+            ↓
+          </span>
         </div>
       </section>
 
-      {/* ── Section 2: Comparison ── */}
-      <section className="mx-auto max-w-[920px] px-5 py-12 sm:px-8 sm:py-20">
+      {/* ── Section 2: 3-step How It Works ── */}
+      <section
+        data-testid="steps-section"
+        className="mx-auto max-w-[960px] px-5 py-[80px] sm:px-8"
+      >
         <h2
           ref={addRevealRef}
           className="seichi-reveal font-[family-name:var(--app-font-display)] text-center text-[28px]"
         >
-          {lh.comparison_title}
+          {landing.steps_title}
         </h2>
         <p
           ref={addRevealRef}
-          className="seichi-reveal mb-10 mt-1.5 text-center text-sm text-[var(--color-muted-fg)]"
+          className="seichi-reveal mb-12 mt-2 text-center text-sm text-[var(--color-muted-fg)]"
         >
-          {lh.comparison_sub}
+          {landing.steps_sub}
         </p>
-        <div className="grid grid-cols-1 gap-2.5 overflow-hidden rounded-[10px] sm:grid-cols-2">
-          <div
-            ref={addRevealRef}
-            className="seichi-reveal-left relative aspect-[16/10] overflow-hidden rounded-md bg-[var(--color-card)]"
-          >
-            <div className="flex h-full w-full items-center justify-center text-sm text-[var(--color-muted-fg)]">
-              ANIME
+
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-3">
+          {(
+            [
+              {
+                num: "1",
+                title: landing.step1_title,
+                desc: landing.step1_desc,
+              },
+              {
+                num: "2",
+                title: landing.step2_title,
+                desc: landing.step2_desc,
+              },
+              {
+                num: "3",
+                title: landing.step3_title,
+                desc: landing.step3_desc,
+              },
+            ] as const
+          ).map((step, i) => (
+            <div
+              key={step.num}
+              ref={addRevealRef}
+              className="seichi-reveal-pop rounded-xl border border-[var(--color-border)] bg-white p-[28px_24px] transition-transform hover:-translate-y-0.5 hover:shadow-[0_8px_24px_rgba(0,0,0,0.06)]"
+              style={{ animationDelay: `${i * 0.1}s` }}
+            >
+              <div
+                className="mb-3.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--color-primary)] text-[13px] font-semibold text-white"
+              >
+                {step.num}
+              </div>
+              <h3
+                className="font-[family-name:var(--app-font-display)] text-[16px]"
+              >
+                {step.title}
+              </h3>
+              <p className="mt-2 text-[13px] leading-relaxed text-[var(--color-muted-fg)]">
+                {step.desc}
+              </p>
             </div>
-            <div className="absolute bottom-2.5 left-2.5 rounded bg-black/50 px-3 py-0.5 text-[9px] font-semibold uppercase tracking-[2px] text-white backdrop-blur-sm">
-              ANIME
-            </div>
-          </div>
-          <div
-            ref={addRevealRef}
-            className="seichi-reveal-right relative aspect-[16/10] overflow-hidden rounded-md bg-[var(--color-card)]"
-          >
-            <div className="flex h-full w-full items-center justify-center text-sm text-[var(--color-muted-fg)]">
-              REALITY
-            </div>
-            <div className="absolute bottom-2.5 left-2.5 rounded bg-black/50 px-3 py-0.5 text-[9px] font-semibold uppercase tracking-[2px] text-white backdrop-blur-sm">
-              REALITY
-            </div>
-          </div>
+          ))}
         </div>
       </section>
 
-      {/* ── Section 3: Features ── */}
-      <section className="mx-auto grid max-w-[800px] grid-cols-1 gap-4 px-5 py-10 sm:grid-cols-3 sm:px-8 sm:py-[60px]">
-        {([
-          [lh.feat_search, lh.feat_search_desc],
-          [lh.feat_route, lh.feat_route_desc],
-          [lh.feat_series, lh.feat_series_desc],
-        ] as const).map(([title, desc], i) => (
-          <div
-            key={i}
-            ref={addRevealRef}
-            className="seichi-reveal-pop rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-[22px_18px] transition-transform hover:-translate-y-0.5 hover:shadow-[0_4px_12px_rgba(0,0,0,0.04)]"
-            style={{ animationDelay: `${i * 0.08}s` }}
-          >
-            <h3 className="font-[family-name:var(--app-font-display)] text-[15px]">{title}</h3>
-            <p className="mt-1.5 text-xs leading-relaxed text-[var(--color-muted-fg)]">{desc}</p>
-          </div>
-        ))}
+      {/* ── Section 3: Anime Gallery ── */}
+      <section
+        data-testid="gallery-section"
+        className="mx-auto max-w-[960px] px-5 pb-[80px] sm:px-8"
+      >
+        <h2
+          ref={addRevealRef}
+          className="seichi-reveal font-[family-name:var(--app-font-display)] text-center text-[28px]"
+        >
+          {landing.gallery_title}
+        </h2>
+        <p
+          ref={addRevealRef}
+          className="seichi-reveal mb-12 mt-2 text-center text-sm text-[var(--color-muted-fg)]"
+        >
+          {landing.gallery_sub}
+        </p>
+
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {ANIME_GALLERY.map((anime, i) => (
+            <div
+              key={anime.bangumiId}
+              ref={addRevealRef}
+              className="seichi-reveal-pop anime-card group relative cursor-pointer overflow-hidden rounded-[10px]"
+              style={{
+                aspectRatio: "3/2",
+                animationDelay: `${i * 0.05}s`,
+              }}
+              onClick={() => setShowAuthModal(true)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") setShowAuthModal(true);
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={`https://image.anitabi.cn/bangumi/${anime.bangumiId}.jpg?plan=h160`}
+                alt={anime.title}
+                width={240}
+                height={160}
+                loading="lazy"
+                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                onError={(e) => {
+                  const target = e.currentTarget;
+                  target.style.display = "none";
+                  const parent = target.parentElement;
+                  if (parent) {
+                    parent.style.background =
+                      "linear-gradient(135deg, oklch(88% 0.04 240), oklch(82% 0.06 260))";
+                  }
+                }}
+              />
+              <div
+                className="absolute inset-0 flex flex-col justify-end p-3"
+                style={{
+                  background:
+                    "linear-gradient(transparent 40%, rgba(0,0,0,0.65))",
+                }}
+              >
+                <div
+                  className="font-[family-name:var(--app-font-display)] text-[13px] font-semibold text-white"
+                >
+                  {anime.title}
+                </div>
+                <div className="mt-0.5 text-[10px] text-white/70">
+                  {anime.count}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
       </section>
 
       {/* ── Footer ── */}
       <footer className="border-t border-[var(--color-border)] py-7 text-center text-[11px] text-[var(--color-muted-fg)]">
-        <span style={{ fontFamily: "var(--app-font-display)" }}>聖地巡礼</span> · seichijunrei
+        <span style={{ fontFamily: "var(--app-font-display)" }}>聖地巡礼</span>{" "}
+        · seichijunrei
       </footer>
 
       {/* ── Auth Modal (overlay) ── */}
       {showAuthModal && (
         <div
+          data-testid="auth-modal"
           className="fixed inset-0 z-[100] flex items-center justify-center bg-black/30 backdrop-blur-sm"
-          onClick={(e) => { if (e.target === e.currentTarget) setShowAuthModal(false); }}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setShowAuthModal(false);
+          }}
         >
           <div
             className="relative mx-4 w-full max-w-[420px] rounded-xl bg-[var(--color-bg)] p-8 shadow-2xl"
@@ -400,11 +557,18 @@ export default function AuthGate() {
             {/* Form or success card */}
             {sent ? (
               <div className="space-y-4">
-                <p className="text-sm font-medium text-[var(--color-fg)]">{t.check_email_heading}</p>
-                <p className="text-xs leading-relaxed text-[var(--color-muted-fg)]">{t.check_email_body}</p>
+                <p className="text-sm font-medium text-[var(--color-fg)]">
+                  {t.check_email_heading}
+                </p>
+                <p className="text-xs leading-relaxed text-[var(--color-muted-fg)]">
+                  {t.check_email_body}
+                </p>
                 <button
                   type="button"
-                  onClick={() => { setSent(false); setStatus(null); }}
+                  onClick={() => {
+                    setSent(false);
+                    setStatus(null);
+                  }}
                   className="min-h-[44px] text-xs underline text-[var(--color-muted-fg)]"
                 >
                   {t.back_to_login}
@@ -414,7 +578,10 @@ export default function AuthGate() {
               <>
                 <form onSubmit={handleLogin} className="space-y-4">
                   <div className="space-y-1.5">
-                    <label htmlFor="auth-email" className="text-xs font-medium text-[var(--color-muted-fg)]">
+                    <label
+                      htmlFor="auth-email"
+                      className="text-xs font-medium text-[var(--color-muted-fg)]"
+                    >
                       {t.email_label}
                     </label>
                     <input
@@ -449,15 +616,45 @@ export default function AuthGate() {
         </div>
       )}
 
-      {/* ── Reveal animation styles ── */}
+      {/* ── Animation styles ── */}
       <style>{`
-        .seichi-reveal, .seichi-reveal-left, .seichi-reveal-right, .seichi-reveal-pop { opacity: 0; }
-        .seichi-reveal.seichi-visible { animation: seichi-fade-up 0.65s ease-out forwards; }
-        .seichi-reveal-left.seichi-visible { animation: slide-in-left 0.65s ease-out forwards; }
-        .seichi-reveal-right.seichi-visible { animation: slide-in-right 0.65s ease-out forwards; }
-        .seichi-reveal-pop.seichi-visible { animation: pop-in 0.5s ease-out forwards; }
+        @keyframes seichi-fade-up {
+          from { opacity: 0; transform: translateY(16px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes seichi-fade-down {
+          from { opacity: 0; transform: translateY(-8px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes seichi-float-in {
+          from { opacity: 0; transform: translateY(20px) scale(0.95); }
+          to   { opacity: 0.85; transform: translateY(0) scale(1); }
+        }
+        @keyframes seichi-bounce {
+          0%, 100% { transform: translateY(0); }
+          50%       { transform: translateY(6px); }
+        }
+
+        .seichi-reveal,
+        .seichi-reveal-pop { opacity: 0; }
+        .seichi-reveal.seichi-visible {
+          animation: seichi-fade-up 0.65s ease-out forwards;
+        }
+        .seichi-reveal-pop.seichi-visible {
+          animation: seichi-pop-in 0.5s ease-out forwards;
+        }
+        @keyframes seichi-pop-in {
+          from { opacity: 0; transform: scale(0.95) translateY(8px); }
+          to   { opacity: 1; transform: scale(1) translateY(0); }
+        }
+
         @media (prefers-reduced-motion: reduce) {
-          .seichi-reveal, .seichi-reveal-left, .seichi-reveal-right, .seichi-reveal-pop { opacity: 1; }
+          .seichi-reveal,
+          .seichi-reveal-pop { opacity: 1; }
+        }
+
+        @media (max-width: 768px) {
+          [data-testid="floating-cards"] > div:nth-child(n+3) { display: none; }
         }
       `}</style>
     </div>

--- a/frontend/components/auth/AuthGate.tsx
+++ b/frontend/components/auth/AuthGate.tsx
@@ -316,7 +316,7 @@ export default function AuthGate() {
           {/* Search bar */}
           <form
             onSubmit={handleSearchSubmit}
-            className="mt-8 flex overflow-hidden rounded-[12px] border border-[var(--color-border)] bg-white shadow-[0_4px_24px_rgba(0,0,0,0.05)] transition-shadow focus-within:border-[var(--color-primary)] focus-within:shadow-[0_4px_28px_rgba(74,130,220,0.15)]"
+            className="mt-8 flex overflow-hidden rounded-[12px] border border-[var(--color-border)] bg-[var(--color-bg)] shadow-[0_4px_24px_rgba(0,0,0,0.05)] transition-shadow focus-within:border-[var(--color-primary)] focus-within:shadow-[0_4px_28px_rgba(74,130,220,0.15)]"
             style={{
               animation: "seichi-fade-up 0.8s ease-out 0.2s backwards",
               transitionDuration: "300ms",
@@ -335,7 +335,7 @@ export default function AuthGate() {
               className="min-h-[52px] min-w-[44px] bg-[var(--color-primary)] px-6 text-[14px] font-semibold text-[var(--color-primary-fg)] transition-opacity hover:opacity-90"
               style={{ fontFamily: "var(--app-font-body)" }}
             >
-              検索
+              {landing.search_button}
             </button>
           </form>
         </div>
@@ -421,7 +421,7 @@ export default function AuthGate() {
             <div
               key={step.num}
               ref={addRevealRef}
-              className="seichi-reveal-pop rounded-xl border border-[var(--color-border)] bg-white p-[28px_24px] transition-transform hover:-translate-y-0.5 hover:shadow-[0_8px_24px_rgba(0,0,0,0.06)]"
+              className="seichi-reveal-pop rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] p-[28px_24px] transition-transform hover:-translate-y-0.5 hover:shadow-[0_8px_24px_rgba(0,0,0,0.06)]"
               style={{ animationDelay: `${i * 0.1}s` }}
             >
               <div

--- a/frontend/lib/dictionaries/en.json
+++ b/frontend/lib/dictionaries/en.json
@@ -53,7 +53,8 @@
       "steps_title": "3 steps to start your pilgrimage",
       "steps_sub": "Just enter an anime title — we handle the rest.",
       "scroll_hint": "Scroll down",
-      "login": "Log in"
+      "login": "Log in",
+      "search_button": "Search"
     }
   },
   "auth": {

--- a/frontend/lib/dictionaries/en.json
+++ b/frontend/lib/dictionaries/en.json
@@ -32,10 +32,29 @@
     "feat_series": "By Series",
     "feat_series_desc": "Browse locations organized by anime.",
     "login": "Log in",
-    "join_beta": "Join beta",
     "pin_yourname": "Your Name · Shinjuku",
     "pin_euphonium": "Euphonium · Uji",
-    "pin_violet": "Violet Evergarden · Kyoto"
+    "pin_violet": "Violet Evergarden · Kyoto",
+    "landing": {
+      "hero_title": "聖地巡礼",
+      "hero_subtitle": "Find anime filming locations and plan your pilgrimage route",
+      "search_placeholder": "Search anime pilgrimage spots...",
+      "stats_spots": "spots",
+      "stats_anime": "anime",
+      "stats_prefectures": "prefectures",
+      "step1_title": "Search by anime",
+      "step1_desc": "Find pilgrimage spots by anime title",
+      "step2_title": "Discover spots",
+      "step2_desc": "Confirm real locations on the map",
+      "step3_title": "Plan your route",
+      "step3_desc": "Auto-generate the optimal pilgrimage route",
+      "gallery_title": "Popular anime",
+      "gallery_sub": "From classics to new releases",
+      "steps_title": "3 steps to start your pilgrimage",
+      "steps_sub": "Just enter an anime title — we handle the rest.",
+      "scroll_hint": "Scroll down",
+      "login": "Log in"
+    }
   },
   "auth": {
     "title": "Seichijunrei",

--- a/frontend/lib/dictionaries/ja.json
+++ b/frontend/lib/dictionaries/ja.json
@@ -53,7 +53,8 @@
       "steps_title": "3ステップで巡礼",
       "steps_sub": "作品名を入力するだけ。あとは全部おまかせ。",
       "scroll_hint": "下にスクロール",
-      "login": "ログイン"
+      "login": "ログイン",
+      "search_button": "検索"
     }
   },
   "auth": {

--- a/frontend/lib/dictionaries/ja.json
+++ b/frontend/lib/dictionaries/ja.json
@@ -32,10 +32,29 @@
     "feat_series": "作品別",
     "feat_series_desc": "作品ごとに聖地を一覧。",
     "login": "ログイン",
-    "join_beta": "ベータ参加",
     "pin_yourname": "君の名は · 新宿",
     "pin_euphonium": "響け · 宇治",
-    "pin_violet": "ヴァイオレット · 京都"
+    "pin_violet": "ヴァイオレット · 京都",
+    "landing": {
+      "hero_title": "聖地巡礼",
+      "hero_subtitle": "アニメの舞台を探して、巡礼ルートを作ろう",
+      "search_placeholder": "アニメの聖地を探す...",
+      "stats_spots": "スポット",
+      "stats_anime": "作品",
+      "stats_prefectures": "都道府県",
+      "step1_title": "作品で検索",
+      "step1_desc": "アニメのタイトルから聖地を検索",
+      "step2_title": "スポットを発見",
+      "step2_desc": "実際の場所を地図で確認",
+      "step3_title": "ルートを計画",
+      "step3_desc": "最適な巡礼ルートを自動生成",
+      "gallery_title": "人気作品",
+      "gallery_sub": "聖地巡礼の定番から最新作まで",
+      "steps_title": "3ステップで巡礼",
+      "steps_sub": "作品名を入力するだけ。あとは全部おまかせ。",
+      "scroll_hint": "下にスクロール",
+      "login": "ログイン"
+    }
   },
   "auth": {
     "title": "聖地巡礼",

--- a/frontend/lib/dictionaries/zh.json
+++ b/frontend/lib/dictionaries/zh.json
@@ -53,7 +53,8 @@
       "steps_title": "三步开始巡礼",
       "steps_sub": "输入作品名，其余交给我们。",
       "scroll_hint": "向下滚动",
-      "login": "登录"
+      "login": "登录",
+      "search_button": "搜索"
     }
   },
   "auth": {

--- a/frontend/lib/dictionaries/zh.json
+++ b/frontend/lib/dictionaries/zh.json
@@ -32,10 +32,29 @@
     "feat_series": "按作品浏览",
     "feat_series_desc": "按动漫作品浏览所有取景地。",
     "login": "登录",
-    "join_beta": "加入测试",
     "pin_yourname": "你的名字 · 新宿",
     "pin_euphonium": "吹响上低音号 · 宇治",
-    "pin_violet": "紫罗兰永恒花园 · 京都"
+    "pin_violet": "紫罗兰永恒花园 · 京都",
+    "landing": {
+      "hero_title": "聖地巡礼",
+      "hero_subtitle": "探索动漫圣地，踏上巡礼之旅",
+      "search_placeholder": "搜索动漫圣地...",
+      "stats_spots": "取景地",
+      "stats_anime": "动漫",
+      "stats_prefectures": "都道府县",
+      "step1_title": "搜索作品",
+      "step1_desc": "通过动漫名称搜索取景地",
+      "step2_title": "发现景点",
+      "step2_desc": "在地图上确认实际位置",
+      "step3_title": "规划路线",
+      "step3_desc": "自动生成最优巡礼路线",
+      "gallery_title": "热门作品",
+      "gallery_sub": "从经典到最新，圣地巡礼必选",
+      "steps_title": "三步开始巡礼",
+      "steps_sub": "输入作品名，其余交给我们。",
+      "scroll_hint": "向下滚动",
+      "login": "登录"
+    }
   },
   "auth": {
     "title": "圣地巡礼",

--- a/frontend/tests/AuthGate-landing.test.tsx
+++ b/frontend/tests/AuthGate-landing.test.tsx
@@ -1,0 +1,298 @@
+/**
+ * Unit tests for AuthGate landing page rewrite (Card W3-1)
+ *
+ * AC: Landing hero text, stats labels, 3-step labels render in all 3 locales -> unit
+ * AC: No session / first visit — landing renders with all sections visible -> unit (jsdom)
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Dict } from "@/lib/i18n";
+import jaDict from "@/lib/dictionaries/ja.json";
+import zhDict from "@/lib/dictionaries/zh.json";
+import enDict from "@/lib/dictionaries/en.json";
+
+const jaFull = jaDict as unknown as Dict;
+const zhFull = zhDict as unknown as Dict;
+const enFull = enDict as unknown as Dict;
+
+// AuthGate uses useDict, useLocale, useSetLocale, getSupabaseClient
+// We mock the i18n context and supabase so we can test the landing page
+// without auth state loading.
+vi.mock("@/lib/i18n-context", () => ({
+  useDict: vi.fn(),
+  useLocale: vi.fn(() => "ja"),
+  useSetLocale: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseClient: vi.fn(() => null),
+}));
+
+// AppShell is rendered when session exists — we never reach it in these tests
+vi.mock("@/components/layout/AppShell", () => ({
+  default: () => <div data-testid="app-shell" />,
+}));
+
+import { useDict } from "@/lib/i18n-context";
+import AuthGate from "@/components/auth/AuthGate";
+
+function renderLanding(dict: Dict = jaFull) {
+  vi.mocked(useDict).mockReturnValue(dict);
+  return render(<AuthGate />);
+}
+
+// ── Locale: Japanese ──────────────────────────────────────────────────────────
+
+describe("AuthGate landing — Japanese (ja)", () => {
+  it("renders the hero title", () => {
+    renderLanding(jaFull);
+    // The large 聖地巡礼 h1 is present
+    const headings = screen.getAllByText("聖地巡礼");
+    expect(headings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders hero subtitle", () => {
+    renderLanding(jaFull);
+    expect(
+      screen.getByText("アニメの舞台を探して、巡礼ルートを作ろう"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders search input with correct placeholder", () => {
+    renderLanding(jaFull);
+    const input = screen.getByPlaceholderText("アニメの聖地を探す...");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("renders spot count stat label", () => {
+    renderLanding(jaFull);
+    expect(screen.getByText("スポット")).toBeInTheDocument();
+  });
+
+  it("renders anime count stat label", () => {
+    renderLanding(jaFull);
+    // "作品" appears as stat label
+    const elements = screen.getAllByText("作品");
+    expect(elements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders prefecture stat label", () => {
+    renderLanding(jaFull);
+    expect(screen.getByText("都道府県")).toBeInTheDocument();
+  });
+
+  it("renders stat numbers 2,400+ and 180+ and 47", () => {
+    renderLanding(jaFull);
+    expect(screen.getByText("2,400+")).toBeInTheDocument();
+    expect(screen.getByText("180+")).toBeInTheDocument();
+    expect(screen.getByText("47")).toBeInTheDocument();
+  });
+
+  it("renders step 1 title", () => {
+    renderLanding(jaFull);
+    expect(screen.getByText("作品で検索")).toBeInTheDocument();
+  });
+
+  it("renders step 2 title", () => {
+    renderLanding(jaFull);
+    expect(screen.getByText("スポットを発見")).toBeInTheDocument();
+  });
+
+  it("renders step 3 title", () => {
+    renderLanding(jaFull);
+    expect(screen.getByText("ルートを計画")).toBeInTheDocument();
+  });
+
+  it("renders step 1 description", () => {
+    renderLanding(jaFull);
+    expect(
+      screen.getByText("アニメのタイトルから聖地を検索"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders step 2 description", () => {
+    renderLanding(jaFull);
+    expect(screen.getByText("実際の場所を地図で確認")).toBeInTheDocument();
+  });
+
+  it("renders step 3 description", () => {
+    renderLanding(jaFull);
+    expect(
+      screen.getByText("最適な巡礼ルートを自動生成"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render join_beta button", () => {
+    renderLanding(jaFull);
+    expect(screen.queryByText("ベータ参加")).not.toBeInTheDocument();
+  });
+
+  it("does not render language switcher buttons", () => {
+    renderLanding(jaFull);
+    // The old switcher had explicit locale labels as buttons
+    expect(screen.queryByText("日本語")).not.toBeInTheDocument();
+    expect(screen.queryByText("中文")).not.toBeInTheDocument();
+  });
+
+  it("renders login button that opens auth modal", () => {
+    renderLanding(jaFull);
+    // There should be a login button (not join_beta)
+    const loginBtn = screen.getByText("ログイン");
+    expect(loginBtn).toBeInTheDocument();
+  });
+});
+
+// ── Locale: Chinese ──────────────────────────────────────────────────────────
+
+describe("AuthGate landing — Chinese (zh)", () => {
+  it("renders hero subtitle in Chinese", () => {
+    renderLanding(zhFull);
+    expect(
+      screen.getByText("探索动漫圣地，踏上巡礼之旅"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders search placeholder in Chinese", () => {
+    renderLanding(zhFull);
+    const input = screen.getByPlaceholderText("搜索动漫圣地...");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("renders spot stat label in Chinese", () => {
+    renderLanding(zhFull);
+    expect(screen.getByText("取景地")).toBeInTheDocument();
+  });
+
+  it("renders step 1 title in Chinese", () => {
+    renderLanding(zhFull);
+    expect(screen.getByText("搜索作品")).toBeInTheDocument();
+  });
+
+  it("renders step 2 title in Chinese", () => {
+    renderLanding(zhFull);
+    expect(screen.getByText("发现景点")).toBeInTheDocument();
+  });
+
+  it("renders step 3 title in Chinese", () => {
+    renderLanding(zhFull);
+    expect(screen.getByText("规划路线")).toBeInTheDocument();
+  });
+
+  it("does not render join_beta in Chinese", () => {
+    renderLanding(zhFull);
+    expect(screen.queryByText("加入测试")).not.toBeInTheDocument();
+  });
+});
+
+// ── Locale: English ──────────────────────────────────────────────────────────
+
+describe("AuthGate landing — English (en)", () => {
+  it("renders hero subtitle in English", () => {
+    renderLanding(enFull);
+    expect(
+      screen.getByText(
+        "Find anime filming locations and plan your pilgrimage route",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders search placeholder in English", () => {
+    renderLanding(enFull);
+    const input = screen.getByPlaceholderText(
+      "Search anime pilgrimage spots...",
+    );
+    expect(input).toBeInTheDocument();
+  });
+
+  it("renders spot stat label in English", () => {
+    renderLanding(enFull);
+    expect(screen.getByText("spots")).toBeInTheDocument();
+  });
+
+  it("renders step 1 title in English", () => {
+    renderLanding(enFull);
+    expect(screen.getByText("Search by anime")).toBeInTheDocument();
+  });
+
+  it("renders step 2 title in English", () => {
+    renderLanding(enFull);
+    expect(screen.getByText("Discover spots")).toBeInTheDocument();
+  });
+
+  it("renders step 3 title in English", () => {
+    renderLanding(enFull);
+    expect(screen.getByText("Plan your route")).toBeInTheDocument();
+  });
+
+  it("does not render join_beta in English", () => {
+    renderLanding(enFull);
+    expect(screen.queryByText("Join beta")).not.toBeInTheDocument();
+  });
+
+  it("renders login button in English", () => {
+    renderLanding(enFull);
+    expect(screen.getByText("Log in")).toBeInTheDocument();
+  });
+});
+
+// ── Structural / session-independent ─────────────────────────────────────────
+
+describe("AuthGate landing — structure", () => {
+  it("renders all three step number badges", () => {
+    renderLanding(jaFull);
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders footer with brand name", () => {
+    renderLanding(jaFull);
+    // Footer contains 聖地巡礼 — could be multiple instances but at least one
+    const all = screen.getAllByText("聖地巡礼");
+    expect(all.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("floating photo cards section is present in DOM", () => {
+    const { container } = renderLanding(jaFull);
+    // The floating cards container has a specific test id or aria role
+    const floatingSection = container.querySelector(
+      "[data-testid='floating-cards']",
+    );
+    expect(floatingSection).not.toBeNull();
+  });
+
+  it("hero section is present", () => {
+    const { container } = renderLanding(jaFull);
+    const hero = container.querySelector("[data-testid='hero-section']");
+    expect(hero).not.toBeNull();
+  });
+
+  it("steps section is present", () => {
+    const { container } = renderLanding(jaFull);
+    const steps = container.querySelector("[data-testid='steps-section']");
+    expect(steps).not.toBeNull();
+  });
+
+  it("gallery section is present", () => {
+    const { container } = renderLanding(jaFull);
+    const gallery = container.querySelector("[data-testid='gallery-section']");
+    expect(gallery).not.toBeNull();
+  });
+
+  it("search input is present and has type text", () => {
+    renderLanding(jaFull);
+    const input = screen.getByPlaceholderText("アニメの聖地を探す...");
+    expect(input.tagName).toBe("INPUT");
+  });
+
+  it("auth modal is hidden on initial render", () => {
+    const { container } = renderLanding(jaFull);
+    const modal = container.querySelector("[data-testid='auth-modal']");
+    // Modal either not in DOM or not visible initially
+    if (modal) {
+      expect(modal).not.toBeVisible();
+    } else {
+      expect(modal).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Landing hero with floating Anitabi photo cards (CSS animated, CDN fallback)
- Centered search input (submits to auth modal)
- Stats row: 2400+ spots, 180+ anime, 47 prefectures
- 3-step explanation section
- Anime gallery section
- Removed "Join beta" button and language switcher
- 35 unit tests (TDD, all 3 locales)

## Card
W3-1 from journey redesign iteration.

## Test plan
- [x] Hero text renders in ja/zh/en
- [x] Stats labels in all locales
- [x] 3-step labels in all locales
- [x] No "join_beta" text
- [x] No language switcher buttons
- [x] data-testid attributes present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real search form on the landing page
  * Floating photo cards and an anime gallery

* **Improvements**
  * Image fallback handling for cards and gallery
  * Keyboard accessibility for gallery items and updated animations/responsiveness

* **Localization**
  * Updated landing-page copy for English, Japanese, and Chinese (restructured landing text)

* **Tests**
  * Added landing-page tests covering rendering across locales and initial UI state
<!-- end of auto-generated comment: release notes by coderabbit.ai -->