### PR TITLE
refactor: split retriever.py into strategy submodules (#134)

### DIFF
--- a/backend/agents/retriever.py
+++ b/backend/agents/retriever.py
@@ -1,6 +1,6 @@
 """Retriever abstraction for executor-facing data access.
 
-This module provides a deterministic strategy layer above SQLAgent:
+Strategy dispatch and caching facade:
 
 - sql: structured SQL retrieval
 - geo: direct PostGIS proximity search
@@ -10,19 +10,23 @@ This module provides a deterministic strategy layer above SQLAgent:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from types import SimpleNamespace
 from typing import cast
 
 import structlog
 
 from backend.agents.models import RetrievalRequest
-from backend.agents.sql_agent import SQLAgent, SQLResult, resolve_location
+from backend.agents.retrievers.enrichment import (
+    write_through_bangumi_points,  # noqa: F401
+)
+from backend.agents.retrievers.geo import fetch_geo_rows, get_area_suggestions
+from backend.agents.retrievers.hybrid import merge_rows_preserving_order
+from backend.agents.retrievers.sql import execute_sql_with_fallback
+from backend.agents.sql_agent import SQLAgent, SQLResult  # noqa: F401
 from backend.application.use_cases.fetch_bangumi_points import FetchBangumiPoints
 from backend.application.use_cases.get_bangumi_subject import GetBangumiSubject
-from backend.clients.anitabi import AnitabiClient
 from backend.domain.entities import Point
 from backend.infrastructure.gateways.anitabi import AnitabiClientGateway
 from backend.infrastructure.gateways.bangumi import BangumiClientGateway
@@ -31,11 +35,11 @@ from backend.services.cache import _CACHE_MISS, ResponseCache
 
 logger = structlog.get_logger(__name__)
 
-_DEFAULT_GEO_LIMIT = 200
 _DEFAULT_CACHE_TTL_SECONDS = 900
-_SHARED_RETRIEVAL_CACHE = ResponseCache(
-    default_ttl_seconds=_DEFAULT_CACHE_TTL_SECONDS,
-)
+_SHARED_RETRIEVAL_CACHE = ResponseCache(default_ttl_seconds=_DEFAULT_CACHE_TTL_SECONDS)
+
+# Backward-compatible alias used in tests
+_merge_rows_preserving_order = merge_rows_preserving_order
 
 
 class RetrievalStrategy(str, Enum):
@@ -79,7 +83,6 @@ class Retriever:
         self._cache = cache or _SHARED_RETRIEVAL_CACHE
         self._fetch_bangumi_points = fetch_bangumi_points
         self._get_bangumi_subject = get_bangumi_subject
-
         if isinstance(db, SupabaseClient):
             self._fetch_bangumi_points = (
                 self._fetch_bangumi_points
@@ -93,12 +96,10 @@ class Retriever:
         """Choose a retrieval strategy without an LLM."""
         if request.tool == "search_nearby":
             return RetrievalStrategy.GEO
-
         if request.tool == "search_bangumi":
             if request.bangumi_id and (request.location or request.origin):
                 return RetrievalStrategy.HYBRID
             return RetrievalStrategy.SQL
-
         return RetrievalStrategy.SQL
 
     async def execute(self, request: RetrievalRequest) -> RetrievalResult:
@@ -112,34 +113,36 @@ class Retriever:
                 "strategy": strategy.value,
             },
         )
-
         logger.info(
-            "retrieval_strategy_selected",
-            tool=request.tool,
-            strategy=strategy.value,
+            "retrieval_strategy_selected", tool=request.tool, strategy=strategy.value
         )
-
         cached = await self._cache.get(cache_key)
         if cached is not _CACHE_MISS and isinstance(cached, RetrievalResult):
             logger.info(
-                "retrieval_cache_hit",
-                tool=request.tool,
-                strategy=strategy.value,
+                "retrieval_cache_hit", tool=request.tool, strategy=strategy.value
             )
             return _clone_result(cached, metadata_updates={"cache": "hit"})
-
         handler = {
             RetrievalStrategy.SQL: self._execute_sql,
             RetrievalStrategy.GEO: self._execute_geo,
             RetrievalStrategy.HYBRID: self._execute_hybrid,
         }[strategy]
         result = await handler(request)
-
         if result.success and result.row_count > 0:
             await self._cache.set(cache_key, result)
             return _clone_result(result, metadata_updates={"cache": "write"})
-
         return _clone_result(result, metadata_updates={"cache": "miss"})
+
+    async def _execute_sql_with_fallback(
+        self, request: RetrievalRequest
+    ) -> tuple[SQLResult, dict[str, object]]:
+        return await execute_sql_with_fallback(
+            request,
+            self._sql_agent,
+            self._db,
+            self._fetch_bangumi_points,
+            self._get_bangumi_subject,
+        )
 
     async def _execute_sql(self, request: RetrievalRequest) -> RetrievalResult:
         sql_result, metadata = await self._execute_sql_with_fallback(request)
@@ -153,20 +156,15 @@ class Retriever:
 
     async def _execute_geo(self, request: RetrievalRequest) -> RetrievalResult:
         anchor = request.location or request.origin or ""
-        rows, error = await self._fetch_geo_rows(
-            anchor,
-            radius_m=request.radius or 5000,
+        rows, error = await fetch_geo_rows(
+            self._db, anchor, radius_m=request.radius or 5000
         )
-
         metadata: dict[str, object] = {"source": "geo", "anchor": anchor}
-
-        # Detect sparse results — suggest clarification
         if not error and len(rows) < 5:
-            suggestions = await self._get_area_suggestions(anchor)
+            suggestions = await get_area_suggestions(self._db, anchor)
             if suggestions:
                 metadata["sparse"] = True
                 metadata["suggestions"] = suggestions
-
         return RetrievalResult(
             strategy=RetrievalStrategy.GEO,
             rows=rows,
@@ -177,19 +175,16 @@ class Retriever:
 
     async def _execute_hybrid(self, request: RetrievalRequest) -> RetrievalResult:
         anchor = request.location or request.origin or ""
-
         (sql_result, sql_metadata), (geo_rows, geo_error) = await asyncio.gather(
             self._execute_sql_with_fallback(request),
-            self._fetch_geo_rows(anchor, radius_m=request.radius or 5000),
+            fetch_geo_rows(self._db, anchor, radius_m=request.radius or 5000),
         )
-
         if not sql_result.success:
             return RetrievalResult(
                 strategy=RetrievalStrategy.HYBRID,
                 error=sql_result.error,
                 metadata={"source": "hybrid", "mode": "sql_error", **sql_metadata},
             )
-
         if geo_error:
             return RetrievalResult(
                 strategy=RetrievalStrategy.HYBRID,
@@ -203,21 +198,18 @@ class Retriever:
                     **sql_metadata,
                 },
             )
-
         if request.bangumi_id:
             geo_rows = [
-                row
-                for row in geo_rows
-                if str(row.get("bangumi_id", "")) == request.bangumi_id
+                r
+                for r in geo_rows
+                if str(r.get("bangumi_id", "")) == request.bangumi_id
             ]
-
-        merged_rows = _merge_rows_preserving_order(sql_result.rows, geo_rows)
-
+        merged = merge_rows_preserving_order(sql_result.rows, geo_rows)
         mode = "hybrid" if geo_rows else "sql_fallback"
         return RetrievalResult(
             strategy=RetrievalStrategy.HYBRID,
-            rows=merged_rows,
-            row_count=len(merged_rows),
+            rows=merged,
+            row_count=len(merged),
             metadata={
                 "source": "hybrid",
                 "mode": mode,
@@ -227,288 +219,6 @@ class Retriever:
                 **sql_metadata,
             },
         )
-
-    async def _execute_sql_with_fallback(
-        self,
-        request: RetrievalRequest,
-    ) -> tuple[SQLResult, dict[str, object]]:
-        sql_result = await self._sql_agent.execute(request)
-        metadata: dict[str, object] = {"data_origin": "db"}
-
-        if not sql_result.success:
-            return sql_result, metadata
-
-        has_rows = sql_result.row_count > 0
-        should_fallback = _should_try_db_miss_fallback(request)
-
-        if has_rows and not request.force_refresh:
-            return sql_result, metadata
-        if not has_rows and not should_fallback:
-            return sql_result, metadata
-
-        bangumi_id = request.bangumi_id
-        if bangumi_id is None:
-            raise ValueError("bangumi_id required for fallback retrieval")
-
-        fallback_meta = await self._write_through_bangumi_points(bangumi_id)
-        metadata.update(fallback_meta)
-
-        if fallback_meta.get("write_through"):
-            rerun_result = await self._sql_agent.execute(request)
-            if rerun_result.success:
-                return rerun_result, metadata
-
-        return sql_result, metadata
-
-    async def _write_through_bangumi_points(
-        self,
-        bangumi_id: str,
-    ) -> dict[str, object]:
-        try:
-            if self._fetch_bangumi_points is None:
-                return {
-                    "data_origin": "db_miss",
-                    "fallback_status": "disabled",
-                }
-            points = await self._fetch_bangumi_points(bangumi_id)
-        except Exception as exc:
-            logger.warning(
-                "bangumi_fallback_fetch_failed",
-                bangumi_id=bangumi_id,
-                error=str(exc),
-            )
-            return {
-                "data_origin": "db_miss",
-                "fallback_source": "anitabi",
-                "fallback_error": str(exc),
-            }
-
-        if not points:
-            return {
-                "data_origin": "db_miss",
-                "fallback_source": "anitabi",
-                "fallback_status": "empty",
-            }
-
-        await asyncio.gather(
-            self._ensure_bangumi_record(bangumi_id, points),
-            self._persist_points(points),
-        )
-        await self._update_bangumi_points_count(bangumi_id, len(points))
-
-        logger.info(
-            "bangumi_fallback_write_through_complete",
-            bangumi_id=bangumi_id,
-            point_count=len(points),
-        )
-        return {
-            "data_origin": "fallback",
-            "fallback_source": "anitabi",
-            "fallback_status": "written",
-            "write_through": True,
-            "fetched_points": len(points),
-        }
-
-    async def _ensure_bangumi_record(
-        self,
-        bangumi_id: str,
-        points: list[Point],
-    ) -> None:
-        upsert_bangumi = getattr(self._db, "upsert_bangumi", None)
-        if upsert_bangumi is None:
-            return
-
-        metadata = await self._load_bangumi_metadata(bangumi_id, points)
-
-        # Enrich with Anitabi lite info (correct title, city, cover)
-        lite = await self._fetch_bangumi_lite(bangumi_id)
-        if lite:
-            lite_title = lite.get("title")
-            if isinstance(lite_title, str) and lite_title:
-                metadata["title"] = lite_title
-            lite_cn = lite.get("cn")
-            if isinstance(lite_cn, str) and lite_cn:
-                metadata["title_cn"] = lite_cn
-            lite_city = lite.get("city")
-            if isinstance(lite_city, str) and lite_city:
-                metadata["city"] = lite_city
-            lite_cover = lite.get("cover")
-            if isinstance(lite_cover, str) and lite_cover:
-                metadata["cover_url"] = lite_cover
-
-        await upsert_bangumi(bangumi_id, **metadata)
-
-    async def _load_bangumi_metadata(
-        self,
-        bangumi_id: str,
-        points: list[Point],
-    ) -> dict[str, object]:
-        try:
-            if self._get_bangumi_subject is None:
-                raise RuntimeError("Bangumi subject fallback is not configured")
-            subject_id = int(bangumi_id)
-            subject = await self._get_bangumi_subject(subject_id)
-        except Exception as exc:
-            logger.warning(
-                "bangumi_metadata_fallback_to_minimal",
-                bangumi_id=bangumi_id,
-                error=str(exc),
-            )
-            subject = None
-
-        if subject:
-            return _subject_to_bangumi_fields(subject, points_count=len(points))
-
-        title = points[0].bangumi_title if points else bangumi_id
-        return {
-            "title": title or bangumi_id,
-            "title_cn": title or bangumi_id,
-            "points_count": len(points),
-        }
-
-    async def _fetch_bangumi_lite(self, bangumi_id: str) -> dict[str, object] | None:
-        """Fetch Anitabi /lite info for correct title, city, cover."""
-        try:
-            async with AnitabiClient() as client:
-                return await client.get_bangumi_lite(bangumi_id)
-        except Exception as exc:
-            logger.warning(
-                "bangumi_lite_fetch_failed",
-                bangumi_id=bangumi_id,
-                error=str(exc),
-            )
-            return None
-
-    async def _persist_points(self, points: list[Point]) -> None:
-        upsert_points_batch = getattr(self._db, "upsert_points_batch", None)
-        if upsert_points_batch is None:
-            return
-
-        rows = [_point_to_db_row(point) for point in points]
-        await upsert_points_batch(rows)
-
-    async def _update_bangumi_points_count(
-        self, bangumi_id: str, points_count: int
-    ) -> None:
-        pool = getattr(self._db, "pool", None)
-        if pool is None:
-            return
-
-        execute = getattr(pool, "execute", None)
-        if execute is None:
-            return
-
-        await execute(
-            "UPDATE bangumi SET points_count = $1 WHERE id = $2",
-            points_count,
-            bangumi_id,
-        )
-
-    async def _get_area_suggestions(self, anchor: str) -> list[dict[str, object]]:
-        """Look up known bangumi near an anchor location for clarification."""
-        get_bangumi_by_area = getattr(self._db, "get_bangumi_by_area", None)
-        if get_bangumi_by_area is None:
-            return []
-        coords = await resolve_location(anchor)
-        if coords is None or isinstance(coords, list):
-            return []
-        lat, lon = coords
-        try:
-            results: list[dict[str, object]] = await get_bangumi_by_area(lat, lon)
-            return results
-        except Exception as exc:
-            logger.warning("area_suggestions_failed", error=str(exc))
-            return []
-
-    async def _fetch_geo_rows(
-        self,
-        anchor: str,
-        *,
-        radius_m: int,
-    ) -> tuple[list[dict], str | None]:
-        if not anchor:
-            return [], "Missing location/origin for geo retrieval"
-
-        coords = await resolve_location(anchor)
-        if coords is None:
-            return [], f"Unknown location: {anchor}. Could not resolve coordinates."
-
-        search_points = getattr(self._db, "search_points_by_location", None)
-        if search_points is None:
-            return [], "Database client does not support geo retrieval"
-
-        lat, lon = coords
-        records = await search_points(lat, lon, radius_m, limit=_DEFAULT_GEO_LIMIT)
-        return _records_to_dicts(records), None
-
-
-def _records_to_dicts(
-    records: Sequence[Mapping[str, object]],
-) -> list[dict[str, object]]:
-    """Convert asyncpg records or plain dicts into dicts."""
-    return [dict(record) for record in records]
-
-
-def _point_to_db_row(point: Point) -> dict[str, object]:
-    return {
-        "id": point.id,
-        "bangumi_id": point.bangumi_id,
-        "name": point.name,
-        "name_cn": point.cn_name,
-        "latitude": point.coordinates.latitude,
-        "longitude": point.coordinates.longitude,
-        "episode": point.episode,
-        "time_seconds": point.time_seconds,
-        "image": str(point.screenshot_url),
-        "origin": point.origin,
-        "origin_url": point.origin_url,
-        "location": (
-            f"POINT({point.coordinates.longitude} {point.coordinates.latitude})"
-        ),
-    }
-
-
-def _subject_to_bangumi_fields(
-    subject: Mapping[str, object],
-    *,
-    points_count: int,
-) -> dict[str, object]:
-    images = subject.get("images") or {}
-    rating_obj = subject.get("rating") or {}
-    if not isinstance(images, Mapping):
-        images = {}
-    if not isinstance(rating_obj, Mapping):
-        rating_obj = {}
-    title = subject.get("name") or subject.get("name_cn") or "Unknown"
-    return {
-        "title": title,
-        "title_cn": subject.get("name_cn") or title,
-        "cover_url": images.get("large") or images.get("common") or "",
-        "air_date": subject.get("date"),
-        "summary": str(subject.get("summary") or "")[:2000],
-        "eps_count": subject.get("total_episodes") or subject.get("eps") or 0,
-        "rating": rating_obj.get("score"),
-        "points_count": points_count,
-    }
-
-
-def _should_try_db_miss_fallback(request: RetrievalRequest) -> bool:
-    return request.tool == "search_bangumi" and bool(request.bangumi_id)
-
-
-def _request_to_sql_intent(request: RetrievalRequest) -> SimpleNamespace:
-    extracted_params = SimpleNamespace(
-        bangumi=request.bangumi_id,
-        location=request.location,
-        episode=request.episode,
-        origin=request.origin,
-        radius=request.radius,
-    )
-    intent_name = {
-        "search_bangumi": "search_by_bangumi",
-        "search_nearby": "search_by_location",
-    }.get(request.tool, request.tool)
-    return SimpleNamespace(intent=intent_name, extracted_params=extracted_params)
 
 
 def _clone_result(
@@ -523,30 +233,3 @@ def _clone_result(
         error=result.error,
         metadata={**result.metadata, **(metadata_updates or {})},
     )
-
-
-def _merge_rows_preserving_order(
-    sql_rows: list[dict], geo_rows: list[dict]
-) -> list[dict]:
-    """Merge SQL rows with geo rows, keeping SQL order as the primary ranking."""
-    geo_by_id = {
-        str(row.get("id")): row for row in geo_rows if row.get("id") is not None
-    }
-
-    merged: list[dict] = []
-    for sql_row in sql_rows:
-        row_id = str(sql_row.get("id")) if sql_row.get("id") is not None else None
-        if row_id is None:
-            merged.append(dict(sql_row))
-            continue
-
-        geo_row = geo_by_id.get(row_id)
-        if geo_row is None:
-            merged.append(dict(sql_row))
-            continue
-
-        combined = dict(geo_row)
-        combined.update(sql_row)
-        merged.append(combined)
-
-    return merged

--- a/backend/agents/retrievers/__init__.py
+++ b/backend/agents/retrievers/__init__.py
@@ -1,0 +1,42 @@
+"""Retriever strategy submodules.
+
+Re-exports for convenient import from backend.agents.retrievers.
+"""
+
+from backend.agents.retrievers.enrichment import (
+    ensure_bangumi_record,
+    fetch_bangumi_lite,
+    load_bangumi_metadata,
+    persist_points,
+    point_to_db_row,
+    subject_to_bangumi_fields,
+    update_bangumi_points_count,
+    write_through_bangumi_points,
+)
+from backend.agents.retrievers.geo import (
+    fetch_geo_rows,
+    get_area_suggestions,
+    records_to_dicts,
+)
+from backend.agents.retrievers.hybrid import merge_rows_preserving_order
+from backend.agents.retrievers.sql import (
+    execute_sql_with_fallback,
+    should_try_db_miss_fallback,
+)
+
+__all__ = [
+    "ensure_bangumi_record",
+    "execute_sql_with_fallback",
+    "fetch_bangumi_lite",
+    "fetch_geo_rows",
+    "get_area_suggestions",
+    "load_bangumi_metadata",
+    "merge_rows_preserving_order",
+    "persist_points",
+    "point_to_db_row",
+    "records_to_dicts",
+    "should_try_db_miss_fallback",
+    "subject_to_bangumi_fields",
+    "update_bangumi_points_count",
+    "write_through_bangumi_points",
+]

--- a/backend/agents/retrievers/enrichment.py
+++ b/backend/agents/retrievers/enrichment.py
@@ -1,0 +1,207 @@
+"""Bangumi write-through enrichment: fetch from Anitabi/Bangumi API, persist to DB."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+
+import structlog
+
+from backend.clients.anitabi import AnitabiClient
+from backend.domain.entities import Point
+
+logger = structlog.get_logger(__name__)
+
+
+def point_to_db_row(point: Point) -> dict[str, object]:
+    return {
+        "id": point.id,
+        "bangumi_id": point.bangumi_id,
+        "name": point.name,
+        "name_cn": point.cn_name,
+        "latitude": point.coordinates.latitude,
+        "longitude": point.coordinates.longitude,
+        "episode": point.episode,
+        "time_seconds": point.time_seconds,
+        "image": str(point.screenshot_url),
+        "origin": point.origin,
+        "origin_url": point.origin_url,
+        "location": (
+            f"POINT({point.coordinates.longitude} {point.coordinates.latitude})"
+        ),
+    }
+
+
+def subject_to_bangumi_fields(
+    subject: Mapping[str, object],
+    *,
+    points_count: int,
+) -> dict[str, object]:
+    images = subject.get("images") or {}
+    rating_obj = subject.get("rating") or {}
+    if not isinstance(images, Mapping):
+        images = {}
+    if not isinstance(rating_obj, Mapping):
+        rating_obj = {}
+    title = subject.get("name") or subject.get("name_cn") or "Unknown"
+    return {
+        "title": title,
+        "title_cn": subject.get("name_cn") or title,
+        "cover_url": images.get("large") or images.get("common") or "",
+        "air_date": subject.get("date"),
+        "summary": str(subject.get("summary") or "")[:2000],
+        "eps_count": subject.get("total_episodes") or subject.get("eps") or 0,
+        "rating": rating_obj.get("score"),
+        "points_count": points_count,
+    }
+
+
+async def fetch_bangumi_lite(bangumi_id: str) -> dict[str, object] | None:
+    """Fetch Anitabi /lite info for correct title, city, cover."""
+    try:
+        async with AnitabiClient() as client:
+            return await client.get_bangumi_lite(bangumi_id)
+    except Exception as exc:
+        logger.warning(
+            "bangumi_lite_fetch_failed",
+            bangumi_id=bangumi_id,
+            error=str(exc),
+        )
+        return None
+
+
+async def load_bangumi_metadata(
+    bangumi_id: str,
+    points: list[Point],
+    get_bangumi_subject: Callable[[int], Awaitable[dict[str, object]]] | None,
+) -> dict[str, object]:
+    try:
+        if get_bangumi_subject is None:
+            raise RuntimeError("Bangumi subject fallback is not configured")
+        subject_id = int(bangumi_id)
+        subject = await get_bangumi_subject(subject_id)
+    except Exception as exc:
+        logger.warning(
+            "bangumi_metadata_fallback_to_minimal",
+            bangumi_id=bangumi_id,
+            error=str(exc),
+        )
+        subject = None
+
+    if subject:
+        return subject_to_bangumi_fields(subject, points_count=len(points))
+
+    title = points[0].bangumi_title if points else bangumi_id
+    return {
+        "title": title or bangumi_id,
+        "title_cn": title or bangumi_id,
+        "points_count": len(points),
+    }
+
+
+async def persist_points(db: object, points: list[Point]) -> None:
+    upsert_points_batch = getattr(db, "upsert_points_batch", None)
+    if upsert_points_batch is None:
+        return
+    rows = [point_to_db_row(point) for point in points]
+    await upsert_points_batch(rows)
+
+
+async def update_bangumi_points_count(
+    db: object,
+    bangumi_id: str,
+    points_count: int,
+) -> None:
+    pool = getattr(db, "pool", None)
+    if pool is None:
+        return
+    execute = getattr(pool, "execute", None)
+    if execute is None:
+        return
+    await execute(
+        "UPDATE bangumi SET points_count = $1 WHERE id = $2",
+        points_count,
+        bangumi_id,
+    )
+
+
+async def ensure_bangumi_record(
+    db: object,
+    bangumi_id: str,
+    points: list[Point],
+    get_bangumi_subject: Callable[[int], Awaitable[dict[str, object]]] | None,
+) -> None:
+    upsert_bangumi = getattr(db, "upsert_bangumi", None)
+    if upsert_bangumi is None:
+        return
+
+    metadata = await load_bangumi_metadata(bangumi_id, points, get_bangumi_subject)
+
+    lite = await fetch_bangumi_lite(bangumi_id)
+    if lite:
+        lite_title = lite.get("title")
+        if isinstance(lite_title, str) and lite_title:
+            metadata["title"] = lite_title
+        lite_cn = lite.get("cn")
+        if isinstance(lite_cn, str) and lite_cn:
+            metadata["title_cn"] = lite_cn
+        lite_city = lite.get("city")
+        if isinstance(lite_city, str) and lite_city:
+            metadata["city"] = lite_city
+        lite_cover = lite.get("cover")
+        if isinstance(lite_cover, str) and lite_cover:
+            metadata["cover_url"] = lite_cover
+
+    await upsert_bangumi(bangumi_id, **metadata)
+
+
+async def write_through_bangumi_points(
+    db: object,
+    bangumi_id: str,
+    fetch_bangumi_points: Callable[[str], Awaitable[list[Point]]] | None,
+    get_bangumi_subject: Callable[[int], Awaitable[dict[str, object]]] | None,
+) -> dict[str, object]:
+    try:
+        if fetch_bangumi_points is None:
+            return {
+                "data_origin": "db_miss",
+                "fallback_status": "disabled",
+            }
+        points = await fetch_bangumi_points(bangumi_id)
+    except Exception as exc:
+        logger.warning(
+            "bangumi_fallback_fetch_failed",
+            bangumi_id=bangumi_id,
+            error=str(exc),
+        )
+        return {
+            "data_origin": "db_miss",
+            "fallback_source": "anitabi",
+            "fallback_error": str(exc),
+        }
+
+    if not points:
+        return {
+            "data_origin": "db_miss",
+            "fallback_source": "anitabi",
+            "fallback_status": "empty",
+        }
+
+    await asyncio.gather(
+        ensure_bangumi_record(db, bangumi_id, points, get_bangumi_subject),
+        persist_points(db, points),
+    )
+    await update_bangumi_points_count(db, bangumi_id, len(points))
+
+    logger.info(
+        "bangumi_fallback_write_through_complete",
+        bangumi_id=bangumi_id,
+        point_count=len(points),
+    )
+    return {
+        "data_origin": "fallback",
+        "fallback_source": "anitabi",
+        "fallback_status": "written",
+        "write_through": True,
+        "fetched_points": len(points),
+    }

--- a/backend/agents/retrievers/geo.py
+++ b/backend/agents/retrievers/geo.py
@@ -1,0 +1,62 @@
+"""Geo retrieval strategy: PostGIS proximity search with sparse-result suggestions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import structlog
+
+from backend.agents.sql_agent import resolve_location
+
+logger = structlog.get_logger(__name__)
+
+_DEFAULT_GEO_LIMIT = 200
+
+
+def records_to_dicts(
+    records: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    """Convert asyncpg records or plain dicts into dicts."""
+    return [dict(record) for record in records]
+
+
+async def fetch_geo_rows(
+    db: object,
+    anchor: str,
+    *,
+    radius_m: int,
+) -> tuple[list[dict[str, object]], str | None]:
+    if not anchor:
+        return [], "Missing location/origin for geo retrieval"
+
+    coords = await resolve_location(anchor)
+    if coords is None:
+        return [], f"Unknown location: {anchor}. Could not resolve coordinates."
+
+    search_points = getattr(db, "search_points_by_location", None)
+    if search_points is None:
+        return [], "Database client does not support geo retrieval"
+
+    lat, lon = coords
+    records = await search_points(lat, lon, radius_m, limit=_DEFAULT_GEO_LIMIT)
+    return records_to_dicts(records), None
+
+
+async def get_area_suggestions(
+    db: object,
+    anchor: str,
+) -> list[dict[str, object]]:
+    """Look up known bangumi near an anchor location for clarification."""
+    get_bangumi_by_area = getattr(db, "get_bangumi_by_area", None)
+    if get_bangumi_by_area is None:
+        return []
+    coords = await resolve_location(anchor)
+    if coords is None or isinstance(coords, list):
+        return []
+    lat, lon = coords
+    try:
+        results: list[dict[str, object]] = await get_bangumi_by_area(lat, lon)
+        return results
+    except Exception as exc:
+        logger.warning("area_suggestions_failed", error=str(exc))
+        return []

--- a/backend/agents/retrievers/hybrid.py
+++ b/backend/agents/retrievers/hybrid.py
@@ -1,0 +1,31 @@
+"""Hybrid retrieval: merge SQL-constrained rows with geo proximity results."""
+
+from __future__ import annotations
+
+
+def merge_rows_preserving_order(
+    sql_rows: list[dict[str, object]],
+    geo_rows: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Merge SQL rows with geo rows, keeping SQL order as the primary ranking."""
+    geo_by_id = {
+        str(row.get("id")): row for row in geo_rows if row.get("id") is not None
+    }
+
+    merged: list[dict[str, object]] = []
+    for sql_row in sql_rows:
+        row_id = str(sql_row.get("id")) if sql_row.get("id") is not None else None
+        if row_id is None:
+            merged.append(dict(sql_row))
+            continue
+
+        geo_row = geo_by_id.get(row_id)
+        if geo_row is None:
+            merged.append(dict(sql_row))
+            continue
+
+        combined = dict(geo_row)
+        combined.update(sql_row)
+        merged.append(combined)
+
+    return merged

--- a/backend/agents/retrievers/sql.py
+++ b/backend/agents/retrievers/sql.py
@@ -1,0 +1,45 @@
+"""SQL retrieval with write-through fallback on DB miss."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from backend.agents.models import RetrievalRequest
+from backend.agents.retrievers.enrichment import write_through_bangumi_points
+from backend.agents.sql_agent import SQLAgent, SQLResult
+from backend.domain.entities import Point
+
+
+def should_try_db_miss_fallback(request: RetrievalRequest) -> bool:
+    return request.tool == "search_bangumi" and bool(request.bangumi_id)
+
+
+async def execute_sql_with_fallback(
+    request: RetrievalRequest,
+    sql_agent: SQLAgent,
+    db: object,
+    fetch_bangumi_points: Callable[[str], Awaitable[list[Point]]] | None,
+    get_bangumi_subject: Callable[[int], Awaitable[dict[str, object]]] | None,
+) -> tuple[SQLResult, dict[str, object]]:
+    sql_result = await sql_agent.execute(request)
+    metadata: dict[str, object] = {"data_origin": "db"}
+    if not sql_result.success:
+        return sql_result, metadata
+    has_rows = sql_result.row_count > 0
+    should_fallback = should_try_db_miss_fallback(request)
+    if has_rows and not request.force_refresh:
+        return sql_result, metadata
+    if not has_rows and not should_fallback:
+        return sql_result, metadata
+    bangumi_id = request.bangumi_id
+    if bangumi_id is None:
+        raise ValueError("bangumi_id required for fallback retrieval")
+    fallback_meta = await write_through_bangumi_points(
+        db, bangumi_id, fetch_bangumi_points, get_bangumi_subject
+    )
+    metadata.update(fallback_meta)
+    if fallback_meta.get("write_through"):
+        rerun_result = await sql_agent.execute(request)
+        if rerun_result.success:
+            return rerun_result, metadata
+    return sql_result, metadata

--- a/backend/tests/unit/retrievers/test_enrichment.py
+++ b/backend/tests/unit/retrievers/test_enrichment.py
@@ -1,0 +1,322 @@
+"""Unit tests for bangumi enrichment: write_through_bangumi_points, ensure_bangumi_record, etc."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.agents.retrievers.enrichment import (
+    ensure_bangumi_record,
+    load_bangumi_metadata,
+    persist_points,
+    point_to_db_row,
+    subject_to_bangumi_fields,
+    update_bangumi_points_count,
+    write_through_bangumi_points,
+)
+from backend.domain.entities import Coordinates, Point
+
+
+def _make_point(point_id: str = "p1") -> Point:
+    return Point(
+        id=point_id,
+        name="宇治桥",
+        cn_name="宇治桥",
+        coordinates=Coordinates(latitude=34.8843, longitude=135.7997),
+        bangumi_id="115908",
+        bangumi_title="響け！ユーフォニアム",
+        episode=1,
+        time_seconds=42,
+        screenshot_url="https://example.com/s.jpg",
+        origin="Anitabi",
+        origin_url="https://anitabi.cn/p/p1",
+    )
+
+
+def _make_db(
+    *,
+    has_upsert_batch: bool = True,
+    has_upsert_bangumi: bool = True,
+    has_pool: bool = True,
+) -> MagicMock:
+    db = MagicMock()
+    if has_upsert_batch:
+        db.upsert_points_batch = AsyncMock()
+    else:
+        del db.upsert_points_batch
+    if has_upsert_bangumi:
+        db.upsert_bangumi = AsyncMock()
+    else:
+        del db.upsert_bangumi
+    if has_pool:
+        pool = AsyncMock()
+        pool.execute = AsyncMock()
+        db.pool = pool
+    else:
+        del db.pool
+    return db
+
+
+# ── point_to_db_row ──
+
+
+class TestPointToDbRow:
+    def test_produces_expected_keys(self) -> None:
+        row = point_to_db_row(_make_point())
+        expected_keys = {
+            "id",
+            "bangumi_id",
+            "name",
+            "name_cn",
+            "latitude",
+            "longitude",
+            "episode",
+            "time_seconds",
+            "image",
+            "origin",
+            "origin_url",
+            "location",
+        }
+        assert set(row.keys()) == expected_keys
+
+    def test_location_wkt_format(self) -> None:
+        row = point_to_db_row(_make_point())
+        assert row["location"] == "POINT(135.7997 34.8843)"
+
+    def test_coordinates_are_stored_separately(self) -> None:
+        row = point_to_db_row(_make_point())
+        assert row["latitude"] == 34.8843
+        assert row["longitude"] == 135.7997
+
+
+# ── subject_to_bangumi_fields ──
+
+
+class TestSubjectToBangumiFields:
+    def test_extracts_title_from_name(self) -> None:
+        subject = {"name": "響け", "name_cn": "吹响"}
+        fields = subject_to_bangumi_fields(subject, points_count=5)
+        assert fields["title"] == "響け"
+        assert fields["title_cn"] == "吹响"
+        assert fields["points_count"] == 5
+
+    def test_falls_back_to_name_cn_when_no_name(self) -> None:
+        subject = {"name_cn": "吹响"}
+        fields = subject_to_bangumi_fields(subject, points_count=0)
+        assert fields["title"] == "吹响"
+
+    def test_falls_back_to_unknown_when_no_names(self) -> None:
+        fields = subject_to_bangumi_fields({}, points_count=0)
+        assert fields["title"] == "Unknown"
+
+    def test_extracts_cover_url_from_large_image(self) -> None:
+        subject = {
+            "name": "X",
+            "images": {"large": "https://img/l.jpg", "common": "c.jpg"},
+        }
+        fields = subject_to_bangumi_fields(subject, points_count=0)
+        assert fields["cover_url"] == "https://img/l.jpg"
+
+    def test_falls_back_to_common_image(self) -> None:
+        subject = {"name": "X", "images": {"common": "c.jpg"}}
+        fields = subject_to_bangumi_fields(subject, points_count=0)
+        assert fields["cover_url"] == "c.jpg"
+
+    def test_non_mapping_images_ignored(self) -> None:
+        subject = {"name": "X", "images": "bad"}
+        fields = subject_to_bangumi_fields(subject, points_count=0)
+        assert fields["cover_url"] == ""
+
+    def test_extracts_rating_score(self) -> None:
+        subject = {"name": "X", "rating": {"score": 8.7}}
+        fields = subject_to_bangumi_fields(subject, points_count=0)
+        assert fields["rating"] == 8.7
+
+    def test_non_mapping_rating_ignored(self) -> None:
+        subject = {"name": "X", "rating": 9.0}
+        fields = subject_to_bangumi_fields(subject, points_count=0)
+        assert fields["rating"] is None
+
+    def test_summary_truncated_at_2000_chars(self) -> None:
+        subject = {"name": "X", "summary": "A" * 3000}
+        fields = subject_to_bangumi_fields(subject, points_count=0)
+        assert len(str(fields["summary"])) == 2000
+
+
+# ── load_bangumi_metadata ──
+
+
+class TestLoadBangumiMetadata:
+    @pytest.mark.asyncio
+    async def test_uses_subject_when_available(self) -> None:
+        subject = {"name": "響け", "images": {"large": "https://img.jpg"}}
+        get_subject = AsyncMock(return_value=subject)
+        result = await load_bangumi_metadata("115908", [_make_point()], get_subject)
+        assert result["title"] == "響け"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_minimal_when_get_subject_is_none(self) -> None:
+        result = await load_bangumi_metadata("115908", [_make_point()], None)
+        assert result["title"] == "響け！ユーフォニアム"
+        assert result["points_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_uses_bangumi_id_as_title_when_no_points(self) -> None:
+        result = await load_bangumi_metadata("115908", [], None)
+        assert result["title"] == "115908"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_minimal_on_exception(self) -> None:
+        get_subject = AsyncMock(side_effect=RuntimeError("API error"))
+        result = await load_bangumi_metadata("115908", [_make_point()], get_subject)
+        assert result["title"] == "響け！ユーフォニアム"
+
+
+# ── persist_points ──
+
+
+class TestPersistPoints:
+    @pytest.mark.asyncio
+    async def test_calls_upsert_with_converted_rows(self) -> None:
+        db = _make_db()
+        await persist_points(db, [_make_point()])
+        db.upsert_points_batch.assert_awaited_once()
+        rows = db.upsert_points_batch.await_args.args[0]
+        assert rows[0]["id"] == "p1"
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_db_lacks_upsert_method(self) -> None:
+        db = _make_db(has_upsert_batch=False)
+        await persist_points(db, [_make_point()])
+
+    @pytest.mark.asyncio
+    async def test_no_op_for_empty_points(self) -> None:
+        db = _make_db()
+        await persist_points(db, [])
+        rows = db.upsert_points_batch.await_args.args[0]
+        assert rows == []
+
+
+# ── update_bangumi_points_count ──
+
+
+class TestUpdateBangumiPointsCount:
+    @pytest.mark.asyncio
+    async def test_executes_update_sql(self) -> None:
+        db = _make_db()
+        await update_bangumi_points_count(db, "115908", 10)
+        db.pool.execute.assert_awaited_once()
+        call_args = db.pool.execute.await_args.args
+        assert "UPDATE bangumi" in call_args[0]
+        assert call_args[1] == 10
+        assert call_args[2] == "115908"
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_db_lacks_pool(self) -> None:
+        db = _make_db(has_pool=False)
+        await update_bangumi_points_count(db, "115908", 10)
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_pool_lacks_execute(self) -> None:
+        db = _make_db()
+        del db.pool.execute
+        await update_bangumi_points_count(db, "115908", 10)
+
+
+# ── ensure_bangumi_record ──
+
+
+class TestEnsureBangumiRecord:
+    @pytest.mark.asyncio
+    async def test_calls_upsert_bangumi(self) -> None:
+        db = _make_db()
+        get_subject = AsyncMock(return_value={"name": "響け"})
+        with patch(
+            "backend.agents.retrievers.enrichment.fetch_bangumi_lite",
+            new=AsyncMock(return_value=None),
+        ):
+            await ensure_bangumi_record(db, "115908", [_make_point()], get_subject)
+        db.upsert_bangumi.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_db_lacks_upsert_bangumi(self) -> None:
+        db = _make_db(has_upsert_bangumi=False)
+        with patch(
+            "backend.agents.retrievers.enrichment.fetch_bangumi_lite",
+            new=AsyncMock(return_value=None),
+        ):
+            await ensure_bangumi_record(db, "115908", [_make_point()], None)
+
+    @pytest.mark.asyncio
+    async def test_lite_title_overrides_metadata_title(self) -> None:
+        db = _make_db()
+        lite = {
+            "title": "LiteTitle",
+            "cn": "LiteCN",
+            "city": "京都",
+            "cover": "https://c.jpg",
+        }
+        with patch(
+            "backend.agents.retrievers.enrichment.fetch_bangumi_lite",
+            new=AsyncMock(return_value=lite),
+        ):
+            await ensure_bangumi_record(db, "115908", [_make_point()], None)
+        call_kwargs = db.upsert_bangumi.await_args.kwargs
+        assert call_kwargs["title"] == "LiteTitle"
+        assert call_kwargs["title_cn"] == "LiteCN"
+        assert call_kwargs["city"] == "京都"
+        assert call_kwargs["cover_url"] == "https://c.jpg"
+
+
+# ── write_through_bangumi_points ──
+
+
+class TestWriteThroughBangumiPoints:
+    @pytest.mark.asyncio
+    async def test_disabled_when_fetch_fn_is_none(self) -> None:
+        result = await write_through_bangumi_points(MagicMock(), "115908", None, None)
+        assert result["fallback_status"] == "disabled"
+
+    @pytest.mark.asyncio
+    async def test_returns_error_metadata_on_fetch_exception(self) -> None:
+        fetch_fn = AsyncMock(side_effect=RuntimeError("API down"))
+        result = await write_through_bangumi_points(
+            MagicMock(), "115908", fetch_fn, None
+        )
+        assert result["data_origin"] == "db_miss"
+        assert "fallback_error" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_status_when_no_points(self) -> None:
+        fetch_fn = AsyncMock(return_value=[])
+        result = await write_through_bangumi_points(
+            MagicMock(), "115908", fetch_fn, None
+        )
+        assert result["fallback_status"] == "empty"
+
+    @pytest.mark.asyncio
+    async def test_writes_through_and_returns_written_metadata(self) -> None:
+        db = _make_db()
+        fetch_fn = AsyncMock(return_value=[_make_point()])
+        with patch(
+            "backend.agents.retrievers.enrichment.fetch_bangumi_lite",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await write_through_bangumi_points(db, "115908", fetch_fn, None)
+        assert result["write_through"] is True
+        assert result["fetched_points"] == 1
+        assert result["fallback_status"] == "written"
+        db.upsert_points_batch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_updates_points_count_after_write(self) -> None:
+        db = _make_db()
+        fetch_fn = AsyncMock(return_value=[_make_point(), _make_point("p2")])
+        with patch(
+            "backend.agents.retrievers.enrichment.fetch_bangumi_lite",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await write_through_bangumi_points(db, "115908", fetch_fn, None)
+        assert result["fetched_points"] == 2
+        db.pool.execute.assert_awaited_once()

--- a/backend/tests/unit/retrievers/test_geo.py
+++ b/backend/tests/unit/retrievers/test_geo.py
@@ -1,0 +1,172 @@
+"""Unit tests for geo retrieval strategy: fetch_geo_rows, get_area_suggestions, records_to_dicts."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.agents.retrievers.geo import (
+    fetch_geo_rows,
+    get_area_suggestions,
+    records_to_dicts,
+)
+
+
+def _mock_db(
+    *,
+    has_search: bool = True,
+    has_area: bool = True,
+) -> MagicMock:
+    db = MagicMock()
+    if has_search:
+        db.search_points_by_location = AsyncMock(return_value=[])
+    else:
+        del db.search_points_by_location
+    if has_area:
+        db.get_bangumi_by_area = AsyncMock(return_value=[])
+    else:
+        del db.get_bangumi_by_area
+    return db
+
+
+# ── records_to_dicts ──
+
+
+class TestRecordsToDicts:
+    def test_converts_mappings_to_dicts(self) -> None:
+        records = [{"id": "p1", "name": "A"}, {"id": "p2", "name": "B"}]
+        result = records_to_dicts(records)
+        assert result == [{"id": "p1", "name": "A"}, {"id": "p2", "name": "B"}]
+
+    def test_empty_sequence_returns_empty_list(self) -> None:
+        assert records_to_dicts([]) == []
+
+    def test_each_item_is_a_plain_dict(self) -> None:
+        records = [{"x": 1}]
+        result = records_to_dicts(records)
+        assert isinstance(result[0], dict)
+
+
+# ── fetch_geo_rows ──
+
+
+class TestFetchGeoRows:
+    @pytest.mark.asyncio
+    async def test_returns_error_on_empty_anchor(self) -> None:
+        db = _mock_db()
+        rows, error = await fetch_geo_rows(db, "", radius_m=5000)
+        assert rows == []
+        assert error is not None
+        assert "Missing" in error
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_location_unresolvable(self) -> None:
+        db = _mock_db()
+        with patch(
+            "backend.agents.retrievers.geo.resolve_location",
+            new=AsyncMock(return_value=None),
+        ):
+            rows, error = await fetch_geo_rows(db, "nowhere", radius_m=5000)
+        assert rows == []
+        assert error is not None
+        assert "nowhere" in error
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_db_lacks_geo_method(self) -> None:
+        db = _mock_db(has_search=False)
+        with patch(
+            "backend.agents.retrievers.geo.resolve_location",
+            new=AsyncMock(return_value=(34.88, 135.79)),
+        ):
+            rows, error = await fetch_geo_rows(db, "宇治", radius_m=5000)
+        assert rows == []
+        assert error is not None
+        assert "geo retrieval" in error
+
+    @pytest.mark.asyncio
+    async def test_returns_rows_and_no_error_on_success(self) -> None:
+        db = _mock_db()
+        db.search_points_by_location = AsyncMock(
+            return_value=[{"id": "p1", "name": "A"}]
+        )
+        with patch(
+            "backend.agents.retrievers.geo.resolve_location",
+            new=AsyncMock(return_value=(34.88, 135.79)),
+        ):
+            rows, error = await fetch_geo_rows(db, "宇治", radius_m=5000)
+        assert error is None
+        assert rows == [{"id": "p1", "name": "A"}]
+        db.search_points_by_location.assert_awaited_once_with(
+            34.88, 135.79, 5000, limit=200
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_result_returns_empty_rows_no_error(self) -> None:
+        db = _mock_db()
+        with patch(
+            "backend.agents.retrievers.geo.resolve_location",
+            new=AsyncMock(return_value=(34.88, 135.79)),
+        ):
+            rows, error = await fetch_geo_rows(db, "宇治", radius_m=5000)
+        assert rows == []
+        assert error is None
+
+
+# ── get_area_suggestions ──
+
+
+class TestGetAreaSuggestions:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_db_lacks_method(self) -> None:
+        db = _mock_db(has_area=False)
+        with patch(
+            "backend.agents.retrievers.geo.resolve_location",
+            new=AsyncMock(return_value=(34.88, 135.79)),
+        ):
+            result = await get_area_suggestions(db, "宇治")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_location_unresolvable(self) -> None:
+        db = _mock_db()
+        with patch(
+            "backend.agents.retrievers.geo.resolve_location",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await get_area_suggestions(db, "nowhere")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_results_on_success(self) -> None:
+        db = _mock_db()
+        db.get_bangumi_by_area = AsyncMock(
+            return_value=[{"id": "115908", "title": "響け"}]
+        )
+        with patch(
+            "backend.agents.retrievers.geo.resolve_location",
+            new=AsyncMock(return_value=(34.88, 135.79)),
+        ):
+            result = await get_area_suggestions(db, "宇治")
+        assert result == [{"id": "115908", "title": "響け"}]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_and_logs_on_db_exception(self) -> None:
+        db = _mock_db()
+        db.get_bangumi_by_area = AsyncMock(side_effect=RuntimeError("db error"))
+        with patch(
+            "backend.agents.retrievers.geo.resolve_location",
+            new=AsyncMock(return_value=(34.88, 135.79)),
+        ):
+            result = await get_area_suggestions(db, "宇治")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_coords_is_list(self) -> None:
+        db = _mock_db()
+        with patch(
+            "backend.agents.retrievers.geo.resolve_location",
+            new=AsyncMock(return_value=[]),
+        ):
+            result = await get_area_suggestions(db, "宇治")
+        assert result == []

--- a/backend/tests/unit/retrievers/test_hybrid.py
+++ b/backend/tests/unit/retrievers/test_hybrid.py
@@ -1,0 +1,62 @@
+"""Unit tests for hybrid retrieval: merge_rows_preserving_order."""
+
+from __future__ import annotations
+
+from backend.agents.retrievers.hybrid import merge_rows_preserving_order
+
+
+class TestMergeRowsPreservingOrder:
+    def test_preserves_sql_row_order(self) -> None:
+        sql_rows = [{"id": "p2", "name": "B"}, {"id": "p1", "name": "A"}]
+        geo_rows = [{"id": "p1", "distance_m": 80}, {"id": "p2", "distance_m": 120}]
+        merged = merge_rows_preserving_order(sql_rows, geo_rows)
+        assert [r["id"] for r in merged] == ["p2", "p1"]
+
+    def test_enriches_with_geo_fields(self) -> None:
+        sql_rows = [{"id": "p1", "name": "A"}]
+        geo_rows = [{"id": "p1", "distance_m": 50}]
+        merged = merge_rows_preserving_order(sql_rows, geo_rows)
+        assert merged[0]["distance_m"] == 50
+
+    def test_sql_fields_override_geo_fields(self) -> None:
+        sql_rows = [{"id": "p1", "name": "SQL Name"}]
+        geo_rows = [{"id": "p1", "name": "Geo Name", "distance_m": 50}]
+        merged = merge_rows_preserving_order(sql_rows, geo_rows)
+        assert merged[0]["name"] == "SQL Name"
+        assert merged[0]["distance_m"] == 50
+
+    def test_sql_row_without_geo_match_is_included_unchanged(self) -> None:
+        sql_rows = [{"id": "p1", "name": "A"}, {"id": "p99", "name": "Z"}]
+        geo_rows = [{"id": "p1", "distance_m": 50}]
+        merged = merge_rows_preserving_order(sql_rows, geo_rows)
+        assert len(merged) == 2
+        assert merged[1]["id"] == "p99"
+        assert "distance_m" not in merged[1]
+
+    def test_geo_rows_not_in_sql_are_excluded(self) -> None:
+        sql_rows = [{"id": "p1", "name": "A"}]
+        geo_rows = [{"id": "p1", "distance_m": 50}, {"id": "p9", "distance_m": 10}]
+        merged = merge_rows_preserving_order(sql_rows, geo_rows)
+        assert len(merged) == 1
+        assert merged[0]["id"] == "p1"
+
+    def test_empty_sql_rows_returns_empty(self) -> None:
+        geo_rows = [{"id": "p1", "distance_m": 50}]
+        assert merge_rows_preserving_order([], geo_rows) == []
+
+    def test_empty_geo_rows_returns_sql_rows(self) -> None:
+        sql_rows = [{"id": "p1", "name": "A"}]
+        merged = merge_rows_preserving_order(sql_rows, [])
+        assert merged == [{"id": "p1", "name": "A"}]
+
+    def test_sql_row_without_id_is_included(self) -> None:
+        sql_rows = [{"name": "No ID"}]
+        geo_rows = [{"id": "p1", "distance_m": 50}]
+        merged = merge_rows_preserving_order(sql_rows, geo_rows)
+        assert merged == [{"name": "No ID"}]
+
+    def test_geo_rows_without_id_are_excluded_from_index(self) -> None:
+        sql_rows = [{"id": "p1", "name": "A"}]
+        geo_rows = [{"name": "No ID"}, {"id": "p1", "distance_m": 50}]
+        merged = merge_rows_preserving_order(sql_rows, geo_rows)
+        assert merged[0]["distance_m"] == 50

--- a/backend/tests/unit/retrievers/test_sql.py
+++ b/backend/tests/unit/retrievers/test_sql.py
@@ -1,0 +1,225 @@
+"""Unit tests for SQL retrieval: execute_sql_with_fallback, should_try_db_miss_fallback."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.agents.models import RetrievalRequest
+from backend.agents.retrievers.sql import (
+    execute_sql_with_fallback,
+    should_try_db_miss_fallback,
+)
+from backend.agents.sql_agent import SQLResult
+from backend.domain.entities import Coordinates, Point
+
+
+def _make_req(**kwargs: object) -> RetrievalRequest:
+    return RetrievalRequest(tool="search_bangumi", **kwargs)  # type: ignore[arg-type]
+
+
+def _make_sql_result(
+    *,
+    rows: list[dict] | None = None,
+    error: str | None = None,
+) -> SQLResult:
+    r = rows or []
+    return SQLResult(query="SELECT 1", params=[], rows=r, row_count=len(r), error=error)
+
+
+def _make_point(point_id: str = "p1") -> Point:
+    return Point(
+        id=point_id,
+        name="宇治桥",
+        cn_name="宇治桥",
+        coordinates=Coordinates(latitude=34.8843, longitude=135.7997),
+        bangumi_id="115908",
+        bangumi_title="響け！ユーフォニアム",
+        episode=1,
+        time_seconds=42,
+    )
+
+
+# ── should_try_db_miss_fallback ──
+
+
+class TestShouldTryDbMissFallback:
+    def test_true_for_search_bangumi_with_bangumi_id(self) -> None:
+        req = _make_req(bangumi_id="115908")
+        assert should_try_db_miss_fallback(req) is True
+
+    def test_false_for_search_bangumi_without_bangumi_id(self) -> None:
+        req = _make_req()
+        assert should_try_db_miss_fallback(req) is False
+
+    def test_false_for_search_nearby_tool(self) -> None:
+        req = RetrievalRequest(tool="search_nearby", bangumi_id="115908")
+        assert should_try_db_miss_fallback(req) is False
+
+
+# ── execute_sql_with_fallback ──
+
+
+class TestExecuteSqlWithFallback:
+    @pytest.mark.asyncio
+    async def test_returns_immediately_on_sql_error(self) -> None:
+        sql_agent = MagicMock()
+        sql_agent.execute = AsyncMock(
+            return_value=_make_sql_result(error="syntax error")
+        )
+        req = _make_req(bangumi_id="115908")
+        result, meta = await execute_sql_with_fallback(
+            req, sql_agent, MagicMock(), None, None
+        )
+        assert not result.success
+        assert meta["data_origin"] == "db"
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_rows_without_fallback(self) -> None:
+        sql_agent = MagicMock()
+        sql_agent.execute = AsyncMock(
+            return_value=_make_sql_result(rows=[{"id": "p1"}])
+        )
+        req = _make_req(bangumi_id="115908")
+        result, meta = await execute_sql_with_fallback(
+            req, sql_agent, MagicMock(), None, None
+        )
+        assert result.row_count == 1
+        assert meta["data_origin"] == "db"
+        sql_agent.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_db_miss_with_no_fallback_fn_returns_early(self) -> None:
+        sql_agent = MagicMock()
+        sql_agent.execute = AsyncMock(return_value=_make_sql_result())
+        req = _make_req(bangumi_id="115908")
+        result, meta = await execute_sql_with_fallback(
+            req, sql_agent, MagicMock(), None, None
+        )
+        assert result.row_count == 0
+        sql_agent.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_db_miss_triggers_write_through_and_reruns(self) -> None:
+        db = MagicMock()
+        db.upsert_points_batch = AsyncMock()
+        db.upsert_bangumi = AsyncMock()
+        pool = AsyncMock()
+        pool.execute = AsyncMock()
+        db.pool = pool
+
+        sql_agent = MagicMock()
+        sql_agent.execute = AsyncMock(
+            side_effect=[
+                _make_sql_result(),
+                _make_sql_result(rows=[{"id": "p1"}]),
+            ]
+        )
+        fetch_bangumi_points = AsyncMock(return_value=[_make_point()])
+        get_bangumi_subject = AsyncMock(
+            return_value={
+                "name": "響け！ユーフォニアム",
+                "images": {"large": "https://example.com/cover.jpg"},
+            }
+        )
+
+        req = _make_req(bangumi_id="115908")
+        with (
+            MagicMock() as _anitabi_patch,
+        ):
+            from unittest.mock import patch
+
+            with patch(
+                "backend.agents.retrievers.enrichment.fetch_bangumi_lite",
+                new=AsyncMock(return_value=None),
+            ):
+                result, meta = await execute_sql_with_fallback(
+                    req,
+                    sql_agent,
+                    db,
+                    fetch_bangumi_points,
+                    get_bangumi_subject,
+                )
+
+        assert result.row_count == 1
+        assert meta.get("write_through") is True
+        assert sql_agent.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_triggers_fallback_even_with_rows(self) -> None:
+        db = MagicMock()
+        db.upsert_points_batch = AsyncMock()
+        db.upsert_bangumi = AsyncMock()
+        pool = AsyncMock()
+        pool.execute = AsyncMock()
+        db.pool = pool
+
+        sql_agent = MagicMock()
+        sql_agent.execute = AsyncMock(
+            side_effect=[
+                _make_sql_result(rows=[{"id": "p1"}]),
+                _make_sql_result(rows=[{"id": "p1"}, {"id": "p2"}]),
+            ]
+        )
+        fetch_bangumi_points = AsyncMock(
+            return_value=[_make_point(), _make_point("p2")]
+        )
+        get_bangumi_subject = AsyncMock(return_value={"name": "Test"})
+
+        req = _make_req(bangumi_id="115908", force_refresh=True)
+        from unittest.mock import patch
+
+        with patch(
+            "backend.agents.retrievers.enrichment.fetch_bangumi_lite",
+            new=AsyncMock(return_value=None),
+        ):
+            result, meta = await execute_sql_with_fallback(
+                req,
+                sql_agent,
+                db,
+                fetch_bangumi_points,
+                get_bangumi_subject,
+            )
+
+        assert result.row_count == 2
+        assert sql_agent.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_bangumi_id_missing(self) -> None:
+        # bangumi_id is None -> should_try_db_miss_fallback returns False
+        # -> early return with 0 rows, no fallback triggered
+        sql_agent = MagicMock()
+        sql_agent.execute = AsyncMock(return_value=_make_sql_result())
+        req = RetrievalRequest(tool="search_bangumi")
+
+        result, meta = await execute_sql_with_fallback(
+            req,
+            sql_agent,
+            MagicMock(),
+            AsyncMock(return_value=[]),
+            None,
+        )
+
+        assert result.row_count == 0
+        sql_agent.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_if_bangumi_id_none_with_force_refresh_and_rows(self) -> None:
+        # force_refresh=True bypasses the has_rows short-circuit but bangumi_id=None
+        # -> should_try_db_miss_fallback=False, has_rows=True, force_refresh=True
+        # -> falls through to the bangumi_id None check -> raises ValueError
+        sql_agent = MagicMock()
+        sql_agent.execute = AsyncMock(
+            return_value=_make_sql_result(rows=[{"id": "p1"}])
+        )
+        req = RetrievalRequest(tool="search_bangumi", force_refresh=True)
+
+        with pytest.raises(ValueError, match="bangumi_id"):
+            await execute_sql_with_fallback(
+                req,
+                sql_agent,
+                MagicMock(),
+                AsyncMock(return_value=[]),
+                None,
+            )


### PR DESCRIPTION
## Summary

- Extract geo retrieval logic into `backend/agents/retrievers/geo.py` (`fetch_geo_rows`, `get_area_suggestions`, `records_to_dicts`)
- Extract write-through/enrichment logic into `backend/agents/retrievers/enrichment.py` (`write_through_bangumi_points`, `ensure_bangumi_record`, `load_bangumi_metadata`, `persist_points`, `point_to_db_row`, `subject_to_bangumi_fields`)
- Extract hybrid merge logic into `backend/agents/retrievers/hybrid.py` (`merge_rows_preserving_order`)
- Extract SQL fallback logic into `backend/agents/retrievers/sql.py` (`execute_sql_with_fallback`, `should_try_db_miss_fallback`)
- Create `backend/agents/retrievers/__init__.py` with all re-exports
- Slim `retriever.py` from 553 lines to 235 lines (strategy dispatch + caching facade + public types)

## Test plan

- [ ] All 631 unit tests pass: `uv run pytest backend/tests/unit/ -q --no-header --no-cov`
- [ ] mypy clean: `uv run mypy backend/agents/ backend/interfaces/ backend/domain/ backend/infrastructure/`
- [ ] ruff clean: `uv run ruff format backend/ && uv run ruff check backend/`
- [ ] Public interface `Retriever`, `RetrievalResult`, `RetrievalStrategy` unchanged — all existing imports work
- [ ] `_merge_rows_preserving_order` alias preserved in `retriever.py` for test backward-compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)