### PR TITLE
test(backend): TDD RED phase — frontend contract tests + planner evals

### DIFF
--- a/backend/tests/eval/datasets/frontend_flows_v1.json
+++ b/backend/tests/eval/datasets/frontend_flows_v1.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "clarify-zh-01",
+    "locale": "zh",
+    "query": "涼宮",
+    "expected_steps": ["clarify"],
+    "expected_intent": "clarify"
+  },
+  {
+    "id": "clarify-ja-01",
+    "locale": "ja",
+    "query": "ガンダム",
+    "expected_steps": ["clarify"],
+    "expected_intent": "clarify"
+  },
+  {
+    "id": "clarify-en-01",
+    "locale": "en",
+    "query": "Suzumiya",
+    "expected_steps": ["clarify"],
+    "expected_intent": "clarify"
+  },
+  {
+    "id": "nearby-zh-01",
+    "locale": "zh",
+    "query": "附近有什么动漫圣地",
+    "expected_steps": ["search_nearby"],
+    "expected_intent": "search_nearby"
+  },
+  {
+    "id": "nearby-ja-01",
+    "locale": "ja",
+    "query": "宇治駅の近くに聖地ある？",
+    "expected_steps": ["search_nearby"],
+    "expected_intent": "search_nearby"
+  },
+  {
+    "id": "nearby-en-01",
+    "locale": "en",
+    "query": "What anime spots are near Uji station?",
+    "expected_steps": ["search_nearby"],
+    "expected_intent": "search_nearby"
+  },
+  {
+    "id": "greet-zh-01",
+    "locale": "zh",
+    "query": "你好",
+    "expected_steps": ["greet_user"],
+    "expected_intent": "greet_user"
+  },
+  {
+    "id": "greet-ja-01",
+    "locale": "ja",
+    "query": "こんにちは",
+    "expected_steps": ["greet_user"],
+    "expected_intent": "greet_user"
+  },
+  {
+    "id": "qa-ja-01",
+    "locale": "ja",
+    "query": "聖地巡礼って何？",
+    "expected_steps": ["answer_question"],
+    "expected_intent": "general_qa"
+  },
+  {
+    "id": "qa-zh-01",
+    "locale": "zh",
+    "query": "圣地巡礼是什么意思？",
+    "expected_steps": ["answer_question"],
+    "expected_intent": "general_qa"
+  }
+]

