### PR TITLE
fix(ci): atlas baseline + staging→prod promotion + readable job names

### DIFF
--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -1,3 +1,4 @@
+# Reusable workflow (called by ci.yml; not triggered directly). '_' prefix = internal.
 name: deploy-component
 on:
   workflow_call:
@@ -22,6 +23,7 @@ on:
         required: false
 jobs:
   deploy:
+    name: Deploy
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
@@ -38,7 +40,7 @@ jobs:
           fi
           curl -sSfL "https://release.ariga.io/atlas/atlas-community-linux-amd64-v0.30.0" -o /usr/local/bin/atlas
           chmod +x /usr/local/bin/atlas
-          atlas migrate apply --dir "file://db/migrations" --url "$NEON_DATABASE_URL"
+          atlas migrate apply --dir "file://db/migrations" --url "$NEON_DATABASE_URL" --revisions-schema public
         env:
           NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
       - name: Pulumi up

--- a/.github/workflows/_python-ci.yml
+++ b/.github/workflows/_python-ci.yml
@@ -1,3 +1,4 @@
+# Reusable workflow (called by ci.yml; not triggered directly). '_' prefix = internal.
 name: _python-ci
 
 # Reusable Python CI: ruff (lint + format) + mypy strict + vulture + pip-audit + pytest/cov.
@@ -20,7 +21,7 @@ env:
 
 jobs:
   python-ci:
-    name: Python CI (${{ inputs.app }})
+    name: Python CI
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/_ts-ci.yml
+++ b/.github/workflows/_ts-ci.yml
@@ -1,3 +1,4 @@
+# Reusable workflow (called by ci.yml; not triggered directly). '_' prefix = internal.
 name: _ts-ci
 
 # Reusable TypeScript Worker CI: tsc + oxlint + eslint (strict) + vitest.
@@ -16,7 +17,7 @@ permissions:
 
 jobs:
   ts-ci:
-    name: TS CI (${{ inputs.component }})
+    name: TS CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/_web-ci.yml
+++ b/.github/workflows/_web-ci.yml
@@ -1,3 +1,4 @@
+# Reusable workflow (called by ci.yml; not triggered directly). '_' prefix = internal.
 name: _web-ci
 
 # Reusable frontend (Next.js) CI: tsc + oxlint + eslint (strict) + vitest + next build.
@@ -18,7 +19,7 @@ permissions:
 
 jobs:
   web-ci:
-    name: Web CI (frontend)
+    name: Web CI
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [main, develop]
-    tags: ['v*']
   pull_request:
     branches: [main]
 
@@ -133,9 +132,10 @@ jobs:
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
 
-  # ── Stage 3: Deploy (CI-green gated, single-workflow needs gate) ──
-  # All CI jobs are in `needs:` so CI-green gates CD. cd-staging.yml and
-  # cd-prod.yml are deleted — their function lives here now.
+  # ── Stage 3: Deploy (CI-green gated, push-main promotion path) ──
+  # Promotion: push main → CI → staging → post-staging (api) → prod (human gate) → post-prod.
+  # A single push to main drives the full pipeline; no separate tag trigger needed.
+  # Human approval is enforced by `environment: production` in _deploy-component.yml.
 
   # push main → staging
   deploy-staging:
@@ -165,12 +165,11 @@ jobs:
       environment: staging
       suite: api
 
-  # tag v* → production (human approve via environment: production in
-  # _deploy-component.yml)
+  # staging validated → production (human approve via environment: production in
+  # _deploy-component.yml). needs: post-staging guarantees staging passed api tests.
   deploy-prod:
     name: Deploy production
-    needs: [ci-agent, ci-catalog, ci-frontend, db-validate, security]
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    needs: post-staging
     uses: ./.github/workflows/_deploy-component.yml
     with:
       component: catalog


### PR DESCRIPTION
用户要求的 3 件:
① **atlas**: `--revisions-schema public`。查到 staging 有前次失败 run 残留的空 `atlas_schema_revisions` schema + `public`(0 行)表,atlas 找 schema.table 挂掉;落到已存在的 public 修复。**非 baseline**(无 catalog app schema = 首次 apply)。
② **promotion**: 去掉 tag 触发,push main 单路径:CI → staging → post-staging(api) → deploy-prod(`needs: post-staging` + `environment: production` 人工 gate) → post-prod。prod 只发 staging 验过的。
③ **命名**: inner job 简化(Python CI/TS CI/Web CI/Deploy) + 4 个 _*.yml 加 internal 注释。

⚠️ **merge 前必须配 production environment required reviewers** —— `deploy-prod` 无 `if`,只靠 environment 拦;没配的话每次 push main 会自动部署到 prod。