### PR TITLE
refactor(interfaces): fix long parameter list in session_facade — introduce SessionUpdate (#142)

### DIFF
--- a/backend/interfaces/public_api.py
+++ b/backend/interfaces/public_api.py
@@ -38,6 +38,7 @@ from backend.interfaces.schemas import (
 from backend.interfaces.session_facade import (
     COMPACT_THRESHOLD,
     MAX_ROUTE_HISTORY,
+    SessionUpdate,
     build_context_block,
     build_selected_points_plan,
     build_session_summary,
@@ -264,12 +265,14 @@ class RuntimeAPI:
         """Persist session state, route, user state, and messages."""
         session_state = build_updated_session_state(
             previous_state,
-            request=request,
-            response_intent=response.intent,
-            response_status=response.status,
-            response_success=response.success,
-            response_message=response.message,
-            context_delta=context_delta,
+            SessionUpdate(
+                request=request,
+                response_intent=response.intent,
+                response_status=response.status,
+                response_success=response.success,
+                response_message=response.message,
+                context_delta=context_delta,
+            ),
         )
 
         route_record = None

--- a/backend/interfaces/session_facade.py
+++ b/backend/interfaces/session_facade.py
@@ -6,6 +6,7 @@ compaction, title generation, and selected-point plan construction.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 import structlog
@@ -22,6 +23,18 @@ COMPACT_THRESHOLD = 8
 COMPACT_KEEP_RECENT = 2
 MAX_INTERACTIONS = 20
 MAX_ROUTE_HISTORY = 10
+
+
+@dataclass(frozen=True)
+class SessionUpdate:
+    """Bundles all response fields needed to update session state."""
+
+    request: PublicAPIRequest
+    response_intent: str
+    response_status: str
+    response_success: bool
+    response_message: str = field(default="")
+    context_delta: dict[str, object] | None = field(default=None)
 
 
 def normalize_session_state(state: dict[str, object] | None) -> dict[str, object]:
@@ -54,25 +67,19 @@ def normalize_session_state(state: dict[str, object] | None) -> dict[str, object
 
 def build_updated_session_state(
     previous_state: dict[str, object],
-    *,
-    request: PublicAPIRequest,
-    response_intent: str,
-    response_status: str,
-    response_success: bool,
-    response_message: str = "",
-    context_delta: dict[str, object] | None = None,
+    update: SessionUpdate,
 ) -> dict[str, object]:
     """Append the current interaction and return the updated session state."""
     raw = previous_state["interactions"]
     interactions = list(raw) if isinstance(raw, list) else []
     interactions.append(
         {
-            "text": request.text,
-            "intent": response_intent,
-            "status": response_status,
-            "success": response_success,
+            "text": update.request.text,
+            "intent": update.response_intent,
+            "status": update.response_status,
+            "success": update.response_success,
             "created_at": datetime.now(UTC).isoformat(),
-            "context_delta": context_delta or {},
+            "context_delta": update.context_delta or {},
         }
     )
     interactions = interactions[-MAX_INTERACTIONS:]
@@ -80,9 +87,9 @@ def build_updated_session_state(
     return {
         **previous_state,
         "interactions": interactions,
-        "last_intent": response_intent,
-        "last_status": response_status,
-        "last_message": response_message,
+        "last_intent": update.response_intent,
+        "last_status": update.response_status,
+        "last_message": update.response_message,
         "updated_at": datetime.now(UTC).isoformat(),
     }
 

--- a/backend/tests/unit/test_session_facade.py
+++ b/backend/tests/unit/test_session_facade.py
@@ -6,6 +6,7 @@ from backend.agents.executor_agent import PipelineResult, StepResult
 from backend.agents.models import ExecutionPlan, PlanStep, ToolName
 from backend.interfaces.schemas import PublicAPIRequest
 from backend.interfaces.session_facade import (
+    SessionUpdate,
     as_str_or_none,
     build_context_block,
     build_session_summary,
@@ -70,19 +71,47 @@ class TestNormalizeSessionState:
         assert state["summary"] is None
 
 
+class TestSessionUpdate:
+    def test_defaults(self) -> None:
+        request = PublicAPIRequest(text="hi")
+        update = SessionUpdate(
+            request=request,
+            response_intent="greet_user",
+            response_status="ok",
+            response_success=True,
+        )
+
+        assert update.response_message == ""
+        assert update.context_delta is None
+
+    def test_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        import pytest
+
+        request = PublicAPIRequest(text="hi")
+        update = SessionUpdate(
+            request=request,
+            response_intent="greet_user",
+            response_status="ok",
+            response_success=True,
+        )
+        with pytest.raises(FrozenInstanceError):
+            update.response_intent = "changed"  # type: ignore[misc]
+
+
 class TestBuildUpdatedSessionState:
     def test_appends_interaction(self) -> None:
         prev = normalize_session_state(None)
-        request = PublicAPIRequest(text="test query")
-
-        updated = build_updated_session_state(
-            prev,
-            request=request,
+        update = SessionUpdate(
+            request=PublicAPIRequest(text="test query"),
             response_intent="search_bangumi",
             response_status="ok",
             response_success=True,
             response_message="found 3",
         )
+
+        updated = build_updated_session_state(prev, update)
 
         interactions = updated["interactions"]
         assert isinstance(interactions, list)
@@ -95,22 +124,24 @@ class TestBuildUpdatedSessionState:
 
     def test_appends_multiple_interactions(self) -> None:
         prev = normalize_session_state(None)
-        request1 = PublicAPIRequest(text="first")
 
         state = build_updated_session_state(
             prev,
-            request=request1,
-            response_intent="search_bangumi",
-            response_status="ok",
-            response_success=True,
+            SessionUpdate(
+                request=PublicAPIRequest(text="first"),
+                response_intent="search_bangumi",
+                response_status="ok",
+                response_success=True,
+            ),
         )
-        request2 = PublicAPIRequest(text="second")
         state = build_updated_session_state(
             state,
-            request=request2,
-            response_intent="plan_route",
-            response_status="ok",
-            response_success=True,
+            SessionUpdate(
+                request=PublicAPIRequest(text="second"),
+                response_intent="plan_route",
+                response_status="ok",
+                response_success=True,
+            ),
         )
 
         interactions = state["interactions"]
@@ -120,17 +151,16 @@ class TestBuildUpdatedSessionState:
 
     def test_includes_context_delta(self) -> None:
         prev = normalize_session_state(None)
-        request = PublicAPIRequest(text="test")
         delta = {"bangumi_id": "253", "anime_title": "test anime"}
-
-        updated = build_updated_session_state(
-            prev,
-            request=request,
+        update = SessionUpdate(
+            request=PublicAPIRequest(text="test"),
             response_intent="search_bangumi",
             response_status="ok",
             response_success=True,
             context_delta=delta,
         )
+
+        updated = build_updated_session_state(prev, update)
 
         interactions = updated["interactions"]
         assert isinstance(interactions, list)


### PR DESCRIPTION
## Summary

- Introduces `SessionUpdate` frozen dataclass in `session_facade.py` to bundle the 6 response-fields previously passed as individual keyword arguments to `build_updated_session_state`
- Reduces `build_updated_session_state` signature from 7 parameters (previous_state + 6 kwargs) down to 2 (`previous_state`, `update: SessionUpdate`)
- Updates the single production caller in `public_api.py._persist_result` to construct `SessionUpdate` at the call site
- Migrates all three `TestBuildUpdatedSessionState` tests to use `SessionUpdate`; adds `TestSessionUpdate` class covering defaults and frozen immutability

## Test plan

- [x] `TestSessionUpdate.test_defaults` — unit: verifies `response_message=""` and `context_delta=None` defaults
- [x] `TestSessionUpdate.test_frozen` — unit: verifies `FrozenInstanceError` on mutation attempt
- [x] `TestBuildUpdatedSessionState.*` — 3 existing behavior tests migrated to new call signature
- [x] `uv run pytest backend/tests/unit/ -q` — 633 passed
- [x] `uv run mypy backend/agents/ backend/interfaces/ backend/domain/ backend/infrastructure/` — no issues
- [x] `uv tool run ruff check backend/` — no issues in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)