### PR TITLE
refactor(supabase): remove __getattr__ delegation and pass-through methods

### DIFF
--- a/backend/agents/handlers/plan_selected.py
+++ b/backend/agents/handlers/plan_selected.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from backend.agents.handlers._helpers import optimize_route
 from backend.agents.models import PlanStep
+from backend.infrastructure.supabase.client import SupabaseClient
 
 
 async def execute(
@@ -30,8 +31,7 @@ async def execute(
             "error": "point_ids is required",
         }
 
-    get_points_by_ids = getattr(db, "get_points_by_ids", None)
-    if get_points_by_ids is None:
+    if not isinstance(db, SupabaseClient):
         return {
             "tool": "plan_selected",
             "success": False,
@@ -39,7 +39,7 @@ async def execute(
         }
 
     rows: list[dict[str, object]] = [
-        dict(row) for row in await get_points_by_ids(point_ids)
+        dict(row) for row in await db.points.get_points_by_ids(point_ids)
     ]
     origin_raw = params.get("origin") or context.get("last_location")
     origin = origin_raw if isinstance(origin_raw, str) else None

--- a/backend/agents/handlers/resolve_anime.py
+++ b/backend/agents/handlers/resolve_anime.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import cast
-
 import structlog
 
 from backend.agents.models import PlanStep
@@ -30,9 +28,11 @@ async def execute(
     if not title:
         return {"tool": "resolve_anime", "success": False, "error": "No title provided"}
 
+    if not isinstance(db, SupabaseClient):
+        return {"tool": "resolve_anime", "success": False, "error": "DB not available"}
+
     # 1. DB lookup
-    typed_db = cast(SupabaseClient, db)
-    bangumi_id = await typed_db.bangumi.find_bangumi_by_title(title)
+    bangumi_id = await db.bangumi.find_bangumi_by_title(title)
     if bangumi_id:
         logger.info("resolve_anime_db_hit", title=title, bangumi_id=bangumi_id)
         return {
@@ -45,7 +45,7 @@ async def execute(
     gateway = BangumiClientGateway()
     bangumi_id = await gateway.search_by_title(title)
     if bangumi_id:
-        await typed_db.bangumi.upsert_bangumi_title(title, bangumi_id)
+        await db.bangumi.upsert_bangumi_title(title, bangumi_id)
         logger.info("resolve_anime_api_hit", title=title, bangumi_id=bangumi_id)
         return {
             "tool": "resolve_anime",

--- a/backend/agents/handlers/resolve_anime.py
+++ b/backend/agents/handlers/resolve_anime.py
@@ -32,7 +32,7 @@ async def execute(
 
     # 1. DB lookup
     typed_db = cast(SupabaseClient, db)
-    bangumi_id = await typed_db.find_bangumi_by_title(title)
+    bangumi_id = await typed_db.bangumi.find_bangumi_by_title(title)
     if bangumi_id:
         logger.info("resolve_anime_db_hit", title=title, bangumi_id=bangumi_id)
         return {
@@ -45,7 +45,7 @@ async def execute(
     gateway = BangumiClientGateway()
     bangumi_id = await gateway.search_by_title(title)
     if bangumi_id:
-        await typed_db.upsert_bangumi_title(title, bangumi_id)
+        await typed_db.bangumi.upsert_bangumi_title(title, bangumi_id)
         logger.info("resolve_anime_api_hit", title=title, bangumi_id=bangumi_id)
         return {
             "tool": "resolve_anime",

--- a/backend/agents/retrievers/enrichment.py
+++ b/backend/agents/retrievers/enrichment.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping
+from typing import TYPE_CHECKING
 
 import structlog
 
 from backend.clients.anitabi import AnitabiClient
 from backend.domain.entities import Point
+
+if TYPE_CHECKING:
+    pass
 
 logger = structlog.get_logger(__name__)
 
@@ -100,11 +104,12 @@ async def load_bangumi_metadata(
 
 
 async def persist_points(db: object, points: list[Point]) -> None:
-    upsert_points_batch = getattr(db, "upsert_points_batch", None)
-    if upsert_points_batch is None:
+    from backend.infrastructure.supabase.client import SupabaseClient
+
+    if not isinstance(db, SupabaseClient):
         return
     rows = [point_to_db_row(point) for point in points]
-    await upsert_points_batch(rows)
+    await db.points.upsert_points_batch(rows)
 
 
 async def update_bangumi_points_count(
@@ -131,8 +136,9 @@ async def ensure_bangumi_record(
     points: list[Point],
     get_bangumi_subject: Callable[[int], Awaitable[dict[str, object]]] | None,
 ) -> None:
-    upsert_bangumi = getattr(db, "upsert_bangumi", None)
-    if upsert_bangumi is None:
+    from backend.infrastructure.supabase.client import SupabaseClient
+
+    if not isinstance(db, SupabaseClient):
         return
 
     metadata = await load_bangumi_metadata(bangumi_id, points, get_bangumi_subject)
@@ -152,7 +158,7 @@ async def ensure_bangumi_record(
         if isinstance(lite_cover, str) and lite_cover:
             metadata["cover_url"] = lite_cover
 
-    await upsert_bangumi(bangumi_id, **metadata)
+    await db.bangumi.upsert_bangumi(bangumi_id, **metadata)
 
 
 async def write_through_bangumi_points(

--- a/backend/agents/retrievers/enrichment.py
+++ b/backend/agents/retrievers/enrichment.py
@@ -4,15 +4,11 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping
-from typing import TYPE_CHECKING
 
 import structlog
 
 from backend.clients.anitabi import AnitabiClient
 from backend.domain.entities import Point
-
-if TYPE_CHECKING:
-    pass
 
 logger = structlog.get_logger(__name__)
 

--- a/backend/agents/retrievers/geo.py
+++ b/backend/agents/retrievers/geo.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 import structlog
 
 from backend.agents.sql_agent import resolve_location
+from backend.infrastructure.supabase.client import SupabaseClient
 
 logger = structlog.get_logger(__name__)
 
@@ -33,12 +34,16 @@ async def fetch_geo_rows(
     if coords is None:
         return [], f"Unknown location: {anchor}. Could not resolve coordinates."
 
-    search_points = getattr(db, "search_points_by_location", None)
-    if search_points is None:
+    if isinstance(coords, list):
+        return [], f"Ambiguous location: {anchor}. Multiple candidates found."
+
+    if not isinstance(db, SupabaseClient):
         return [], "Database client does not support geo retrieval"
 
     lat, lon = coords
-    records = await search_points(lat, lon, radius_m, limit=_DEFAULT_GEO_LIMIT)
+    records = await db.points.search_points_by_location(
+        lat, lon, radius_m, limit=_DEFAULT_GEO_LIMIT
+    )
     return records_to_dicts(records), None
 
 

--- a/backend/infrastructure/session/supabase_session.py
+++ b/backend/infrastructure/session/supabase_session.py
@@ -34,7 +34,7 @@ class SupabaseSessionStore:
             logger.debug("session_cache_hit", session_id=session_id)
             return self._cache[session_id]
 
-        state = await self._db.get_session_state(session_id)
+        state = await self._db.session.get_session_state(session_id)
         if state is not None:
             self._evict_if_full()
             self._cache[session_id] = state
@@ -45,13 +45,13 @@ class SupabaseSessionStore:
         """Write-through: update cache and persist to DB."""
         self._evict_if_full()
         self._cache[session_id] = state
-        await self._db.upsert_session_state(session_id, state)
+        await self._db.session.upsert_session_state(session_id, state)
         logger.debug("session_persisted", session_id=session_id)
 
     async def delete(self, session_id: str) -> None:
         """Remove session from cache and DB."""
         self._cache.pop(session_id, None)
-        await self._db.delete_session_state(session_id)
+        await self._db.session.delete_session_state(session_id)
         logger.debug("session_deleted", session_id=session_id)
 
     def _evict_if_full(self) -> None:

--- a/backend/infrastructure/supabase/client.py
+++ b/backend/infrastructure/supabase/client.py
@@ -2,7 +2,7 @@
 
 Usage:
     async with SupabaseClient(dsn="postgresql://...") as db:
-        bangumi = await db.get_bangumi("12345")
+        bangumi_id = await db.bangumi.find_bangumi_by_title("Eupho")
 """
 
 from __future__ import annotations
@@ -32,8 +32,9 @@ __all__ = ["Row", "SupabaseClient"]
 class SupabaseClient:
     """Async PostgreSQL client delegating to domain repository instances.
 
-    Backward-compatible: all methods from the old monolithic class are
-    accessible via ``__getattr__`` delegation.
+    Access repositories via explicit typed properties:
+    ``db.bangumi``, ``db.points``, ``db.session``, ``db.feedback``,
+    ``db.routes``, ``db.messages``, ``db.user_memory``.
     """
 
     def __init__(
@@ -148,55 +149,3 @@ class SupabaseClient:
                 "MessagesRepository not initialized — call connect() first"
             )
         return self._messages
-
-    # --- Explicit delegation for frequently-used methods (mypy-visible) ---
-
-    def _ensure_repos(self) -> None:
-        """Lazily init repos when pool was set directly (tests bypass connect())."""
-        if (
-            self.__dict__.get("_bangumi") is None
-            and self.__dict__.get("_pool") is not None
-        ):
-            self._init_repos(self._pool)  # type: ignore[arg-type]
-
-    async def get_session_state(self, session_id: str) -> dict[str, object] | None:
-        self._ensure_repos()
-        return await self.session.get_session_state(session_id)
-
-    async def upsert_session_state(
-        self, session_id: str, state: dict[str, object]
-    ) -> None:
-        self._ensure_repos()
-        await self.session.upsert_session_state(session_id, state)
-
-    async def delete_session_state(self, session_id: str) -> None:
-        self._ensure_repos()
-        await self.session.delete_session_state(session_id)
-
-    async def find_bangumi_by_title(self, title: str) -> str | None:
-        self._ensure_repos()
-        return await self.bangumi.find_bangumi_by_title(title)
-
-    async def upsert_bangumi_title(self, title: str, bangumi_id: str) -> None:
-        self._ensure_repos()
-        await self.bangumi.upsert_bangumi_title(title, bangumi_id)
-
-    # --- Backward-compatible delegation (remaining methods) ---
-
-    def __getattr__(self, name: str) -> object:
-        # Lazily init repos when _pool was set directly (tests bypass connect()).
-        pool = self.__dict__.get("_pool")
-        if pool is not None and self.__dict__.get("_bangumi") is None:
-            self._init_repos(pool)
-        for repo in (
-            self._bangumi,
-            self._points,
-            self._session,
-            self._feedback,
-            self._user_memory,
-            self._routes,
-            self._messages,
-        ):
-            if repo is not None and hasattr(repo, name):
-                return getattr(repo, name)
-        raise AttributeError(f"'{type(self).__name__}' has no attribute '{name}'")

--- a/backend/interfaces/fastapi_service.py
+++ b/backend/interfaces/fastapi_service.py
@@ -22,7 +22,6 @@ from backend.interfaces.public_api import RuntimeAPI
 from backend.interfaces.routes._deps import (  # noqa: F401
     _contains_json_invalid_error,
     _http_error_code,
-    _require_db_method,
     build_session_store,
     build_supabase_client,
     call_optional_async,

--- a/backend/interfaces/public_api.py
+++ b/backend/interfaces/public_api.py
@@ -26,6 +26,7 @@ from backend.infrastructure.observability import (
     record_runtime_request,
 )
 from backend.infrastructure.session import SessionStore, create_session_store
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.response_builder import (
     application_error_response,
     pipeline_result_to_public_response,
@@ -409,18 +410,13 @@ class RuntimeAPI:
             logger.warning("insert_bot_message_failed", session_id=session_id)
 
     async def _load_user_memory(self, user_id: str | None) -> dict[str, object] | None:
-        if not user_id:
-            return None
-
-        get_user_memory = getattr(self._db, "get_user_memory", None)
-        if get_user_memory is None:
+        if not user_id or not isinstance(self._db, SupabaseClient):
             return None
 
         try:
-            result = await get_user_memory(user_id)
-            if isinstance(result, dict):
-                return result
-            return None
+            result = await self._db.user_memory.get_user_memory(user_id)
+            # Return widened to dict[str, object] for callers expecting the broader type
+            return result  # type: ignore[return-value]
         except Exception:
             logger.warning("get_user_memory_failed", user_id=user_id)
             return None
@@ -439,10 +435,11 @@ class RuntimeAPI:
         if not user_id or result is None or not response.success:
             return
 
-        upsert_conversation = getattr(self._db, "upsert_conversation", None)
-        if upsert_conversation is not None:
+        if isinstance(self._db, SupabaseClient):
             try:
-                await upsert_conversation(session_id, user_id, request.text)
+                await self._db.session.upsert_conversation(
+                    session_id, user_id, request.text
+                )
             except Exception:
                 logger.warning("upsert_conversation_failed", session_id=session_id)
             else:
@@ -462,18 +459,16 @@ class RuntimeAPI:
                     )
 
         bangumi_id = context_delta.get("bangumi_id")
-        if not bangumi_id:
+        if not isinstance(bangumi_id, str) or not isinstance(self._db, SupabaseClient):
             return
 
-        upsert_user_memory = getattr(self._db, "upsert_user_memory", None)
-        if upsert_user_memory is None:
-            return
-
+        anime_title_raw = context_delta.get("anime_title")
+        anime_title = anime_title_raw if isinstance(anime_title_raw, str) else None
         try:
-            await upsert_user_memory(
+            await self._db.user_memory.upsert_user_memory(
                 user_id,
                 bangumi_id=bangumi_id,
-                anime_title=context_delta.get("anime_title"),
+                anime_title=anime_title,
             )
         except Exception:
             logger.warning("upsert_user_memory_failed", user_id=user_id)
@@ -490,14 +485,15 @@ class RuntimeAPI:
     ) -> None:
         await self._session_store.set(session_id, session_state)
 
-        upsert_session = getattr(self._db, "upsert_session", None)
-        if upsert_session is not None:
+        if isinstance(self._db, SupabaseClient):
             metadata = {
                 "intent": response.intent,
                 "status": response.status,
                 "updated_at": session_state["updated_at"],
             }
-            await upsert_session(session_id, session_state, metadata=metadata)
+            await self._db.session.upsert_session(
+                session_id, session_state, metadata=metadata
+            )
 
     async def _maybe_persist_route(
         self,
@@ -527,11 +523,12 @@ class RuntimeAPI:
             return None
 
         plan_params = _get_plan_params(result)
-        bangumi_id = plan_params.get("bangumi") or _infer_bangumi_id(
+        bangumi_id_raw = plan_params.get("bangumi") or _infer_bangumi_id(
             response.data.get("results")
         )
-        if not bangumi_id:
+        if not isinstance(bangumi_id_raw, str):
             return None
+        bangumi_id = bangumi_id_raw
 
         origin_station = plan_params.get("origin")
         if not isinstance(origin_station, str):
@@ -543,7 +540,7 @@ class RuntimeAPI:
         ):
             origin_station = f"{request.origin_lat},{request.origin_lng}"
 
-        route_record = {
+        route_record: dict[str, object] = {
             "route_id": None,
             "bangumi_id": bangumi_id,
             "origin_station": origin_station,
@@ -552,9 +549,8 @@ class RuntimeAPI:
             "created_at": datetime.now(UTC).isoformat(),
         }
 
-        save_route = getattr(self._db, "save_route", None)
-        if save_route is not None:
-            route_id = await save_route(
+        if isinstance(self._db, SupabaseClient):
+            route_id = await self._db.routes.save_route(
                 session_id,
                 bangumi_id,
                 point_ids,

--- a/backend/interfaces/routes/_deps.py
+++ b/backend/interfaces/routes/_deps.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import Annotated, Literal, cast
 
@@ -100,16 +100,10 @@ def _get_db_from_request(request: Request) -> object:
     return cast(object, getattr(request.app.state, "db_client", None))
 
 
-def _require_db_method(
-    db: object, method_name: str
-) -> Callable[..., Awaitable[object]]:
-    method = getattr(db, method_name, None)
-    if method is None or not callable(method):
-        raise HTTPException(
-            status_code=500,
-            detail=f"Database adapter is missing required method: {method_name}.",
-        )
-    return cast(Callable[..., Awaitable[object]], method)
+def _require_supabase(db: object) -> SupabaseClient:
+    if not isinstance(db, SupabaseClient):
+        raise HTTPException(status_code=500, detail="Database client not available.")
+    return db
 
 
 def _public_api_response(response: PublicAPIResponse) -> JSONResponse:

--- a/backend/interfaces/routes/bangumi.py
+++ b/backend/interfaces/routes/bangumi.py
@@ -7,21 +7,15 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.routes._deps import (
     TrustedAuthContext,
     _get_db_from_request,
     _get_trusted_auth_context,
     _json_response,
+    _require_supabase,
 )
 
 router = APIRouter(prefix="/v1/bangumi", tags=["bangumi"])
-
-
-def _require_supabase(db: object) -> SupabaseClient:
-    if not isinstance(db, SupabaseClient):
-        raise HTTPException(status_code=500, detail="Database client not available.")
-    return db
 
 
 @router.get("/popular")

--- a/backend/interfaces/routes/bangumi.py
+++ b/backend/interfaces/routes/bangumi.py
@@ -7,15 +7,21 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.routes._deps import (
     TrustedAuthContext,
     _get_db_from_request,
     _get_trusted_auth_context,
     _json_response,
-    _require_db_method,
 )
 
 router = APIRouter(prefix="/v1/bangumi", tags=["bangumi"])
+
+
+def _require_supabase(db: object) -> SupabaseClient:
+    if not isinstance(db, SupabaseClient):
+        raise HTTPException(status_code=500, detail="Database client not available.")
+    return db
 
 
 @router.get("/popular")
@@ -26,9 +32,8 @@ async def handle_bangumi_popular(
 ) -> JSONResponse:
     if limit < 1:
         raise HTTPException(status_code=422, detail="limit must be a positive integer.")
-    db = _get_db_from_request(request)
-    list_popular = _require_db_method(db, "list_popular")
-    rows_obj: object = await list_popular(limit=limit)
+    db = _require_supabase(_get_db_from_request(request))
+    rows_obj: object = await db.bangumi.list_popular(limit=limit)
     rows: list[object] = list(rows_obj) if isinstance(rows_obj, list) else []
     return _json_response({"bangumi": rows})
 
@@ -47,8 +52,7 @@ async def handle_bangumi_nearby(
         raise HTTPException(status_code=422, detail="lng must be between -180 and 180.")
     if radius_m < 1:
         raise HTTPException(status_code=422, detail="radius_m must be positive.")
-    db = _get_db_from_request(request)
-    get_bangumi_by_area = _require_db_method(db, "get_bangumi_by_area")
-    rows_obj: object = await get_bangumi_by_area(lat, lng, radius_m)
+    db = _require_supabase(_get_db_from_request(request))
+    rows_obj: object = await db.bangumi.get_bangumi_by_area(lat, lng, radius_m)
     rows: list[object] = list(rows_obj) if isinstance(rows_obj, list) else []
     return _json_response({"bangumi": rows})

--- a/backend/interfaces/routes/conversations.py
+++ b/backend/interfaces/routes/conversations.py
@@ -4,20 +4,26 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.routes._deps import (
     ConversationPatchRequest,
     TrustedAuthContext,
     _error_response,
     _get_db_from_request,
     _json_response,
-    _require_db_method,
     _require_trusted_user,
 )
 
 router = APIRouter(prefix="/v1", tags=["conversations"])
+
+
+def _require_supabase(db: object) -> SupabaseClient:
+    if not isinstance(db, SupabaseClient):
+        raise HTTPException(status_code=500, detail="Database client not available.")
+    return db
 
 
 @router.get("/conversations")
@@ -26,9 +32,8 @@ async def handle_get_conversations(
     auth: Annotated[TrustedAuthContext, Depends(_require_trusted_user)],
 ) -> JSONResponse:
     assert auth.user_id is not None
-    db = _get_db_from_request(request)
-    get_conversations = _require_db_method(db, "get_conversations")
-    conversations_obj: object = await get_conversations(auth.user_id)
+    db = _require_supabase(_get_db_from_request(request))
+    conversations_obj: object = await db.session.get_conversations(auth.user_id)
     return _json_response(conversations_obj)
 
 
@@ -40,9 +45,8 @@ async def handle_patch_conversation(
     auth: Annotated[TrustedAuthContext, Depends(_require_trusted_user)],
 ) -> JSONResponse:
     assert auth.user_id is not None
-    db = _get_db_from_request(request)
-    get_conversation = _require_db_method(db, "get_conversation")
-    conversation_obj: object = await get_conversation(session_id)
+    db = _require_supabase(_get_db_from_request(request))
+    conversation_obj: object = await db.session.get_conversation(session_id)
     conversation = conversation_obj if isinstance(conversation_obj, dict) else None
     if conversation is None or conversation.get("user_id") != auth.user_id:
         return _error_response(
@@ -50,8 +54,9 @@ async def handle_patch_conversation(
             "Conversation not found.",
             status_code=404,
         )
-    update_conversation_title = _require_db_method(db, "update_conversation_title")
-    await update_conversation_title(session_id, payload.title, user_id=auth.user_id)
+    await db.session.update_conversation_title(
+        session_id, payload.title, user_id=auth.user_id
+    )
     return _json_response({"ok": True})
 
 
@@ -62,9 +67,8 @@ async def handle_get_messages(
     auth: Annotated[TrustedAuthContext, Depends(_require_trusted_user)],
 ) -> JSONResponse:
     assert auth.user_id is not None
-    db = _get_db_from_request(request)
-    get_conversation = _require_db_method(db, "get_conversation")
-    conversation_obj: object = await get_conversation(session_id)
+    db = _require_supabase(_get_db_from_request(request))
+    conversation_obj: object = await db.session.get_conversation(session_id)
     conversation = conversation_obj if isinstance(conversation_obj, dict) else None
     if conversation is None or conversation.get("user_id") != auth.user_id:
         return _error_response(
@@ -73,8 +77,7 @@ async def handle_get_messages(
             status_code=404,
         )
 
-    get_messages = _require_db_method(db, "get_messages")
-    messages_obj: object = await get_messages(session_id)
+    messages_obj: object = await db.messages.get_messages(session_id)
     return _json_response({"messages": messages_obj})
 
 
@@ -84,7 +87,6 @@ async def handle_get_routes(
     auth: Annotated[TrustedAuthContext, Depends(_require_trusted_user)],
 ) -> JSONResponse:
     assert auth.user_id is not None
-    db = _get_db_from_request(request)
-    get_user_routes = _require_db_method(db, "get_user_routes")
-    routes_obj: object = await get_user_routes(auth.user_id)
+    db = _require_supabase(_get_db_from_request(request))
+    routes_obj: object = await db.routes.get_user_routes(auth.user_id)
     return _json_response({"routes": routes_obj})

--- a/backend/interfaces/routes/conversations.py
+++ b/backend/interfaces/routes/conversations.py
@@ -4,26 +4,20 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
-from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.routes._deps import (
     ConversationPatchRequest,
     TrustedAuthContext,
     _error_response,
     _get_db_from_request,
     _json_response,
+    _require_supabase,
     _require_trusted_user,
 )
 
 router = APIRouter(prefix="/v1", tags=["conversations"])
-
-
-def _require_supabase(db: object) -> SupabaseClient:
-    if not isinstance(db, SupabaseClient):
-        raise HTTPException(status_code=500, detail="Database client not available.")
-    return db
 
 
 @router.get("/conversations")

--- a/backend/interfaces/routes/feedback.py
+++ b/backend/interfaces/routes/feedback.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
-from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.routes._deps import (
     FeedbackRequest,
     _get_db_from_request,
     _json_response,
+    _require_supabase,
 )
 
 router = APIRouter(prefix="/v1", tags=["feedback"])
@@ -20,9 +20,7 @@ async def handle_feedback(
     payload: FeedbackRequest,
     request: Request,
 ) -> JSONResponse:
-    db = _get_db_from_request(request)
-    if not isinstance(db, SupabaseClient):
-        raise HTTPException(status_code=500, detail="Database client not available.")
+    db = _require_supabase(_get_db_from_request(request))
     feedback_id_obj = await db.feedback.save_feedback(
         payload.session_id,
         payload.query_text,

--- a/backend/interfaces/routes/feedback.py
+++ b/backend/interfaces/routes/feedback.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.routes._deps import (
     FeedbackRequest,
     _get_db_from_request,
     _json_response,
-    _require_db_method,
 )
 
 router = APIRouter(prefix="/v1", tags=["feedback"])
@@ -21,8 +21,9 @@ async def handle_feedback(
     request: Request,
 ) -> JSONResponse:
     db = _get_db_from_request(request)
-    save_feedback = _require_db_method(db, "save_feedback")
-    feedback_id_obj = await save_feedback(
+    if not isinstance(db, SupabaseClient):
+        raise HTTPException(status_code=500, detail="Database client not available.")
+    feedback_id_obj = await db.feedback.save_feedback(
         payload.session_id,
         payload.query_text,
         payload.intent,

--- a/backend/interfaces/session_facade.py
+++ b/backend/interfaces/session_facade.py
@@ -15,6 +15,7 @@ from backend.agents.base import create_agent, get_default_model
 from backend.agents.executor_agent import PipelineResult
 from backend.agents.models import ExecutionPlan, PlanStep, ToolName
 from backend.infrastructure.session import SessionStore
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.schemas import PublicAPIRequest
 
 logger = structlog.get_logger(__name__)
@@ -404,14 +405,13 @@ async def generate_and_save_title(
     except Exception:
         logger.warning("conversation_title_generation_failed", session_id=session_id)
 
-    update_conversation_title = getattr(db, "update_conversation_title", None)
-    if update_conversation_title is None:
+    if not isinstance(db, SupabaseClient):
         return
 
     try:
-        await update_conversation_title(session_id, title, user_id=user_id)
+        await db.session.update_conversation_title(session_id, title, user_id=user_id)
     except TypeError:
-        await update_conversation_title(session_id, title)
+        await db.session.update_conversation_title(session_id, title)
     except Exception:
         logger.warning("update_conversation_title_failed", session_id=session_id)
 

--- a/backend/tests/eval/test_plan_quality.py
+++ b/backend/tests/eval/test_plan_quality.py
@@ -106,8 +106,8 @@ def _make_mock_db() -> object:
     db.search_points_by_location = AsyncMock(return_value=[])
     db.query_bangumi_points = AsyncMock(return_value=[])
     db.query_nearby_points = AsyncMock(return_value=[])
-    db.find_bangumi_by_title = AsyncMock(return_value="262243")
-    db.upsert_bangumi_title = AsyncMock(return_value=None)
+    db.bangumi.find_bangumi_by_title = AsyncMock(return_value="262243")
+    db.bangumi.upsert_bangumi_title = AsyncMock(return_value=None)
     db.save_route = AsyncMock(return_value=None)
     db.load_route = AsyncMock(return_value=None)
     return db

--- a/backend/tests/unit/conftest_fastapi.py
+++ b/backend/tests/unit/conftest_fastapi.py
@@ -13,19 +13,27 @@ from fastapi import FastAPI
 
 from backend.config.settings import Settings
 from backend.infrastructure.session.memory import InMemorySessionStore
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.fastapi_service import create_fastapi_app
 from backend.interfaces.public_api import RuntimeAPI
 from backend.interfaces.schemas import PublicAPIResponse
 
 
 def build_stub_db() -> MagicMock:
-    db = MagicMock()
-    db.get_conversations = AsyncMock(return_value=[])
-    db.get_conversation = AsyncMock(return_value={"user_id": "user-1"})
-    db.get_messages = AsyncMock(return_value=[])
-    db.get_user_routes = AsyncMock(return_value=[])
-    db.save_feedback = AsyncMock(return_value="fb-001")
-    db.update_conversation_title = AsyncMock(return_value=None)
+    db = MagicMock(spec=SupabaseClient)
+    db.bangumi = MagicMock()
+    db.points = MagicMock()
+    db.session = MagicMock()
+    db.feedback = MagicMock()
+    db.routes = MagicMock()
+    db.messages = MagicMock()
+    db.user_memory = MagicMock()
+    db.messages.get_messages = AsyncMock(return_value=[])
+    db.feedback.save_feedback = AsyncMock(return_value="fb-001")
+    db.session.get_conversations = AsyncMock(return_value=[])
+    db.session.get_conversation = AsyncMock(return_value={"user_id": "user-1"})
+    db.routes.get_user_routes = AsyncMock(return_value=[])
+    db.session.update_conversation_title = AsyncMock(return_value=None)
     return db
 
 

--- a/backend/tests/unit/retrievers/test_enrichment.py
+++ b/backend/tests/unit/retrievers/test_enrichment.py
@@ -16,6 +16,7 @@ from backend.agents.retrievers.enrichment import (
     write_through_bangumi_points,
 )
 from backend.domain.entities import Coordinates, Point
+from backend.infrastructure.supabase.client import SupabaseClient
 
 
 def _make_point(point_id: str = "p1") -> Point:
@@ -40,21 +41,21 @@ def _make_db(
     has_upsert_bangumi: bool = True,
     has_pool: bool = True,
 ) -> MagicMock:
-    db = MagicMock()
+    db = MagicMock(spec=SupabaseClient)
     if has_upsert_batch:
-        db.upsert_points_batch = AsyncMock()
+        db.points.upsert_points_batch = AsyncMock()
     else:
-        del db.upsert_points_batch
+        db.points = MagicMock(spec=[])
     if has_upsert_bangumi:
-        db.upsert_bangumi = AsyncMock()
+        db.bangumi.upsert_bangumi = AsyncMock()
     else:
-        del db.upsert_bangumi
+        db.bangumi = MagicMock(spec=[])
     if has_pool:
         pool = AsyncMock()
         pool.execute = AsyncMock()
         db.pool = pool
     else:
-        del db.pool
+        db.pool = None
     return db
 
 
@@ -181,20 +182,19 @@ class TestPersistPoints:
     async def test_calls_upsert_with_converted_rows(self) -> None:
         db = _make_db()
         await persist_points(db, [_make_point()])
-        db.upsert_points_batch.assert_awaited_once()
-        rows = db.upsert_points_batch.await_args.args[0]
+        db.points.upsert_points_batch.assert_awaited_once()
+        rows = db.points.upsert_points_batch.await_args.args[0]
         assert rows[0]["id"] == "p1"
 
     @pytest.mark.asyncio
-    async def test_no_op_when_db_lacks_upsert_method(self) -> None:
-        db = _make_db(has_upsert_batch=False)
-        await persist_points(db, [_make_point()])
+    async def test_no_op_when_db_not_supabase_client(self) -> None:
+        await persist_points(object(), [_make_point()])
 
     @pytest.mark.asyncio
     async def test_no_op_for_empty_points(self) -> None:
         db = _make_db()
         await persist_points(db, [])
-        rows = db.upsert_points_batch.await_args.args[0]
+        rows = db.points.upsert_points_batch.await_args.args[0]
         assert rows == []
 
 
@@ -237,16 +237,15 @@ class TestEnsureBangumiRecord:
             new=AsyncMock(return_value=None),
         ):
             await ensure_bangumi_record(db, "115908", [_make_point()], get_subject)
-        db.upsert_bangumi.assert_awaited_once()
+        db.bangumi.upsert_bangumi.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_no_op_when_db_lacks_upsert_bangumi(self) -> None:
-        db = _make_db(has_upsert_bangumi=False)
+    async def test_no_op_when_db_not_supabase_client(self) -> None:
         with patch(
             "backend.agents.retrievers.enrichment.fetch_bangumi_lite",
             new=AsyncMock(return_value=None),
         ):
-            await ensure_bangumi_record(db, "115908", [_make_point()], None)
+            await ensure_bangumi_record(object(), "115908", [_make_point()], None)
 
     @pytest.mark.asyncio
     async def test_lite_title_overrides_metadata_title(self) -> None:
@@ -262,7 +261,7 @@ class TestEnsureBangumiRecord:
             new=AsyncMock(return_value=lite),
         ):
             await ensure_bangumi_record(db, "115908", [_make_point()], None)
-        call_kwargs = db.upsert_bangumi.await_args.kwargs
+        call_kwargs = db.bangumi.upsert_bangumi.await_args.kwargs
         assert call_kwargs["title"] == "LiteTitle"
         assert call_kwargs["title_cn"] == "LiteCN"
         assert call_kwargs["city"] == "京都"
@@ -307,7 +306,7 @@ class TestWriteThroughBangumiPoints:
         assert result["write_through"] is True
         assert result["fetched_points"] == 1
         assert result["fallback_status"] == "written"
-        db.upsert_points_batch.assert_awaited_once()
+        db.points.upsert_points_batch.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_updates_points_count_after_write(self) -> None:

--- a/backend/tests/unit/retrievers/test_geo.py
+++ b/backend/tests/unit/retrievers/test_geo.py
@@ -11,18 +11,15 @@ from backend.agents.retrievers.geo import (
     get_area_suggestions,
     records_to_dicts,
 )
+from backend.infrastructure.supabase.client import SupabaseClient
 
 
 def _mock_db(
     *,
-    has_search: bool = True,
     has_area: bool = True,
 ) -> MagicMock:
-    db = MagicMock()
-    if has_search:
-        db.search_points_by_location = AsyncMock(return_value=[])
-    else:
-        del db.search_points_by_location
+    db = MagicMock(spec=SupabaseClient)
+    db.points.search_points_by_location = AsyncMock(return_value=[])
     if has_area:
         db.get_bangumi_by_area = AsyncMock(return_value=[])
     else:
@@ -73,13 +70,12 @@ class TestFetchGeoRows:
         assert "nowhere" in error
 
     @pytest.mark.asyncio
-    async def test_returns_error_when_db_lacks_geo_method(self) -> None:
-        db = _mock_db(has_search=False)
+    async def test_returns_error_when_db_is_not_supabase_client(self) -> None:
         with patch(
             "backend.agents.retrievers.geo.resolve_location",
             new=AsyncMock(return_value=(34.88, 135.79)),
         ):
-            rows, error = await fetch_geo_rows(db, "宇治", radius_m=5000)
+            rows, error = await fetch_geo_rows(object(), "宇治", radius_m=5000)
         assert rows == []
         assert error is not None
         assert "geo retrieval" in error
@@ -87,7 +83,7 @@ class TestFetchGeoRows:
     @pytest.mark.asyncio
     async def test_returns_rows_and_no_error_on_success(self) -> None:
         db = _mock_db()
-        db.search_points_by_location = AsyncMock(
+        db.points.search_points_by_location = AsyncMock(
             return_value=[{"id": "p1", "name": "A"}]
         )
         with patch(
@@ -97,7 +93,7 @@ class TestFetchGeoRows:
             rows, error = await fetch_geo_rows(db, "宇治", radius_m=5000)
         assert error is None
         assert rows == [{"id": "p1", "name": "A"}]
-        db.search_points_by_location.assert_awaited_once_with(
+        db.points.search_points_by_location.assert_awaited_once_with(
             34.88, 135.79, 5000, limit=200
         )
 
@@ -111,6 +107,18 @@ class TestFetchGeoRows:
             rows, error = await fetch_geo_rows(db, "宇治", radius_m=5000)
         assert rows == []
         assert error is None
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_coords_is_ambiguous(self) -> None:
+        db = _mock_db()
+        with patch(
+            "backend.agents.retrievers.geo.resolve_location",
+            new=AsyncMock(return_value=[]),
+        ):
+            rows, error = await fetch_geo_rows(db, "宇治", radius_m=5000)
+        assert rows == []
+        assert error is not None
+        assert "Ambiguous" in error
 
 
 # ── get_area_suggestions ──

--- a/backend/tests/unit/test_executor_agent.py
+++ b/backend/tests/unit/test_executor_agent.py
@@ -8,12 +8,16 @@ from backend.agents.executor_agent import ExecutorAgent
 from backend.agents.handlers._helpers import optimize_route
 
 
-class FakeDB:
+class FakeBangumiRepo:
     async def find_bangumi_by_title(self, title: str) -> str | None:
         return "12345"
 
     async def upsert_bangumi_title(self, title: str, bid: str) -> None:
         pass
+
+
+class FakeDB:
+    bangumi = FakeBangumiRepo()
 
 
 @pytest.fixture

--- a/backend/tests/unit/test_fastapi_service_helpers.py
+++ b/backend/tests/unit/test_fastapi_service_helpers.py
@@ -11,7 +11,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from backend.config.settings import Settings
@@ -21,10 +20,10 @@ from backend.interfaces.fastapi_service import (
     _call_optional_async,
     _contains_json_invalid_error,
     _http_error_code,
-    _require_db_method,
     create_fastapi_app,
 )
 from backend.interfaces.public_api import RuntimeAPI
+from backend.interfaces.routes._deps import _require_supabase
 
 
 @pytest.fixture
@@ -199,21 +198,6 @@ def test_contains_json_invalid_error_returns_false_for_other_types() -> None:
     assert _contains_json_invalid_error(errors_obj) is False
 
 
-def test_require_db_method_returns_callable() -> None:
-    class _Db:
-        async def get_messages(self, session_id: str) -> list[dict[str, object]]:
-            return []
-
-    method = _require_db_method(_Db(), "get_messages")
-    assert callable(method)
-
-
-def test_require_db_method_raises_http_exception_for_missing_method() -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        _require_db_method(object(), "missing")
-    assert exc_info.value.status_code == 500
-
-
 @pytest.mark.asyncio
 async def test_call_optional_async_awaits_async_method() -> None:
     target = SimpleNamespace(close=AsyncMock())
@@ -225,3 +209,17 @@ async def test_call_optional_async_awaits_async_method() -> None:
 async def test_call_optional_async_ignores_missing_method() -> None:
     target = SimpleNamespace()
     await _call_optional_async(target, "close")
+
+
+def test_require_supabase_returns_client_when_valid(mock_db: MagicMock) -> None:
+    result = _require_supabase(mock_db)
+    assert result is mock_db
+
+
+def test_require_supabase_raises_500_when_not_supabase_client() -> None:
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        _require_supabase(object())
+    assert exc_info.value.status_code == 500
+    assert "Database client not available" in exc_info.value.detail

--- a/backend/tests/unit/test_fastapi_service_helpers.py
+++ b/backend/tests/unit/test_fastapi_service_helpers.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 
 from backend.config.settings import Settings
 from backend.infrastructure.session.memory import InMemorySessionStore
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.fastapi_service import (
     _call_optional_async,
     _contains_json_invalid_error,
@@ -26,28 +27,18 @@ from backend.interfaces.fastapi_service import (
 from backend.interfaces.public_api import RuntimeAPI
 
 
-class _MissingConversationDb:
-    async def get_messages(self, session_id: str) -> list[dict[str, object]]:
-        return []
-
-
-class _MissingRoutesDb:
-    async def get_conversations(self, user_id: str) -> list[dict[str, object]]:
-        return []
-
-
 @pytest.fixture
 def mock_db() -> MagicMock:
-    db = MagicMock()
+    db = MagicMock(spec=SupabaseClient)
     pool = AsyncMock()
     pool.fetch = AsyncMock(return_value=[])
     db.pool = pool
-    db.search_points_by_location = AsyncMock(return_value=[])
-    db.get_conversations = AsyncMock(return_value=[])
-    db.get_conversation = AsyncMock(return_value={"user_id": "user-1"})
-    db.get_messages = AsyncMock(return_value=[])
-    db.get_user_routes = AsyncMock(return_value=[])
-    db.save_feedback = AsyncMock(return_value="feedback-1")
+    db.points.search_points_by_location = AsyncMock(return_value=[])
+    db.session.get_conversations = AsyncMock(return_value=[])
+    db.session.get_conversation = AsyncMock(return_value={"user_id": "user-1"})
+    db.messages.get_messages = AsyncMock(return_value=[])
+    db.routes.get_user_routes = AsyncMock(return_value=[])
+    db.feedback.save_feedback = AsyncMock(return_value="feedback-1")
     return db
 
 
@@ -86,7 +77,7 @@ def test_missing_user_header_returns_structured_invalid_request_error_on_convers
 def test_messages_route_returns_structured_404_when_ownership_mismatch(
     mock_db: MagicMock,
 ) -> None:
-    mock_db.get_conversation.return_value = {"user_id": "someone-else"}
+    mock_db.session.get_conversation.return_value = {"user_id": "someone-else"}
     app = create_fastapi_app(
         runtime_api=RuntimeAPI(mock_db, session_store=InMemorySessionStore()),
         settings=Settings(),
@@ -104,7 +95,7 @@ def test_messages_route_returns_structured_404_when_ownership_mismatch(
 
 
 def test_missing_db_method_fails_fast_on_routes_endpoint() -> None:
-    db = _MissingRoutesDb()
+    db = object()  # not a SupabaseClient — routes should return 500
     app = create_fastapi_app(
         runtime_api=RuntimeAPI(db, session_store=InMemorySessionStore()),
         settings=Settings(),

--- a/backend/tests/unit/test_handlers.py
+++ b/backend/tests/unit/test_handlers.py
@@ -93,7 +93,7 @@ class TestBaseSearch:
 class TestResolveAnime:
     async def test_db_hit(self) -> None:
         db = MagicMock()
-        db.find_bangumi_by_title = AsyncMock(return_value="253")
+        db.bangumi.find_bangumi_by_title = AsyncMock(return_value="253")
         step = _step(ToolName.RESOLVE_ANIME, {"title": "Eupho"})
 
         result = await execute_resolve(step, {}, db, None)
@@ -101,12 +101,12 @@ class TestResolveAnime:
         assert result["success"] is True
         assert result["data"]["bangumi_id"] == "253"
         assert result["data"]["title"] == "Eupho"
-        db.find_bangumi_by_title.assert_awaited_once_with("Eupho")
+        db.bangumi.find_bangumi_by_title.assert_awaited_once_with("Eupho")
 
     async def test_db_miss_api_hit(self) -> None:
         db = MagicMock()
-        db.find_bangumi_by_title = AsyncMock(return_value=None)
-        db.upsert_bangumi_title = AsyncMock()
+        db.bangumi.find_bangumi_by_title = AsyncMock(return_value=None)
+        db.bangumi.upsert_bangumi_title = AsyncMock()
 
         mock_gateway = MagicMock()
         mock_gateway.search_by_title = AsyncMock(return_value="999")
@@ -121,11 +121,11 @@ class TestResolveAnime:
 
         assert result["success"] is True
         assert result["data"]["bangumi_id"] == "999"
-        db.upsert_bangumi_title.assert_awaited_once_with("NewAnime", "999")
+        db.bangumi.upsert_bangumi_title.assert_awaited_once_with("NewAnime", "999")
 
     async def test_both_miss(self) -> None:
         db = MagicMock()
-        db.find_bangumi_by_title = AsyncMock(return_value=None)
+        db.bangumi.find_bangumi_by_title = AsyncMock(return_value=None)
 
         mock_gateway = MagicMock()
         mock_gateway.search_by_title = AsyncMock(return_value=None)

--- a/backend/tests/unit/test_handlers.py
+++ b/backend/tests/unit/test_handlers.py
@@ -11,6 +11,7 @@ from backend.agents.handlers.plan_route import execute as execute_plan_route
 from backend.agents.handlers.resolve_anime import execute as execute_resolve
 from backend.agents.handlers.search_bangumi import execute as execute_search
 from backend.agents.models import PlanStep, RetrievalRequest, ToolName
+from backend.infrastructure.supabase.client import SupabaseClient
 
 
 def _step(tool: ToolName, params: dict[str, object] | None = None) -> PlanStep:
@@ -90,9 +91,13 @@ class TestBaseSearch:
 # ---------------------------------------------------------------------------
 
 
+def _mock_supabase() -> MagicMock:
+    return MagicMock(spec=SupabaseClient)
+
+
 class TestResolveAnime:
     async def test_db_hit(self) -> None:
-        db = MagicMock()
+        db = _mock_supabase()
         db.bangumi.find_bangumi_by_title = AsyncMock(return_value="253")
         step = _step(ToolName.RESOLVE_ANIME, {"title": "Eupho"})
 
@@ -104,7 +109,7 @@ class TestResolveAnime:
         db.bangumi.find_bangumi_by_title.assert_awaited_once_with("Eupho")
 
     async def test_db_miss_api_hit(self) -> None:
-        db = MagicMock()
+        db = _mock_supabase()
         db.bangumi.find_bangumi_by_title = AsyncMock(return_value=None)
         db.bangumi.upsert_bangumi_title = AsyncMock()
 
@@ -124,7 +129,7 @@ class TestResolveAnime:
         db.bangumi.upsert_bangumi_title.assert_awaited_once_with("NewAnime", "999")
 
     async def test_both_miss(self) -> None:
-        db = MagicMock()
+        db = _mock_supabase()
         db.bangumi.find_bangumi_by_title = AsyncMock(return_value=None)
 
         mock_gateway = MagicMock()
@@ -160,6 +165,13 @@ class TestResolveAnime:
         result = await execute_resolve(step, {}, MagicMock(), None)
 
         assert result["success"] is False
+
+    async def test_non_supabase_db_returns_failure(self) -> None:
+        step = _step(ToolName.RESOLVE_ANIME, {"title": "Eupho"})
+        result = await execute_resolve(step, {}, object(), None)
+
+        assert result["success"] is False
+        assert result["error"] == "DB not available"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_pipeline.py
+++ b/backend/tests/unit/test_pipeline.py
@@ -22,8 +22,8 @@ def mock_db():
     pool.fetch = AsyncMock(return_value=[])
     db.pool = pool
     db.search_points_by_location = AsyncMock(return_value=[])
-    db.find_bangumi_by_title = AsyncMock(return_value=None)
-    db.upsert_bangumi_title = AsyncMock()
+    db.bangumi.find_bangumi_by_title = AsyncMock(return_value=None)
+    db.bangumi.upsert_bangumi_title = AsyncMock()
     return db
 
 

--- a/backend/tests/unit/test_public_api_errors.py
+++ b/backend/tests/unit/test_public_api_errors.py
@@ -56,13 +56,13 @@ def mock_db():
     pool = AsyncMock()
     pool.fetch = AsyncMock(return_value=[])
     db.pool = pool
-    db.search_points_by_location = AsyncMock(return_value=[])
-    db.get_user_memory = AsyncMock(return_value=None)
-    db.upsert_session = AsyncMock()
-    db.upsert_conversation = AsyncMock()
-    db.upsert_user_memory = AsyncMock()
-    db.update_conversation_title = AsyncMock()
-    db.save_route = AsyncMock(return_value="route-1")
+    db.points.search_points_by_location = AsyncMock(return_value=[])
+    db.session.get_user_memory = AsyncMock(return_value=None)
+    db.session.upsert_session = AsyncMock()
+    db.session.upsert_conversation = AsyncMock()
+    db.session.upsert_user_memory = AsyncMock()
+    db.session.update_conversation_title = AsyncMock()
+    db.routes.save_route = AsyncMock(return_value="route-1")
     return db
 
 

--- a/backend/tests/unit/test_public_api_facade.py
+++ b/backend/tests/unit/test_public_api_facade.py
@@ -9,6 +9,7 @@ import pytest
 from backend.agents.executor_agent import PipelineResult
 from backend.agents.models import ExecutionPlan, PlanStep, ToolName
 from backend.infrastructure.session.memory import InMemorySessionStore
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.public_api import (
     PublicAPIRequest,
     RuntimeAPI,
@@ -51,17 +52,17 @@ def _mock_pipeline(monkeypatch):
 
 @pytest.fixture
 def mock_db():
-    db = MagicMock()
+    db = MagicMock(spec=SupabaseClient)
     pool = AsyncMock()
     pool.fetch = AsyncMock(return_value=[])
     db.pool = pool
-    db.search_points_by_location = AsyncMock(return_value=[])
-    db.get_user_memory = AsyncMock(return_value=None)
-    db.upsert_session = AsyncMock()
-    db.upsert_conversation = AsyncMock()
-    db.upsert_user_memory = AsyncMock()
-    db.update_conversation_title = AsyncMock()
-    db.save_route = AsyncMock(return_value="route-1")
+    db.points.search_points_by_location = AsyncMock(return_value=[])
+    db.user_memory.get_user_memory = AsyncMock(return_value=None)
+    db.session.upsert_session = AsyncMock()
+    db.session.upsert_conversation = AsyncMock()
+    db.user_memory.upsert_user_memory = AsyncMock()
+    db.session.update_conversation_title = AsyncMock()
+    db.routes.save_route = AsyncMock(return_value="route-1")
     return db
 
 
@@ -110,9 +111,9 @@ class TestUserIdPropagation:
 
         await api.handle(PublicAPIRequest(text="京吹の聖地"), user_id="user-abc")
 
-        mock_db.get_user_memory.assert_awaited_once_with("user-abc")
-        mock_db.upsert_conversation.assert_awaited_once()
-        args = mock_db.upsert_conversation.await_args.args
+        mock_db.user_memory.get_user_memory.assert_awaited_once_with("user-abc")
+        mock_db.session.upsert_conversation.assert_awaited_once()
+        args = mock_db.session.upsert_conversation.await_args.args
         assert args[1] == "user-abc"
 
     async def test_skips_user_scoped_db_calls_when_user_id_absent(self, mock_db):
@@ -120,8 +121,8 @@ class TestUserIdPropagation:
 
         await api.handle(PublicAPIRequest(text="京吹の聖地"), user_id=None)
 
-        mock_db.get_user_memory.assert_not_awaited()
-        mock_db.upsert_conversation.assert_not_awaited()
+        mock_db.user_memory.get_user_memory.assert_not_awaited()
+        mock_db.session.upsert_conversation.assert_not_awaited()
 
 
 class TestLocalePassthrough:
@@ -186,7 +187,7 @@ class TestLocalePassthrough:
 
 class TestBuildContextBlockWithUserMemory:
     async def test_handle_passes_context_block_to_pipeline(self, mock_db):
-        mock_db.get_user_memory.return_value = {
+        mock_db.user_memory.get_user_memory.return_value = {
             "visited_anime": [
                 {"bangumi_id": "105", "title": "君の名は", "last_at": "2026-03-01"}
             ]

--- a/backend/tests/unit/test_public_api_persistence.py
+++ b/backend/tests/unit/test_public_api_persistence.py
@@ -9,6 +9,7 @@ import pytest
 from backend.agents.executor_agent import PipelineResult, StepResult
 from backend.agents.models import ExecutionPlan, PlanStep, ToolName
 from backend.infrastructure.session.memory import InMemorySessionStore
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.public_api import PublicAPIRequest, RuntimeAPI
 
 
@@ -47,17 +48,17 @@ def _mock_pipeline(monkeypatch):
 
 @pytest.fixture
 def mock_db():
-    db = MagicMock()
+    db = MagicMock(spec=SupabaseClient)
     pool = AsyncMock()
     pool.fetch = AsyncMock(return_value=[])
     db.pool = pool
-    db.search_points_by_location = AsyncMock(return_value=[])
-    db.get_user_memory = AsyncMock(return_value=None)
-    db.upsert_session = AsyncMock()
-    db.upsert_conversation = AsyncMock()
-    db.upsert_user_memory = AsyncMock()
-    db.update_conversation_title = AsyncMock()
-    db.save_route = AsyncMock(return_value="route-1")
+    db.points.search_points_by_location = AsyncMock(return_value=[])
+    db.user_memory.get_user_memory = AsyncMock(return_value=None)
+    db.session.upsert_session = AsyncMock()
+    db.session.upsert_conversation = AsyncMock()
+    db.user_memory.upsert_user_memory = AsyncMock()
+    db.session.update_conversation_title = AsyncMock()
+    db.routes.save_route = AsyncMock(return_value="route-1")
     return db
 
 
@@ -78,9 +79,9 @@ class TestGreetUserEphemeral:
 
         db = MagicMock()
         db.get_user_memory = AsyncMock(return_value=None)
-        db.upsert_session = AsyncMock()
-        db.upsert_conversation = AsyncMock()
-        db.upsert_user_memory = AsyncMock()
+        db.session.upsert_session = AsyncMock()
+        db.session.upsert_conversation = AsyncMock()
+        db.user_memory.upsert_user_memory = AsyncMock()
         db.insert_request_log = AsyncMock()
 
         session_store = MagicMock()
@@ -99,9 +100,9 @@ class TestGreetUserEphemeral:
         assert response.route_history == []
         session_store.get.assert_not_awaited()
         session_store.set.assert_not_awaited()
-        db.upsert_session.assert_not_awaited()
-        db.upsert_conversation.assert_not_awaited()
-        db.upsert_user_memory.assert_not_awaited()
+        db.session.upsert_session.assert_not_awaited()
+        db.session.upsert_conversation.assert_not_awaited()
+        db.user_memory.upsert_user_memory.assert_not_awaited()
         db.insert_request_log.assert_not_awaited()
 
 
@@ -117,7 +118,7 @@ class TestRuntimeAPISession:
         saved_state = await store.get(response.session_id)
         assert saved_state is not None
         assert saved_state["last_intent"] == "search_bangumi"
-        mock_db.upsert_session.assert_awaited_once()
+        mock_db.session.upsert_session.assert_awaited_once()
 
     async def test_handle_reuses_existing_session(self, mock_db):
         store = InMemorySessionStore()
@@ -221,8 +222,8 @@ class TestUserMemoryUpsert:
             api = RuntimeAPI(mock_db, session_store=InMemorySessionStore())
             await api.handle(PublicAPIRequest(text="響け"), user_id="u1")
 
-        mock_db.upsert_user_memory.assert_awaited_once()
-        kwargs = mock_db.upsert_user_memory.await_args.kwargs
+        mock_db.user_memory.upsert_user_memory.assert_awaited_once()
+        kwargs = mock_db.user_memory.upsert_user_memory.await_args.kwargs
         assert kwargs["bangumi_id"] == "253"
         assert kwargs["anime_title"] == "響け！ユーフォニアム"
 
@@ -231,7 +232,7 @@ class TestUserMemoryUpsert:
 
         await api.handle(PublicAPIRequest(text="宇治の近く"), user_id="u1")
 
-        mock_db.upsert_user_memory.assert_not_awaited()
+        mock_db.user_memory.upsert_user_memory.assert_not_awaited()
 
 
 class TestCompactThresholdTrigger:

--- a/backend/tests/unit/test_public_api_pipeline.py
+++ b/backend/tests/unit/test_public_api_pipeline.py
@@ -9,6 +9,7 @@ import pytest
 from backend.agents.executor_agent import PipelineResult
 from backend.agents.models import ExecutionPlan, PlanStep, ToolName
 from backend.infrastructure.session.memory import InMemorySessionStore
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.interfaces.public_api import (
     PublicAPIRequest,
     RuntimeAPI,
@@ -50,17 +51,17 @@ def _mock_pipeline(monkeypatch):
 
 @pytest.fixture
 def mock_db():
-    db = MagicMock()
+    db = MagicMock(spec=SupabaseClient)
     pool = AsyncMock()
     pool.fetch = AsyncMock(return_value=[])
     db.pool = pool
-    db.search_points_by_location = AsyncMock(return_value=[])
-    db.get_user_memory = AsyncMock(return_value=None)
-    db.upsert_session = AsyncMock()
-    db.upsert_conversation = AsyncMock()
-    db.upsert_user_memory = AsyncMock()
-    db.update_conversation_title = AsyncMock()
-    db.save_route = AsyncMock(return_value="route-1")
+    db.points.search_points_by_location = AsyncMock(return_value=[])
+    db.user_memory.get_user_memory = AsyncMock(return_value=None)
+    db.session.upsert_session = AsyncMock()
+    db.session.upsert_conversation = AsyncMock()
+    db.user_memory.upsert_user_memory = AsyncMock()
+    db.session.update_conversation_title = AsyncMock()
+    db.routes.save_route = AsyncMock(return_value="route-1")
     return db
 
 
@@ -131,7 +132,7 @@ class TestRuntimeAPIExecution:
         ]
         assert len(response.debug["step_results"]) == 0
         assert response.route_history[0]["route_id"] == "route-1"
-        mock_db.save_route.assert_awaited_once()
+        mock_db.routes.save_route.assert_awaited_once()
 
     async def test_handle_preserves_coordinate_origin_in_route_history(self, mock_db):
         result = _make_result(
@@ -181,7 +182,7 @@ class TestRuntimeAPIExecution:
             )
 
         assert response.route_history[0]["origin_station"] == "34.9,135.8"
-        save_route_kwargs = mock_db.save_route.await_args.kwargs
+        save_route_kwargs = mock_db.routes.save_route.await_args.kwargs
         assert save_route_kwargs["origin_station"] == "34.9,135.8"
         assert save_route_kwargs["origin_lat"] == 34.9
         assert save_route_kwargs["origin_lon"] == 135.8

--- a/backend/tests/unit/test_retriever.py
+++ b/backend/tests/unit/test_retriever.py
@@ -13,22 +13,20 @@ from backend.agents.retriever import (
     _merge_rows_preserving_order,
 )
 from backend.domain.entities import Coordinates, Point
+from backend.infrastructure.supabase.client import SupabaseClient
 from backend.services.cache import ResponseCache
 
 
 @pytest.fixture
 def mock_db():
-    db = MagicMock()
+    db = MagicMock(spec=SupabaseClient)
     pool = AsyncMock()
     pool.fetch = AsyncMock(return_value=[])
     pool.execute = AsyncMock()
     db.pool = pool
-    db.search_points_by_location = AsyncMock(return_value=[])
-    db.get_bangumi = AsyncMock(
-        return_value={"id": "115908", "title": "響け！ユーフォニアム"}
-    )
-    db.upsert_bangumi = AsyncMock()
-    db.upsert_points_batch = AsyncMock(return_value=0)
+    db.points.search_points_by_location = AsyncMock(return_value=[])
+    db.bangumi.upsert_bangumi = AsyncMock()
+    db.points.upsert_points_batch = AsyncMock(return_value=0)
     return db
 
 
@@ -97,7 +95,7 @@ class TestRetrievalExecution:
 
     @pytest.mark.asyncio
     async def test_geo_strategy_uses_supabase_geo_search(self, mock_db):
-        mock_db.search_points_by_location.return_value = [
+        mock_db.points.search_points_by_location.return_value = [
             {"id": "p1", "bangumi_id": "115908", "distance_m": 100},
         ]
         retriever = Retriever(mock_db)
@@ -107,7 +105,7 @@ class TestRetrievalExecution:
         assert result.success
         assert result.strategy == RetrievalStrategy.GEO
         assert result.row_count == 1
-        mock_db.search_points_by_location.assert_awaited_once()
+        mock_db.points.search_points_by_location.assert_awaited_once()
         mock_db.pool.fetch.assert_not_called()
 
     @pytest.mark.asyncio
@@ -131,7 +129,6 @@ class TestRetrievalExecution:
             [],
             [{"id": "p1", "bangumi_id": "115908", "title": "響け！ユーフォニアム"}],
         ]
-        mock_db.get_bangumi.return_value = None
         fetch_bangumi_points = AsyncMock(return_value=[_make_point()])
         get_bangumi_subject = AsyncMock(
             return_value={
@@ -160,9 +157,9 @@ class TestRetrievalExecution:
         assert result.metadata["write_through"] is True
         fetch_bangumi_points.assert_awaited_once_with("115908")
         get_bangumi_subject.assert_awaited_once_with(115908)
-        mock_db.upsert_bangumi.assert_awaited_once()
-        mock_db.upsert_points_batch.assert_awaited_once()
-        written_rows = mock_db.upsert_points_batch.await_args.args[0]
+        mock_db.bangumi.upsert_bangumi.assert_awaited_once()
+        mock_db.points.upsert_points_batch.assert_awaited_once()
+        written_rows = mock_db.points.upsert_points_batch.await_args.args[0]
         assert written_rows[0]["latitude"] == 34.8843
         assert written_rows[0]["longitude"] == 135.7997
         assert written_rows[0]["location"] == "POINT(135.7997 34.8843)"
@@ -174,7 +171,7 @@ class TestRetrievalExecution:
             {"id": "p1", "bangumi_id": "115908", "name": "A"},
             {"id": "p2", "bangumi_id": "115908", "name": "B"},
         ]
-        mock_db.search_points_by_location.return_value = [
+        mock_db.points.search_points_by_location.return_value = [
             {"id": "p2", "bangumi_id": "115908", "distance_m": 120},
             {"id": "p1", "bangumi_id": "115908", "distance_m": 80},
             {"id": "p3", "bangumi_id": "999", "distance_m": 30},
@@ -198,10 +195,9 @@ class TestRetrievalExecution:
             [],
             [{"id": "p1", "bangumi_id": "115908", "name": "A"}],
         ]
-        mock_db.search_points_by_location.return_value = [
+        mock_db.points.search_points_by_location.return_value = [
             {"id": "p1", "bangumi_id": "115908", "distance_m": 80},
         ]
-        mock_db.get_bangumi.return_value = None
         retriever = Retriever(
             mock_db,
             cache=cache,
@@ -222,7 +218,7 @@ class TestRetrievalExecution:
         assert result.strategy == RetrievalStrategy.HYBRID
         assert result.metadata["data_origin"] == "fallback"
         assert result.rows[0]["distance_m"] == 80
-        mock_db.upsert_points_batch.assert_awaited_once()
+        mock_db.points.upsert_points_batch.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_hybrid_falls_back_to_sql_on_unknown_anchor(self, mock_db):

--- a/backend/tests/unit/test_routes_data.py
+++ b/backend/tests/unit/test_routes_data.py
@@ -16,7 +16,7 @@ from backend.tests.unit.conftest_fastapi import (
 
 def _build_stub_db_with_bangumi() -> AsyncMock:
     db = build_stub_db()
-    db.list_popular = AsyncMock(
+    db.bangumi.list_popular = AsyncMock(
         return_value=[
             {
                 "id": "115908",
@@ -29,7 +29,7 @@ def _build_stub_db_with_bangumi() -> AsyncMock:
             }
         ]
     )
-    db.get_bangumi_by_area = AsyncMock(return_value=[])
+    db.bangumi.get_bangumi_by_area = AsyncMock(return_value=[])
     return db
 
 
@@ -64,10 +64,10 @@ async def test_popular_default_limit_is_8() -> None:
         resp = await client.get("/v1/bangumi/popular")
 
     assert resp.status_code == 200
-    db.list_popular.assert_awaited_once()
+    db.bangumi.list_popular.assert_awaited_once()
     called_limit = (
-        db.list_popular.await_args.kwargs.get("limit")
-        or db.list_popular.await_args.args[0]
+        db.bangumi.list_popular.await_args.kwargs.get("limit")
+        or db.bangumi.list_popular.await_args.args[0]
     )
     assert called_limit == 8
 
@@ -88,7 +88,7 @@ async def test_popular_non_integer_limit_returns_422() -> None:
 
 async def test_popular_empty_db_returns_empty_array() -> None:
     db = build_stub_db()
-    db.list_popular = AsyncMock(return_value=[])
+    db.bangumi.list_popular = AsyncMock(return_value=[])
     app, _ = build_app(db=db)
     async with async_client(app) as client:
         resp = await client.get("/v1/bangumi/popular")
@@ -117,7 +117,7 @@ async def test_popular_with_x_user_id_header_passes_auth_context() -> None:
 
 async def test_nearby_returns_200_with_bangumi_array() -> None:
     db = build_stub_db()
-    db.get_bangumi_by_area = AsyncMock(
+    db.bangumi.get_bangumi_by_area = AsyncMock(
         return_value=[
             {
                 "bangumi_id": "115908",
@@ -143,7 +143,7 @@ async def test_nearby_returns_200_with_bangumi_array() -> None:
 
 async def test_nearby_empty_returns_empty_array() -> None:
     db = build_stub_db()
-    db.get_bangumi_by_area = AsyncMock(return_value=[])
+    db.bangumi.get_bangumi_by_area = AsyncMock(return_value=[])
     app, _ = build_app(db=db)
     async with async_client(app) as client:
         resp = await client.get("/v1/bangumi/nearby?lat=0.0&lng=0.0&radius_m=1000")
@@ -153,7 +153,7 @@ async def test_nearby_empty_returns_empty_array() -> None:
 
 async def test_nearby_lat_out_of_range_returns_422() -> None:
     db = build_stub_db()
-    db.get_bangumi_by_area = AsyncMock(return_value=[])
+    db.bangumi.get_bangumi_by_area = AsyncMock(return_value=[])
     app, _ = build_app(db=db)
     async with async_client(app) as client:
         resp = await client.get("/v1/bangumi/nearby?lat=91.0&lng=135.8&radius_m=50000")
@@ -162,7 +162,7 @@ async def test_nearby_lat_out_of_range_returns_422() -> None:
 
 async def test_nearby_missing_lat_returns_422() -> None:
     db = build_stub_db()
-    db.get_bangumi_by_area = AsyncMock(return_value=[])
+    db.bangumi.get_bangumi_by_area = AsyncMock(return_value=[])
     app, _ = build_app(db=db)
     async with async_client(app) as client:
         resp = await client.get("/v1/bangumi/nearby?lng=135.8&radius_m=50000")
@@ -171,7 +171,7 @@ async def test_nearby_missing_lat_returns_422() -> None:
 
 async def test_nearby_without_auth_header_still_returns_200() -> None:
     db = build_stub_db()
-    db.get_bangumi_by_area = AsyncMock(return_value=[])
+    db.bangumi.get_bangumi_by_area = AsyncMock(return_value=[])
     app, _ = build_app(db=db)
     async with async_client(app) as client:
         resp = await client.get("/v1/bangumi/nearby?lat=35.0&lng=135.0&radius_m=1000")
@@ -180,7 +180,7 @@ async def test_nearby_without_auth_header_still_returns_200() -> None:
 
 async def test_nearby_with_x_user_id_header_passes_auth_context() -> None:
     db = build_stub_db()
-    db.get_bangumi_by_area = AsyncMock(return_value=[])
+    db.bangumi.get_bangumi_by_area = AsyncMock(return_value=[])
     app, _ = build_app(db=db)
     async with async_client(app) as client:
         resp = await client.get(
@@ -192,7 +192,7 @@ async def test_nearby_with_x_user_id_header_passes_auth_context() -> None:
 
 async def test_nearby_zero_radius_returns_422() -> None:
     db = build_stub_db()
-    db.get_bangumi_by_area = AsyncMock(return_value=[])
+    db.bangumi.get_bangumi_by_area = AsyncMock(return_value=[])
     app, _ = build_app(db=db)
     async with async_client(app) as client:
         resp = await client.get("/v1/bangumi/nearby?lat=35.0&lng=135.0&radius_m=0")
@@ -202,7 +202,7 @@ async def test_nearby_zero_radius_returns_422() -> None:
 
 async def test_nearby_negative_radius_returns_422() -> None:
     db = build_stub_db()
-    db.get_bangumi_by_area = AsyncMock(return_value=[])
+    db.bangumi.get_bangumi_by_area = AsyncMock(return_value=[])
     app, _ = build_app(db=db)
     async with async_client(app) as client:
         resp = await client.get("/v1/bangumi/nearby?lat=35.0&lng=135.0&radius_m=-1000")
@@ -212,7 +212,7 @@ async def test_nearby_negative_radius_returns_422() -> None:
 
 async def test_nearby_positive_radius_returns_200() -> None:
     db = build_stub_db()
-    db.get_bangumi_by_area = AsyncMock(return_value=[])
+    db.bangumi.get_bangumi_by_area = AsyncMock(return_value=[])
     app, _ = build_app(db=db)
     async with async_client(app) as client:
         resp = await client.get("/v1/bangumi/nearby?lat=35.0&lng=135.0&radius_m=1")

--- a/backend/tests/unit/test_routes_runtime.py
+++ b/backend/tests/unit/test_routes_runtime.py
@@ -132,7 +132,7 @@ async def test_unhandled_exception_returns_500() -> None:
 
 async def test_patch_conversation_nonexistent_returns_404() -> None:
     db = build_stub_db()
-    db.get_conversation = AsyncMock(return_value=None)
+    db.session.get_conversation = AsyncMock(return_value=None)
     app, _ = build_app(db=db)
 
     async with async_client(app) as client:
@@ -146,7 +146,7 @@ async def test_patch_conversation_nonexistent_returns_404() -> None:
     body = resp.json()
     assert body["error"]["code"] == "not_found"
     assert body["error"]["message"] == "Conversation not found."
-    db.update_conversation_title.assert_not_awaited()
+    db.session.update_conversation_title.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -156,7 +156,7 @@ async def test_patch_conversation_nonexistent_returns_404() -> None:
 
 async def test_patch_conversation_wrong_user_returns_404() -> None:
     db = build_stub_db()
-    db.get_conversation = AsyncMock(return_value={"user_id": "other-user"})
+    db.session.get_conversation = AsyncMock(return_value={"user_id": "other-user"})
     app, _ = build_app(db=db)
 
     async with async_client(app) as client:
@@ -170,7 +170,7 @@ async def test_patch_conversation_wrong_user_returns_404() -> None:
     body = resp.json()
     assert body["error"]["code"] == "not_found"
     assert body["error"]["message"] == "Conversation not found."
-    db.update_conversation_title.assert_not_awaited()
+    db.session.update_conversation_title.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -180,8 +180,8 @@ async def test_patch_conversation_wrong_user_returns_404() -> None:
 
 async def test_patch_conversation_valid_returns_200() -> None:
     db = build_stub_db()
-    db.get_conversation = AsyncMock(return_value={"user_id": "user-1"})
-    db.update_conversation_title = AsyncMock(return_value=None)
+    db.session.get_conversation = AsyncMock(return_value={"user_id": "user-1"})
+    db.session.update_conversation_title = AsyncMock(return_value=None)
     app, _ = build_app(db=db)
 
     async with async_client(app) as client:
@@ -194,4 +194,4 @@ async def test_patch_conversation_valid_returns_200() -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["ok"] is True
-    db.update_conversation_title.assert_awaited_once()
+    db.session.update_conversation_title.assert_awaited_once()

--- a/backend/tests/unit/test_supabase_client.py
+++ b/backend/tests/unit/test_supabase_client.py
@@ -1,4 +1,4 @@
-"""Unit tests for SupabaseClient write-through helpers."""
+"""Unit tests for SupabaseClient repository property delegation."""
 
 from __future__ import annotations
 
@@ -18,13 +18,27 @@ def mock_pool() -> AsyncMock:
     return pool
 
 
+def _make_client(pool: AsyncMock) -> SupabaseClient:
+    """Create a SupabaseClient with repos initialized from a mock pool."""
+    client = SupabaseClient.__new__(SupabaseClient)
+    client._pool = pool
+    client._bangumi = None
+    client._points = None
+    client._session = None
+    client._feedback = None
+    client._user_memory = None
+    client._routes = None
+    client._messages = None
+    client._init_repos(pool)
+    return client
+
+
 @pytest.mark.asyncio
 async def test_upsert_point_uses_geography_cast_for_location() -> None:
-    client = SupabaseClient("postgresql://example")
     pool = AsyncMock()
-    client._pool = pool
+    client = _make_client(pool)
 
-    await client.upsert_point(
+    await client.points.upsert_point(
         "p1",
         bangumi_id="115908",
         name="宇治桥",
@@ -42,8 +56,6 @@ async def test_upsert_point_uses_geography_cast_for_location() -> None:
 
 @pytest.mark.asyncio
 async def test_upsert_points_batch_accepts_latitude_and_longitude() -> None:
-    client = SupabaseClient("postgresql://example")
-
     conn = MagicMock()
     conn.executemany = AsyncMock()
     tx = AsyncMock()
@@ -57,9 +69,9 @@ async def test_upsert_points_batch_accepts_latitude_and_longitude() -> None:
 
     pool = MagicMock()
     pool.acquire.return_value = acquire_ctx
-    client._pool = pool
+    client = _make_client(pool)
 
-    await client.upsert_points_batch(
+    await client.points.upsert_points_batch(
         [
             {
                 "id": "p1",
@@ -99,11 +111,10 @@ async def test_upsert_points_batch_accepts_latitude_and_longitude() -> None:
 
 @pytest.mark.asyncio
 async def test_upsert_point_casts_embedding_to_vector() -> None:
-    client = SupabaseClient("postgresql://example")
     pool = AsyncMock()
-    client._pool = pool
+    client = _make_client(pool)
 
-    await client.upsert_point(
+    await client.points.upsert_point(
         "p1",
         bangumi_id="115908",
         name="宇治桥",
@@ -121,12 +132,11 @@ async def test_upsert_point_casts_embedding_to_vector() -> None:
 
 @pytest.mark.asyncio
 async def test_search_points_by_location_uses_runtime_contract_query() -> None:
-    client = SupabaseClient("postgresql://example")
     pool = AsyncMock()
     pool.fetch = AsyncMock(return_value=[])
-    client._pool = pool
+    client = _make_client(pool)
 
-    await client.search_points_by_location(34.8843, 135.7997, 5000, limit=10)
+    await client.points.search_points_by_location(34.8843, 135.7997, 5000, limit=10)
 
     sql = pool.fetch.await_args.args[0]
     assert "SELECT *" not in sql
@@ -140,27 +150,24 @@ async def test_search_points_by_location_uses_runtime_contract_query() -> None:
 class TestFindBangumiByTitle:
     async def test_exact_title_match(self, mock_pool):
         mock_pool.fetchrow.return_value = {"id": "115908"}
-        client = SupabaseClient.__new__(SupabaseClient)
-        client._pool = mock_pool
-        result = await client.find_bangumi_by_title("響け！ユーフォニアム")
+        client = _make_client(mock_pool)
+        result = await client.bangumi.find_bangumi_by_title("響け！ユーフォニアム")
         assert result == "115908"
         call_args = mock_pool.fetchrow.call_args[0]
         assert "ilike" in call_args[0].lower() or "$1" in call_args[0]
 
     async def test_no_match_returns_none(self, mock_pool):
         mock_pool.fetchrow.return_value = None
-        client = SupabaseClient.__new__(SupabaseClient)
-        client._pool = mock_pool
-        result = await client.find_bangumi_by_title("unknown anime xyz")
+        client = _make_client(mock_pool)
+        result = await client.bangumi.find_bangumi_by_title("unknown anime xyz")
         assert result is None
 
 
 class TestGetPointsByIds:
     async def test_returns_empty_for_empty_input(self, mock_pool):
-        client = SupabaseClient.__new__(SupabaseClient)
-        client._pool = mock_pool
+        client = _make_client(mock_pool)
 
-        result = await client.get_points_by_ids([])
+        result = await client.points.get_points_by_ids([])
 
         assert result == []
         mock_pool.fetch.assert_not_awaited()
@@ -170,10 +177,9 @@ class TestGetPointsByIds:
             {"id": "p2", "name": "Byodoin"},
             {"id": "p1", "name": "Uji Bridge"},
         ]
-        client = SupabaseClient.__new__(SupabaseClient)
-        client._pool = mock_pool
+        client = _make_client(mock_pool)
 
-        result = await client.get_points_by_ids(["p2", "p1"])
+        result = await client.points.get_points_by_ids(["p2", "p1"])
 
         assert result == [
             {"id": "p2", "name": "Byodoin"},
@@ -186,9 +192,8 @@ class TestGetPointsByIds:
 class TestUpsertBangumiTitle:
     async def test_upserts_title(self, mock_pool):
         mock_pool.execute.return_value = None
-        client = SupabaseClient.__new__(SupabaseClient)
-        client._pool = mock_pool
-        await client.upsert_bangumi_title("進撃の巨人", "6718")
+        client = _make_client(mock_pool)
+        await client.bangumi.upsert_bangumi_title("進撃の巨人", "6718")
         mock_pool.execute.assert_awaited_once()
         sql, *args = mock_pool.execute.call_args[0]
         assert "6718" in args or "進撃の巨人" in args
@@ -196,14 +201,12 @@ class TestUpsertBangumiTitle:
 
 @pytest.fixture
 def persistence_db(mock_pool: AsyncMock) -> SupabaseClient:
-    client = SupabaseClient.__new__(SupabaseClient)
-    client._pool = mock_pool
-    return client
+    return _make_client(mock_pool)
 
 
 class TestUpsertConversation:
     async def test_inserts_or_touches_conversation(self, persistence_db, mock_pool):
-        await persistence_db.upsert_conversation(
+        await persistence_db.session.upsert_conversation(
             session_id="sess-1",
             user_id="user-1",
             first_query="京吹の聖地を探して",
@@ -218,7 +221,7 @@ class TestUpsertConversation:
         persistence_db,
         mock_pool,
     ):
-        await persistence_db.upsert_conversation(
+        await persistence_db.session.upsert_conversation(
             session_id="sess-1",
             user_id="user-1",
             first_query="京吹の聖地を探して",
@@ -230,7 +233,7 @@ class TestUpsertConversation:
 
 class TestUpdateConversationTitle:
     async def test_updates_conversation_title(self, persistence_db, mock_pool):
-        await persistence_db.update_conversation_title("sess-1", "京吹 宇治")
+        await persistence_db.session.update_conversation_title("sess-1", "京吹 宇治")
 
         sql = mock_pool.execute.await_args.args[0]
         assert "UPDATE conversations" in sql
@@ -241,7 +244,7 @@ class TestGetConversations:
     async def test_returns_empty_list_when_no_rows(self, persistence_db, mock_pool):
         mock_pool.fetch.return_value = []
 
-        result = await persistence_db.get_conversations("user-1")
+        result = await persistence_db.session.get_conversations("user-1")
 
         assert result == []
 
@@ -256,7 +259,7 @@ class TestGetConversations:
             }
         ]
 
-        result = await persistence_db.get_conversations("user-1")
+        result = await persistence_db.session.get_conversations("user-1")
 
         assert len(result) == 1
         assert result[0]["session_id"] == "sess-1"
@@ -266,7 +269,7 @@ class TestUserMemory:
     async def test_upsert_inserts_first_entry(self, persistence_db, mock_pool):
         mock_pool.fetchrow.return_value = None
 
-        await persistence_db.upsert_user_memory(
+        await persistence_db.user_memory.upsert_user_memory(
             "user-1",
             bangumi_id="253",
             anime_title="響け！ユーフォニアム",
@@ -285,7 +288,7 @@ class TestUserMemory:
             )
         }
 
-        await persistence_db.upsert_user_memory(
+        await persistence_db.user_memory.upsert_user_memory(
             "user-1",
             bangumi_id="253",
             anime_title="響け！ユーフォニアム",
@@ -304,7 +307,7 @@ class TestUserMemory:
     ):
         mock_pool.fetchrow.return_value = None
 
-        result = await persistence_db.get_user_memory("user-1")
+        result = await persistence_db.user_memory.get_user_memory("user-1")
 
         assert result is None
 
@@ -314,6 +317,6 @@ class TestUserMemory:
             "visited_points": "[]",
         }
 
-        result = await persistence_db.get_user_memory("user-1")
+        result = await persistence_db.user_memory.get_user_memory("user-1")
 
         assert result["visited_anime"][0]["bangumi_id"] == "253"

--- a/backend/tests/unit/test_supabase_session.py
+++ b/backend/tests/unit/test_supabase_session.py
@@ -12,9 +12,9 @@ from backend.infrastructure.session.supabase_session import SupabaseSessionStore
 @pytest.fixture()
 def mock_db() -> AsyncMock:
     db = AsyncMock()
-    db.get_session_state.return_value = None
-    db.upsert_session_state.return_value = None
-    db.delete_session_state.return_value = None
+    db.session.get_session_state.return_value = None
+    db.session.upsert_session_state.return_value = None
+    db.session.delete_session_state.return_value = None
     return db
 
 
@@ -28,18 +28,18 @@ async def test_save_and_get(mock_db: AsyncMock) -> None:
     assert result == state
 
     # DB write was called
-    mock_db.upsert_session_state.assert_called_once_with("s1", state)
+    mock_db.session.upsert_session_state.assert_called_once_with("s1", state)
     # DB read was NOT called (served from cache)
-    mock_db.get_session_state.assert_not_called()
+    mock_db.session.get_session_state.assert_not_called()
 
 
 async def test_cache_miss_reads_db(mock_db: AsyncMock) -> None:
-    mock_db.get_session_state.return_value = {"interactions": [1]}
+    mock_db.session.get_session_state.return_value = {"interactions": [1]}
     store = SupabaseSessionStore(mock_db)
 
     result = await store.get("s1")
     assert result == {"interactions": [1]}
-    mock_db.get_session_state.assert_called_once_with("s1")
+    mock_db.session.get_session_state.assert_called_once_with("s1")
 
 
 async def test_get_returns_none_on_miss(mock_db: AsyncMock) -> None:
@@ -47,7 +47,7 @@ async def test_get_returns_none_on_miss(mock_db: AsyncMock) -> None:
 
     result = await store.get("nonexistent")
     assert result is None
-    mock_db.get_session_state.assert_called_once_with("nonexistent")
+    mock_db.session.get_session_state.assert_called_once_with("nonexistent")
 
 
 async def test_cache_eviction(mock_db: AsyncMock) -> None:
@@ -68,11 +68,11 @@ async def test_delete(mock_db: AsyncMock) -> None:
     await store.delete("s1")
 
     assert "s1" not in store._cache
-    mock_db.delete_session_state.assert_called_once_with("s1")
+    mock_db.session.delete_session_state.assert_called_once_with("s1")
 
 
 async def test_delete_nonexistent(mock_db: AsyncMock) -> None:
     """Deleting a session that doesn't exist should not raise."""
     store = SupabaseSessionStore(mock_db)
     await store.delete("nonexistent")
-    mock_db.delete_session_state.assert_called_once_with("nonexistent")
+    mock_db.session.delete_session_state.assert_called_once_with("nonexistent")


### PR DESCRIPTION
## Summary

- Removes `__getattr__` delegation loop that resolved method calls across 7 repositories at runtime, hiding the ownership of each method
- Removes `_ensure_repos()` lazy initialization helper and 5 pass-through methods (`find_bangumi_by_title`, `upsert_bangumi_title`, `get_session_state`, `upsert_session_state`, `delete_session_state`)
- All callers updated to use explicit repository properties: `db.bangumi.*`, `db.points.*`, `db.session.*`, `db.user_memory.*`, `db.routes.*`, `db.messages.*`
- `isinstance(db, SupabaseClient)` guards at trust boundaries replace `getattr(db, "method", None)` duck-typing
- All test mocks updated from plain `MagicMock()` to `MagicMock(spec=SupabaseClient)` so they pass the isinstance checks correctly

## Test plan

- [x] All 707 unit tests pass (`uv run pytest backend/tests/unit/ -q --no-cov`)
- [x] mypy clean (`uv run mypy backend/agents/ backend/interfaces/ backend/domain/ backend/infrastructure/`)
- [x] ruff format + check clean (`uv run ruff format . && uv run ruff check backend/`)
- [x] No `__getattr__` remaining in `client.py`
- [x] No new `Any` types introduced

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Refactored the database client architecture to use strongly-typed repository accessors instead of dynamic method discovery. Database operations now validate client types at runtime and return early error responses when the database is unavailable, improving reliability and enabling better error detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->