### PR TITLE
docs(agents): context-docs supplement — stack skill routing + F7/F8/workerd conventions + CI/infra/migrations/worktree/git rules

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - ".github/workflows/**"
+---
+# GitHub Actions authoring rules
+
+- **Layering**: reusable composites are `_*.yml`; the top-level `ci.yml` / `deploy.yml` are the callers
+  that route the reusables per changed package (path filters). Shared logic goes in a `_`-file, not
+  copy-paste. (`codeql.yml` / `dependabot-agent.yml` are standalone top-level workflows.)
+- **Pin every third-party action by full 40-char commit SHA** + a trailing `# vX.Y.Z`. Never a floating
+  tag/branch.
+- **Run `actionlint` on touched workflow files** (`/opt/homebrew/bin/actionlint`) and verify
+  reusable-workflow input/secret contracts before claiming CI syntax is valid.
+- **Warn-only gates use `continue-on-error: true` deliberately** (e.g. the `agnix` agent-config lint) —
+  a sanctioned exception, NOT a code-quality suppression. Real gates (lint / typecheck / test /
+  coverage / security) stay blocking.
+- **Least privilege**: explicit `permissions:` (default `contents: read`); widen per-job only.
+- Deploy is manual: `deploy.yml` = `workflow_dispatch` + `environment: production` approval.

--- a/.claude/rules/git-commit.md
+++ b/.claude/rules/git-commit.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "**/*"
+---
+# Git commit + .claude tracking
+
+- The git hooks run **more than ruff/mypy**. Every commit runs the fast gate — ruff + ruff-format +
+  oxlint + **gitleaks (secret scan)** + whitespace/EOF fixers (<5s); pre-push adds mypy, frontend
+  typecheck/lint, and frontend + backend **test-coverage** gates. Any *fixer* hook (`ruff --fix`,
+  `ruff-format`, `end-of-file-fixer`) can modify files and **abort the commit**.
+- **After any failed commit, assume hooks modified/staged files**: `git status --short`, inspect,
+  re-stage the intentional hook fixes, and retry.
+- `.claude/` is **gitignored but selectively tracked** — some agents/skills/rules are force-added,
+  others aren't. Before relying on a `.claude/` agent/hook/rule as repo-shared context, verify with
+  `git ls-files`; new tracked additions under `.claude/` need an explicit `git add -f`.

--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "infra/**"
+---
+# Pulumi IaC rules
+
+- Pulumi (TypeScript, `infra/index.ts`) is the IaC for Cloudflare. Use the `pulumi` skill.
+- **Scope**: R2 (catalog media + Pulumi state), Worker routes (web `/*`, edge `/v1/*`+`/img/*`), DNS,
+  secrets. **No Hyperdrive** — the catalog reaches Neon over `@neondatabase/serverless` (neon-http).
+  *(Today `index.ts` declares the catalog R2 bucket + `DATABASE_URL` config secret; routes / DNS /
+  per-stack params are the Wave 2+ scope.)*
+- **Split-brain rule**: *routes belong to Pulumi, worker code belongs to wrangler* — a no-route
+  `wrangler deploy` must not clobber Pulumi-managed routes.
+- **State backend = R2** (s3-compatible; the Wave 0 spike ran on local state).
+- Stacks: `Pulumi.yaml` + `Pulumi.<stack>.yaml` (`Pulumi.prod.yaml`; staging / preview per env).
+- **Secrets** live in Pulumi encrypted config (`secure:` in the stack file) / ESC — never plaintext.
+  CF Worker secrets are pushed via CI (`wrangler secret put`) from Pulumi outputs
+  (`@pulumi/cloudflare` v6 has no `WorkersSecret` resource), not hand-set.

--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - "db/**"
+---
+# Atlas migration rules (shared Neon schema)
+
+- Versioned migrations live in `db/migrations/*.sql` with `atlas.sum`. Regenerate the sum with
+  `atlas migrate hash` — never hand-edit it.
+- New migration: `atlas migrate diff <name> --dir file://db/migrations --to <schema-source>
+  --dev-url <ephemeral-neon-branch>`; commit the `.sql` + updated `atlas.sum`. Use a throwaway **Neon
+  branch** as `--dev-url`; never diff against prod.
+- CI applies on deploy (`_deploy-component.yml`, gated on `NEON_DATABASE_URL`):
+  `atlas migrate apply --dir file://db/migrations --url "$NEON_DATABASE_URL" --revisions-schema public`.

