### PR TITLE
fix(brand): rename follow-through — runtime-facing Seichijunrei residuals (refs #310)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Seichijunrei — Environment Variables
+# Animichi — Environment Variables
 # Copy to .env and fill in your values.
 
 # ============================================================

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ dev:
 	cd apps/agent && uv sync --extra dev
 
 serve:
-	cd apps/agent && uv run seichijunrei-api
+	cd apps/agent && uv run animichi-api
 
 test:
 	cd apps/agent && $(PYTEST) agent/tests/unit/ -v
@@ -153,16 +153,16 @@ dev-local:
 		echo "✓ Data exists ($$COUNT bangumi)"; \
 	fi
 	@# 4. Start Edge Function for auth emails (with local SITE_URL)
-	@supabase functions serve send-auth-email --no-verify-jwt --env-file supabase/.env.local > /tmp/seichijunrei-edge.log 2>&1 & echo $$! > /tmp/seichijunrei-edge.pid
+	@supabase functions serve send-auth-email --no-verify-jwt --env-file supabase/.env.local > /tmp/animichi-edge.log 2>&1 & echo $$! > /tmp/animichi-edge.pid
 	@echo "✓ Edge Function started (SITE_URL=http://localhost:3001)"
 	@# 5. Start backend with .env (background, daemonized)
-	@env $$(grep -v '^\#' .env | grep -v '^$$' | xargs) bash -c 'cd apps/agent && uv run uvicorn agent.interfaces.fastapi_service:app --host 0.0.0.0 --port 8080' > /tmp/seichijunrei-backend.log 2>&1 & echo $$! > /tmp/seichijunrei-backend.pid
+	@env $$(grep -v '^\#' .env | grep -v '^$$' | xargs) bash -c 'cd apps/agent && uv run uvicorn agent.interfaces.fastapi_service:app --host 0.0.0.0 --port 8080' > /tmp/animichi-backend.log 2>&1 & echo $$! > /tmp/animichi-backend.pid
 	@# 6. Wait for backend health
 	@echo "Waiting for backend..."
 	@for i in $$(seq 1 60); do curl -s http://localhost:8080/healthz >/dev/null 2>&1 && break || sleep 2; done
-	@curl -s http://localhost:8080/healthz >/dev/null 2>&1 && echo "✓ Backend ready on :8080" || (echo "✗ Backend failed — check /tmp/seichijunrei-backend.log" && exit 1)
+	@curl -s http://localhost:8080/healthz >/dev/null 2>&1 && echo "✓ Backend ready on :8080" || (echo "✗ Backend failed — check /tmp/animichi-backend.log" && exit 1)
 	@# 7. Start frontend on :3001 (matching config.toml site_url)
-	@cd frontend && npm run dev > /tmp/seichijunrei-frontend.log 2>&1 & echo $$! > /tmp/seichijunrei-frontend.pid
+	@cd frontend && npm run dev > /tmp/animichi-frontend.log 2>&1 & echo $$! > /tmp/animichi-frontend.pid
 	@sleep 3
 	@echo "✓ Frontend starting on :3001"
 	@echo ""
@@ -176,9 +176,9 @@ dev-local:
 
 dev-stop:
 	@echo "Stopping local dev services..."
-	@-test -f /tmp/seichijunrei-edge.pid && kill $$(cat /tmp/seichijunrei-edge.pid) 2>/dev/null && rm /tmp/seichijunrei-edge.pid && echo "✓ Edge Function stopped" || true
-	@-test -f /tmp/seichijunrei-backend.pid && kill $$(cat /tmp/seichijunrei-backend.pid) 2>/dev/null && rm /tmp/seichijunrei-backend.pid && echo "✓ Backend stopped" || true
-	@-test -f /tmp/seichijunrei-frontend.pid && kill $$(cat /tmp/seichijunrei-frontend.pid) 2>/dev/null && rm /tmp/seichijunrei-frontend.pid && echo "✓ Frontend stopped" || true
+	@-test -f /tmp/animichi-edge.pid && kill $$(cat /tmp/animichi-edge.pid) 2>/dev/null && rm /tmp/animichi-edge.pid && echo "✓ Edge Function stopped" || true
+	@-test -f /tmp/animichi-backend.pid && kill $$(cat /tmp/animichi-backend.pid) 2>/dev/null && rm /tmp/animichi-backend.pid && echo "✓ Backend stopped" || true
+	@-test -f /tmp/animichi-frontend.pid && kill $$(cat /tmp/animichi-frontend.pid) 2>/dev/null && rm /tmp/animichi-frontend.pid && echo "✓ Frontend stopped" || true
 	@-lsof -ti :8080 | xargs kill 2>/dev/null; true
 	@-lsof -ti :3001 | xargs kill 2>/dev/null; true
 	@echo "Done. (Supabase still running — use 'supabase stop' to shut down)"

--- a/apps/agent/agent/agents/export/ics.py
+++ b/apps/agent/agent/agents/export/ics.py
@@ -32,7 +32,7 @@ def build_ics_calendar(
     lines: list[str] = [
         "BEGIN:VCALENDAR",
         "VERSION:2.0",
-        "PRODID:-//Seichijunrei//EN",
+        "PRODID:-//Animichi//EN",
         "CALSCALE:GREGORIAN",
     ]
 

--- a/apps/agent/agent/agents/pilgrimage_agent.py
+++ b/apps/agent/agent/agents/pilgrimage_agent.py
@@ -37,7 +37,7 @@ COMPACT_THRESHOLD = 40  # ~5 turns × 8 messages/turn
 _KEEP_RECENT = 8  # Keep latest turn fully uncompressed
 
 _INSTRUCTIONS = """\
-You are the runtime agent for Seichijunrei (聖地巡礼), an anime pilgrimage search \
+You are the runtime agent for Animichi, an anime pilgrimage (聖地巡礼) search \
 and route planning app. Users ask about real-world locations from anime.
 
 ## Your job

--- a/apps/agent/agent/config/__init__.py
+++ b/apps/agent/agent/config/__init__.py
@@ -1,4 +1,4 @@
-"""Configuration module for Seichijunrei Bot."""
+"""Configuration module for Animichi Bot."""
 
 from .settings import Settings, get_settings
 

--- a/apps/agent/agent/config/settings.py
+++ b/apps/agent/agent/config/settings.py
@@ -87,7 +87,7 @@ class Settings(BaseSettings):
     service_host: str = Field(default="0.0.0.0", description="HTTP service bind host")
     service_port: int = Field(default=8080, description="HTTP service bind port")
     observability_service_name: str = Field(
-        default="seichijunrei-runtime",
+        default="animichi-runtime",
         description="Service name reported to observability backends",
     )
     observability_service_version: str = Field(

--- a/apps/agent/agent/domain/entities.py
+++ b/apps/agent/agent/domain/entities.py
@@ -1,5 +1,5 @@
 """
-Domain entities for Seichijunrei Bot.
+Domain entities for Animichi Bot.
 These are the core business objects used throughout the application.
 """
 
@@ -210,7 +210,7 @@ class Route(BaseModel):
         return groups
 
 
-class SeichijunreiSession(BaseModel):
+class AnimichiSession(BaseModel):
     """User session state."""
 
     session_id: str

--- a/apps/agent/agent/interfaces/routes/health.py
+++ b/apps/agent/agent/interfaces/routes/health.py
@@ -38,7 +38,7 @@ _GIT_BRANCH = _git_short(["git", "branch", "--show-current"])
 async def handle_root(request: Request) -> JSONResponse:
     settings = _get_settings_from_request(request)
     payload = {
-        "service": "seichijunrei-runtime",
+        "service": "animichi-runtime",
         "status": "ok",
         "app_env": settings.app_env,
         "endpoints": {
@@ -56,7 +56,7 @@ async def handle_health(request: Request) -> JSONResponse:
     settings = _get_settings_from_request(request)
     payload = {
         "status": "ok",
-        "service": "seichijunrei-runtime",
+        "service": "animichi-runtime",
         "git_commit": _GIT_COMMIT,
         "git_branch": _GIT_BRANCH,
         "started_at": _STARTED_AT,

--- a/apps/agent/agent/tests/api/test_live_api.py
+++ b/apps/agent/agent/tests/api/test_live_api.py
@@ -8,7 +8,7 @@ Run after starting the local stack:
   (cd catalog && npx wrangler dev --port 8787)         # DATABASE_URL in .dev.vars
   CATALOG_API_URL=http://127.0.0.1:8787 \
     DEFAULT_AGENT_MODEL=openai:mimo-v2.5-pro@https://api.xiaomimimo.com/v1 \
-    uv run seichijunrei-api                             # agent on :8080
+    uv run animichi-api                                 # agent on :8080
 
 Skips automatically when the stack is not reachable (CI / unit runs).
 """

--- a/apps/agent/agent/tests/integration/__init__.py
+++ b/apps/agent/agent/tests/integration/__init__.py
@@ -1,1 +1,1 @@
-"""Integration tests for Seichijunrei Bot."""
+"""Integration tests for Animichi Bot."""

--- a/apps/agent/agent/tests/integration/conftest.py
+++ b/apps/agent/agent/tests/integration/conftest.py
@@ -187,9 +187,9 @@ def _make_agent_result(text: str, _locale: str) -> AgentResult:
     if text.strip() in {"你好", "你是谁"}:
         output = GreetingResponseModel(
             intent="greet_user",
-            message="我是 Seichijunrei，可以帮你查找动漫圣地并规划巡礼路线。",
+            message="我是 Animichi，可以帮你查找动漫圣地并规划巡礼路线。",
             data=QADataModel(
-                message="我是 Seichijunrei，可以帮你查找动漫圣地并规划巡礼路线。",
+                message="我是 Animichi，可以帮你查找动漫圣地并规划巡礼路线。",
             ),
         )
         return AgentResult(

--- a/apps/agent/agent/tests/unit/test_entities.py
+++ b/apps/agent/agent/tests/unit/test_entities.py
@@ -8,12 +8,12 @@ from pydantic import ValidationError
 
 from agent.clients.errors import APIError
 from agent.domain.entities import (
+    AnimichiSession,
     Bangumi,
     Coordinates,
     Point,
     Route,
     RouteSegment,
-    SeichijunreiSession,
     Station,
     TransportInfo,
 )
@@ -488,12 +488,12 @@ class TestRoute:
         )
 
 
-class TestSeichijunreiSession:
-    """Test SeichijunreiSession entity."""
+class TestAnimichiSession:
+    """Test AnimichiSession entity."""
 
     def test_create_session(self):
         """Test creating a pilgrimage session."""
-        session = SeichijunreiSession(session_id="test-session-123")
+        session = AnimichiSession(session_id="test-session-123")
         assert session.session_id == "test-session-123"
         assert session.station is None
         assert session.selected_bangumi_ids == []
@@ -519,7 +519,7 @@ class TestSeichijunreiSession:
             points_count=10,
         )
 
-        session = SeichijunreiSession(
+        session = AnimichiSession(
             session_id="test-session-456",
             station=station,
             selected_bangumi_ids=["BG001", "BG002"],
@@ -534,7 +534,7 @@ class TestSeichijunreiSession:
 
     def test_session_update_timestamp(self):
         """Test updating session timestamp."""
-        session = SeichijunreiSession(session_id="test-session-789")
+        session = AnimichiSession(session_id="test-session-789")
         original_updated = session.updated_at
 
         # Small delay to ensure timestamp changes
@@ -548,15 +548,15 @@ class TestSeichijunreiSession:
     def test_search_radius_validation(self):
         """Test search radius validation."""
         # Valid ranges
-        SeichijunreiSession(session_id="test", search_radius_km=1.0)
-        SeichijunreiSession(session_id="test", search_radius_km=20.0)
+        AnimichiSession(session_id="test", search_radius_km=1.0)
+        AnimichiSession(session_id="test", search_radius_km=20.0)
 
         # Invalid ranges
         with pytest.raises(ValueError):
-            SeichijunreiSession(session_id="test", search_radius_km=0.5)
+            AnimichiSession(session_id="test", search_radius_km=0.5)
 
         with pytest.raises(ValueError):
-            SeichijunreiSession(session_id="test", search_radius_km=21.0)
+            AnimichiSession(session_id="test", search_radius_km=21.0)
 
 
 class TestDomainExceptions:

--- a/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
+++ b/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
@@ -52,7 +52,7 @@ def test_root_endpoint_returns_service_info(mock_db: MagicMock) -> None:
 
     assert response.status_code == 200
     body = response.json()
-    assert body["service"] == "seichijunrei-runtime"
+    assert body["service"] == "animichi-runtime"
     assert body["endpoints"]["healthz"] == "/healthz"
 
 

--- a/apps/agent/agent/tests/unit/test_routes_health.py
+++ b/apps/agent/agent/tests/unit/test_routes_health.py
@@ -27,7 +27,7 @@ async def test_healthz_returns_ok_with_status_and_service() -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "ok"
-    assert body["service"] == "seichijunrei-runtime"
+    assert body["service"] == "animichi-runtime"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/agent/agent/tests/unit/test_runtime_models.py
+++ b/apps/agent/agent/tests/unit/test_runtime_models.py
@@ -136,8 +136,8 @@ def test_qa_and_greet_models_include_data_message() -> None:
     )
     greet = GreetingResponseModel(
         intent="greet_user",
-        message="我是 Seichijunrei。",
-        data={"status": "info", "message": "我是 Seichijunrei。"},
+        message="我是 Animichi。",
+        data={"status": "info", "message": "我是 Animichi。"},
         ui={"component": "GeneralAnswer"},
     )
     assert qa.data.message

--- a/apps/agent/agent/tests/unit/test_seo_static_files.py
+++ b/apps/agent/agent/tests/unit/test_seo_static_files.py
@@ -85,10 +85,10 @@ class TestTitleAndDescription:
         width = _display_width(title)
         assert 50 <= width <= 60, f"Title width {width}: {title}"
 
-    def test_title_contains_japanese_and_seichijunrei(self) -> None:
+    def test_title_contains_japanese_and_animichi(self) -> None:
         source = _read_layout()
         assert "聖地巡礼" in source
-        assert "Seichijunrei" in source
+        assert "Animichi" in source
 
     def test_description_display_width_120_to_160(self) -> None:
         source = _read_layout()

--- a/apps/agent/agent/tools/__init__.py
+++ b/apps/agent/agent/tools/__init__.py
@@ -1,4 +1,4 @@
-"""Utility package placeholder for Seichijunrei Bot.
+"""Utility package placeholder for Animichi Bot.
 
 Previously contained map/PDF output tools; those have been removed to
 keep the core project focused on conversational route planning.

--- a/apps/agent/agent/utils/__init__.py
+++ b/apps/agent/agent/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Utility modules for Seichijunrei Bot."""
+"""Utility modules for Animichi Bot."""
 
 from .logger import get_logger, setup_logging
 

--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
-name = "seichijunrei"
+name = "animichi"
 version = "0.1.0"
 description = "AI-powered travel assistant for anime pilgrims using Gemini LLM"
 requires-python = ">=3.11"
 authors = [
-    {name = "Seichijunrei Team", email = "team@seichijunrei.com"}
+    {name = "Animichi Team", email = "team@animichi.com"}
 ]
-keywords = ["anime", "travel", "ai", "gemini", "seichijunrei", "agent"]
+keywords = ["anime", "travel", "ai", "gemini", "animichi", "agent"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -44,7 +44,7 @@ dependencies = [
 ]
 
 [project.scripts]
-seichijunrei-api = "agent.interfaces.fastapi_service:main"
+animichi-api = "agent.interfaces.fastapi_service:main"
 
 [project.optional-dependencies]
 dev = [

--- a/apps/agent/pytest.ini
+++ b/apps/agent/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-# Pytest configuration for Seichijunrei Bot
+# Pytest configuration for Animichi Bot
 
 # Test discovery patterns
 python_files = test_*.py *_test.py

--- a/apps/agent/uv.lock
+++ b/apps/agent/uv.lock
@@ -174,6 +174,100 @@ wheels = [
 ]
 
 [[package]]
+name = "animichi"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "asyncpg" },
+    { name = "authlib" },
+    { name = "ddgs" },
+    { name = "fastapi" },
+    { name = "google-genai" },
+    { name = "httpx" },
+    { name = "idna" },
+    { name = "logfire", extra = ["fastapi", "httpx"] },
+    { name = "pydantic" },
+    { name = "pydantic-ai" },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "starlette" },
+    { name = "structlog" },
+    { name = "urllib3" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "asyncpg-stubs" },
+    { name = "mypy" },
+    { name = "psycopg2-binary" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+    { name = "sqlfluff" },
+    { name = "testcontainers" },
+    { name = "vulture" },
+]
+scripts = [
+    { name = "reverse-geocoder" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "asyncpg", specifier = ">=0.31.0" },
+    { name = "authlib", specifier = ">=1.6.12" },
+    { name = "ddgs", specifier = ">=9.14.1" },
+    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "google-genai", specifier = ">=1.16.0" },
+    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "idna", specifier = ">=3.15" },
+    { name = "logfire", extras = ["fastapi", "httpx"], specifier = ">=4.29.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
+    { name = "pydantic", specifier = ">=2.12.0" },
+    { name = "pydantic-ai", specifier = ">=1.99.0" },
+    { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "rich", specifier = ">=14.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
+    { name = "structlog", specifier = ">=25.0.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "asyncpg-stubs", specifier = ">=0.30.1" },
+    { name = "mypy", specifier = ">=1.19.1" },
+    { name = "psycopg2-binary", specifier = ">=2.9.11" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "ruff", specifier = ">=0.14.13" },
+    { name = "sqlfluff", specifier = ">=4.2.2" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.14.2" },
+    { name = "vulture", specifier = ">=2.16" },
+]
+scripts = [{ name = "reverse-geocoder", specifier = ">=1.5.1" }]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4102,100 +4196,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
-
-[[package]]
-name = "seichijunrei"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "asyncpg" },
-    { name = "authlib" },
-    { name = "ddgs" },
-    { name = "fastapi" },
-    { name = "google-genai" },
-    { name = "httpx" },
-    { name = "idna" },
-    { name = "logfire", extra = ["fastapi", "httpx"] },
-    { name = "pydantic" },
-    { name = "pydantic-ai" },
-    { name = "pydantic-settings" },
-    { name = "python-dotenv" },
-    { name = "rich" },
-    { name = "starlette" },
-    { name = "structlog" },
-    { name = "urllib3" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "asyncpg-stubs" },
-    { name = "mypy" },
-    { name = "psycopg2-binary" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-    { name = "sqlfluff" },
-    { name = "testcontainers" },
-    { name = "vulture" },
-]
-scripts = [
-    { name = "reverse-geocoder" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "asyncpg", specifier = ">=0.31.0" },
-    { name = "authlib", specifier = ">=1.6.12" },
-    { name = "ddgs", specifier = ">=9.14.1" },
-    { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "google-genai", specifier = ">=1.16.0" },
-    { name = "httpx", specifier = ">=0.28.0" },
-    { name = "idna", specifier = ">=3.15" },
-    { name = "logfire", extras = ["fastapi", "httpx"], specifier = ">=4.29.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
-    { name = "pydantic", specifier = ">=2.12.0" },
-    { name = "pydantic-ai", specifier = ">=1.99.0" },
-    { name = "pydantic-settings", specifier = ">=2.13.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "rich", specifier = ">=14.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.0" },
-    { name = "starlette", specifier = ">=1.0.1" },
-    { name = "structlog", specifier = ">=25.0.0" },
-    { name = "urllib3", specifier = ">=2.7.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
-]
-provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "asyncpg-stubs", specifier = ">=0.30.1" },
-    { name = "mypy", specifier = ">=1.19.1" },
-    { name = "psycopg2-binary", specifier = ">=2.9.11" },
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "ruff", specifier = ">=0.14.13" },
-    { name = "sqlfluff", specifier = ">=4.2.2" },
-    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.14.2" },
-    { name = "vulture", specifier = ">=2.16" },
-]
-scripts = [{ name = "reverse-geocoder", specifier = ">=1.5.1" }]
 
 [[package]]
 name = "shellingham"

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -17,7 +17,7 @@ const zenMaruGothic = Zen_Maru_Gothic({ subsets: ["latin"], weight: ["400", "500
 
 const SITE_URL = "https://seichijunrei.zhenjia.org";
 const SITE_TITLE =
-  "アニメ聖地巡礼 スポット検索・ルート計画 | Seichijunrei";
+  "アニメ聖地巡礼 スポット検索・ルート計画 | Animichi";
 const SITE_DESCRIPTION =
   "アニメ聖地巡礼のスポット検索・ルート計画サービス。作品名から聖地巡礼の場所を探して、最適な巡礼ルートを自動生成。アニメの舞台を地図で確認しよう。";
 
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     url: SITE_URL,
-    siteName: "Seichijunrei",
+    siteName: "Animichi",
     locale: "ja_JP",
     type: "website",
     images: [

--- a/frontend/components/layout/SharedHeader.tsx
+++ b/frontend/components/layout/SharedHeader.tsx
@@ -187,7 +187,7 @@ function Brand() {
       />
       <div className="flex flex-col">
         <span className="text-[10px] tracking-[1px] text-muted-foreground">
-          Seichijunrei
+          Animichi
         </span>
         <span className="font-display text-sm font-bold leading-tight text-foreground">
           聖地巡礼

--- a/frontend/lib/dictionaries/en.json
+++ b/frontend/lib/dictionaries/en.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "title": "Seichijunrei",
+    "title": "Animichi",
     "description": "Find anime pilgrimage spots and plan your route"
   },
   "landing": {
@@ -75,7 +75,7 @@
       "hero_auth_hint": "Log in only when you want to save or sync.",
       "walking_route": "Walking route",
       "hiw_title": "How a title becomes a route",
-      "hiw_sub": "Seichijunrei turns a title, place, or nearby location into a practical route.",
+      "hiw_sub": "Animichi turns a title, place, or nearby location into a practical route.",
       "hiw_step1_title": "Search an anime or place",
       "hiw_step1_desc": "Find your favorite title, a station, or explore what's nearby.",
       "hiw_step2_title": "Compare scene and real spot",
@@ -167,14 +167,14 @@
     "send": "Send",
     "thinking": "Thinking…",
     "thought_complete": "Done",
-    "bot_name": "Seichijunrei",
+    "bot_name": "Animichi",
     "bot_icon": "聖",
     "feedback_sent": "✓ Feedback sent",
     "feedback_placeholder": "What went wrong? (optional)",
     "feedback_good_title": "Good response",
     "feedback_bad_title": "Bad response",
     "anchor_results": "{count} results",
-    "welcome_title": "Seichijunrei",
+    "welcome_title": "Animichi",
     "welcome_subtitle": "Search by anime, explore spots near a place, or ask for a pilgrimage route that fits your trip.",
     "welcome_helper": "You can also just say hi and ask what I can help with.",
     "empty_hint": "Search for anime pilgrimage spots or plan a route",
@@ -186,7 +186,7 @@
   },
   "sidebar": {
     "logo_icon": "聖",
-    "logo_text": "Seichijunrei",
+    "logo_text": "Animichi",
     "new_chat": "+ New chat",
     "recent": "Recent searches",
     "rename_hint": "Double-click to rename",
@@ -195,7 +195,7 @@
     "footer": "Pilgrim"
   },
   "header": {
-    "title": "Seichijunrei",
+    "title": "Animichi",
     "subtitle": "Find anime locations · Plan your route",
     "map_open": "Close map",
     "map_closed": "Map"
@@ -406,7 +406,7 @@
     "other_group": "Other",
     "spots_count": "{count} spots",
     "map_unavailable": "Map unavailable — view spot locations below",
-    "meta_title": "{title} Pilgrimage Guide | Seichijunrei",
+    "meta_title": "{title} Pilgrimage Guide | Animichi",
     "meta_description": "{count} pilgrimage spots for {title} — {city}. Plan routes with AI.",
     "meta_description_no_city": "{count} pilgrimage spots for {title}. Plan routes with AI."
   },

--- a/frontend/lib/dictionaries/ja.json
+++ b/frontend/lib/dictionaries/ja.json
@@ -406,7 +406,7 @@
     "other_group": "その他",
     "spots_count": "{count} スポット",
     "map_unavailable": "マップを読み込めませんでした — 下のスポット一覧をご覧ください",
-    "meta_title": "{title} 聖地巡礼ガイド | Seichijunrei",
+    "meta_title": "{title} 聖地巡礼ガイド | Animichi",
     "meta_description": "{title}の聖地 {count} スポット — {city}。AIでルート計画も。",
     "meta_description_no_city": "{title}の聖地 {count} スポット。AIでルート計画も。"
   },

--- a/frontend/lib/dictionaries/zh.json
+++ b/frontend/lib/dictionaries/zh.json
@@ -406,7 +406,7 @@
     "other_group": "其他",
     "spots_count": "{count} 个取景地",
     "map_unavailable": "地图加载失败 — 请查看下方取景地列表",
-    "meta_title": "{title} 圣地巡礼指南 | Seichijunrei",
+    "meta_title": "{title} 圣地巡礼指南 | Animichi",
     "meta_description": "{title}的圣地 {count} 个取景地 — {city}。AI 路线规划。",
     "meta_description_no_city": "{title}的圣地 {count} 个取景地。AI 路线规划。"
   },

--- a/frontend/lib/structured-data.ts
+++ b/frontend/lib/structured-data.ts
@@ -3,7 +3,7 @@ const SITE_URL = "https://seichijunrei.zhenjia.org";
 export const websiteJsonLd = {
   "@context": "https://schema.org",
   "@type": "WebSite",
-  name: "Seichijunrei",
+  name: "Animichi",
   url: SITE_URL,
   potentialAction: {
     "@type": "SearchAction",
@@ -18,7 +18,7 @@ export const websiteJsonLd = {
 export const organizationJsonLd = {
   "@context": "https://schema.org",
   "@type": "Organization",
-  name: "Seichijunrei",
+  name: "Animichi",
   url: SITE_URL,
   logo: `${SITE_URL}/og-image.png`,
 };
@@ -32,7 +32,7 @@ export const faqJsonLd = {
       name: "聖地巡礼とは何ですか？",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "聖地巡礼とは、アニメや映画の舞台となった実在の場所を訪れることです。Seichijunreiでは、作品名からスポットを検索し、効率的な巡礼ルートを自動生成できます。",
+        text: "聖地巡礼とは、アニメや映画の舞台となった実在の場所を訪れることです。Animichiでは、作品名からスポットを検索し、効率的な巡礼ルートを自動生成できます。",
       },
     },
     {

--- a/frontend/lib/types/chat.ts
+++ b/frontend/lib/types/chat.ts
@@ -5,7 +5,7 @@
 import type { UIMessage } from "ai";
 
 /** Metadata attached to assistant messages via messageMetadata / data parts. */
-export interface SeichijunreiMetadata {
+export interface AnimichiMetadata {
   session_id?: string;
   intent?: string;
   route_history?: Record<string, unknown>[];
@@ -13,4 +13,4 @@ export interface SeichijunreiMetadata {
 }
 
 /** Project-wide typed UIMessage with our custom metadata. */
-export type SeichijunreiMessage = UIMessage<SeichijunreiMetadata>;
+export type AnimichiMessage = UIMessage<AnimichiMetadata>;

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -31,7 +31,7 @@ export type {
 
 export type { ErrorCode, ChatMessage } from "./components";
 
-export type { SeichijunreiMetadata, SeichijunreiMessage } from "./chat";
+export type { AnimichiMetadata, AnimichiMessage } from "./chat";
 
 // ── Type guards ────────────────────────────────────────────────────────────
 

--- a/frontend/tests/SharedFooter.test.tsx
+++ b/frontend/tests/SharedFooter.test.tsx
@@ -20,9 +20,9 @@ describe("SharedFooter", () => {
     expect(screen.getByText("聖地巡礼")).toBeInTheDocument();
   });
 
-  it("renders seichijunrei text", () => {
+  it("renders animichi text", () => {
     render(<SharedFooter />);
-    expect(screen.getByText("seichijunrei")).toBeInTheDocument();
+    expect(screen.getByText("animichi")).toBeInTheDocument();
   });
 
   it("renders locale button with current locale label", () => {

--- a/frontend/tests/SharedHeader.test.tsx
+++ b/frontend/tests/SharedHeader.test.tsx
@@ -28,9 +28,9 @@ describe("SharedHeader", () => {
     expect(logo).toHaveAttribute("href", "/");
   });
 
-  it("renders brand tagline 'Seichijunrei'", () => {
+  it("renders brand tagline 'Animichi'", () => {
     render(<SharedHeader />);
-    expect(screen.getByText("Seichijunrei")).toBeInTheDocument();
+    expect(screen.getByText("Animichi")).toBeInTheDocument();
   });
 
   // ── Login button ──

--- a/frontend/tests/login-page.test.tsx
+++ b/frontend/tests/login-page.test.tsx
@@ -40,7 +40,7 @@ describe("LoginPage", () => {
     render(<LoginPage />);
 
     expect(screen.getByText("聖地巡礼")).toBeDefined();
-    expect(screen.getByText("Seichijunrei")).toBeDefined();
+    expect(screen.getByText("Animichi")).toBeDefined();
   });
 
   it("renders login form with email input and submit button", async () => {

--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "seichijunrei-frontend",
+  "name": "animichi-frontend",
   "main": ".open-next/worker.js",
   "compatibility_date": "2025-04-01",
   "compatibility_flags": ["nodejs_compat"],

--- a/packages/contract/openapi.json
+++ b/packages/contract/openapi.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "title": "Seichijunrei Catalog Service",
+    "title": "Animichi Catalog Service",
     "version": "0.1.0",
     "description": "Read methods of the TS Catalog service, consumed by the Python Agent service."
   },

--- a/packages/contract/scripts/emit-openapi.ts
+++ b/packages/contract/scripts/emit-openapi.ts
@@ -20,7 +20,7 @@ const generator = new OpenAPIGenerator({
 
 const spec = await generator.generate(catalogContract, {
   info: {
-    title: "Seichijunrei Catalog Service",
+    title: "Animichi Catalog Service",
     version: "0.1.0",
     description:
       "Read methods of the TS Catalog service, consumed by the Python Agent service.",

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -51,7 +51,7 @@ async function handleImageProxy(request: Request, ctx: ExecutionContext): Promis
   const cached = await caches.default.match(cacheKey);
   if (cached) return cached;
   const upstream = await fetch(`https://image.anitabi.cn/${imagePath}`, {
-    headers: { "User-Agent": "Seichijunrei/1.0" },
+    headers: { "User-Agent": "Animichi/1.0" },
   });
   if (!upstream.ok) {
     return new Response(upstream.body, {


### PR DESCRIPTION
## What

Quality assessment on #310 found the rename **incomplete**: 114 runtime-facing `seichijunrei` hits remained at `e3ae89d` (base of this PR), including two P1s — the production agent's system prompt introduces itself as "Seichijunrei" in every greeting, and the legacy (still-production) frontend ships old brand strings. This PR retires **72 hits across 36 files** (string-only, zero behavior change). The 42 that remain are each classified below — **the classification table, not the change list, is the definition of done.**

## Changed

| Pri | Area | Change |
|---|---|---|
| P1 | `apps/agent/.../pilgrimage_agent.py` | System prompt self-identity → "runtime agent for **Animichi**, an anime pilgrimage (聖地巡礼)…" (concept term kept) + self-name test fixtures (`我是 Animichi`) in integration `conftest.py` / `test_runtime_models.py` |
| P1 | Legacy frontend (production) | `SharedHeader` brand, `layout.tsx` title/siteName, `dictionaries/{en,ja,zh}.json` (title/bot_name/welcome_title/logo_text/hiw_sub/meta_title), `structured-data.ts` WebSite/Organization `name` + FAQ text (URLs untouched) + brand-asserting tests (incl. `SharedFooter.test.tsx`, which was **red on base** — #310 renamed the footer but not its test) |
| P2 | `frontend/wrangler.jsonc` | Worker name `seichijunrei-frontend` → `animichi-frontend` (deploy caveat below) |
| P2 | `worker/app.ts` | 4th missed UA: image-proxy `User-Agent: Animichi/1.0` |
| P2 | `packages/contract` | `emit-openapi.ts` title → "Animichi Catalog Service"; `openapi.json` **regenerated via the emit script** (not hand-edited) |
| P2 | Service identity chain | `settings.py` `animichi-runtime` + `routes/health.py` ×2 + asserting tests; `pyproject.toml` name `animichi` / authors / keywords / `animichi-api` entry point; `uv.lock` regenerated (`uv lock`, pure rename, zero version drift); `Makefile` serve target; `test_live_api.py` docstring. Dockerfile/CI verified: zero references to the old package/entry-point names |
| P3 | Internal types | `SeichijunreiSession` → `AnimichiSession` (entities + tests); `SeichijunreiMetadata/Message` → `AnimichiMetadata/Message` (`frontend/lib/types`) — repo-wide grep confirmed these were the only reference sites |
| — | Sweep | ics `PRODID:-//Animichi//EN` (user-visible in exported calendars), module docstrings, `pytest.ini`/`.env.example` headers, Makefile `/tmp/animichi-*` scratch names |

## Negative proof — all 42 remaining hits classified

`git grep -in "seichijunrei" -- ':!docs' ':!*.md' ':!apps/agent/agent/tests/eval/results' ':!apps/agent/agent/clients/python'`

| # | Bucket | Hits | Why it legitimately stays |
|---|---|---|---|
| 17 | **Domain migration → Iteration 0 (#252)** | `frontend/app/layout.tsx:18`, `frontend/lib/structured-data.ts:1`, `frontend/public/robots.txt:4`, `frontend/public/sitemap.xml:5-9`, `.env.test.example:15`, `test_seo_static_files.py:8`, `test_routes_health.py:39,45,52` (CORS origin values), `supabase/functions/send-auth-email/index.ts:26,30` (SITE_URL/SENDER env defaults), `scripts/local-login.sh:50`, `scripts/qa_login.sh:19` | All are `seichijunrei.zhenjia.org` / `seichijunrei.com` **URL values** — the designed Iteration 0 domain effort (`2026-07-06-seo-geo-plan.md §3`), explicitly out of scope per #310 |
| 8 | **Auth-email surface (follow-up)** | `send-auth-email/index.ts:46,70` (subject "Seichijunrei — Login link", footer), `supabase/templates/magic-link.html:4`, `send-auth-email-test.ts:69,84`, `e2e/auth-flow-local.spec.ts:71,73`, `e2e/fixtures/email.ts:90` | User-visible brand, but deploy-coupled: repo-side rename desyncs e2e expectations from the **deployed** Edge Function until it is redeployed in lockstep — and this whole Supabase-auth path is being replaced by Neon Auth (SD-31). One coherent follow-up PR (function + template + fixtures + redeploy) |
| 5 | **Provisioned test identities** | `scripts/qa_auth.py:106` + `scripts/qa_login.sh:18` (`qa-bot@seichijunrei.test` QA auth user), `scripts/local-login.sh:16` (`dev@seichijunrei.test`), `e2e/fixtures/email.ts:97` (`seichijunreiqa@mails.dev` live mailbox), `:99` (generated `@seichijunrei.test`) | Renaming breaks real provisioned auth users / external mailboxes used by automated QA |
| 5 | **Local dev-stack identity** | `supabase/config.toml:1` (`project_id`), `Makefile:145,148,150` + `scripts/e2e-setup.sh:23` (`supabase_db_seichijunrei-agent`) | Supabase `project_id` keys local Docker container/volume names — renaming orphans every developer's local stack (data loss / reseed). Revisit when Supabase is retired post-Neon-Auth |
| 3 | **Pulumi — needs human decision** | `infra/Pulumi.yaml:1` (`name: seichijunrei-infra`), `infra/Pulumi.prod.yaml:3,5` (project-namespaced config keys) | **State-migration sensitive**: Pulumi project rename requires stack state export/import + config-key rename. Deliberately untouched; see follow-ups |
| 2 | **npm scope — declared defer (#310)** | `packages/contract/package.json:2` (`@seichijunrei/contract`), `src/index.ts:2` (comment naming that package) | Iteration-0 specs wire this exact name into `workers/catalog`; renaming now breaks planned work |
| 2 | **Local machine paths / tool state** | `scripts/qa_login.sh:14` (`~/Documents/Seichijunrei-agent/.venv`), `.serena/project.yml:93` | Local filesystem dir name is unchanged (#310's declared defer); serena `project_name` keys local tool memories |

Also intact by design: the `seichijunrei_client.py` / `SeichijunreiClient` public SDK (#310: breaking change, own PR) and eval results history (excluded from the grep, owned by the eval workstream).

## Deploy caveat — frontend Worker rename

`frontend/wrangler.jsonc` name `seichijunrei-frontend` → `animichi-frontend` means the **next standalone frontend deploy creates a new Worker script** instead of updating the old one (same class of caveat as #310's gateway rename). Mitigations:

- Production routing is unaffected: the `animichi.com/*` route lives on the root `animichi` Worker (root `wrangler.toml`), which bundles OpenNext itself; no CI workflow references `frontend/wrangler.jsonc`.
- At next standalone deploy: verify no dashboard-side route/service binding/cron points at `seichijunrei-frontend`, migrate any that do, then **manually delete the stale `seichijunrei-frontend` Worker**.

## Follow-ups (not in this PR)

1. **Pulumi project rename** (`seichijunrei-infra` → `animichi-infra`): requires stack state migration (`pulumi stack export/import`) + renaming the `seichijunrei-infra:*` config keys in `Pulumi.prod.yaml`. Needs an explicit human go/no-go.
2. **Auth-email brand cluster** (subject/footer/template + e2e fixtures + Edge Function redeploy in lockstep) — or fold into the Neon Auth migration (SD-31).
3. Domain migration (Iteration 0 #252), `@seichijunrei/contract` scope (iter-0), `SeichijunreiClient` SDK (own PR) — all previously declared.

## Gates

- `make check` (ruff + mypy strict + 841 unit + 53 integration) — exit 0
- `cd frontend && npm test` — 18 files / 165 tests passed (includes the previously-red `SharedFooter.test.tsx`)
- `pnpm run test:worker` — 16/16 passed (Node 24 per `.nvmrc`; fails on Node 22.16 for pre-existing environmental reasons: no native TS type-stripping)
- `packages/contract` typecheck clean; `openapi.json` byte-identical to fresh emit-script output
- No suppressions added; no tests deleted; `uv.lock` diff is the package rename only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
