### PR TITLE
fix(ci): first-full-CI-run fallout — SAST scope, vulture whitelist, migrations path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       frontend: ${{ steps.f.outputs.frontend }}
       contract: ${{ steps.f.outputs.contract }}
       worker: ${{ steps.f.outputs.worker }}
+      migrations: ${{ steps.f.outputs.migrations }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -38,6 +39,7 @@ jobs:
             agent: ['apps/agent/**', 'packages/contract/**']
             frontend: ['frontend/**']
             worker: ['worker/**']
+            migrations: ['supabase/migrations/**', 'db/**']
 
   # ── Stage 1: Component CI (reusable workflows, all parallel) ──
   # affected-only on PRs; full run on push/tag.
@@ -114,7 +116,7 @@ jobs:
     name: DB Migrations (dry-run)
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.catalog == 'true' || needs.changes.outputs.agent == 'true' }}
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.migrations == 'true' }}
     env:
       SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
     steps:

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,7 +1,26 @@
-# Semgrep scan scope — exclude non-shipped artifacts from SAST.
-#
-# docs/design/ holds committed design-sync mockup canvases (static HTML/JS
-# artifacts for design review, never served as product code). Their demo
-# scripts trip browser-security rules (e.g. wildcard postMessage) that are
-# meaningless outside a shipped origin. Product code stays fully in scope.
+# NOTE: creating a .semgrepignore REPLACES semgrep's built-in defaults, so the
+# default patterns must be restated here (first section) before repo-specific
+# additions (second section). Removing the defaults exposed tests/ to SAST and
+# broke CI once — keep them.
+
+# ── Semgrep default ignore patterns ──────────────────────────────
+node_modules/
+build/
+dist/
+vendor/
+.env/
+.venv/
+.tox/
+*.min.js
+test/
+tests/
+*_test.go
+.semgrep
+.semgrep_logs
+.git/
+
+# ── Repo-specific ────────────────────────────────────────────────
+# Committed design-sync mockup canvases (static design-review artifacts,
+# never served as product code); their demo scripts trip browser-security
+# rules that are meaningless outside a shipped origin.
 docs/design/

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,7 @@
+# Semgrep scan scope — exclude non-shipped artifacts from SAST.
+#
+# docs/design/ holds committed design-sync mockup canvases (static HTML/JS
+# artifacts for design review, never served as product code). Their demo
+# scripts trip browser-security rules (e.g. wildcard postMessage) that are
+# meaningless outside a shipped origin. Product code stays fully in scope.
+docs/design/

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,10 @@
+# SonarCloud automatic-analysis config (AutoScan reads this file; there is no
+# CI-side scanner). Keep in sync with the CI lint scopes.
+#
+# - vulture_whitelist.py is a vulture DSL artifact (bare names by design, not
+#   importable source; already outside the ruff scope per its header). Sonar
+#   reads the bare names as useless-expression bugs and fails the quality gate
+#   on any new whitelist entry.
+# - docs/design/ holds committed design-sync mockup canvases (static design
+#   artifacts, never shipped) — same scope-out as .semgrepignore.
+sonar.exclusions=apps/agent/vulture_whitelist.py,docs/design/**

--- a/apps/agent/vulture_whitelist.py
+++ b/apps/agent/vulture_whitelist.py
@@ -28,6 +28,11 @@ exc_tb
 # Site: agent/infrastructure/observability/metrics.py
 amount
 
+# pydantic `@field_validator` + `@classmethod` signature: `cls` is mandated by
+# the decorator contract even when the validator body never touches it.
+# Site: agent/clients/catalog_errors.py (_coerce_unknown)
+cls
+
 # Protocol method signatures (asyncpg abstraction): params declared on `...`
 # stub methods so concrete impls and call sites type-check.
 # Site: agent/infrastructure/supabase/client_types.py


### PR DESCRIPTION
Unblocks #318 (3 failing checks are all pre-existing base issues surfaced by the first full CI run). Details in the commit message. After merge: rerun #318's failed checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)