--- a/.claude/rules/worktree-hygiene.md
+++ b/.claude/rules/worktree-hygiene.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "**/*"
+---
+# Worktree / branch hygiene
+
+- Before editing, reviewing, merging, or deleting in a worktree, record the current branch, HEAD,
+  dirty state (`git status --short --branch`), worktree list (`git worktree list --porcelain`), and
+  remote-ref freshness. Run `git fetch` / `prune` before declaring branches stale or merged. Don't
+  trust stale branch/worktree memory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,20 @@ integrated — **do not add new Supabase-auth code**; see the ADR / rebuild-spec
   | serena | LSP-backed semantic code nav/edits when codegraph isn't enough. |
   | logfire | Observability — the agent and Workers share the Logfire dashboard. |
 
+- **Stack skills — invoke the Skill tool when the task matches** (docs fallback = context7 for any lib without a skill: Hono, oRPC, Drizzle, TanStack Start):
+
+  | Skill | Reach for it when |
+  |---|---|
+  | `ai@pydantic-skills` | Writing/altering the PydanticAI agent, tools, `ModelRetry` guards, typed output (`apps/agent`). |
+  | `logfire@pydantic-skills` | Instrumentation / querying observability — the sanctioned OTel path (see F8 in `apps/agent/AGENTS.md`). |
+  | `fastapi` | FastAPI service surface, routing, lifespan, dependencies (`apps/agent`). |
+  | `cloudflare:workers-best-practices` · `:wrangler` · `:durable-objects` | Catalog/edge Worker code, `wrangler.toml`, bindings, local `wrangler dev`. |
+  | `neon` / `neon-postgres` | Neon data-plane queries, branching, egress tuning. |
+  | `pulumi` | IaC in `infra/` — Cloudflare R2 / routes / DNS / secrets, stacks, ESC. |
+  | `auth-skills` (Better Auth) | Auth work as we migrate onto Neon Auth (Better Auth) (`workers/users`, login). |
+  | `ai-sdk` | Frontend AI SDK streaming/UI in the TanStack rebuild (`apps/web`). |
+  | `atlas` *(if installed)* | Schema migrations in `db/migrations` — diff/lint/apply. |
+
 ## Harness (4-role agent system)
 
 Planner → Executor → Reviewer → Tester. Role definitions live in `.claude/agents/`; orchestration via

--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -56,4 +56,25 @@ user messages: `agent/agents/error_messages.py`. Adding an error code → follow
 Anitabi (`api.anitabi.cn`) + Bangumi (`api.bgm.tv`) share Bangumi.tv subject IDs as our primary keys
 (`eps=1` → movie, `eps>1` → TV). Full reference: `docs/api-reference/`.
 
+## HTTP + observability conventions (F7/F8)
+
+- **httpx only** — aiohttp is retired (F7). **One shared `httpx.AsyncClient` per client**, created
+  lazily and closed via the FastAPI lifespan `aclose()` (`agent/interfaces/fastapi_service.py`) — never per-request.
+  Leave `trust_env` at httpx's default (`True`) so proxy/CA env vars are respected.
+- **Status-based retry** — classify by **status code, never by URL/substring**: 5xx, transport errors,
+  and transient 4xx (408/429) retry with backoff; other 4xx raise immediately (`agent/clients/catalog_client.py`).
+- **Observability = logfire only** (F8). Never hand-roll OpenTelemetry or add `opentelemetry-api|sdk`
+  directly (logfire pins its own). Go through `agent/infrastructure/observability/runtime.py`
+  (`runtime_span` / `http_span`, `record_*`); `setup_logfire` calls
+  `logfire.configure(send_to_logfire="if-token-present")`, which no-ops without `LOGFIRE_TOKEN`.
+  Test spans via `logfire.testing.capfire`.
+- **Typed DB** — asyncpg with the `asyncpg-stubs` dev dep; no untyped pool/record access.
+
+## Test environment reality
+
+- Integration/eval suites that import `pg_container` (`agent/tests/conftest_db.py`) need a
+  **Docker-compatible runtime** (Docker / Colima on Mac) and use **testcontainers PostGIS**
+  (`postgis/postgis:16-3.4`). `SUPABASE_DB_URL` / `supabase start` alone is NOT sufficient for those
+  suites. Unit tests need no Docker.
+
 ## TDD: invoke `/backend-tdd` before writing Python.

--- a/workers/catalog/AGENTS.md
+++ b/workers/catalog/AGENTS.md
@@ -32,4 +32,16 @@ Root guide: `../../AGENTS.md`.
   `route_optimizer.py` is retired.
 - Data-quality gate (X15): coordinate validation / dedup / episode completeness / volume-drift.
 
