### PR TITLE
fix(ci): atlas migrate via pinned CLI — deploy-staging binary-by-SHA 404

### DIFF
--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -30,10 +30,13 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Atlas migrate
-        uses: ariga/atlas-action/migrate/apply@e7cdee90ecc06996f1c055bc01a62f03666cecb4 # v1.15.5
-        with:
-          dir: "file://db/migrations"
-          url: ${{ secrets.NEON_DATABASE_URL }}
+        if: ${{ secrets.NEON_DATABASE_URL != '' }}
+        run: |
+          curl -sSfL "https://release.ariga.io/atlas/atlas-community-linux-amd64-v0.30.0" -o /usr/local/bin/atlas
+          chmod +x /usr/local/bin/atlas
+          atlas migrate apply --dir "file://db/migrations" --url "$NEON_DATABASE_URL"
+        env:
+          NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
       - name: Pulumi up
         uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7.0.0
         with:


### PR DESCRIPTION
deploy-staging 首次真跑(main 37aa7e1)暴露 atlas-action 的 **binary-by-SHA 404**:subaction shim 按 commit SHA 拼 binary URL,但 ariga 只按 version tag 发布 binary(SHA-named URL 实测 404、version-named 200)。SHA-pin 与 atlas-action 固有冲突(之前 Docker 形式也 SHA-pin fail)。

**修**:绕开 atlas-action,改 pinned **atlas CLI v0.30.0** 的 `run:` step(符合"无可 SHA-pin 官方 action → run CLI"原则)+ `if: secrets.NEON_DATABASE_URL != ''` guard(缺 secret 优雅跳过)。zizmor/yaml clean。

⚠️ **deploy 还需 5 个 repo secret**(下次 deploy 前补):`NEON_DATABASE_URL` `PULUMI_CONFIG_PASSPHRASE` `PULUMI_BACKEND_URL` `R2_ACCESS_KEY_ID` `R2_SECRET_ACCESS_KEY`。CF 的 2 个已配。chat 暴露过的 creds 必须 rotate 后再配。