### PR TITLE
fix(ci): atlas-action subaction path + pipeline filter

### DIFF
--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -13,9 +13,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - name: Atlas migrate
-        uses: ariga/atlas-action@e7cdee90ecc06996f1c055bc01a62f03666cecb4 # v1.15.5
+        uses: ariga/atlas-action/migrate/apply@e7cdee90ecc06996f1c055bc01a62f03666cecb4 # v1.15.5
         with:
-          action: migrate/apply
           dir: "file://db/migrations"
           url: ${{ secrets.NEON_DATABASE_URL }}
       - name: Pulumi up

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -13,7 +13,7 @@ jobs:
         id: f
         with:
           filters: |
-            catalog: ['workers/catalog/**', 'packages/contract/**', 'db/migrations/**', 'infra/**']
+            catalog: ['workers/catalog/**', 'packages/contract/**', 'db/migrations/**', 'infra/**', '.github/workflows/_deploy-component.yml', '.github/workflows/cd-staging.yml']
   catalog:
     needs: changes
     if: ${{ needs.changes.outputs.catalog == 'true' }}


### PR DESCRIPTION
CD staging first-run found: root atlas-action is a Docker action; SHA-pinning it fails because its Dockerfile COPYs a prebuilt binary absent from the git tree. Switch to the migrate/apply subaction (node24, no Docker build). cd-staging affected filter now also covers _deploy-component.yml + cd-staging.yml so pipeline fixes re-trigger catalog.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal deployment workflow configuration to streamline component deployment and catalog update processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->