+## workerd gotchas (Drizzle / timestamptz)
+
+- **Drizzle is queries-only through the raw `sql` tagged template** — reads and geo run through `sql`
+  passed to Drizzle's `execute`, **never the fluent query builder** (its `select` / `from` chain
+  **hangs** under workerd + the Neon HTTP driver). `src/db/schema.ts` (`drizzle-orm/pg-core`) exists
+  for typing only.
+- **timestamptz comes back as a raw string under workerd** (the pg driver doesn't parse it to `Date`;
+  Node would). Normalize at the boundary — `new Date(stamp).toISOString()` (see `src/api/search.ts`).
+- **zod runs only at the handler/contract boundary** to validate untrusted public input — the one
+  sanctioned place for a zod *value* import (contrast `src/types.ts`, which stays `import type` only;
+  see Contract discipline above).
+
 ## Tests: TDD via `vitest-pool-workers`; keep `test/contract-parity.worker.test.ts` green.


### PR DESCRIPTION
**context-docs 增补:栈 skill routing + F7/F8/workerd 约定 + CI/infra/migrations/worktree/git rules（codex claude-mem 3 月核验 + 官方 skill 调研合成）**

Synthesizes two research streams (the codex claude-mem March verification pass + the official-skill survey) into the #313 context-docs structure. Adds **only** what the current `feat/frontend-rebuild` tree does not already cover — every block was diffed against the existing `AGENTS.md` files and `.claude/rules/`.

## Added

**Root `AGENTS.md`** — a "Stack skills" routing sub-table under `## Tool routing` (existing skill-first / Codex / CodeGraph / MCP tables untouched): when to reach for `ai@pydantic-skills`, `logfire@pydantic-skills`, `fastapi`, `cloudflare:*`, `neon`/`neon-postgres`, `pulumi`, `auth-skills` (Better Auth), `ai-sdk`, `atlas`, with context7 as the docs fallback.

**`apps/agent/AGENTS.md`** — two sections:
- **HTTP + observability (F7/F8)**: httpx-only (aiohttp retired); one shared `AsyncClient` closed via the FastAPI lifespan; status-based retry (classify by status, never URL/substring); logfire-only observability (never hand-roll OTel); typed asyncpg via `asyncpg-stubs`.
- **Test environment reality**: integration/eval suites importing `pg_container` need Docker/Colima + testcontainers PostGIS (`postgis/postgis:16-3.4`); `supabase start` alone is insufficient.

**`workers/catalog/AGENTS.md`** — workerd gotchas: Drizzle is queries-only through the raw `sql` template (the fluent builder hangs under workerd + Neon HTTP); timestamptz returns a raw string → normalize with `new Date(stamp).toISOString()`; zod validates untrusted public input at the handler boundary only.

**`.claude/rules/*.md`** (new, path-scoped, force-added since `.claude/` is gitignored):
- `ci.md` — GHA authoring: `_*.yml` reusables, SHA-pinned actions, run `actionlint`, `continue-on-error` is a sanctioned warn-only exception, least-privilege `permissions:`, manual `workflow_dispatch` deploy.
- `infra.md` — Pulumi IaC scope, "routes belong to Pulumi, worker code belongs to wrangler", R2 state, stacks, encrypted secrets.
- `migrations.md` — Atlas: `db/migrations/*.sql` + `atlas.sum`, diff against an ephemeral Neon branch, CI apply command.
- `worktree-hygiene.md` — record branch/HEAD/dirty/worktree state + `git fetch` before declaring branches stale.
- `git-commit.md` — the two-stage pre-commit gate (fast commit / heavy pre-push), re-check status after a failed commit, `.claude/` is gitignored-but-selectively-tracked (`git add -f`).

## Reconciled against the tree (not taken verbatim)
- **Dropped Hyperdrive** from infra.md + the pulumi skill row — `infra/index.ts` states "No Hyperdrive needed: catalog uses `@neondatabase/serverless` (neon-http)".
- **Corrected the pre-commit description** — the actual gate is fast-on-commit (ruff/oxlint/gitleaks) + heavy-on-push (mypy/typecheck/coverage), not "ruff+mypy on commit".
- **Matched resolvable `agent/`-prefixed paths** and removed a malformed inline-code span.

## Skipped (already covered by #313)
- Codex "ban `codex exec`" — already in root `AGENTS.md` Tool routing.
- Python 1-10-50 / no-`Any` / error-mirror, TS oRPC / error-registry / zod-not-in-`types.ts` — already in the existing docs.
- **`reviewer.md` phantom eval targets** — the current file already uses `make test-eval` exclusively; the Makefile confirms `test-eval` is the sole eval target. No change needed (the phantom `test-eval-component|planner` names survive only in stale `docs/superpowers/` design docs, out of scope here).

## agnix @0.37.5 self-check
New rules files: **clean** (0 warnings). No new errors introduced — the 1 reported error is a pre-existing, unrelated `docs/design/.../skill/SKILL.md` name mismatch. Remaining warnings on the touched files are pre-existing heuristic noise (nested-AGENTS.md by design; inline code with dots read as file paths — same pattern as dozens already in the repo).

Docs-only; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)