### PR TITLE
fix(ci): zizmor permissions startup_failure + CodeRabbit #193 notes

### DIFF
--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -61,9 +61,11 @@ jobs:
   zizmor:
     name: zizmor (GHA security)
     runs-on: ubuntu-latest
+    # advanced-security: false (below) → no SARIF upload → security-events not
+    # needed. Requesting it caused startup_failure: a reusable job cannot request
+    # more than the caller (ci.yml) grants (contents: read → security-events: none).
     permissions:
       contents: read
-      security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
修复 main 上新 orchestrator 的 **startup_failure**(`ci.yml#L70`):

**根因**: `_security.yml` 的 `zizmor` job 请求 `security-events: write`,但 caller `ci.yml` 是 `permissions: contents: read`(即 `security-events: none`)。GitHub 规则:reusable workflow 的 job 不能请求超过 caller 授予的权限 → 编译期 startup_failure。act/actionlint/ruby-yaml 都抓不到(GitHub 编译期专属校验)。

**修复**: zizmor 配了 `advanced-security: false`(不上传 SARIF),本就不需要 `security-events: write` → 删掉这个多余权限(ponytail 正解:删权限,而非给 caller 提权)。grep 确认 zizmor 是唯一超权处,无第二个。

附带 CodeRabbit #193 收尾:`tool_state` 坏味道的 ponytail 注释 + S104 ignore 的生命周期注释(Wave 3 清理)。

merge 后 push main 会重跑新 orchestrator —— 这次该编译通过、严格闸首次真跑 + 触发首次 staging 部署。