--- a/backend/tests/eval/test_frontend_flows.py
+++ b/backend/tests/eval/test_frontend_flows.py
@@ -1,0 +1,65 @@
+"""Eval tests for frontend flow scenarios -- TDD RED phase.
+
+Tests planner's ability to handle clarify, nearby, greet, and QA intents
+triggered by the new frontend flows.
+
+Run: make test-eval (or pytest backend/tests/eval/test_frontend_flows.py -v)
+Requires: LLM API key (GEMINI_API_KEY or OPENAI_API_KEY)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.tests.eval.eval_common import EvalCase, load_dataset
+
+DATASET_PATH = Path(__file__).parent / "datasets" / "frontend_flows_v1.json"
+INTENT_GATE = 0.9  # 90% intent accuracy
+STEP_GATE = 0.8  # 80% step sequence accuracy
+
+
+@pytest.fixture(scope="module")
+def cases() -> list[EvalCase]:
+    return load_dataset(DATASET_PATH)
+
+
+@pytest.fixture(scope="module")
+def results(cases: list[EvalCase]) -> list[object]:
+    """Run all cases through the planner and collect results."""
+    try:
+        from backend.agents.pipeline import ReActPipeline  # noqa: F401
+    except ImportError:
+        pytest.skip("Backend not available")
+
+    # RED phase: return empty results until wired to real planner
+    return []
+
+
+def test_dataset_loads(cases: list[EvalCase]) -> None:
+    """Verify the dataset file is valid and has expected structure."""
+    assert len(cases) >= 10
+    for case in cases:
+        assert case.id
+        assert case.query
+        assert case.locale in ("ja", "zh", "en")
+        assert len(case.expected_steps) > 0
+        assert case.expected_intent
+
+
+def test_intent_gate() -> None:
+    """Intent accuracy gate -- must pass >= 90%."""
+    pytest.skip("RED phase -- run with real planner to measure intent accuracy")
+
+
+def test_step_gate() -> None:
+    """Step sequence accuracy gate -- must pass >= 80%."""
+    pytest.skip("RED phase -- run with real planner to measure step accuracy")
+
+
+def test_clarify_precision() -> None:
+    """Ambiguous input must trigger clarify, not search_bangumi."""
+    pytest.skip(
+        "RED phase -- run with real planner to verify clarify precision"
+    )

--- a/backend/tests/integration/test_frontend_contracts.py
+++ b/backend/tests/integration/test_frontend_contracts.py
@@ -1,0 +1,297 @@
+"""Frontend contract tests — TDD RED phase.
+
+Defines the exact response shape the frontend consumes.
+Failures reveal backend gaps. Requires: make serve + env vars.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import cast
+
+import pytest
+
+_API_URL = os.environ.get("SEICHI_API_URL", "")
+_API_KEY = os.environ.get("SEICHI_API_KEY", "")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _API_URL or not _API_KEY,
+        reason="SEICHI_API_URL and SEICHI_API_KEY required",
+    ),
+]
+
+_HDR: dict[str, str] = {
+    "Authorization": f"Bearer {_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def _post(path: str, body: dict[str, object]) -> tuple[int, dict[str, object]]:
+    import aiohttp
+
+    async with aiohttp.ClientSession() as s:
+        async with s.post(
+            f"{_API_URL}{path}",
+            json=body,
+            headers=_HDR,
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as r:
+            return r.status, cast(dict[str, object], await r.json())
+
+
+async def _get(path: str) -> tuple[int, object]:
+    import aiohttp
+
+    async with aiohttp.ClientSession() as s:
+        async with s.get(
+            f"{_API_URL}{path}",
+            headers=_HDR,
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as r:
+            return r.status, await r.json()
+
+
+async def _search_euphonium() -> list[dict[str, object]]:
+    """Search euphonium and return rows (helper for route tests)."""
+    st, body = await _post(
+        "/v1/runtime", {"text": "響け！ユーフォニアム", "locale": "ja"}
+    )
+    assert st == 200
+    data = cast(dict[str, object], body["data"])
+    results = cast(dict[str, object], data["results"])
+    return cast(list[dict[str, object]], results["rows"])
+
+
+async def _plan_route(point_ids: list[str]) -> tuple[int, dict[str, object]]:
+    """Plan route with given point IDs (helper)."""
+    return await _post(
+        "/v1/runtime",
+        {
+            "selected_point_ids": point_ids,
+            "origin": "宇治駅",
+            "locale": "ja",
+        },
+    )
+
+
+def _parse_sse(raw: str) -> list[dict[str, object]]:
+    """Parse raw SSE text into [{event, data}, ...]."""
+    events: list[dict[str, object]] = []
+    cur_event: str | None = None
+    data_buf: list[str] = []
+    for line in raw.split("\n"):
+        if line.startswith("event: "):
+            cur_event = line[7:]
+        elif line.startswith("data: "):
+            data_buf.append(line[6:])
+        elif line == "" and cur_event is not None:
+            raw_data = "\n".join(data_buf)
+            try:
+                parsed = json.loads(raw_data)
+            except json.JSONDecodeError:
+                parsed = raw_data
+            events.append({"event": cur_event, "data": parsed})
+            cur_event = None
+            data_buf = []
+    return events
+
+
+# ── AC-1: Search by anime title ─────────────────────────────────────────────
+
+
+class TestAC1SearchBangumi:
+    """Search by anime title returns typed PilgrimagePoint rows."""
+
+    async def test_returns_200_with_success(self) -> None:
+        status, body = await _post(
+            "/v1/runtime",
+            {"text": "響け！ユーフォニアムの聖地", "locale": "ja"},
+        )
+        assert status == 200
+        assert body["success"] is True
+
+    async def test_intent_is_search_bangumi(self) -> None:
+        status, body = await _post(
+            "/v1/runtime",
+            {"text": "響け！ユーフォニアム", "locale": "ja"},
+        )
+        assert status == 200
+        assert body["intent"] in ("search_bangumi", "search_by_bangumi")
+
+    async def test_rows_are_present_and_non_empty(self) -> None:
+        rows = await _search_euphonium()
+        assert isinstance(rows, list)
+        assert len(rows) > 0
+
+    async def test_rows_have_required_pilgrimage_point_fields(self) -> None:
+        """Every row must match frontend PilgrimagePoint type."""
+        rows = await _search_euphonium()
+        required = {"id", "name", "latitude", "longitude", "bangumi_id"}
+        for row in rows:
+            for f in required:
+                assert f in row, f"Missing required field: {f}"
+            assert isinstance(row["latitude"], (int, float))
+            assert isinstance(row["longitude"], (int, float))
+            assert row["latitude"] != 0 or row["longitude"] != 0
+
+
+# ── AC-2: Nearby search ─────────────────────────────────────────────────────
+
+_NEARBY_BODY: dict[str, object] = {
+    "text": "附近有什么动漫圣地",
+    "locale": "zh",
+    "origin_lat": 34.886,
+    "origin_lng": 135.805,
+}
+
+
+class TestAC2SearchNearby:
+    """Nearby search with coordinates returns distance-sorted results."""
+
+    async def test_intent_is_search_nearby(self) -> None:
+        status, body = await _post("/v1/runtime", _NEARBY_BODY)
+        assert status == 200
+        assert body["intent"] in ("search_nearby", "search_by_location")
+
+    async def test_rows_have_distance_m(self) -> None:
+        """Each row should include distance_m for frontend sorting."""
+        status, body = await _post("/v1/runtime", _NEARBY_BODY)
+        assert status == 200
+        data = cast(dict[str, object], body["data"])
+        results = cast(dict[str, object], data["results"])
+        rows = cast(list[dict[str, object]], results["rows"])
+        assert isinstance(rows, list)
+        for row in rows:
+            assert "distance_m" in row, "Row must include distance_m"
+            assert isinstance(row["distance_m"], (int, float))
+
+
+# ── AC-3: Clarification with candidates ─────────────────────────────────────
+
+
+class TestAC3ClarifyWithCandidates:
+    """Ambiguous query returns clarify with REQUIRED candidates[]."""
+
+    async def test_clarify_has_question_and_options(self) -> None:
+        status, body = await _post("/v1/runtime", {"text": "涼宮", "locale": "zh"})
+        assert status == 200
+        data = cast(dict[str, object], body["data"])
+        assert (
+            data.get("status") == "needs_clarification"
+            or body.get("intent") == "clarify"
+        )
+        assert "question" in data
+        assert isinstance(data["options"], list)
+        assert len(cast(list[object], data["options"])) >= 2
+
+    async def test_clarify_has_candidates_with_metadata(self) -> None:
+        """Backend must send candidates[] with structured metadata."""
+        status, body = await _post("/v1/runtime", {"text": "涼宮", "locale": "zh"})
+        assert status == 200
+        data = cast(dict[str, object], body["data"])
+        assert "candidates" in data, "Backend must send candidates[] with metadata"
+        cands = cast(list[dict[str, object]], data["candidates"])
+        assert isinstance(cands, list) and len(cands) >= 2
+        for c in cands:
+            for key in ("title", "spot_count", "city", "cover_url"):
+                assert key in c, f"candidate missing {key}"
+
+
+# ── AC-4: Route planning with selected points ───────────────────────────────
+
+
+class TestAC4PlanSelectedRoute:
+    """Route planning with selected point IDs returns timed itinerary."""
+
+    async def test_plan_selected_returns_route(self) -> None:
+        rows = await _search_euphonium()
+        ids = [str(r["id"]) for r in rows[:3]]
+        assert len(ids) >= 2, "Need at least 2 points"
+        status, body = await _plan_route(ids)
+        assert status == 200
+        assert body["intent"] in ("plan_selected", "plan_route")
+
+    async def test_route_has_ordered_points_and_count(self) -> None:
+        rows = await _search_euphonium()
+        ids = [str(r["id"]) for r in rows[:3]]
+        status, body = await _plan_route(ids)
+        assert status == 200
+        route = cast(dict[str, object], cast(dict[str, object], body["data"])["route"])
+        ordered = cast(list[object], route["ordered_points"])
+        assert isinstance(ordered, list) and len(ordered) >= 2
+        assert route["point_count"] == len(ordered)
+
+    async def test_route_has_timed_itinerary(self) -> None:
+        """Frontend needs timed_itinerary for timeline display."""
+        rows = await _search_euphonium()
+        ids = [str(r["id"]) for r in rows[:3]]
+        status, body = await _plan_route(ids)
+        assert status == 200
+        route = cast(dict[str, object], cast(dict[str, object], body["data"])["route"])
+        assert "timed_itinerary" in route, "route must contain timed_itinerary"
+        itin = cast(dict[str, object], route["timed_itinerary"])
+        assert isinstance(itin["stops"], list)
+        assert isinstance(itin["legs"], list)
+        assert isinstance(itin["total_minutes"], (int, float))
+        assert isinstance(itin["total_distance_m"], (int, float))
+
+
+# ── AC-5: SSE streaming ─────────────────────────────────────────────────────
+
+
+class TestAC5SSEStream:
+    """SSE streaming returns step events + done event with full response."""
+
+    async def _stream_euphonium(self) -> list[dict[str, object]]:
+        import aiohttp
+
+        async with aiohttp.ClientSession() as s:
+            async with s.post(
+                f"{_API_URL}/v1/runtime/stream",
+                json={"text": "響け！ユーフォニアム", "locale": "ja"},
+                headers=_HDR,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as r:
+                assert r.status == 200
+                return _parse_sse(await r.text())
+
+    async def test_sse_stream_returns_step_and_done_events(self) -> None:
+        events = await self._stream_euphonium()
+        steps = [e for e in events if e.get("event") == "step"]
+        dones = [e for e in events if e.get("event") == "done"]
+        assert len(steps) >= 1, "No step events received"
+        assert len(dones) == 1, "Expected exactly 1 done event"
+
+    async def test_done_event_has_full_response_shape(self) -> None:
+        events = await self._stream_euphonium()
+        dones = [e for e in events if e.get("event") == "done"]
+        assert len(dones) == 1
+        done = cast(dict[str, object], dones[0]["data"])
+        assert "intent" in done
+        assert "data" in done
+        assert "message" in done
+
+
+# ── AC-6: Popular anime endpoint ─────────────────────────────────────────────
+
+
+class TestAC6BangumiPopular:
+    """Popular anime endpoint returns bangumi list with cover URLs."""
+
+    async def test_popular_returns_200_list(self) -> None:
+        status, body = await _get("/v1/bangumi/popular")
+        assert status == 200
+        items = cast(dict[str, object], body).get("bangumi")
+        assert isinstance(items, list) and len(items) > 0
+
+    async def test_popular_items_have_required_fields(self) -> None:
+        status, body = await _get("/v1/bangumi/popular")
+        assert status == 200
+        items = cast(list[dict[str, object]], cast(dict[str, object], body)["bangumi"])
+        for item in items:
+            assert "id" in item or "bangumi_id" in item
+            assert "title" in item
+            assert "cover_url" in item


### PR DESCRIPTION
## Summary
TDD RED phase: write tests that define what the frontend expects. Run against real backend to find gaps.

### Contract Tests (6 ACs)
| AC | Endpoint | Asserts |
|---|---|---|
| AC-1 | POST /v1/runtime (search) | PilgrimagePoint fields: id, name, lat, lng, bangumi_id |
| AC-2 | POST /v1/runtime (nearby) | distance_m sorted, multiple anime |
| AC-3 | POST /v1/runtime (clarify) | candidates[] REQUIRED with cover_url, spot_count, city |
| AC-4 | POST /v1/runtime (plan_selected) | timed_itinerary with stops, legs |
| AC-5 | POST /v1/runtime/stream | SSE: step events + done event |
| AC-6 | GET /v1/bangumi/popular | bangumi_id, title, cover_url |

### Eval Cases (10)
- clarify (zh/ja/en): ambiguous input → clarify intent
- nearby (zh/ja/en): location queries → search_nearby
- greet (zh/ja): greetings → greet_user
- qa (ja/zh): questions → general_qa
- Gates: 90% intent, 80% step accuracy

### RED phase
Tests are expected to fail. Known gaps:
- AC-3: backend may not send candidates[] yet
- AC-4: timed_itinerary may not exist yet
- Eval runner stubbed (skip) until wired to real planner

## Test plan
- [ ] `python -c "import ast; ast.parse(open('backend/tests/integration/test_frontend_contracts.py').read())"` — syntax valid
- [ ] `python -c "import json; json.load(open('backend/tests/eval/datasets/frontend_flows_v1.json'))"` — JSON valid
- [ ] `supabase start && make serve` → `pytest backend/tests/integration/test_frontend_contracts.py -v` — record pass/fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added frontend flow evaluation tests with multilingual test cases covering clarification, nearby search, user greeting, and general Q&A scenarios.
  * Added integration tests validating runtime API contracts for search, route planning, streaming, and content discovery endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->