### PR TITLE
refactor(handlers): deduplicate search_bangumi and search_nearby via _base_search

### DIFF
--- a/backend/agents/handlers/_base_search.py
+++ b/backend/agents/handlers/_base_search.py
@@ -1,0 +1,56 @@
+"""Shared retrieval execution template for search handlers."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from backend.agents.handlers._helpers import build_query_payload
+from backend.agents.models import RetrievalRequest, ToolName
+from backend.agents.retriever import Retriever
+
+
+def resolve_bangumi_id(
+    params: dict[str, object],
+    context: dict[str, object],
+) -> str | None:
+    """Return bangumi_id from params, falling back to resolve_anime context."""
+    bid = params.get("bangumi_id")
+    if isinstance(bid, str) and bid:
+        return bid
+    resolved = context.get(ToolName.RESOLVE_ANIME.value)
+    if isinstance(resolved, dict):
+        fallback = resolved.get("bangumi_id")
+        if isinstance(fallback, str) and fallback:
+            return fallback
+    return None
+
+
+def build_bangumi_request(
+    bangumi_id: str,
+    params: dict[str, object],
+) -> RetrievalRequest:
+    """Build a RetrievalRequest for search_bangumi from validated params."""
+    episode = params.get("episode")
+    origin = params.get("origin")
+    return RetrievalRequest(
+        tool="search_bangumi",
+        bangumi_id=bangumi_id,
+        episode=episode if isinstance(episode, int) else None,
+        origin=origin if isinstance(origin, str) else None,
+        force_refresh=bool(params.get("force_refresh", False)),
+    )
+
+
+async def execute_retrieval(
+    req: RetrievalRequest,
+    retriever: object,
+) -> dict[str, object]:
+    """Execute a retrieval request and return a standard result dict."""
+    typed = cast(Retriever, retriever)
+    result = await typed.execute(req)
+    return {
+        "tool": req.tool,
+        "success": result.success,
+        "data": build_query_payload(result),
+        "error": result.error,
+    }

--- a/backend/agents/handlers/search_bangumi.py
+++ b/backend/agents/handlers/search_bangumi.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import cast
-
-from backend.agents.handlers._helpers import build_query_payload
-from backend.agents.models import PlanStep, RetrievalRequest, ToolName
-from backend.agents.retriever import Retriever
+from backend.agents.handlers._base_search import (
+    build_bangumi_request,
+    execute_retrieval,
+    resolve_bangumi_id,
+)
+from backend.agents.models import PlanStep
 
 
 async def execute(
@@ -15,41 +16,13 @@ async def execute(
     db: object,
     retriever: object,
 ) -> dict[str, object]:
-    """Search pilgrimage points for a specific bangumi.
-
-    Returns a dict with keys: tool, success, data?, error?
-    """
+    """Search pilgrimage points for a specific bangumi."""
     params = step.params or {}
-    bangumi_id = params.get("bangumi_id")
-    if not isinstance(bangumi_id, str) or not bangumi_id:
-        resolved = context.get(ToolName.RESOLVE_ANIME.value)
-        if isinstance(resolved, dict):
-            resolved_id = resolved.get("bangumi_id")
-            if isinstance(resolved_id, str) and resolved_id:
-                bangumi_id = resolved_id
-    if not isinstance(bangumi_id, str) or not bangumi_id:
+    bangumi_id = resolve_bangumi_id(params, context)
+    if not bangumi_id:
         return {
             "tool": "search_bangumi",
             "success": False,
             "error": "No bangumi_id available",
         }
-
-    episode = params.get("episode")
-    episode_value = episode if isinstance(episode, int) else None
-    origin = params.get("origin")
-    origin_value = origin if isinstance(origin, str) else None
-    req = RetrievalRequest(
-        tool="search_bangumi",
-        bangumi_id=bangumi_id,
-        episode=episode_value,
-        origin=origin_value,
-        force_refresh=bool(params.get("force_refresh", False)),
-    )
-    typed_retriever = cast(Retriever, retriever)
-    retrieval = await typed_retriever.execute(req)
-    return {
-        "tool": "search_bangumi",
-        "success": retrieval.success,
-        "data": build_query_payload(retrieval),
-        "error": retrieval.error,
-    }
+    return await execute_retrieval(build_bangumi_request(bangumi_id, params), retriever)

--- a/backend/agents/handlers/search_nearby.py
+++ b/backend/agents/handlers/search_nearby.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-from typing import cast
-
-from backend.agents.handlers._helpers import build_query_payload
+from backend.agents.handlers._base_search import execute_retrieval
 from backend.agents.models import PlanStep, RetrievalRequest
-from backend.agents.retriever import Retriever
 
 
 async def execute(
@@ -15,24 +12,12 @@ async def execute(
     db: object,
     retriever: object,
 ) -> dict[str, object]:
-    """Search pilgrimage points near a location.
-
-    Returns a dict with keys: tool, success, data?, error?
-    """
+    """Search pilgrimage points near a location."""
     params = step.params or {}
     location = params.get("location")
-    if not isinstance(location, str):
-        location = ""
     req = RetrievalRequest(
         tool="search_nearby",
-        location=location,
+        location=location if isinstance(location, str) else "",
         radius=params.get("radius"),
     )
-    typed_retriever = cast(Retriever, retriever)
-    retrieval = await typed_retriever.execute(req)
-    return {
-        "tool": "search_nearby",
-        "success": retrieval.success,
-        "data": build_query_payload(retrieval),
-        "error": retrieval.error,
-    }
+    return await execute_retrieval(req, retriever)

--- a/backend/tests/unit/test_handlers.py
+++ b/backend/tests/unit/test_handlers.py
@@ -5,15 +5,84 @@ from __future__ import annotations
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from backend.agents.handlers._base_search import execute_retrieval, resolve_bangumi_id
 from backend.agents.handlers.answer_question import execute, execute_clarify
 from backend.agents.handlers.plan_route import execute as execute_plan_route
 from backend.agents.handlers.resolve_anime import execute as execute_resolve
 from backend.agents.handlers.search_bangumi import execute as execute_search
-from backend.agents.models import PlanStep, ToolName
+from backend.agents.models import PlanStep, RetrievalRequest, ToolName
 
 
 def _step(tool: ToolName, params: dict[str, object] | None = None) -> PlanStep:
     return PlanStep(tool=tool, params=params or {})
+
+
+# ---------------------------------------------------------------------------
+# _base_search
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeResult:
+    success: bool
+    rows: list[dict[str, object]]
+    row_count: int
+    error: str | None = None
+    metadata: dict[str, object] | None = None
+    strategy: object = None
+
+    def __post_init__(self) -> None:
+        if self.metadata is None:
+            self.metadata = {}
+        if self.strategy is None:
+            from backend.agents.retriever import RetrievalStrategy
+
+            self.strategy = RetrievalStrategy.SQL
+
+
+class TestBaseSearch:
+    async def test_returns_success_dict(self) -> None:
+        fake = _FakeResult(success=True, rows=[{"id": "p1"}], row_count=1)
+        retriever = MagicMock()
+        retriever.execute = AsyncMock(return_value=fake)
+        req = RetrievalRequest(tool="search_bangumi", bangumi_id="253")
+
+        result = await execute_retrieval(req, retriever)
+
+        assert result["tool"] == "search_bangumi"
+        assert result["success"] is True
+        assert result["data"]["row_count"] == 1
+
+    async def test_returns_failure_dict(self) -> None:
+        fake = _FakeResult(success=False, rows=[], row_count=0, error="not found")
+        retriever = MagicMock()
+        retriever.execute = AsyncMock(return_value=fake)
+        req = RetrievalRequest(tool="search_nearby", location="Kyoto")
+
+        result = await execute_retrieval(req, retriever)
+
+        assert result["tool"] == "search_nearby"
+        assert result["success"] is False
+        assert result["error"] == "not found"
+
+    def test_resolve_bangumi_id_from_params(self) -> None:
+        result = resolve_bangumi_id({"bangumi_id": "253"}, {})
+        assert result == "253"
+
+    def test_resolve_bangumi_id_from_context(self) -> None:
+        result = resolve_bangumi_id({}, {"resolve_anime": {"bangumi_id": "999"}})
+        assert result == "999"
+
+    def test_resolve_bangumi_id_returns_none_when_missing(self) -> None:
+        result = resolve_bangumi_id({}, {})
+        assert result is None
+
+    def test_resolve_bangumi_id_params_takes_precedence(self) -> None:
+        result = resolve_bangumi_id(
+            {"bangumi_id": "111"},
+            {"resolve_anime": {"bangumi_id": "999"}},
+        )
+        assert result == "111"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extracted shared retrieval execution pattern from `search_bangumi.py` and `search_nearby.py` into `backend/agents/handlers/_base_search.py`
- New helpers: `execute_retrieval` (cast → retriever.execute → result dict), `resolve_bangumi_id` (params + context fallback), `build_bangumi_request` (typed RetrievalRequest builder)
- Both handlers now delegate to these helpers; each handler file has minimal logic (3-4 lines of function body)
- No behavioral changes — all 639 unit tests pass

## Test plan

- [x] `TestBaseSearch.test_returns_success_dict` — unit, new
- [x] `TestBaseSearch.test_returns_failure_dict` — unit, new
- [x] `TestBaseSearch.test_resolve_bangumi_id_from_params` — unit, new
- [x] `TestBaseSearch.test_resolve_bangumi_id_from_context` — unit, new
- [x] `TestBaseSearch.test_resolve_bangumi_id_returns_none_when_missing` — unit, new
- [x] `TestBaseSearch.test_resolve_bangumi_id_params_takes_precedence` — unit, new
- [x] Existing `TestSearchBangumi` and `TestSearchNearby` tests all pass unchanged
- [x] `uv run mypy`: no issues in 71 source files
- [x] `uv run ruff check`: all checks passed

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)