### PR TITLE
fix(ci): atlas step secrets-in-if startup_failure

### DIFF
--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -30,8 +30,12 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Atlas migrate
-        if: ${{ secrets.NEON_DATABASE_URL != '' }}
+        # NOTE: secrets context is NOT allowed in step `if:` (GitHub compile-time
+        # error → startup_failure). Guard inside run via the env var instead.
         run: |
+          if [ -z "$NEON_DATABASE_URL" ]; then
+            echo "NEON_DATABASE_URL not set — skipping atlas migrate"; exit 0
+          fi
           curl -sSfL "https://release.ariga.io/atlas/atlas-community-linux-amd64-v0.30.0" -o /usr/local/bin/atlas
           chmod +x /usr/local/bin/atlas
           atlas migrate apply --dir "file://db/migrations" --url "$NEON_DATABASE_URL"


### PR DESCRIPTION
main 的 ci.yml 在 merge #201 后再次 startup_failure(jobs=0)。根因:`_deploy-component.yml` 的 Atlas migrate step 用了 `if: secrets.NEON_DATABASE_URL != ''` —— **secrets context 在 step if 里非法**(GitHub 编译期错,ruby-yaml/act 都抓不到)。修:删 step if,改 run 内 shell guard(`[ -z "$NEON_DATABASE_URL" ] && exit 0`),保留缺-secret-优雅跳过语义。grep 确认全仓库无其他 secrets-in-if。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the deployment workflow so database migrations are skipped cleanly when no database URL is provided.
  * Prevented deployment failures caused by workflow validation, while keeping migrations unchanged when the required connection is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->