### PR TITLE
chore: PR/issue templates + root screenshot gitignore

### DIFF
--- a/.github/ISSUE_TEMPLATE/debt-card.md
+++ b/.github/ISSUE_TEMPLATE/debt-card.md
@@ -1,0 +1,22 @@
+---
+name: Debt card
+about: Tech debt cleanup item (refactor backlog / boy-scout)
+title: "<short title>"
+labels: type:debt
+---
+
+## Summary
+
+<!-- What to clean up, where (file/module paths), and the target end state. -->
+
+## Why
+
+<!-- Optional: what debt or risk this removes (duplicate paths, suppressions, coverage exclusions, ...). -->
+
+## Scope note
+
+<!-- Standalone card, or boy-scout item to apply opportunistically the next time the file is touched? Link the backlog doc it came from. -->
+
+## Spec source
+
+<!-- e.g. `docs/superpowers/plans/2026-07-07-refactor-backlog.md` (commit <sha>) -->

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,31 @@
+---
+name: Story / Enabler card
+about: Iteration card for a user-facing story or backend/infra enabler
+title: "S<iteration>.<n> — <short title>"
+labels: type:story
+---
+
+## Releasable statement
+
+<!-- One paragraph: what ships when this card is done, phrased as an outcome. State what is explicitly out of scope. -->
+
+## AC summary
+
+- AC count: <n>
+- Test type distribution: unit=0, integration=0, browser=0, eval=0, api=0, manual/ops=0
+
+## Dependencies
+
+<!-- Other cards this depends on, e.g. "S5.4 (catalog public-data enabler)". Write "None" if independent. -->
+
+## Spec source
+
+<!-- e.g. `docs/superpowers/specs/2026-07-06-frontend-rebuild/iter-5.md` (commit <sha>) -->
+
+<!--
+Labels to set:
+- type:story (user-facing) or type:enabler (backend/infra)
+- iteration:<n>
+- area:* (foundation, chat, route-detail, walk, shiori, discover, workbench, open-api, seo, image-search, transit, eval, security)
+Milestone: Iteration <n>
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+# Summary
+
+<!-- What does this PR do? Link the issue/card it implements (e.g. Closes #123). -->
+
+## Acceptance Criteria
+
+<!--
+Quality Ratchet: every AC must have a test type annotation AND a test present in this PR's diff.
+Reviewer verifies ac_total == ac_with_test.
+Test type: unit | integration | eval | browser | api
+-->
+
+| # | Acceptance criterion | Test type | Test file (in this diff) |
+|---|---------------------|-----------|--------------------------|
+| 1 |                     |           |                          |
+
+## Quality Gates
+
+- [ ] `make check` passes (lint + typecheck + test)
+- [ ] Every AC row above has a test type and a test file present in this PR's diff
+- [ ] Coverage thresholds were NOT lowered (frontend `vitest.config.ts`, backend `pytest.ini`) — thresholds may only be ratcheted UP; if this PR raises coverage, floors are updated to the new value
+- [ ] No suppressions added (`eslint-disable`, `@ts-ignore`, `type: ignore`, `noqa`, `pragma: no cover`, `continue-on-error`, `skip`) — if a rule fired, the code was fixed instead
+- [ ] No hardcoded secrets; design tokens used (no raw Tailwind palette colors)
+
+## Notes for Reviewer
+
+<!-- Anything non-obvious: trade-offs, follow-ups, out-of-scope items. -->

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ outputs/
 !supabase/templates/*.html
 !docs/mockups/**/*.html
 
+# QA/debug screenshots dumped at repo root (root-level only; frontend/ and docs/ assets unaffected)
+/*.png
+
 # Test outputs
 test_results.json
 


### PR DESCRIPTION
## Summary

Pure config/docs/templates PR — no runtime code changes.

### 1. `.github/PULL_REQUEST_TEMPLATE.md`
Encodes the Quality Ratchet from CLAUDE.md into every PR:
- AC table: each acceptance criterion annotated with test type (`unit|integration|eval|browser|api`) + the test file in this PR's diff (reviewer verifies `ac_total == ac_with_test`)
- `make check` checkbox
- Coverage thresholds only-up declaration (frontend `vitest.config.ts`, backend `pytest.ini`)
- No-suppression declaration (`eslint-disable` / `@ts-ignore` / `type: ignore` / `noqa` / `skip` etc.)

### 2. `.github/ISSUE_TEMPLATE/` (story.md, debt-card.md)
Markdown templates aligned with the existing 82-issue corpus (Iteration 0–7 milestones):
- **story.md** — Releasable statement / AC summary (AC count + test type distribution) / Dependencies / Spec source; label guidance for `type:story|enabler`, `iteration:N`, `area:*`
- **debt-card.md** — Summary / Why / Scope note / Spec source; `type:debt` label (matches #222/#226 format)

### 3. `.gitignore` root screenshot rule
Root-anchored `/*.png` stops QA/debug screenshot pollution at the repo root (60+ untracked PNGs currently sitting there in working dirs). Root-only anchor leaves `frontend/`, `docs/`, and all nested image assets untouched. Verified `git ls-files '*.png' | grep -v '/'` is empty — no tracked root PNGs, so no `git rm --cached` needed.

## Quality Gates

- `make lint` passes (ruff check + format: all green)
- No suppressions added
- Doc/config-only: no coverage impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)