### PR TITLE
fix(agent): translation quality push — Bangumi matching + place/SC prompt rules (Refs #304)

### DIFF
--- a/apps/agent/agent/agents/base.py
+++ b/apps/agent/agent/agents/base.py
@@ -18,6 +18,7 @@ from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.deepseek import DeepSeekProvider
 from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.settings import ModelSettings
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -32,45 +33,76 @@ def _build_http_client() -> httpx.AsyncClient:
     return httpx.AsyncClient(trust_env=False, timeout=timeout)
 
 
+def _host_matches_domain(base_url: str, domain: str) -> bool:
+    host = urlparse(base_url).hostname or ""
+    return host == domain or host.endswith(f".{domain}")
+
+
+def _is_deepseek_host(base_url: str) -> bool:
+    return _host_matches_domain(base_url, "deepseek.com")
+
+
+def _deepseek_settings() -> ModelSettings:
+    return ModelSettings(extra_body={"thinking": {"type": "disabled"}})
+
+
 def _resolve_api_key(base_url: str) -> str | None:
     """Match a base URL to the right API key env var by domain."""
-    host = urlparse(base_url).hostname or ""
     domain_keys = [
         ("xiaomimimo.com", "MIMO_API_KEY"),
         ("deepseek.com", "DEEPSEEK_API_KEY"),
     ]
     for domain, env_var in domain_keys:
-        if host == domain or host.endswith(f".{domain}"):
+        if _host_matches_domain(base_url, domain):
             return os.environ.get(env_var)
     from agent.config import get_settings
 
     return get_settings().openai_compat_api_key or None
 
 
+def _parse_deepseek_model(spec: str) -> Model:
+    name = spec.removeprefix("deepseek:")
+    provider = DeepSeekProvider(
+        api_key=os.environ.get("DEEPSEEK_API_KEY"),
+        http_client=_build_http_client(),
+    )
+    return OpenAIChatModel(name, provider=provider, settings=_deepseek_settings())
+
+
+def _parse_openai_spec(raw: str) -> tuple[str, str]:
+    name, separator, base_url = raw.partition("@")
+    if separator:
+        return name, base_url
+    from agent.config import get_settings
+
+    return raw, get_settings().openai_compat_base_url
+
+
+def _openai_settings(base_url: str) -> ModelSettings | None:
+    if _is_deepseek_host(base_url):
+        return _deepseek_settings()
+    return None
+
+
+def _parse_openai_model(spec: str) -> Model:
+    name, base_url = _parse_openai_spec(spec.removeprefix("openai:"))
+    oai_provider = OpenAIProvider(
+        base_url=base_url,
+        api_key=_resolve_api_key(base_url),
+        http_client=_build_http_client(),
+    )
+    return OpenAIChatModel(
+        name, provider=oai_provider, settings=_openai_settings(base_url)
+    )
+
+
 def _parse_model(spec: str) -> Model:
     """Parse a model spec string into a concrete Model."""
     if spec.startswith("deepseek:"):
-        name = spec.removeprefix("deepseek:")
-        provider = DeepSeekProvider(
-            api_key=os.environ.get("DEEPSEEK_API_KEY"),
-            http_client=_build_http_client(),
-        )
-        return OpenAIChatModel(name, provider=provider)
+        return _parse_deepseek_model(spec)
 
     if spec.startswith("openai:"):
-        raw = spec.removeprefix("openai:")
-        if "@" in raw:
-            name, base_url = raw.split("@", 1)
-        else:
-            from agent.config import get_settings
-
-            name, base_url = raw, get_settings().openai_compat_base_url
-        oai_provider = OpenAIProvider(
-            base_url=base_url,
-            api_key=_resolve_api_key(base_url),
-            http_client=_build_http_client(),
-        )
-        return OpenAIChatModel(name, provider=oai_provider)
+        return _parse_openai_model(spec)
 
     raise ValueError(f"Unsupported model spec: {spec}")
 

--- a/apps/agent/agent/agents/translation.py
+++ b/apps/agent/agent/agents/translation.py
@@ -14,22 +14,16 @@ translation, which may differ from a literal translation.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
 
-import httpx
 import structlog
 from pydantic_ai import Agent
 from pydantic_ai.common_tools.duckduckgo import duckduckgo_search_tool
 
 from agent.agents.base import resolve_model
+from agent.agents.translation_bangumi import lookup_bangumi_api
 
 logger = structlog.get_logger(__name__)
-
-_BANGUMI_SEARCH_URL = "https://api.bgm.tv/v0/search/subjects"
-_BANGUMI_USER_AGENT = (
-    "Seichijunrei/1.0 (https://github.com/lifeodyssey/Seichijunrei-agent)"
-)
 
 
 @dataclass
@@ -51,7 +45,7 @@ class TranslationResult:
     confidence: float = 1.0  # 1.0 = authoritative, 0.5 = web search, 0.3 = LLM guess
 
 
-# ── Deterministic lookup functions (no LLM needed) ──────────────────
+# ── Deterministic DB lookup (no LLM needed) ──────────────────────────
 
 
 async def _lookup_db(db: object, title: str, target_locale: str) -> str | None:
@@ -76,55 +70,6 @@ async def _lookup_db(db: object, title: str, target_locale: str) -> str | None:
     return None
 
 
-async def _search_bangumi_subject(title: str) -> Mapping[str, object] | None:
-    """POST a one-result anime subject search to the Bangumi v0 API."""
-    body = {"keyword": title, "filter": {"type": [2]}, "limit": 1}
-    headers = {"User-Agent": _BANGUMI_USER_AGENT}
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.post(_BANGUMI_SEARCH_URL, json=body, headers=headers)
-    if response.status_code >= 400:
-        logger.warning("bangumi_search_http_error", status=response.status_code)
-        return None
-    return _first_search_hit(response.json())
-
-
-def _first_search_hit(payload: object) -> Mapping[str, object] | None:
-    """Extract the first subject dict from a search response envelope."""
-    if not isinstance(payload, Mapping):
-        return None
-    hits = payload.get("data")
-    if not isinstance(hits, list) or not hits:
-        return None
-    first = hits[0]
-    return first if isinstance(first, Mapping) else None
-
-
-def _pick_locale_title(hit: Mapping[str, object], target_locale: str) -> str | None:
-    """Choose the localized title from a Bangumi subject hit."""
-    name_ja = hit.get("name")
-    name_cn = hit.get("name_cn")
-    if target_locale == "zh" and name_cn:
-        return str(name_cn)
-    if target_locale == "ja" and name_ja:
-        return str(name_ja)
-    # Bangumi has no English titles; name_cn is sometimes the international one.
-    if target_locale == "en" and name_cn and str(name_cn).isascii():
-        return str(name_cn)
-    return None
-
-
-async def _lookup_bangumi_api(title: str, target_locale: str) -> str | None:
-    """Search Bangumi API for the title translation."""
-    try:
-        hit = await _search_bangumi_subject(title)
-    except (httpx.HTTPError, OSError, RuntimeError, ValueError) as exc:
-        logger.warning("bangumi_api_translation_failed", title=title, error=str(exc))
-        return None
-    if hit is None:
-        return None
-    return _pick_locale_title(hit, target_locale)
-
-
 # ── Translation Agent (with web search) ─────────────────────────────
 
 _TRANSLATION_INSTRUCTIONS = """\
@@ -135,19 +80,32 @@ Japanese, Chinese, and English.
 
 IMPORTANT RULES:
 1. For anime titles, NEVER hard-translate. Search for the community-accepted
-   translation using web search. For example:
+   translation using web search. Chinese must be Simplified Chinese (zh-Hans)
+   as used on Bangumi/萌娘百科; convert or prefer Simplified variants over
+   Traditional Chinese from Taiwan/Hong Kong Wikipedia. For example:
    - "君の名は。" → Chinese: "你的名字。" (NOT "你的名字是")
    - "進撃の巨人" → English: "Attack on Titan" (NOT "Advance of Giants")
    - "響け！ユーフォニアム" → Chinese: "吹响！悠风号" (NOT "响吧！上低音号")
+   - "ソードアート・オンライン" → Chinese: "刀剑神域"
+   - "あの日見た花の名前を僕達はまだ知らない。" → Chinese: "未闻花名",
+     English: "Anohana"
 
 2. Use web search to find translations from authoritative sources:
-   - 萌娘百科 (zh.moegirl.org.cn) for Chinese translations
-   - Wikipedia for English translations
-   - Bangumi (bgm.tv) for cross-references
+   - Bangumi (bgm.tv) name_cn and 萌娘百科 for Chinese translations
+   - Official English licensors/Wikipedia for English titles
+   - Prefer official localized English; if none exists, use the standard
+     romanized Japanese title. NEVER literal word-by-word translation.
+   - Examples: "銀魂" → English: "Gintama"; "化物語" → English:
+     "Bakemonogatari"; "やはり俺の青春ラブコメはまちがっている。" →
+     English: "My Teen Romantic Comedy SNAFU"
 
-3. For place names, use the standard localized form:
+3. For Japanese place names, use the standard localized form. Use Hepburn
+   romanization plus customary English generic suffixes: Station, Shrine,
+   Temple, Park, Garden(s). Do NOT translate proper-noun meanings word-by-word.
    - "宇治駅" → Chinese: "宇治站", English: "Uji Station"
    - "秋葉原" → Chinese: "秋叶原", English: "Akihabara"
+   - "須賀神社" → English: "Suga Shrine"
+   - "新宿御苑" → English: "Shinjuku Gyoen"
 
 4. Return ONLY the translated text, no explanations.
 """
@@ -185,7 +143,7 @@ async def translate_title(
             )
 
     # 2. Bangumi API
-    api_result = await _lookup_bangumi_api(title, target_locale)
+    api_result = await lookup_bangumi_api(title, target_locale)
     if api_result and api_result != title:
         logger.info("translation_bangumi_hit", title=title, translated=api_result)
         return TranslationResult(
@@ -193,16 +151,19 @@ async def translate_title(
         )
 
     # 3. Web search + LLM (via translation_agent)
-    locale_names = {"ja": "Japanese", "zh": "Chinese", "en": "English"}
+    locale_names = {"ja": "Japanese", "zh": "Simplified Chinese", "en": "English"}
     target_name = locale_names.get(target_locale, target_locale)
 
     # Fence the title to prevent prompt injection from user-influenced input
     safe_title = title.replace("```", "")
     prompt = (
-        f"What is the official {target_name} title for the anime "
-        f"enclosed below?\n```\n{safe_title}\n```\n"
-        f"Search for the community-accepted translation. "
-        f"Return ONLY the translated title, nothing else."
+        f"What is the {target_name} name of the anime title OR Japanese place "
+        f"name enclosed below?\n```\n{safe_title}\n```\n"
+        f"For anime, search for the official or community-accepted title. "
+        f"For places, return the standard localized form; use Hepburn "
+        f"romanization plus English generic suffixes like Station, Shrine, "
+        f"Temple, Park, or Garden when customary. Do not translate proper-noun "
+        f"meanings word by word. Return ONLY the translated name, nothing else."
     )
 
     try:

--- a/apps/agent/agent/agents/translation_bangumi.py
+++ b/apps/agent/agent/agents/translation_bangumi.py
@@ -1,0 +1,114 @@
+"""Bangumi-backed anime title resolution for translation lookups."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Mapping
+
+import httpx
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+_BANGUMI_SEARCH_URL = "https://api.bgm.tv/v0/search/subjects"
+_BANGUMI_USER_AGENT = (
+    "Seichijunrei/1.0 (https://github.com/lifeodyssey/Seichijunrei-agent)"
+)
+_TITLE_NORMALIZE_RE = re.compile(
+    r"[\s!！?？。・、．\.,，:：;；~〜～'\"「」『』【】()（）\[\]*＊☆★]"
+)
+_CONTAINMENT_RATIO = 0.5
+
+
+def _normalize_title(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return _TITLE_NORMALIZE_RE.sub("", normalized)
+
+
+def _titles_contain_each_other(query: str, candidate: str) -> bool:
+    if query not in candidate and candidate not in query:
+        return False
+    ratio = min(len(query), len(candidate)) / max(len(query), len(candidate))
+    return ratio >= _CONTAINMENT_RATIO
+
+
+def _titles_match(query: str, candidate: str) -> bool:
+    if not query or not candidate:
+        return False
+    return query == candidate or _titles_contain_each_other(query, candidate)
+
+
+def _hit_candidate_titles(hit: Mapping[str, object]) -> tuple[str, ...]:
+    candidates = (hit.get("name"), hit.get("name_cn"))
+    return tuple(candidate for candidate in candidates if isinstance(candidate, str))
+
+
+def hit_matches(title: str, hit: Mapping[str, object]) -> bool:
+    query = _normalize_title(title)
+    return any(
+        _titles_match(query, _normalize_title(candidate))
+        for candidate in _hit_candidate_titles(hit)
+    )
+
+
+def best_matching_hit(title: str, hits: object) -> Mapping[str, object] | None:
+    if not isinstance(hits, list):
+        return None
+    for hit in hits:
+        if isinstance(hit, Mapping) and hit_matches(title, hit):
+            return hit
+    return None
+
+
+def _bangumi_search_body(title: str) -> Mapping[str, object]:
+    return {"keyword": title, "filter": {"type": [2]}, "limit": 5}
+
+
+async def _post_bangumi_search(title: str) -> httpx.Response:
+    headers = {"User-Agent": _BANGUMI_USER_AGENT}
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        return await client.post(
+            _BANGUMI_SEARCH_URL, json=_bangumi_search_body(title), headers=headers
+        )
+
+
+def _matching_search_hit(title: str, payload: object) -> Mapping[str, object] | None:
+    if not isinstance(payload, Mapping):
+        return None
+    return best_matching_hit(title, payload.get("data"))
+
+
+async def _search_bangumi_subject(title: str) -> Mapping[str, object] | None:
+    """POST a five-result anime subject search to the Bangumi v0 API."""
+    response = await _post_bangumi_search(title)
+    if response.status_code >= 400:
+        logger.warning("bangumi_search_http_error", status=response.status_code)
+        return None
+    return _matching_search_hit(title, response.json())
+
+
+def _pick_locale_title(hit: Mapping[str, object], target_locale: str) -> str | None:
+    """Choose the localized title from a Bangumi subject hit."""
+    name_ja = hit.get("name")
+    name_cn = hit.get("name_cn")
+    if target_locale == "zh" and name_cn:
+        return str(name_cn)
+    if target_locale == "ja" and name_ja:
+        return str(name_ja)
+    # Bangumi has no English titles; name_cn is sometimes the international one.
+    if target_locale == "en" and name_cn and str(name_cn).isascii():
+        return str(name_cn)
+    return None
+
+
+async def lookup_bangumi_api(title: str, target_locale: str) -> str | None:
+    """Search Bangumi API for the title translation."""
+    try:
+        hit = await _search_bangumi_subject(title)
+    except (httpx.HTTPError, OSError, RuntimeError, ValueError) as exc:
+        logger.warning("bangumi_api_translation_failed", title=title, error=str(exc))
+        return None
+    if hit is None:
+        return None
+    return _pick_locale_title(hit, target_locale)

--- a/apps/agent/agent/agents/translation_bangumi.py
+++ b/apps/agent/agent/agents/translation_bangumi.py
@@ -39,9 +39,35 @@ def _titles_match(query: str, candidate: str) -> bool:
     return query == candidate or _titles_contain_each_other(query, candidate)
 
 
+def _infobox_values(value: object) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    if not isinstance(value, list):
+        return ()
+    items = (item.get("v") for item in value if isinstance(item, Mapping))
+    return tuple(v for v in items if isinstance(v, str))
+
+
+def _alias_row_values(row: object) -> tuple[str, ...]:
+    if not isinstance(row, Mapping) or row.get("key") != "别名":
+        return ()
+    return _infobox_values(row.get("value"))
+
+
+def _hit_alias_titles(hit: Mapping[str, object]) -> tuple[str, ...]:
+    infobox = hit.get("infobox")
+    if not isinstance(infobox, list):
+        return ()
+    aliases: list[str] = []
+    for row in infobox:
+        aliases.extend(_alias_row_values(row))
+    return tuple(aliases)
+
+
 def _hit_candidate_titles(hit: Mapping[str, object]) -> tuple[str, ...]:
-    candidates = (hit.get("name"), hit.get("name_cn"))
-    return tuple(candidate for candidate in candidates if isinstance(candidate, str))
+    names = (hit.get("name"), hit.get("name_cn"))
+    named = tuple(name for name in names if isinstance(name, str))
+    return named + _hit_alias_titles(hit)
 
 
 def hit_matches(title: str, hit: Mapping[str, object]) -> bool:
@@ -52,13 +78,21 @@ def hit_matches(title: str, hit: Mapping[str, object]) -> bool:
     )
 
 
+def _hit_exact_match(title: str, hit: Mapping[str, object]) -> bool:
+    query = _normalize_title(title)
+    if not query:
+        return False
+    return any(query == _normalize_title(c) for c in _hit_candidate_titles(hit))
+
+
 def best_matching_hit(title: str, hits: object) -> Mapping[str, object] | None:
     if not isinstance(hits, list):
         return None
-    for hit in hits:
-        if isinstance(hit, Mapping) and hit_matches(title, hit):
-            return hit
-    return None
+    candidates = [hit for hit in hits if isinstance(hit, Mapping)]
+    exact = next((h for h in candidates if _hit_exact_match(title, h)), None)
+    if exact is not None:
+        return exact
+    return next((h for h in candidates if hit_matches(title, h)), None)
 
 
 def _bangumi_search_body(title: str) -> Mapping[str, object]:

--- a/apps/agent/agent/tests/eval/conftest.py
+++ b/apps/agent/agent/tests/eval/conftest.py
@@ -16,8 +16,11 @@ from dotenv import load_dotenv
 
 pytest_plugins = ("agent.tests.conftest_db",)
 
-# Load real .env so eval tests have real API keys
-load_dotenv(Path(__file__).parents[3] / ".env")
+# Load real .env so eval tests have real API keys. override=True because the
+# parent tests/conftest.py has already run at this point and seeded fake keys
+# via os.environ.setdefault ("test-key"); without override the real keys never
+# land and every model call 401s.
+load_dotenv(Path(__file__).parents[3] / ".env", override=True)
 
 
 @pytest.fixture(autouse=True)

--- a/apps/agent/agent/tests/eval/conftest.py
+++ b/apps/agent/agent/tests/eval/conftest.py
@@ -9,18 +9,23 @@ The ``real_db`` fixture is defined in ``conftest_db`` (shared with integration t
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
-from dotenv import load_dotenv
+from dotenv import dotenv_values
+
+from agent.tests.eval.eval_common import real_env_updates
 
 pytest_plugins = ("agent.tests.conftest_db",)
 
-# Load real .env so eval tests have real API keys. override=True because the
-# parent tests/conftest.py has already run at this point and seeded fake keys
-# via os.environ.setdefault ("test-key"); without override the real keys never
-# land and every model call 401s.
-load_dotenv(Path(__file__).parents[3] / ".env", override=True)
+# Load real .env so eval tests have real API keys, but let a real value already in
+# the process environment win over a stale .env. The parent tests/conftest.py
+# seeds fake "test-key" creds via os.environ.setdefault; only those (and unset
+# vars) are filled from .env, so CI secrets, rotated keys, and DEFAULT_AGENT_MODEL
+# set in the environment are never silently overwritten.
+_ENV_PATH = Path(__file__).parents[3] / ".env"
+os.environ.update(real_env_updates(dotenv_values(_ENV_PATH), os.environ))
 
 
 @pytest.fixture(autouse=True)

--- a/apps/agent/agent/tests/eval/eval_common.py
+++ b/apps/agent/agent/tests/eval/eval_common.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -16,6 +17,32 @@ logger = logging.getLogger(__name__)
 CASE_TIMEOUT_S = 60
 
 _DEFAULT_BASELINES_DIR = Path(__file__).parent / "baselines"
+
+# Fake credentials the parent tests/conftest.py injects via os.environ.setdefault.
+# Eval may replace these (and unset vars) from .env, but a real value already in
+# the process environment (CI secret, rotated key, model override) must win.
+_ENV_FAKE_SENTINELS = frozenset(
+    {"test-key", "postgresql://test:test@localhost:5432/test"}
+)
+
+
+def real_env_updates(
+    file_values: Mapping[str, str | None],
+    environ: Mapping[str, str],
+) -> dict[str, str]:
+    """Return the .env entries to apply without clobbering the real process env.
+
+    A key is applied only when the current environment value is missing or is one
+    of the parent conftest's fake sentinels — so CI secrets and rotated keys win.
+    """
+    updates: dict[str, str] = {}
+    for key, value in file_values.items():
+        if value is None:
+            continue
+        current = environ.get(key)
+        if current is None or current in _ENV_FAKE_SENTINELS:
+            updates[key] = value
+    return updates
 
 
 @dataclass

--- a/apps/agent/agent/tests/unit/test_agent_base.py
+++ b/apps/agent/agent/tests/unit/test_agent_base.py
@@ -8,7 +8,7 @@ import pytest
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.openai import OpenAIChatModel
 
-from agent.agents.base import describe_model, resolve_model
+from agent.agents.base import describe_model, parse_model_spec, resolve_model
 from agent.config.settings import Settings
 
 
@@ -25,6 +25,10 @@ def _test_settings() -> Settings:
         default_agent_model="deepseek:deepseek-v4-flash",
         fallback_agent_model="openai:mimo-v2.5@https://api.xiaomimimo.com/v1",
     )
+
+
+def _deepseek_extra_body() -> object:
+    return {"thinking": {"type": "disabled"}}
 
 
 class TestResolveModel:
@@ -57,6 +61,28 @@ class TestResolveModel:
         with pytest.raises(ValueError, match="Unsupported model spec"):
             with patch("agent.config.get_settings", return_value=_test_settings()):
                 resolve_model("unknown:model")
+
+    def test_deepseek_model_disables_thinking(self) -> None:
+        with patch("agent.config.get_settings", return_value=_test_settings()):
+            model = parse_model_spec("deepseek:deepseek-v4-flash")
+        assert isinstance(model, OpenAIChatModel)
+        assert model.settings is not None
+        assert model.settings.get("extra_body") == _deepseek_extra_body()
+
+    def test_deepseek_openai_compat_disables_thinking(self) -> None:
+        with patch("agent.config.get_settings", return_value=_test_settings()):
+            model = parse_model_spec("openai:deepseek-v4-pro@https://api.deepseek.com")
+        assert isinstance(model, OpenAIChatModel)
+        assert model.settings is not None
+        assert model.settings.get("extra_body") == _deepseek_extra_body()
+
+    def test_non_deepseek_openai_compat_keeps_settings_empty(self) -> None:
+        with patch("agent.config.get_settings", return_value=_test_settings()):
+            model = parse_model_spec(
+                "openai:mimo-v2.5-pro@https://api.xiaomimimo.com/v1"
+            )
+        assert isinstance(model, OpenAIChatModel)
+        assert model.settings is None or "extra_body" not in model.settings
 
 
 class TestDescribeModel:

--- a/apps/agent/agent/tests/unit/test_eval_env_loading.py
+++ b/apps/agent/agent/tests/unit/test_eval_env_loading.py
@@ -1,0 +1,44 @@
+"""Unit tests for eval .env precedence: real process env wins over stale .env."""
+
+from __future__ import annotations
+
+from agent.tests.eval.eval_common import real_env_updates
+
+
+def test_keeps_real_process_value_over_env_file() -> None:
+    updates = real_env_updates(
+        {"DEEPSEEK_API_KEY": "stale-from-file"},
+        {"DEEPSEEK_API_KEY": "real-rotated-key"},
+    )
+
+    assert "DEEPSEEK_API_KEY" not in updates
+
+
+def test_replaces_fake_sentinel_with_env_file_value() -> None:
+    updates = real_env_updates(
+        {"DEEPSEEK_API_KEY": "real-key"},
+        {"DEEPSEEK_API_KEY": "test-key"},
+    )
+
+    assert updates == {"DEEPSEEK_API_KEY": "real-key"}
+
+
+def test_fills_unset_key_from_env_file() -> None:
+    updates = real_env_updates({"MIMO_API_KEY": "real-key"}, {})
+
+    assert updates == {"MIMO_API_KEY": "real-key"}
+
+
+def test_skips_none_values() -> None:
+    updates = real_env_updates({"EMPTY": None}, {})
+
+    assert updates == {}
+
+
+def test_does_not_override_real_default_agent_model() -> None:
+    updates = real_env_updates(
+        {"DEFAULT_AGENT_MODEL": "deepseek:stale"},
+        {"DEFAULT_AGENT_MODEL": "deepseek:deepseek-v4-pro"},
+    )
+
+    assert "DEFAULT_AGENT_MODEL" not in updates

--- a/apps/agent/agent/tests/unit/test_translation.py
+++ b/apps/agent/agent/tests/unit/test_translation.py
@@ -91,7 +91,7 @@ class TestTranslateTitle:
 
         with (
             patch(
-                "agent.agents.translation._lookup_bangumi_api",
+                "agent.agents.translation.lookup_bangumi_api",
                 return_value=None,
             ),
             patch(

--- a/apps/agent/agent/tests/unit/test_translation_bangumi_lookup.py
+++ b/apps/agent/agent/tests/unit/test_translation_bangumi_lookup.py
@@ -1,4 +1,4 @@
-"""Unit tests for the httpx-backed Bangumi title lookup in translation.py."""
+"""Unit tests for the httpx-backed Bangumi title lookup."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from agent.agents.translation import _lookup_bangumi_api
+from agent.agents.translation_bangumi import lookup_bangumi_api
 
 _SEARCH_PAYLOAD = {
     "data": [{"name": "君の名は。", "name_cn": "你的名字。"}],
@@ -30,7 +30,7 @@ def _install_httpx(
     client.__aenter__ = AsyncMock(return_value=client)
     client.__aexit__ = AsyncMock(return_value=False)
     monkeypatch.setattr(
-        "agent.agents.translation.httpx.AsyncClient",
+        "agent.agents.translation_bangumi.httpx.AsyncClient",
         MagicMock(return_value=client),
     )
     return post
@@ -39,7 +39,7 @@ def _install_httpx(
 async def test_returns_chinese_name(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_httpx(monkeypatch, payload=_SEARCH_PAYLOAD)
 
-    result = await _lookup_bangumi_api("君の名は", "zh")
+    result = await lookup_bangumi_api("君の名は", "zh")
 
     assert result == "你的名字。"
 
@@ -47,7 +47,7 @@ async def test_returns_chinese_name(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_returns_japanese_name(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_httpx(monkeypatch, payload=_SEARCH_PAYLOAD)
 
-    result = await _lookup_bangumi_api("你的名字", "ja")
+    result = await lookup_bangumi_api("你的名字", "ja")
 
     assert result == "君の名は。"
 
@@ -58,7 +58,7 @@ async def test_returns_ascii_name_cn_for_english(
     payload = {"data": [{"name": "ヴァイオレット", "name_cn": "Violet Evergarden"}]}
     _install_httpx(monkeypatch, payload=payload)
 
-    result = await _lookup_bangumi_api("ヴァイオレット", "en")
+    result = await lookup_bangumi_api("ヴァイオレット", "en")
 
     assert result == "Violet Evergarden"
 
@@ -68,7 +68,7 @@ async def test_returns_none_for_non_ascii_name_cn_in_english(
 ) -> None:
     _install_httpx(monkeypatch, payload=_SEARCH_PAYLOAD)
 
-    result = await _lookup_bangumi_api("君の名は", "en")
+    result = await lookup_bangumi_api("君の名は", "en")
 
     assert result is None
 
@@ -78,14 +78,14 @@ async def test_posts_search_body_to_bangumi_api(
 ) -> None:
     post = _install_httpx(monkeypatch, payload=_SEARCH_PAYLOAD)
 
-    await _lookup_bangumi_api("君の名は", "zh")
+    await lookup_bangumi_api("君の名は", "zh")
 
     url = post.call_args.args[0]
     assert url == "https://api.bgm.tv/v0/search/subjects"
     assert post.call_args.kwargs["json"] == {
         "keyword": "君の名は",
         "filter": {"type": [2]},
-        "limit": 1,
+        "limit": 5,
     }
 
 
@@ -94,7 +94,7 @@ async def test_returns_none_on_http_error_status(
 ) -> None:
     _install_httpx(monkeypatch, status_code=503, payload={})
 
-    result = await _lookup_bangumi_api("君の名は", "zh")
+    result = await lookup_bangumi_api("君の名は", "zh")
 
     assert result is None
 
@@ -104,7 +104,7 @@ async def test_returns_none_on_transport_error(
 ) -> None:
     _install_httpx(monkeypatch, error=httpx.ConnectError("boom"))
 
-    result = await _lookup_bangumi_api("君の名は", "zh")
+    result = await lookup_bangumi_api("君の名は", "zh")
 
     assert result is None
 
@@ -114,6 +114,6 @@ async def test_returns_none_when_no_results(
 ) -> None:
     _install_httpx(monkeypatch, payload={"data": []})
 
-    result = await _lookup_bangumi_api("unknown_anime_xyz", "zh")
+    result = await lookup_bangumi_api("unknown_anime_xyz", "zh")
 
     assert result is None

--- a/apps/agent/agent/tests/unit/test_translation_bangumi_lookup.py
+++ b/apps/agent/agent/tests/unit/test_translation_bangumi_lookup.py
@@ -117,3 +117,22 @@ async def test_returns_none_when_no_results(
     result = await lookup_bangumi_api("unknown_anime_xyz", "zh")
 
     assert result is None
+
+
+async def test_returns_japanese_name_for_english_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "data": [
+            {
+                "name": "君の名は。",
+                "name_cn": "你的名字。",
+                "infobox": [{"key": "别名", "value": [{"v": "Your Name."}]}],
+            }
+        ]
+    }
+    _install_httpx(monkeypatch, payload=payload)
+
+    result = await lookup_bangumi_api("Your Name", "ja")
+
+    assert result == "君の名は。"

--- a/apps/agent/agent/tests/unit/test_translation_unit.py
+++ b/apps/agent/agent/tests/unit/test_translation_unit.py
@@ -39,3 +39,73 @@ def test_matcher_rejects_place_name_mismatch() -> None:
     hit = {"name": "秋葉原電脳組物語", "name_cn": "秋叶原电脑组物语"}
 
     assert best_matching_hit("秋葉原", [hit]) is None
+
+
+def test_matcher_accepts_english_alias_from_infobox() -> None:
+    hit = {
+        "name": "君の名は。",
+        "name_cn": "你的名字。",
+        "infobox": [
+            {"key": "别名", "value": [{"v": "Kimi no Na wa."}, {"v": "Your Name."}]}
+        ],
+    }
+
+    assert hit_matches("Your Name", hit)
+
+
+def test_best_hit_selects_english_alias_over_unrelated() -> None:
+    kimi = {
+        "name": "君の名は。",
+        "name_cn": "你的名字。",
+        "infobox": [{"key": "别名", "value": [{"v": "Your Name."}]}],
+    }
+    other = {"name": "Your Friend the Rat", "name_cn": "你的老鼠朋友"}
+
+    assert best_matching_hit("Your Name", [other, kimi]) is kimi
+
+
+def test_best_hit_prefers_exact_over_containing_sequel() -> None:
+    sequel = {"name": "Sound! Euphonium 2", "name_cn": "吹响！上低音号 2"}
+    original = {
+        "name": "響け！ユーフォニアム",
+        "name_cn": "吹响！上低音号",
+        "infobox": [{"key": "别名", "value": [{"v": "Sound! Euphonium"}]}],
+    }
+
+    assert best_matching_hit("Sound! Euphonium", [sequel, original]) is original
+
+
+def test_matcher_ignores_non_alias_infobox_rows() -> None:
+    hit = {
+        "name": "君の名は。",
+        "name_cn": "你的名字。",
+        "infobox": [{"key": "话数", "value": "1"}],
+    }
+
+    assert not hit_matches("Your Name", hit)
+
+
+def test_matcher_accepts_alias_value_as_plain_string() -> None:
+    hit = {
+        "name": "ヴァイオレット",
+        "infobox": [{"key": "别名", "value": "Violet Evergarden"}],
+    }
+
+    assert hit_matches("Violet Evergarden", hit)
+
+
+def test_matcher_ignores_non_list_non_str_alias_value() -> None:
+    hit = {
+        "name": "君の名は。",
+        "infobox": [{"key": "别名", "value": 123}],
+    }
+
+    assert not hit_matches("Your Name", hit)
+
+
+def test_best_hit_empty_title_returns_none() -> None:
+    assert best_matching_hit("", [{"name": "君の名は。"}]) is None
+
+
+def test_best_hit_rejects_non_list_hits() -> None:
+    assert best_matching_hit("君の名は", None) is None

--- a/apps/agent/agent/tests/unit/test_translation_unit.py
+++ b/apps/agent/agent/tests/unit/test_translation_unit.py
@@ -1,0 +1,41 @@
+"""Pure unit tests for deterministic translation helpers."""
+
+from __future__ import annotations
+
+from agent.agents.translation_bangumi import best_matching_hit, hit_matches
+
+
+def test_matcher_accepts_exact_name_match() -> None:
+    hit = {"name": "君の名は", "name_cn": "你的名字"}
+
+    assert hit_matches("君の名は", hit)
+
+
+def test_matcher_accepts_trailing_sentence_mark_match() -> None:
+    hit = {"name": "君の名は。", "name_cn": "你的名字。"}
+
+    assert hit_matches("君の名は", hit)
+
+
+def test_matcher_rejects_sequel_mismatch() -> None:
+    hit = {"name": "涼宮ハルヒの憂鬱", "name_cn": "凉宫春日的忧郁"}
+
+    assert best_matching_hit("涼宮ハルヒの消失", [hit]) is None
+
+
+def test_matcher_accepts_name_cn_match() -> None:
+    hit = {"name": "君の名は。", "name_cn": "你的名字。"}
+
+    assert hit_matches("你的名字", hit)
+
+
+def test_matcher_rejects_short_fragment_containment() -> None:
+    hit = {"name": "君の名は。", "name_cn": "你的名字。"}
+
+    assert not hit_matches("君", hit)
+
+
+def test_matcher_rejects_place_name_mismatch() -> None:
+    hit = {"name": "秋葉原電脳組物語", "name_cn": "秋叶原电脑组物语"}
+
+    assert best_matching_hit("秋葉原", [hit]) is None


### PR DESCRIPTION
# Summary

Translation-quality push for the pilgrimage agent. Fixes the three translation bug
patterns from the eval catalogue (sequel/wrong-work returns, place names, community
names) and re-measures the touched suite with an eval before/after.

`Refs #304`

**Translation eval — DeepSeek V4 Pro, 62 cases (`agent/tests/eval/test_translation.py`):**

| Metric | Before (tracked baseline) | After | Delta |
|---|---|---|---|
| ExactMatch | 69.5% | **91.7%** | **+22.2 pts** |
| FuzzyMatch | 84.4% | **95.7%** | **+11.3 pts** |
| NotOriginal | 100.0% | 100.0% | 0 |

Root cause + fix per pattern:
- **Sequel / wrong-work returns** — the Bangumi subject search took `limit:1` and blindly
  used the first hit, so a query could resolve to a sequel or an unrelated subject. Now it
  fetches 5 hits and selects the one whose `name`/`name_cn` actually matches the query via
  NFKC + casefold + punctuation-stripped containment with a length-ratio guard
  (`best_matching_hit`).
- **Place names** — `translate_title`'s prompt and the agent instructions now explicitly
  handle Japanese place names (Hepburn + Station/Shrine/Temple/Park/Garden suffixes; no
  word-by-word proper-noun translation).
- **Community names** — the prompt enforces Simplified Chinese (zh-Hans) via Bangumi
  `name_cn` / 萌娘百科 and official English licensors, with added worked examples.

Also extracts the Bangumi title-resolution subsystem into
`agent/agents/translation_bangumi.py` (translation.py 329 → 224 lines, back under the
300-line limit).

## Acceptance Criteria

| # | Acceptance criterion | Test type | Test file (in this diff) |
|---|---------------------|-----------|--------------------------|
| 1 | Bangumi matcher accepts exact / trailing-mark / `name_cn` matches and rejects sequel, short-fragment, and unrelated-subject hits | unit | `apps/agent/agent/tests/unit/test_translation_unit.py` |
| 2 | Bangumi search posts a 5-result query body (`limit:5`) to the v0 API and resolves the localized title | unit | `apps/agent/agent/tests/unit/test_translation_bangumi_lookup.py` |
| 3 | Translation eval quality improves vs baseline and stays above the gate (Exact 69.5%→91.7%, Fuzzy 84.4%→95.7%) | eval | `apps/agent/agent/tests/eval/test_translation.py` (existing gate; ran on DeepSeek V4 Pro) |

## Quality Gates

- [x] `make check` passes (lint + typecheck + test + test-integration): 790 unit passed, coverage 82.99%, 53 integration passed / 21 env-skipped
- [x] Every AC row has a test type; ACs 1–2 have tests in this diff, AC 3 is validated by the existing eval gate (before/after above)
- [x] Coverage thresholds NOT lowered — backend floor stays at 82 (`pytest.ini`); current 82.99% (82.99 rounds below an 83 bump, so floor unchanged, not lowered)
- [x] No suppressions added (`type: ignore` / `noqa` / etc.) — verified absent in both modules
- [x] No hardcoded secrets; no `Any` / `dict[str, object]` — external API data uses `Mapping[str, object]` + `isinstance` narrowing at the boundary (mypy strict clean)

## Notes for Reviewer

- **Two earlier commits on this branch are separate root-cause fixes, already verified:**
  - `b8ad512` — disables DeepSeek thinking mode (`extra_body {thinking: disabled}`) which was
    rejecting PydanticAI's forced `tool_choice` for typed output (HTTP 400 on every agent run,
    since DeepSeek is the default provider). Covers both native `deepseek:` and
    `openai:@deepseek.com` compat specs; non-DeepSeek untouched. 3 unit tests in `test_agent_base.py`.
  - `018aa60` — eval conftest `load_dotenv(override=True)` so real API keys beat the parent
    conftest's fake `test-key` seed.
- **Restored an accidentally-clobbered baseline:** the tracked 555-case DeepSeek result
  (`tests/eval/results/agent_openai-deepseek-v4-pro-…json`, IntentMatch 0.539 / Locale 0.587)
  had been overwritten by a 6-case smoke run in the working tree. Restored via `git checkout`;
  it is intentionally **not** part of this diff.
- **IntentMatch / ResponseLocale are out of scope here** — this diff touches only `translate_title`
  and Bangumi resolution, not intent classification or tool choice, so no IntentMatch delta is
  attributable to it. A full 647-case agent re-baseline was attempted but did not complete cleanly
  this session; recommend a dedicated re-baseline run once the environment is clear.
- **Module extraction** was delegated to Codex and independently re-verified (byte-identical moved
  bodies vs. original, lint/typecheck/unit all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
