### PR TITLE
S0.4: Map-stack ADR (MapLibre GL + self-hosted PMTiles on R2/Workers) + runnable spike

### DIFF
--- a/docs/adr/0001-map-stack-maplibre-protomaps.md
+++ b/docs/adr/0001-map-stack-maplibre-protomaps.md
@@ -1,0 +1,44 @@
+# ADR-0001 · 地图栈:MapLibre GL + Protomaps PMTiles 自托管(Cloudflare R2 + Workers)
+
+> 状态:ACCEPTED(2026-07-11)
+> 范围:S0.4(issue #237);blocks S1.4 / S1.5 / S2.2 / S5.2 / S6.2;离线伏笔 S3.6 / S3.10
+> 调研全文(决策矩阵、需求映射、成本账、风险):`docs/superpowers/specs/2026-07-11-map-stack-adr.md`
+> Spike:`docs/superpowers/spikes/map-stack/`(独立可运行)
+>
+> 本目录(`docs/adr/`)自本条起为架构决策记录统一归档处(修复 report C「无统一 ADR 目录」缺口)。
+> 早于本目录的 ADR 存于 `docs/superpowers/specs/`(如 2026-06-13-architecture-adr.md、2026-04-15-api-adr.md),不迁移。
+
+## Context
+
+前端重建需要一套地图栈,服务五类消费者(chat 静态地图卡、路线轨迹、MODE FLIP 交互地图、
+作品页 bubble map、双栏 hover 联动),iteration 3 的 Walk mode 还要求离线可用。
+约束:全栈 Cloudflare(能用 CF 基建的优先)、solo dev 成本敏感、static-first(chat 卡)、
+日语标注第一公民、Mapbox 被 X1 明令禁用。
+
+## Decision
+
+1. **引擎 = MapLibre GL JS v5**(BSD-3,无 key,无按 load 计费)。SSR 下 client-only 懒挂载,地图 chunk 独立分包。
+2. **Tile 供应 = Protomaps 日构建 → `pmtiles extract` 日本区域 → 自托管 R2**。
+   实测:宇治·京都 bbox z0-15 仅 20.4MB / 25 秒可得;日本全域成本落在 R2 免费层~美分级。零 egress,无 API key。
+3. **服务形状 = edge worker 新增 `/tiles/{z}/{x}/{y}.mvt` ZXY 端点**,采用 Protomaps 官方
+   Cloudflare worker 逻辑(R2 binding + Cache API + CORS),与现有 `/img/*` 反代缓存模式同构;
+   bucket = `seichijunrei-assets`(`wrangler.toml` 直接声明,spec 认可的 D9 例外);
+   CJK glyphs/sprites 同 bucket 自托管。
+4. **静态层 contract(static-first)**:品牌插画 + SVG pin 即时渲染 → 空闲时可选
+   non-interactive GL 静默 hydrate → 点击升格交互;任何 tile 故障停留插画层(永无碎 tile)。
+5. **离线(Walk)**:同一 PMTiles 基建两路径——SW 预取路线 bbox 的 ZXY URL;或
+   `pmtiles extract` 区域包 + pmtiles `FileSource` 本地全离线读。
+6. **日语标注**:`@protomaps/basemaps` `lang:"ja"` 样式(41 语言,CJK 内建);zh/en 切换同数据换样式。
+7. **备选登记**:OpenFreeMap = 开发期/应急后备(免费无限无 key,但无 SLA);
+   GSI 地理院タイル = 未来日本官方叠加层选项;MapTiler 不采(free tier 禁商用);
+   Google Maps 被离线需求一票否决;Mapbox 维持 X1 禁用。
+
+## Consequences
+
+- 地图边际成本 ≈ $0,流量峰值不产生按 load 账单;数据与服务全部在自有 CF 控制面。
+- 换来月度 `scripts/build-pmtiles.sh` 数据更新职责(不更新也不会坏)与 ODbL 署名义务
+  (© OpenStreetMap contributors + Protomaps)。
+- 上游断供退路:planetiler 自建管线;应急切换:OpenFreeMap style URL。
+- S1.4/S1.5/S2.2/S5.2/S6.2 全部只依赖「MapLibre 实例 + 数据驱动样式 + DOM/SVG 叠加」,
+  无商业 SDK 独有能力;S3.6 离线由自托管 PMTiles 唯一优雅满足——这是本选型的决定性理由。
+- apps/web 内 demo route、生产 `[[r2_buckets]]`、`perf-mobile-cold` 正式测量待 S0.2 合流后接线(issue #237 跟踪)。

--- a/docs/superpowers/specs/2026-07-11-map-stack-adr.md
+++ b/docs/superpowers/specs/2026-07-11-map-stack-adr.md
@@ -1,0 +1,263 @@
+# 地图栈 ADR · MapLibre GL + PMTiles 自托管(R2 + Workers)——调研与决策全记录
+
+> 状态:ACCEPTED(2026-07-11,S0.4 / issue #237;X1 既定方向经本轮调研 + spike 验证后确认)
+> 决策人:用户(经 spec X1 冻结方向);本文档 = 选型证据链 + 需求映射 + 分阶段策略
+> 简版决策记录:`docs/adr/0001-map-stack-maplibre-protomaps.md`(本文是它的调研附录)
+> Spike 代码:`docs/superpowers/spikes/map-stack/`(独立可运行,不依赖 apps/web)
+> 关联:spec `2026-07-06-frontend-rebuild/iter-0.md` S0.4;被 block:S1.4 / S1.5 / S2.2 / S5.2 / S6.2;离线伏笔:S3.6 / S3.10
+
+## 1. 背景与约束
+
+前端重建(TanStack Start + apps/web)需要一套地图栈,同时喂饱五类消费者:chat 静态地图卡、
+路线轨迹升格、MODE FLIP 交互地图、作品页 bubble map、双栏 hover 联动;iteration 3 的
+Walk mode 还要求**离线**可用。约束按重要度排:
+
+- **全栈 Cloudflare**(用户 2026-07 追加铁律):凡 CF 基建能解决的优先用上。repo 里已有
+  现成抓手——Pulumi 声明的 R2 bucket `catalog-media`(`infra/index.ts`)、edge worker
+  成熟的 `/img/*` 反代 + Cache API 缓存模式(`worker/app.ts` `handleImageProxy`)。
+- **成本敏感**:solo dev,优先自托管/免费层;拒绝按 map-load 计费的商业模式绑死获客环
+  (分享页爆火 = 成功时刻,不能同时是账单事故)。
+- **static-first**:chat 地图卡默认静态层,点击才挂 GL(`spec-chat-page-design.md` §4;
+  该文中 "Mapbox" 字样按 X1 一律读作 MapLibre)。
+- **日语标注是第一公民**:全产品日文为主(user-journey §6.8),地名标注质量直接是产品质量。
+- **离线**(S3.6/S3.10):Walk mode 断网可用,route bundle 里要能装下地图数据。
+- **X1 已冻结**:MapLibre GL + Protomaps(pmtiles on R2),**Mapbox 明令禁用**
+  (`NEXT_PUBLIC_MAPBOX_TOKEN` 由 S0.3 移除)。本 ADR 的职责不是重开选型,而是
+  **用调研和 spike 证明 X1 成立**、把五个被 block story 的需求逐条对上,并把
+  tile 供应、成本、离线路径、风险写成可执行的决定。若证据显示 X1 不成立,本 ADR 有义务推翻它——调研结论是:成立。
+
+## 2. 候选与决策矩阵
+
+### 2.1 引擎层(渲染库)
+
+| 维度 | **MapLibre GL JS v5.24** | Google Maps JS API | Mapbox GL JS v3 |
+|---|---|---|---|
+| License | BSD-3(开源,fork 自 mapbox-gl v1) | 专有,须走 Google 渲染器 | v2 起专有,绑定 Mapbox 账号 |
+| 计费 | $0(库本身永远免费) | Dynamic Maps 每月 1 万次免费,之后 $7/千次 loads | 每月 5 万 loads 免费,之后阶梯计费 |
+| 自带 tile? | 无——tile 供应自由选(见 2.2) | 强制 Google tile,禁离线缓存 | 强制 Mapbox token,tile 含 Zenrin 日本数据 |
+| 静态首屏成本 | 可绕开:静态层用插画+SVG,GL 按需挂载;GL 本体 lazy chunk | 每次挂载即计费 + 脚本重;无"半静态"档 | 同 MapLibre 技术形态,但每次 GL 挂载计一次 load |
+| 交互性能 | WebGL 矢量,风格/数据驱动样式全开放;v5 含 globe | WebGL 矢量,性能好但样式自由度低(Cloud Styling) | WebGL 矢量,业界标杆 |
+| 离线/PMTiles | ✅ pmtiles 协议官方插件;`FileSource` 读本地 File/Blob | ❌ ToS 禁止缓存 tile,离线不可行 → **S3.6 直接死** | Web 端无离线;离线只在移动原生 SDK |
+| Capacitor/WebView | ✅ 纯 web 库,WKWebView/Android WebView WebGL 即跑 | 可跑但每 WebView 挂载都是计费 load | 可跑,同样计费 |
+| 日本地图质量 | 取决于 tile 源(见 2.2) | 日本本土最强(自家数据) | Zenrin 合作,日本质量好 |
+| CF Workers/SSR | 客户端 only(需 window);SSR 下 lazy client-mount 即可 | 同为客户端 only | 同为客户端 only |
+| 生态 | react-map-gl v8、@protomaps/basemaps、社区活跃 | 封闭生态 | 封闭生态(v2 起) |
+
+**结论**:Google 被离线一票否决(Walk mode 是 journey 的审判点,S3.6 明确要求断网可用),
+且按 load 计费与"分享页爆火"的获客环相冲。Mapbox 被 X1 明令禁用,license/计费/token
+遥测本身也站不住。**引擎 = MapLibre GL JS**,唯一疑点转移到 tile 供应——这才是本 ADR 真正的选型题。
+
+### 2.2 Tile 供应层(给 MapLibre 喂什么)
+
+| 维度 | **A. CF-native 自托管:PMTiles on R2 + Workers**(Protomaps 日构建) | B. OpenFreeMap(免费托管) | C. MapTiler Cloud | D. GSI 地理院タイル(补充项) |
+|---|---|---|---|---|
+| 月成本 | **≈ $0**:日本区域 extract 存 R2(免费层 10GB 内,见 §6);零 egress;Workers 请求走现有付费计划($5/mo 含 1000 万次,已在付) | $0,无限请求、无 key、无注册 | Free tier **禁商用**;商用最低 Flex $30/mo(2.5 万 sessions) | $0(出典「国土地理院」+ 链接) |
+| API key | **无** | **无** | 必须(可经 Worker 反代藏 key + 省配额,但 ToS 对缓存有约束) | 无 |
+| 日语标注 | ✅ Protomaps 41 语言含 `name:ja`;`@protomaps/basemaps` 一行 `lang:'ja'` 出日语样式;MapLibre 内建 CJK 渲染 | ✅ OpenMapTiles schema 含 `name:ja`,但官方样式需自行改日语优先 | ✅ 日本区数据 = OSM + 国土地理院基盤地図(MIERUNE 分发),质量好 | ✅ 官方日本地图,标注最正统;仅日本域内 |
+| 离线(Walk) | ✅ **同一基建两用**:`pmtiles extract` 出区域包 → SW 缓存 / `FileSource` 本地读;零额外供应商 | ❌ 托管服务是 z/x/y 散文件,无区域打包;自托管=整颗行星(Btrfs/MBTiles),重 | ⚠️ 数据下载在高价计划里 | ⚠️ raster 散 tile,可逐张缓存但体积差 |
+| 可控性/SLA | 数据在自己 R2,worker 自己写;唯一上游依赖 = Protomaps 日构建下载(断供可退 planetiler 自建,见 §7) | 无 SLA,一人项目(Hetzner + Cloudflare 赞助带宽;2025-08 扛过 100k req/s,韧性有实证但无承诺) | 99.9% SLA 在 Custom 档 | 政府服务,稳定;但 raster、样式不可定制 |
+| 品牌样式自由度 | ✅ 全开放:動森 token 配色的自定义 style JSON、插画静态层随便做 | ⚠️ 样式可自定义(schema 是 OpenMapTiles,和 Protomaps schema 不同,两套 style 不通用) | ✅ 可自定义 | ❌ raster 即所得 |
+| CF-native 契合 | **满分**:R2 + Workers + Cache API + 自定义域,照抄 `/img/*` 形状加 `/tiles/*` 路由 | 部分(它自己也被 CF 赞助 CDN,但不在我们控制面) | 无(外部 SaaS;反代可补) | 无(外部,反代可补) |
+| 维护成本 | 月度脚本:`pmtiles extract` 新构建 → rclone 上传 R2(`scripts/build-pmtiles.sh`,可挂 cron;不更新地图也不会坏) | 零 | 零 | 零 |
+| License/署名 | ODbL Produced Work:署名 © OpenStreetMap + Protomaps | 署名 OpenFreeMap + OpenMapTiles + OSM(MapLibre 自动) | 商业 ToS | 出典「国土地理院」+ タイル一覧页链接,商用可 |
+
+**结论**:**A(PMTiles on R2)为主供应**——成本≈0、无 key、离线与在线共用一条 extract
+工具链、全套在自家 CF 控制面里,和 X1 完全一致。**B(OpenFreeMap)记为开发期免注册后备
+与应急逃生门**(主路径故障时的快速切换,但产品的 D7 降级态仍按设计走插画层,不引入第二 schema
+的样式维护负担)。**C(MapTiler)不采**:free tier 禁商用是硬伤,$30/mo 起步买不到 A 给不了的东西。
+**D(GSI)不做基底**,记为未来叠加选项(登山/等高线/官方航拍,Walk 深化时再议)。
+
+### 2.3 决策矩阵(汇总打分)
+
+打分 1-5,权重按本产品语境(离线与成本是硬门槛):
+
+| 维度(权重) | A. MapLibre+R2 PMTiles | B. MapLibre+OpenFreeMap | C. MapLibre+MapTiler | D. Google Maps | E. Mapbox |
+|---|---|---|---|---|---|
+| 静态首屏成本(×2) | 5(插画层零 tile;GL 惰性) | 5(同左) | 4(同形态,session 计费悬顶) | 2(挂载即计费+脚本重) | 3 |
+| 交互性能(×1) | 4 | 4 | 4 | 4 | 5 |
+| 离线/PMTiles(×2) | **5** | 2 | 2 | **0** | 1 |
+| Capacitor/移动(×1) | 5 | 5 | 4 | 3 | 3 |
+| 日本地图质量·日语标注(×2) | 4(OSM 日本 + name:ja 样式) | 4 | 4.5(OSM+基盤地図) | **5** | 4.5 |
+| License/费用(×2) | **5**(≈$0,BSD-3,无 key) | 4.5(免费但无 SLA) | 2(商用 $30/mo 起+key) | 1 | 0(X1 禁用) |
+| CF Workers/SSR/CF-native(×1) | **5** | 3 | 2 | 1 | 1 |
+| 加权合计(满分 55) | **51** | 41.5 | 33 | 21 | 22(且被禁) |
+
+## 3. 决策
+
+### D1 · 引擎 = MapLibre GL JS v5(BSD-3,npm `maplibre-gl@^5.24`)
+
+客户端渲染库唯一选择(§2.1)。SSR 约束:MapLibre 需要 `window`/WebGL,TanStack Start 下
+一律 **client-only 懒挂载**(`useEffect`/dynamic import;地图 chunk 独立分包,不进首屏 bundle)。
+
+### D2 · Tile 供应 = Protomaps 日构建 → `pmtiles extract` 日本区域 → R2 自托管
+
+- 数据源:`build.protomaps.com` 日构建(planet z0-15,**实测 2026-07-10 构建 = 136.7GB**),
+  ODbL,schema 文档化,`@protomaps/basemaps` 官方样式含 `lang:'ja'`。
+- 只取日本:`pmtiles extract --bbox=<日本>` 远程按需拉取(spike 实测:宇治·京都 bbox
+  z0-15 = **20.4MB,25 秒,45 个 range 请求**——不需要下载行星文件)。体积与成本账见 §6。
+- 覆盖策略:第一阶段按 spec 至少 Kansai/Kanto;日本全域 z15 体积依然平价(§6),
+  建议直接全日本一步到位,免得"点位刚好在 bbox 外"这类边界折腾。
+- 更新:后续交付 `scripts/build-pmtiles.sh`(spec 对 S0.4 点名的产物,apps/web 接线时一并落地;
+  月度手动或 cron)重新 extract + 上传;spike 内已有其雏形
+  `docs/superpowers/spikes/map-stack/scripts/fetch-tiles.sh`。地图数据不更新也不腐坏。
+
+### D3 · 服务形状 = edge worker 新增 `/tiles/*` ZXY 端点(照抄 `/img/*` 模式)
+
+- 采用 Protomaps 官方 Cloudflare worker 逻辑(`protomaps/PMTiles` 仓库
+  `serverless/cloudflare`):R2 binding 读 pmtiles、按 z/x/y 切片返回、Cache API 缓存
+  (默认 `public, max-age=86400`)、CORS 白名单。**与 repo 现有
+  `worker/app.ts` 的 `handleImageProxy`(Cache API + `waitUntil` 回填)完全同构**,
+  作为 Hono 路由挂进现有 edge worker 即可,不新开 worker。
+- 端点形态选 **ZXY**(`/tiles/{z}/{x}/{y}.mvt`)而非裸 range 透传:每 tile 一个 URL,
+  CDN 缓存粒度最优、同源无 CORS、不暴露 bucket 结构;客户端 style 直接写
+  `tiles: ["https://<host>/tiles/{z}/{x}/{y}.mvt"]`,连 pmtiles 协议都不用进生产前端包
+  (pmtiles 协议留给离线 FileSource 场景)。
+- 字体(CJK glyphs)与雪碧图同样自托管:`protomaps/basemaps-assets` 拷入同一 bucket,
+  `/tiles/fonts/...`、`/tiles/sprites/...` 同源供给(spike 阶段暂用 GitHub Pages 官方资产,
+  生产切 R2,消灭第三方运行时依赖)。
+- Bucket:按 spec 用新桶 `seichijunrei-assets`,`wrangler.toml` 直接声明 `[[r2_buckets]]`
+  (spec 明示这是 D9「Pulumi 非目标」的显式例外;`infra/index.ts` 的 `catalog-media`
+  先例说明两种声明方式并存,后续如收归 Pulumi 是纯机械迁移)。
+- R2 冷读延迟(官方文档自述可达 500ms+)由 Cache API + 自定义域缓存吸收;tile 内容按天
+  immutable,缓存命中率天然高。
+
+### D4 · 静态层 contract(chat 地图卡,static-first 的落地语义)
+
+`spec-chat-page-design.md` §4 原案照办,并把"static"钉成如下三态渐进:
+
+1. **即时态(0ms)**:品牌插画底图(静态资产)+ **SVG pin 叠加层**。投影/pin 布局/升格
+   编排写 plain TS(headless 核,§5 约束),React 只是适配器。流式更新直接改 SVG,零 WebGL。
+2. **静默 hydrate(可选,idle 时)**:视口内且浏览器空闲时,挂载 **non-interactive**
+   MapLibre 实例(`interactive:false`、无控件、`fadeDuration:0`)替换插画层,呈现真实地理。
+   失败(tile 4xx/5xx、WebGL 不可用)则**停留在插画层**——这正是 S0.4 AC3 与 S1.4 D7
+   降级态的实现:永远没有"碎 tile 图标"。
+3. **升格(用户点击)**:同一实例开启手势与控件,进入交互态(S2.2 的 MODE FLIP 就是
+   这个升格的全屏版)。
+
+矢量 GL 的空白区渲染为背景色而非碎图占位——S0.4 AC2(bbox 超出覆盖返回空 tile 时
+地图显示底色)由引擎语义免费满足,spike 已验证。
+
+### D5 · 离线(iter-3 伏笔,本 ADR 只钉可行性与形状)
+
+同一 PMTiles 基建两条离线路径,S3.6 落地时二选一或并用:
+
+- **SW 缓存 ZXY**:Walk route bundle 预取路线 bbox 的 `/tiles/z/x/y` URL 集(z12-15),
+  标准 Cache API,无 range 特技(D3 选 ZXY 的连带红利)。
+- **FileSource 区域包**:`pmtiles extract` 出路线区域的小 pmtiles(宇治全域才 20MB 级)
+  → 存 OPFS/Capacitor filesystem → `new PMTiles(new FileSource(file))` 全离线渲染
+  (pmtiles JS 内建 `FileSource`,spike demo 3 已验证 Blob 路径)。
+- S3.10 的 OSRM 折线是另一条数据流(Geofabrik japan extract 喂自托管 OSRM),与 tile
+  栈解耦;折线只是 GeoJSON line layer,MapLibre 侧零新依赖。
+
+### D6 · 日语标注
+
+`@protomaps/basemaps` 的 `layers(source, theme, { lang: "ja" })` 生成日语优先样式
+(`name:ja` → 本地 `name` 回退);MapLibre 内建 CJK 文本渲染;glyphs 用官方
+basemaps-assets(含 CJK 字形,自托管见 D3)。中文/英文 locale 切换 = 换 `lang` 重建
+layers,同一 tile 数据,零额外供应成本(i18n AC 的地图部分由此满足)。
+
+## 4. 被 block story 的需求映射
+
+| Story | 它要什么 | 本决策怎么给 |
+|---|---|---|
+| **S1.4** 搜索结果:点位卡 + 静态地图(C3a)/ bubble 总览(C3b) | 静态地图 ≤50 pin;圏泡(面积∝件数)且低 zoom 永不画散 pin;D7 降级 = 手绘 SVG + 「地図アプリで開く」;ja/zh/en 地名 | D4 三态静态卡(pin=SVG 叠加,数据驱动);C3b = 聚合结果画 SVG 圆(静态层)或 GL circle layer 半径按 `sqrt(count)` 数据驱动;D7 = D4 的失败停留态;地名 i18n = D6 |
+| **S1.5** 路线卡 + 地图升格(轨迹/重编号/降透明/金 pill) | 轨迹绘制、pin 按步行序重编号、非路线点降透明、金色 route pill | GL line layer(暖棕虚线 `#8a6f4d dasharray`)+ symbol/DOM marker 重编号 + feature-state 降透明;pill 是 DOM 叠加,与引擎无关。升格 = D4 状态 3 |
+| **S2.2** MODE FLIP + pin 语言 + 进度 pill | 360ms FLIP idle⇄全屏地图;48px 相框 pin(済 teal 徽 / 現在 58px 金环★ / 未訪 白底编号);双击防抖 | FLIP 是容器动画(CSS/JS),地图实例复用不重建(MapLibre `resize()` 跟随容器);相框 pin 用 DOM Marker(每路线 ≤ 十几枚,DOM 成本可忽略,还能直接吃動森 token/阴影);状态切换改 class,不碰 GL |
+| **S5.2** 作品页 bubble map | 泡面积∝点位数、地域名匹配、点泡 → zoom → 機位 sheet | GL circle layer 数据驱动半径 + `flyTo` + click 事件出 sheet;单泡/零照片空态是数据层逻辑,引擎无关 |
+| **S6.2** 双栏常驻地图 + 双向 hover 联动(150ms 防抖) | 左列行 ⇄ 右栏 pin 双向高亮、防抖、无幽灵高亮 | headless anchoring 核(事件总线)+ MapLibre `feature-state` 高亮/DOM marker class;防抖在核里做,与地图库解耦(§5 headless 约束的直接收益) |
+| **S3.6/S3.10**(伏笔) | route bundle 离线渲染;OSRM 折线 | D5 两路径;折线 = line layer,进同一 bundle 缓存 |
+
+一句话:五个 story 全部只消费「MapLibre 实例 + 数据驱动样式 + DOM/SVG 叠加」三件套,
+没有一个需要商业 SDK 独有能力;而离线(S3.6)只有自托管 PMTiles 能优雅满足。
+
+## 5. 分阶段策略(静态卡 → 交互 → 离线)
+
+| 阶段 | 交付 | 消费 story | 依赖的本 ADR 决策 |
+|---|---|---|---|
+| **Phase A(iter-1)** | 插画+SVG 静态卡、静默 hydrate、`StaticMap.tsx` 包装、`/tiles/*` 上线(Kansai/Kanto 起步或直接全日本) | S1.4、S1.5(轨迹升格) | D1-D4、D6 |
+| **Phase B(iter-2/5/6)** | 全交互:FLIP 升格、相框 pin、bubble map、hover 联动 | S2.2、S5.2、S6.2 | D1-D3、D6(+A 的组件) |
+| **Phase C(iter-3)** | 离线:route bundle 预取 / FileSource 区域包;OSRM 折线叠加 | S3.6、S3.10 | D5(复用 D2 工具链) |
+
+跨阶段铁则:投影/聚合/anchoring/升格编排写 **plain TS headless 核**(spec-chat-page-design
+§5,未来可回贡 Anitabi),React 与 MapLibre 都是适配器;地图 chunk 永远独立分包。
+
+## 6. Tile 供应与成本账(实测 2026-07-11)
+
+**体积(pmtiles extract 自 20260710 日构建,z0-15 除注明外)**:
+
+| 范围 | bbox | 实测体积 | 备注 |
+|---|---|---|---|
+| 宇治·京都 z0-15(spike 用) | 135.68,34.85,135.85,35.02 | **20.4MB** | 25s / 45 个 range 请求 / 传输 22MB(overfetch 0.05) |
+| 宇治·京都 z≤12 | 同上 | 2.8MB | z12→z15 实测 ≈ **7.3×**(与官方「每加一级约翻倍」≈8× 吻合) |
+| Kansai z≤12 | 134.2,33.8,136.6,35.7 | 33.3MB | z15 估算 ≈ 33.3 × 7.3 ≈ **0.24GB** |
+| Kanto z≤12 | 138.4,34.8,140.9,36.5 | 35.2MB | z15 估算 ≈ **0.26GB**(全球最密城市群也不过如此) |
+| 日本全域 z≤12 | 127.0,26.0,146.0,45.8 | 327MB(4m46s / 58 请求) | z15 估算 ≈ **≤2.4GB**(×7.3 为偏都市的上界系数) |
+
+**月度成本(R2 定价 2026-07 官方页)**:存储 $0.015/GB-月(免费层 10GB);Class A
+$4.50/百万(免费层 100 万);Class B $0.36/百万(免费层 1000 万);**egress $0**。
+spec 最低要求的 Kansai+Kanto z15 ≈ **0.5GB**,日本全域 z15 ≈ **2.4GB——都在 R2 免费层内,
+存储成本 $0**(即便估算翻倍也只是 ~$0.07/月量级)。读放大被两层缓存(浏览器 + CF Cache API)
+压扁,Class B 只发生在 cache miss。Workers 请求走现有 $5/mo 付费计划(含 1000 万次)。
+对照:同等流量在 Google/Mapbox/MapTiler 是按 loads/sessions 线性计费。
+**结论:地图栈边际成本≈0,爆流量时账单不随 loads 线性走;直接收全日本,不必抠 bbox。**
+
+**供应链**:上游 = Protomaps 日构建(免费下载,官方明言别热链、要自托管——我们正是这么用);
+断供后备 = planetiler 自建管线(开源,Geofabrik japan extract 喂入,几小时级构建);
+应急后备 = OpenFreeMap 托管(换 style URL 即切,仅样式不同,数据同为 OSM)。
+
+## 7. 风险与缓解
+
+| 风险 | 等级 | 缓解 |
+|---|---|---|
+| R2 冷读延迟(官方自述可达 500ms+) | 中 | Cache API + 自定义域(Protomaps CF 文档明确要求自定义域才有缓存);tile 按天 immutable,命中率高;首屏走 D4 插画层,GL 是渐进增强 |
+| OSM 日本乡下/新开发区精度不及 Google | 中低 | 圣地本身来自 Anitabi(坐标独立于底图);底图只是空间语境;GSI 官方 tile 记为叠加后备;Google 静态嵌入(「地図アプリで開く」外链)兜底导航场景 |
+| CJK glyph 首包重(日文字形 pbf 按 256 码位分片,首屏多拉几片) | 中低 | glyphs 自托管同源 + HTTP 缓存;非交互静态卡(D4 态 1)零 glyph;spike 实测请求瀑布见 README |
+| Protomaps 日构建停更/断供 | 低 | 本地已存档 extract 可继续用(地图不更新不等于坏);planetiler 自建管线为退路(§6) |
+| 一人上游(pmtiles 生态 bus factor) | 低 | 格式规格公开(v3 spec)、多语言实现、Linux 基金会背书(OSMF 官方 vector tiles 也押注 pmtiles 方向);数据永远在自己桶里 |
+| Kanto z15 体积超预期(全球最密城市群) | 低 | 已实测消解:Kanto z≤12 仅 35.2MB,z15 估算 0.26GB;日本全域 z15 ≈2.4GB 仍在免费层 |
+| ODbL 合规 | 低 | 地图角落署名 © OpenStreetMap contributors + Protomaps;OpenFreeMap 后备启用时加其署名 |
+| `perf-mobile-cold` 3s 首 tile 预算(S0.4 AC1)在 spike 阶段无正式测量 | 中 | spike 记录未节流请求瀑布与体积证据;正式 Playwright 节流测量随 demo route 进 apps/web(S0.2 落地后接线,见 §8 范围说明);若超预算,D4 让静态卡先行、GL 延后挂载,AC 语义仍满足 |
+| 无 WebGL 环境(极老设备 WebView、无 GPU 的 headless/CI 浏览器) | 中低 | D4 态 1(插画+SVG)本身就是完整降级链终点——**spike 实证**:在无 WebGL 的 headless Chromium(gstack browse)中,静态卡正确停留在插画层、页面不碎;两条推论:① GL 挂载前做 WebGL 能力检测,失败留在插画层(D4 已内建此语义);② E2E/perf 测试必须用带 SwiftShader 软渲染的浏览器(Playwright 自带 Chromium 可用),普通无 GPU headless 会静默空图 |
+
+## 8. Spike 结论与范围说明
+
+Spike(`docs/superpowers/spikes/map-stack/`,Codex 实现,独立 Vite + TS 项目)已全部验证
+(真 Chrome QA:console 零错误零警告;AC2/AC3 语义、离线 FileSource、worker 模式
+`/tiles/{z}/{x}/{y}.mvt` 200/204 均实测通过;无 WebGL 的 headless 下按 D4 停留插画层):
+
+1. **静态地图卡**:插画+SVG 即时渲染 → non-interactive GL 静默 hydrate(動森 token
+   pin:teal `#19c8b9` 普通站 / gold `#f0b429` ★高光站 / 暖棕 `#8a6f4d` 虚线路径,
+   数值出自 user-journey §6.6 pin 语言),tile 故障停留插画层(AC3 语义)。
+2. **交互地图**:标记/缩放/`flyTo`;飞出覆盖区显示背景色而非碎图(AC2 语义)。
+3. **离线**:pmtiles → Blob → `FileSource` 全离线渲染(D5 可行性)。
+4. **`/tiles/*` Worker**:Protomaps 官方 worker 形状 + `wrangler dev` 本地 R2 模拟
+   (`--local` binding,无需真桶),证明 D3 服务形状与 `/img/*` 同构。
+5. **供应链**:spike 内 `scripts/fetch-tiles.sh` 远程 extract(§6 实测数字的来源;
+   生产版 `scripts/build-pmtiles.sh` 随 apps/web 接线交付)。
+
+**范围说明**:iter-0 S0.4 的 releasable statement 提及 apps/web 内 demo route 与生产
+R2 桶;因 apps/web 骨架(S0.2)由并行工序建设中,本 PR 交付 ADR + 独立 spike,
+demo route 接线、`[[r2_buckets]]` 声明与 `perf-mobile-cold` 正式测量作为 S0.2 合流后的
+后续小卡完成(见 issue #237 进度评论)。规避了对并行工序的目录依赖,不碰产品代码。
+
+## 9. 来源
+
+- Protomaps on Cloudflare(部署模型/缓存/成本/延迟注记):https://docs.protomaps.com/deploy/cloudflare
+- Protomaps 日构建与 extract(planet ~120GB 文档值;2026-07-10 实测 HEAD 136.7GB):https://docs.protomaps.com/basemaps/downloads
+- PMTiles 格式(单文件 + HTTP Range,云存储直读):https://docs.protomaps.com/pmtiles/
+- PMTiles×MapLibre 协议接入:https://docs.protomaps.com/pmtiles/maplibre
+- `FileSource`(浏览器本地 File/Blob 离线读,`js/src/index.ts` 导出):https://github.com/protomaps/PMTiles
+- 官方 Cloudflare worker:https://github.com/protomaps/PMTiles/tree/main/serverless/cloudflare
+- go-pmtiles CLI(extract):https://github.com/protomaps/go-pmtiles
+- Protomaps 本地化(41 语言含 ja,CJK 处理):https://docs.protomaps.com/basemaps/localization
+- R2 定价:https://developers.cloudflare.com/r2/pricing/
+- OpenFreeMap(免费/无限/自托管/署名):https://openfreemap.org 及 https://openfreemap.org/tos/
+- OpenFreeMap 扛 100k req/s + Cloudflare 赞助带宽:https://blog.hyperknot.com/p/openfreemap-survived-100000-requests
+- MapTiler Cloud 定价(free tier 非商用;Flex $30/mo):https://www.maptiler.com/cloud/pricing/
+- MapTiler 日本上陆(MIERUNE,OSM+基盤地図情報):https://internet.watch.impress.co.jp/docs/column/chizu3/1232026.html
+- Google Maps Platform 2025-03 计价改制(per-SKU 免费额度;Essentials 1 万/月;Dynamic Maps $7/千):https://developers.google.com/maps/billing-and-pricing/pricing 、https://mapsplatform.google.com/pricing/
+- Mapbox GL JS v2+ 专有 license 与 5 万 loads 免费层:https://github.com/mapbox/mapbox-gl-js 、https://www.mapbox.com/pricing
+- Mapbox×Zenrin(日本数据分销):https://www.zenrin.co.jp/product/category/iot/api/mapbox/index.html
+- GSI 地理院タイル利用規約(商用可,出典明示):https://maps.gsi.go.jp/development/ichiran.html 、https://www.gsi.go.jp/kikakuchousei/kikakuchousei40182.html
+- maplibre-gl 5.24.0 / pmtiles 4.4.1 / @protomaps/basemaps 5.7.2 版本与 BSD-3 license:npm registry(2026-07-11 查询)
+- repo 内部先例:`worker/app.ts`(`/img/*` proxy + Cache API)、`infra/index.ts`(R2 `catalog-media`)、`wrangler.toml`

--- a/docs/superpowers/spikes/map-stack/.gitignore
+++ b/docs/superpowers/spikes/map-stack/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+public/tiles/*.pmtiles
+.wrangler/
+worker/.wrangler/
+
+# Root .gitignore ignores HTML globally; keep this spike entrypoint tracked.
+!index.html

--- a/docs/superpowers/spikes/map-stack/README.md
+++ b/docs/superpowers/spikes/map-stack/README.md
@@ -1,0 +1,77 @@
+# Map Stack Spike
+
+This standalone spike proves the accepted map-stack ADR at
+`docs/superpowers/specs/2026-07-11-map-stack-adr.md` without touching product
+apps, shared workers, root package files, or cloud accounts.
+
+## What It Proves
+
+| Spike surface | ADR item | S0.4 acceptance coverage |
+| --- | --- | --- |
+| Static-first card with branded SVG, SVG projected pins, dashed route, idle MapLibre hydration, and tile-failure toggle | §8.1, D4 | AC3: card remains useful when tiles fail |
+| Interactive MapLibre map with PMTiles source, DOM markers, GL dashed route, and fly-outside-coverage button | §8.2, D1, D3 | AC2: out-of-coverage tiles render as plain background |
+| Source switch for `pmtiles://` range reads vs local `/tiles/{z}/{x}/{y}.mvt` worker | §8.4, D3 | Proves the ZXY Worker shape before product integration |
+| Offline button using `Blob` → `File` → `new PMTiles(new FileSource(file))` | §8.3, D5 | Proves Walk-mode offline tile path |
+| `worker/tiles.ts` over local Wrangler R2 simulation | §8.4, D3 | No API keys, no cloud calls |
+
+## Run
+
+```bash
+npm ci
+npm run dev
+```
+
+Open the Vite URL. The default source is the local PMTiles archive served by
+Vite via range requests:
+
+```text
+http://localhost:5173/
+```
+
+The style uses `@protomaps/basemaps` 5.x with the package README's documented
+v4 basemaps sprite URL. POI icon layers are disabled in the spike style because
+the v4 sprite sheet does not include every 5.x POI icon name.
+
+For the local worker-backed ZXY path:
+
+```bash
+npm run worker:seed
+npm run worker:dev
+```
+
+Then open:
+
+```text
+http://localhost:5173/?source=worker
+```
+
+Worker smoke endpoints:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8787/tiles/14/14372/6495.mvt
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8787/tiles/14/14552/6451.mvt
+```
+
+## Data Measurements
+
+| Region / zooms | Size / timing / requests |
+| --- | --- |
+| `uji-kyoto` z0-15 | 20.4MB / 25s / 45 range requests |
+| `uji` z≤12 | 2.8MB, so z12→z15 is about 7.3x |
+| Kansai z≤12 | 33.3MB |
+| Kanto z≤12 | 35.2MB |
+| Japan z≤12 | 327MB in 4m46s / 58 requests |
+| Japan z15 estimate | ≤2.4GB, inside the R2 free tier |
+
+The staged archive is `public/tiles/uji-kyoto.pmtiles`, extracted from
+`https://build.protomaps.com/20260710.pmtiles` with bbox
+`135.68,34.85,135.85,35.02`.
+
+## Attribution
+
+© OpenStreetMap contributors, Protomaps.
+
+## Security And Scope
+
+No API key exists anywhere in this spike. The worker uses Wrangler local R2
+simulation only; it does not call Cloudflare APIs or require a cloud account.

--- a/docs/superpowers/spikes/map-stack/index.html
+++ b/docs/superpowers/spikes/map-stack/index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='28' fill='%2319c8b9'/%3E%3C/svg%3E" />
+    <title>Seichijunrei Map Stack Spike</title>
+  </head>
+  <body>
+    <header class="page-header">
+      <p class="eyebrow">S0.4 · MapLibre GL JS + PMTiles</p>
+      <h1>宇治巡礼 map-stack spike</h1>
+      <div class="mode-switch" aria-label="source mode">
+        <button id="mode-pmtiles" type="button">pmtiles://</button>
+        <button id="mode-worker" type="button">worker /tiles</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="panel" aria-labelledby="static-title">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">ADR D4</p>
+            <h2 id="static-title">Static-first card</h2>
+          </div>
+          <label class="toggle">
+            <input id="static-failure" type="checkbox" />
+            <span>simulate tile failure</span>
+          </label>
+        </div>
+        <div id="static-card" class="map-card static-card"></div>
+      </section>
+
+      <section class="panel" aria-labelledby="interactive-title">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">ADR D1 / D3</p>
+            <h2 id="interactive-title">Interactive coverage demo</h2>
+          </div>
+          <div class="button-row">
+            <button id="fly-tokyo" type="button">fly outside coverage</button>
+            <button id="fly-uji" type="button">back to Uji</button>
+          </div>
+        </div>
+        <div id="interactive-map" class="map-card interactive-map"></div>
+      </section>
+
+      <section class="panel" aria-labelledby="offline-title">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">ADR D5</p>
+            <h2 id="offline-title">Offline FileSource demo</h2>
+          </div>
+          <button id="load-offline" type="button">load region file offline</button>
+        </div>
+        <div id="offline-map" class="map-card offline-map is-empty">
+          <p>Load the PMTiles file to render from a browser FileSource.</p>
+        </div>
+        <p class="caption">
+          Once loaded, DevTools-offline keeps this map fully working with no tile network I/O.
+        </p>
+      </section>
+    </main>
+
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/docs/superpowers/spikes/map-stack/package-lock.json
+++ b/docs/superpowers/spikes/map-stack/package-lock.json
@@ -1,0 +1,2464 @@
+{
+  "name": "seichijunrei-map-stack-spike",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "seichijunrei-map-stack-spike",
+      "version": "0.0.0",
+      "dependencies": {
+        "@protomaps/basemaps": "5.7.2",
+        "maplibre-gl": "^5.0.0",
+        "pmtiles": "^4.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0",
+        "vite": "^7.0.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260708.1.tgz",
+      "integrity": "sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260708.1.tgz",
+      "integrity": "sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260708.1.tgz",
+      "integrity": "sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260708.1.tgz",
+      "integrity": "sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260708.1.tgz",
+      "integrity": "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.2"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.1.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
+      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.12.tgz",
+      "integrity": "sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@protomaps/basemaps": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@protomaps/basemaps/-/basemaps-5.7.2.tgz",
+      "integrity": "sha512-K1Yk6bWdULulYg+R2QRVXx4NzJZan5YQhpejEG0c1/sXruJrfPIPZuakpf3jwAgVmjIRVQwAv+yRafDeN0aaUQ==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "generate_style": "src/cli.ts"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
+    "node_modules/kdbush": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "license": "ISC"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/maplibre-gl": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260708.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260708.1.tgz",
+      "integrity": "sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260708.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pmtiles": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.4.1.tgz",
+      "integrity": "sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260708.1.tgz",
+      "integrity": "sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260708.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260708.1",
+        "@cloudflare/workerd-linux-64": "1.20260708.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260708.1",
+        "@cloudflare/workerd-windows-64": "1.20260708.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.110.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.110.0.tgz",
+      "integrity": "sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260708.1",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260708.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260708.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/docs/superpowers/spikes/map-stack/package.json
+++ b/docs/superpowers/spikes/map-stack/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "seichijunrei-map-stack-spike",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "fetch-tiles": "bash scripts/fetch-tiles.sh",
+    "worker:seed": "bash scripts/seed-local-r2.sh",
+    "worker:dev": "WRANGLER_WRITE_LOGS=false WRANGLER_LOG_PATH=.wrangler/logs XDG_CONFIG_HOME=.wrangler/config XDG_CACHE_HOME=.wrangler/cache wrangler dev --config worker/wrangler.toml --persist-to .wrangler/state --ip 127.0.0.1 --port 8787 --local"
+  },
+  "dependencies": {
+    "@protomaps/basemaps": "5.7.2",
+    "maplibre-gl": "^5.0.0",
+    "pmtiles": "^4.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^7.0.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/docs/superpowers/spikes/map-stack/scripts/fetch-tiles.sh
+++ b/docs/superpowers/spikes/map-stack/scripts/fetch-tiles.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+OUT="public/tiles/uji-kyoto.pmtiles"
+BBOX="135.68,34.85,135.85,35.02"
+
+if [[ -f "$OUT" ]]; then
+  echo "$OUT already exists; skipping download."
+  exit 0
+fi
+
+if ! command -v pmtiles >/dev/null 2>&1; then
+  echo "pmtiles CLI is required." >&2
+  echo "Install with: brew install pmtiles" >&2
+  echo "Or download go-pmtiles releases: https://github.com/protomaps/go-pmtiles/releases" >&2
+  exit 1
+fi
+
+probe_build() {
+  if [[ -n "${BUILD:-}" ]]; then
+    echo "$BUILD"
+    return 0
+  fi
+
+  for offset in 0 1 2 3 4 5 6; do
+    candidate="$(date -u -v-"${offset}"d +%Y%m%d 2>/dev/null || date -u -d "-${offset} day" +%Y%m%d)"
+    url="https://build.protomaps.com/${candidate}.pmtiles"
+    if curl -fsI "$url" >/dev/null; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+build="$(probe_build)" || {
+  echo "No retained Protomaps daily build found in the last 7 days." >&2
+  exit 1
+}
+
+mkdir -p public/tiles
+pmtiles extract "https://build.protomaps.com/${build}.pmtiles" "$OUT" --bbox="$BBOX"

--- a/docs/superpowers/spikes/map-stack/scripts/seed-local-r2.sh
+++ b/docs/superpowers/spikes/map-stack/scripts/seed-local-r2.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export WRANGLER_WRITE_LOGS=false
+export WRANGLER_LOG_PATH="$PWD/.wrangler/logs"
+export XDG_CONFIG_HOME="$PWD/.wrangler/config"
+export XDG_CACHE_HOME="$PWD/.wrangler/cache"
+
+if [[ ! -f public/tiles/uji-kyoto.pmtiles ]]; then
+  echo "Missing public/tiles/uji-kyoto.pmtiles; run npm run fetch-tiles first." >&2
+  exit 1
+fi
+
+mkdir -p .wrangler/logs .wrangler/config .wrangler/cache .wrangler/state
+
+npx wrangler r2 object put "seichijunrei-assets-dev/tiles/uji-kyoto.pmtiles" \
+  --file=public/tiles/uji-kyoto.pmtiles \
+  --local \
+  --persist-to=.wrangler/state \
+  --force \
+  --config worker/wrangler.toml

--- a/docs/superpowers/spikes/map-stack/src/constants.ts
+++ b/docs/superpowers/spikes/map-stack/src/constants.ts
@@ -1,0 +1,68 @@
+export const COLORS = {
+  teal: "#19c8b9",
+  gold: "#f0b429",
+  brown: "#8a6f4d",
+  cream: "#faf6ee",
+  ink: "#2f2a21",
+  line: "#3a3228"
+} as const;
+
+export const TILE_URL = "/tiles/uji-kyoto.pmtiles";
+export const BAD_TILE_URL = "/tiles/missing-uji.pmtiles";
+export const WORKER_TILE_URL = "http://127.0.0.1:8787/tiles/{z}/{x}/{y}.mvt";
+
+export const UJI_CENTER: LngLat = [135.811, 34.8937];
+export const TOKYO_CENTER: LngLat = [139.77, 35.68];
+
+export const STATIC_BOUNDS = {
+  west: 135.8038,
+  south: 34.8892,
+  east: 135.821,
+  north: 34.897
+} as const;
+
+export const STATIC_SIZE = { width: 1000, height: 620 } as const;
+
+export type LngLat = readonly [number, number];
+
+export type SpotKind = "start" | "normal" | "highlight";
+
+export interface Spot {
+  readonly id: string;
+  readonly label: string;
+  readonly coord: LngLat;
+  readonly kind: SpotKind;
+}
+
+export const SPOTS: readonly Spot[] = [
+  {
+    id: "ujibashi",
+    label: "宇治橋",
+    coord: [135.8077, 34.893],
+    kind: "start"
+  },
+  {
+    id: "omotesando",
+    label: "平等院表参道",
+    coord: [135.8064, 34.8912],
+    kind: "normal"
+  },
+  {
+    id: "ujijinja",
+    label: "宇治神社",
+    coord: [135.8118, 34.8918],
+    kind: "normal"
+  },
+  {
+    id: "daikichiyama",
+    label: "大吉山展望台",
+    coord: [135.8189, 34.8951],
+    kind: "highlight"
+  },
+  {
+    id: "keihan-uji",
+    label: "京阪宇治駅",
+    coord: [135.8079, 34.8945],
+    kind: "normal"
+  }
+] as const;

--- a/docs/superpowers/spikes/map-stack/src/interactive.ts
+++ b/docs/superpowers/spikes/map-stack/src/interactive.ts
@@ -1,0 +1,43 @@
+import maplibregl from "maplibre-gl";
+import { TOKYO_CENTER, UJI_CENTER } from "./constants";
+import { createMapStyle } from "./map-style";
+import { addDomMarkers } from "./markers";
+import { routeLayer, routeSource } from "./route";
+import type { SourceMode } from "./source-mode";
+
+const addRoute = (map: maplibregl.Map): void => {
+  if (map.getSource("uji-route")) {
+    return;
+  }
+  map.addSource("uji-route", routeSource());
+  map.addLayer(routeLayer());
+};
+
+export const mountInteractiveMap = (
+  root: HTMLElement,
+  mode: SourceMode,
+  flyTokyo: HTMLButtonElement,
+  flyUji: HTMLButtonElement
+): void => {
+  const map = new maplibregl.Map({
+    container: root,
+    style: createMapStyle(mode),
+    center: [...UJI_CENTER],
+    zoom: 13.9,
+    attributionControl: { compact: true },
+    fadeDuration: 0
+  });
+
+  map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
+  map.on("load", () => {
+    addRoute(map);
+    addDomMarkers(map);
+  });
+
+  flyTokyo.addEventListener("click", () => {
+    map.flyTo({ center: [...TOKYO_CENTER], zoom: 12, duration: 900 });
+  });
+  flyUji.addEventListener("click", () => {
+    map.flyTo({ center: [...UJI_CENTER], zoom: 13.9, duration: 900 });
+  });
+};

--- a/docs/superpowers/spikes/map-stack/src/main.ts
+++ b/docs/superpowers/spikes/map-stack/src/main.ts
@@ -1,0 +1,37 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "./style.css";
+import { mountInteractiveMap } from "./interactive";
+import { mountOfflineDemo } from "./offline";
+import { registerPmtilesProtocol } from "./protocol";
+import { getSourceMode, setSourceMode } from "./source-mode";
+import { mountStaticCard } from "./static-card";
+
+const requireElement = <T extends HTMLElement>(id: string): T => {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Missing #${id}`);
+  }
+  return element as T;
+};
+
+registerPmtilesProtocol();
+
+const mode = getSourceMode();
+requireElement<HTMLButtonElement>(`mode-${mode}`).classList.add("is-active");
+requireElement<HTMLButtonElement>("mode-pmtiles").addEventListener("click", () => setSourceMode("pmtiles"));
+requireElement<HTMLButtonElement>("mode-worker").addEventListener("click", () => setSourceMode("worker"));
+
+mountStaticCard(
+  requireElement<HTMLElement>("static-card"),
+  requireElement<HTMLInputElement>("static-failure")
+);
+mountInteractiveMap(
+  requireElement<HTMLElement>("interactive-map"),
+  mode,
+  requireElement<HTMLButtonElement>("fly-tokyo"),
+  requireElement<HTMLButtonElement>("fly-uji")
+);
+mountOfflineDemo(
+  requireElement<HTMLElement>("offline-map"),
+  requireElement<HTMLButtonElement>("load-offline")
+);

--- a/docs/superpowers/spikes/map-stack/src/map-style.ts
+++ b/docs/superpowers/spikes/map-stack/src/map-style.ts
@@ -1,0 +1,59 @@
+import type { StyleSpecification } from "maplibre-gl";
+import { LIGHT, layers, type Flavor } from "@protomaps/basemaps";
+import { COLORS, TILE_URL, WORKER_TILE_URL } from "./constants";
+import type { SourceMode } from "./source-mode";
+
+const attribution = "© OpenStreetMap contributors, Protomaps";
+
+const toAbsolute = (path: string): string => {
+  return new URL(path, window.location.origin).toString();
+};
+
+export const pmtilesUrl = (path: string): string => {
+  return `pmtiles://${toAbsolute(path)}`;
+};
+
+const pmtilesSourceUrl = (tilePath: string): string => {
+  return tilePath.startsWith("pmtiles://") ? tilePath : pmtilesUrl(tilePath);
+};
+
+const sourceFor = (mode: SourceMode, tilePath: string) => {
+  if (mode === "worker") {
+    return {
+      type: "vector" as const,
+      tiles: [WORKER_TILE_URL],
+      minzoom: 0,
+      maxzoom: 15,
+      attribution
+    };
+  }
+
+  return {
+    type: "vector" as const,
+    url: pmtilesSourceUrl(tilePath),
+    attribution
+  };
+};
+
+const brandLightFlavor = (): Flavor => ({
+  ...LIGHT,
+  background: COLORS.cream,
+  pois: undefined
+});
+
+export const createMapStyle = (
+  mode: SourceMode,
+  tilePath: string = TILE_URL
+): StyleSpecification => {
+  return {
+    version: 8,
+    name: "seichijunrei-map-stack-spike",
+    // Production copies these basemaps assets to R2 same-origin with the tiles.
+    glyphs: "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
+    sprite: "https://protomaps.github.io/basemaps-assets/sprites/v4/light",
+    sources: {
+      protomaps: sourceFor(mode, tilePath)
+    },
+    layers: layers("protomaps", brandLightFlavor(), { lang: "ja" })
+  };
+};

--- a/docs/superpowers/spikes/map-stack/src/markers.ts
+++ b/docs/superpowers/spikes/map-stack/src/markers.ts
@@ -1,0 +1,50 @@
+import maplibregl from "maplibre-gl";
+import { COLORS, SPOTS, type Spot } from "./constants";
+
+const pinText = (spot: Spot, index: number): string => {
+  if (spot.kind === "start") {
+    return "出";
+  }
+  if (spot.kind === "highlight") {
+    return "★";
+  }
+  return String(index + 1);
+};
+
+const classNameFor = (spot: Spot): string => {
+  return `pin-marker pin-${spot.kind}`;
+};
+
+const markerElement = (spot: Spot, index: number): HTMLElement => {
+  const marker = document.createElement("div");
+  marker.className = classNameFor(spot);
+  marker.textContent = pinText(spot, index);
+  marker.title = spot.label;
+  return marker;
+};
+
+export const addDomMarkers = (map: maplibregl.Map): maplibregl.Marker[] => {
+  return SPOTS.map((spot, index) => {
+    return new maplibregl.Marker({
+      element: markerElement(spot, index),
+      anchor: "bottom"
+    })
+      .setLngLat([...spot.coord])
+      .addTo(map);
+  });
+};
+
+export const svgPin = (spot: Spot, index: number, x: number, y: number): string => {
+  const label = pinText(spot, index);
+  const fill = spot.kind === "highlight" ? COLORS.gold : spot.kind === "start" ? COLORS.teal : "#fff";
+  const stroke = spot.kind === "normal" ? COLORS.teal : COLORS.line;
+  const textFill = spot.kind === "normal" ? COLORS.teal : "#fff";
+  const r = spot.kind === "highlight" ? 21 : 18;
+
+  return `
+    <g transform="translate(${x.toFixed(1)} ${y.toFixed(1)})">
+      <circle cx="0" cy="0" r="${r}" fill="${fill}" stroke="${stroke}" stroke-width="3" />
+      <text x="0" y="6" text-anchor="middle" font-size="18" font-weight="800" fill="${textFill}">${label}</text>
+    </g>
+  `;
+};

--- a/docs/superpowers/spikes/map-stack/src/offline.ts
+++ b/docs/superpowers/spikes/map-stack/src/offline.ts
@@ -1,0 +1,53 @@
+import maplibregl from "maplibre-gl";
+import { FileSource, PMTiles } from "pmtiles";
+import { TILE_URL, UJI_CENTER } from "./constants";
+import { createMapStyle } from "./map-style";
+import { addDomMarkers } from "./markers";
+import { protocol } from "./protocol";
+import { routeLayer, routeSource } from "./route";
+
+const addRoute = (map: maplibregl.Map): void => {
+  map.addSource("uji-route", routeSource());
+  map.addLayer(routeLayer());
+};
+
+const loadFileArchive = async (): Promise<void> => {
+  const response = await fetch(TILE_URL);
+  if (!response.ok) {
+    throw new Error(`PMTiles fetch failed: ${response.status}`);
+  }
+  const blob = await response.blob();
+  const file = new File([blob], "uji.pmtiles", { type: "application/octet-stream" });
+  protocol.add(new PMTiles(new FileSource(file)));
+};
+
+export const mountOfflineDemo = (root: HTMLElement, button: HTMLButtonElement): void => {
+  button.addEventListener("click", () => {
+    button.disabled = true;
+    button.textContent = "loading...";
+
+    loadFileArchive()
+      .then(() => {
+        root.classList.remove("is-empty");
+        root.textContent = "";
+        const map = new maplibregl.Map({
+          container: root,
+          style: createMapStyle("pmtiles", "pmtiles://uji.pmtiles"),
+          center: [...UJI_CENTER],
+          zoom: 13.8,
+          fadeDuration: 0
+        });
+        map.addControl(new maplibregl.NavigationControl(), "top-right");
+        map.on("load", () => {
+          addRoute(map);
+          addDomMarkers(map);
+        });
+        button.textContent = "loaded offline file";
+      })
+      .catch((error: unknown) => {
+        button.disabled = false;
+        button.textContent = "load region file offline";
+        root.textContent = error instanceof Error ? error.message : "Offline load failed";
+      });
+  });
+};

--- a/docs/superpowers/spikes/map-stack/src/projection.ts
+++ b/docs/superpowers/spikes/map-stack/src/projection.ts
@@ -1,0 +1,35 @@
+import type { LngLat } from "./constants";
+
+export interface Bounds {
+  readonly west: number;
+  readonly south: number;
+  readonly east: number;
+  readonly north: number;
+}
+
+export interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+const mercatorY = (lat: number): number => {
+  const radians = (lat * Math.PI) / 180;
+  return Math.log(Math.tan(Math.PI / 4 + radians / 2));
+};
+
+export const projectWebMercator = (
+  [lon, lat]: LngLat,
+  bounds: Bounds,
+  size: Size
+): Point => {
+  const x = ((lon - bounds.west) / (bounds.east - bounds.west)) * size.width;
+  const top = mercatorY(bounds.north);
+  const bottom = mercatorY(bounds.south);
+  const y = ((top - mercatorY(lat)) / (top - bottom)) * size.height;
+  return { x, y };
+};

--- a/docs/superpowers/spikes/map-stack/src/protocol.ts
+++ b/docs/superpowers/spikes/map-stack/src/protocol.ts
@@ -1,0 +1,8 @@
+import maplibregl from "maplibre-gl";
+import { Protocol } from "pmtiles";
+
+export const protocol = new Protocol({ metadata: true });
+
+export const registerPmtilesProtocol = (): void => {
+  maplibregl.addProtocol("pmtiles", protocol.tile);
+};

--- a/docs/superpowers/spikes/map-stack/src/route.ts
+++ b/docs/superpowers/spikes/map-stack/src/route.ts
@@ -1,0 +1,35 @@
+import type { GeoJSONSourceSpecification, LineLayerSpecification } from "maplibre-gl";
+import { COLORS, SPOTS } from "./constants";
+
+const routeCoordinates = SPOTS.map((spot) => spot.coord);
+
+export const routeSource = (): GeoJSONSourceSpecification => {
+  return {
+    type: "geojson",
+    data: {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: routeCoordinates.map(([lon, lat]) => [lon, lat])
+      }
+    }
+  };
+};
+
+export const routeLayer = (): LineLayerSpecification => {
+  return {
+    id: "uji-route",
+    type: "line",
+    source: "uji-route",
+    layout: {
+      "line-cap": "round",
+      "line-join": "round"
+    },
+    paint: {
+      "line-color": COLORS.brown,
+      "line-width": 4,
+      "line-dasharray": [1.2, 1.2]
+    }
+  };
+};

--- a/docs/superpowers/spikes/map-stack/src/source-mode.ts
+++ b/docs/superpowers/spikes/map-stack/src/source-mode.ts
@@ -1,0 +1,17 @@
+export type SourceMode = "pmtiles" | "worker";
+
+const isSourceMode = (value: string | null): value is SourceMode => {
+  return value === "pmtiles" || value === "worker";
+};
+
+export const getSourceMode = (): SourceMode => {
+  const params = new URLSearchParams(window.location.search);
+  const mode = params.get("source");
+  return isSourceMode(mode) ? mode : "pmtiles";
+};
+
+export const setSourceMode = (mode: SourceMode): void => {
+  const params = new URLSearchParams(window.location.search);
+  params.set("source", mode);
+  window.location.search = params.toString();
+};

--- a/docs/superpowers/spikes/map-stack/src/static-card.ts
+++ b/docs/superpowers/spikes/map-stack/src/static-card.ts
@@ -1,0 +1,176 @@
+import maplibregl from "maplibre-gl";
+import {
+  BAD_TILE_URL,
+  COLORS,
+  SPOTS,
+  STATIC_BOUNDS,
+  STATIC_SIZE,
+  TILE_URL
+} from "./constants";
+import { createMapStyle } from "./map-style";
+import { svgPin } from "./markers";
+import { projectWebMercator, type Point, type Size } from "./projection";
+
+const idle = (callback: () => void): void => {
+  const idleWindow = window as Window & {
+    requestIdleCallback?: (handler: () => void, options: { timeout: number }) => number;
+  };
+  if (typeof idleWindow.requestIdleCallback === "function") {
+    idleWindow.requestIdleCallback(callback, { timeout: 1800 });
+    return;
+  }
+  globalThis.setTimeout(callback, 250);
+};
+
+const nextFrame = (): Promise<void> => {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+};
+
+const onceIdle = (map: maplibregl.Map): Promise<void> => {
+  return new Promise((resolve) => map.once("idle", () => resolve()));
+};
+
+const overlaySvg = (points: readonly Point[], size: Size): string => {
+  const path = points.map((point) => `${point.x.toFixed(1)},${point.y.toFixed(1)}`).join(" ");
+  const pins = SPOTS.map((spot, index) => svgPin(spot, index, points[index].x, points[index].y)).join("");
+
+  return `
+    <svg class="route-overlay" viewBox="0 0 ${size.width} ${size.height}" aria-hidden="true">
+      <polyline points="${path}" fill="none" stroke="${COLORS.brown}" stroke-width="8"
+        stroke-linecap="round" stroke-dasharray="18 16" opacity="0.95" />
+      ${pins}
+    </svg>
+  `;
+};
+
+const illustrationPoints = (): readonly Point[] => {
+  return SPOTS.map((spot) => projectWebMercator(spot.coord, STATIC_BOUNDS, STATIC_SIZE));
+};
+
+const illustrationOverlaySvg = (): string => {
+  return overlaySvg(illustrationPoints(), STATIC_SIZE);
+};
+
+const staticBounds = (): [[number, number], [number, number]] => {
+  return [
+    [STATIC_BOUNDS.west, STATIC_BOUNDS.south],
+    [STATIC_BOUNDS.east, STATIC_BOUNDS.north]
+  ];
+};
+
+const mapSize = (layer: HTMLElement): Size => {
+  return { width: layer.clientWidth, height: layer.clientHeight };
+};
+
+const mapPoints = (map: maplibregl.Map): readonly Point[] => {
+  return SPOTS.map((spot) => {
+    const point = map.project([spot.coord[0], spot.coord[1]]);
+    return { x: point.x, y: point.y };
+  });
+};
+
+const syncOverlayToMap = (root: HTMLElement, layer: HTMLElement, map: maplibregl.Map): void => {
+  const overlay = root.querySelector<SVGSVGElement>(".route-overlay");
+  if (!overlay) {
+    throw new Error("Static card overlay failed");
+  }
+  overlay.outerHTML = overlaySvg(mapPoints(map), mapSize(layer));
+};
+
+const settleVisibleMap = async (
+  root: HTMLElement,
+  layer: HTMLElement,
+  fallback: HTMLElement,
+  map: maplibregl.Map,
+  isCurrent: () => boolean
+): Promise<void> => {
+  layer.classList.add("is-visible");
+  fallback.classList.add("is-hidden");
+  await nextFrame();
+  if (!isCurrent()) {
+    return;
+  }
+  // resize() refreshes MapLibre's painter/transform from the now-visible box;
+  // fitBounds() must follow so projections use the final card dimensions.
+  map.resize();
+  map.fitBounds(staticBounds(), { animate: false, padding: 0 });
+  await onceIdle(map);
+  if (isCurrent()) {
+    syncOverlayToMap(root, layer, map);
+  }
+};
+
+const illustration = (): string => {
+  return `
+    <div class="static-illustration">
+      <svg viewBox="0 0 1000 620" role="img" aria-label="Branded Uji route illustration">
+        <defs>
+          <linearGradient id="sky" x1="0" x2="1" y1="0" y2="1">
+            <stop offset="0" stop-color="#faf6ee" />
+            <stop offset="1" stop-color="#d9fff9" />
+          </linearGradient>
+        </defs>
+        <rect width="1000" height="620" rx="24" fill="url(#sky)" />
+        <path d="M0 410 C170 360 250 500 420 438 S690 330 1000 392 L1000 620 L0 620 Z"
+          fill="#e7d8bc" />
+        <path d="M30 520 C190 468 360 560 520 502 S790 430 1000 492"
+          fill="none" stroke="${COLORS.teal}" stroke-width="42" stroke-linecap="round" opacity=".78" />
+        <path d="M0 455 C220 398 322 508 472 450 S720 380 1000 420"
+          fill="none" stroke="#fff8e7" stroke-width="16" stroke-linecap="round" opacity=".95" />
+        <circle cx="782" cy="132" r="58" fill="${COLORS.gold}" opacity=".9" />
+        <path d="M96 330 h118 l46 -82 l54 82 h98 l72 -120 l92 154 h330"
+          fill="none" stroke="${COLORS.brown}" stroke-width="22" stroke-linejoin="round" opacity=".42" />
+      </svg>
+    </div>
+  `;
+};
+
+export const mountStaticCard = (root: HTMLElement, checkbox: HTMLInputElement): void => {
+  let map: maplibregl.Map | null = null;
+  let renderId = 0;
+
+  const render = (simulateFailure: boolean): void => {
+    renderId += 1;
+    const currentRenderId = renderId;
+    map?.remove();
+    map = null;
+    root.innerHTML = `${illustration()}<div class="static-map-layer"></div>${illustrationOverlaySvg()}`;
+    const layer = root.querySelector<HTMLElement>(".static-map-layer");
+    const fallback = root.querySelector<HTMLElement>(".static-illustration");
+    if (!layer || !fallback) {
+      throw new Error("Static card scaffold failed");
+    }
+
+    idle(() => {
+      if (currentRenderId !== renderId) {
+        return;
+      }
+      let failed = false;
+      const nextMap = new maplibregl.Map({
+        container: layer,
+        style: createMapStyle("pmtiles", simulateFailure ? BAD_TILE_URL : TILE_URL),
+        bounds: staticBounds(),
+        interactive: false,
+        attributionControl: false,
+        fadeDuration: 0
+      });
+      map = nextMap;
+      const isCurrent = (): boolean => currentRenderId === renderId && map === nextMap;
+
+      nextMap.on("error", () => {
+        failed = true;
+        layer.classList.remove("is-visible");
+        fallback.classList.remove("is-hidden");
+      });
+      nextMap.once("idle", () => {
+        if (failed || !isCurrent()) {
+          return;
+        }
+        void settleVisibleMap(root, layer, fallback, nextMap, isCurrent);
+      });
+    });
+  };
+
+  checkbox.addEventListener("change", () => render(checkbox.checked));
+  render(checkbox.checked);
+};

--- a/docs/superpowers/spikes/map-stack/src/style.css
+++ b/docs/superpowers/spikes/map-stack/src/style.css
@@ -1,0 +1,238 @@
+:root {
+  color: #2f2a21;
+  background: #faf6ee;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    linear-gradient(180deg, rgba(25, 200, 185, 0.09), transparent 280px),
+    #faf6ee;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  min-height: 40px;
+  border: 2px solid #2f2a21;
+  border-radius: 999px;
+  padding: 0 18px;
+  color: #2f2a21;
+  background: #fffaf0;
+  cursor: pointer;
+  box-shadow: 0 3px 0 #2f2a21;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.page-header,
+main {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+}
+
+.page-header {
+  padding: 42px 0 22px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px 24px;
+  align-items: end;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: clamp(32px, 6vw, 64px);
+  line-height: 0.98;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #8a6f4d;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.mode-switch,
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.mode-switch .is-active {
+  background: #19c8b9;
+  color: #fff;
+}
+
+main {
+  display: grid;
+  gap: 24px;
+  padding-bottom: 64px;
+}
+
+.panel {
+  border: 2px solid #2f2a21;
+  border-radius: 24px;
+  padding: 20px;
+  background: rgba(255, 250, 240, 0.86);
+  box-shadow: 0 8px 0 rgba(47, 42, 33, 0.12);
+}
+
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+h2 {
+  margin: 0;
+  font-size: clamp(24px, 4vw, 38px);
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  border: 2px solid #8a6f4d;
+  border-radius: 999px;
+  padding: 0 16px;
+  background: #faf6ee;
+  font-weight: 700;
+}
+
+.map-card {
+  position: relative;
+  overflow: hidden;
+  min-height: 420px;
+  border: 2px solid #2f2a21;
+  border-radius: 24px;
+  background: #faf6ee;
+  isolation: isolate;
+}
+
+.static-card {
+  aspect-ratio: 1000 / 620;
+  min-height: 340px;
+}
+
+.interactive-map,
+.offline-map {
+  height: min(70vh, 620px);
+}
+
+.static-illustration,
+.static-map-layer,
+.route-overlay {
+  position: absolute;
+  inset: 0;
+}
+
+.static-illustration,
+.static-map-layer {
+  transition: opacity 180ms ease;
+}
+
+.static-illustration svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.static-map-layer {
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  z-index: 1;
+}
+
+.static-map-layer.is-visible {
+  opacity: 1;
+}
+
+.static-illustration.is-hidden {
+  opacity: 0;
+}
+
+.route-overlay {
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.pin-marker {
+  width: 38px;
+  height: 38px;
+  border: 3px solid #19c8b9;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  color: #19c8b9;
+  background: #fff;
+  font-weight: 900;
+  box-shadow: 0 4px 0 rgba(47, 42, 33, 0.28);
+}
+
+.pin-start {
+  color: #fff;
+  background: #19c8b9;
+  border-color: #2f2a21;
+}
+
+.pin-highlight {
+  width: 46px;
+  height: 46px;
+  color: #fff;
+  background: #f0b429;
+  border-color: #2f2a21;
+}
+
+.offline-map.is-empty {
+  display: grid;
+  place-items: center;
+  min-height: 280px;
+  color: #8a6f4d;
+  font-weight: 800;
+}
+
+.caption {
+  margin: 12px 0 0;
+  color: #5d503d;
+  font-size: 14px;
+}
+
+@media (max-width: 720px) {
+  .page-header,
+  .section-head {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .page-header,
+  .section-head {
+    display: grid;
+  }
+
+  .panel {
+    padding: 14px;
+  }
+}

--- a/docs/superpowers/spikes/map-stack/tsconfig.json
+++ b/docs/superpowers/spikes/map-stack/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": false,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "worker"]
+}

--- a/docs/superpowers/spikes/map-stack/worker/tiles.ts
+++ b/docs/superpowers/spikes/map-stack/worker/tiles.ts
@@ -1,0 +1,187 @@
+import {
+  Compression,
+  EtagMismatch,
+  PMTiles,
+  ResolvedValueCache,
+  TileType
+} from "pmtiles";
+import type { RangeResponse, Source } from "pmtiles";
+
+interface Env {
+  readonly BUCKET: R2BucketLike;
+}
+
+interface R2BucketLike {
+  get(key: string, options: R2GetOptions): Promise<R2ObjectBodyLike | null>;
+}
+
+interface R2GetOptions {
+  readonly range: { readonly offset: number; readonly length: number };
+  readonly onlyIf?: { readonly etagMatches: string };
+}
+
+interface R2ObjectBodyLike {
+  readonly etag: string;
+  readonly body: ReadableStream | null;
+  readonly httpMetadata?: {
+    readonly cacheControl?: string;
+    readonly cacheExpiry?: Date;
+  };
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+interface WorkerContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+interface TileRequest {
+  readonly z: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+const ARCHIVE_KEY = "tiles/uji-kyoto.pmtiles";
+const ALLOWED_ORIGINS = new Set(["http://localhost:5173", "http://127.0.0.1:5173"]);
+const CACHE_CONTROL = "public, max-age=86400";
+
+class KeyNotFoundError extends Error {}
+
+const edgeCache = (): Cache => {
+  return (caches as CacheStorage & { readonly default: Cache }).default;
+};
+
+const nativeDecompress = async (
+  buffer: ArrayBuffer,
+  compression: Compression
+): Promise<ArrayBuffer> => {
+  if (compression === Compression.None || compression === Compression.Unknown) {
+    return buffer;
+  }
+  if (compression !== Compression.Gzip) {
+    throw new Error("Compression method not supported");
+  }
+  const stream = new Response(buffer).body?.pipeThrough(new DecompressionStream("gzip"));
+  if (!stream) {
+    throw new Error("Unable to decompress PMTiles bytes");
+  }
+  return new Response(stream).arrayBuffer();
+};
+
+const sharedCache = new ResolvedValueCache(25, undefined, nativeDecompress);
+
+class R2Source implements Source {
+  constructor(private readonly env: Env) {}
+
+  getKey(): string {
+    return ARCHIVE_KEY;
+  }
+
+  async getBytes(
+    offset: number,
+    length: number,
+    _signal?: AbortSignal,
+    etag?: string
+  ): Promise<RangeResponse> {
+    const options: R2GetOptions = {
+      range: { offset, length },
+      ...(etag ? { onlyIf: { etagMatches: etag } } : {})
+    };
+    const response = await this.env.BUCKET.get(ARCHIVE_KEY, options);
+    if (!response) {
+      throw new KeyNotFoundError("Archive not found");
+    }
+    if (!response.body) {
+      throw new EtagMismatch();
+    }
+    return {
+      data: await response.arrayBuffer(),
+      etag: response.etag,
+      cacheControl: response.httpMetadata?.cacheControl,
+      expires: response.httpMetadata?.cacheExpiry?.toISOString()
+    };
+  }
+}
+
+const parseTile = (pathname: string): TileRequest | null => {
+  const match = /^\/tiles\/(\d+)\/(\d+)\/(\d+)\.mvt$/.exec(pathname);
+  if (!match) {
+    return null;
+  }
+  return {
+    z: Number(match[1]),
+    x: Number(match[2]),
+    y: Number(match[3])
+  };
+};
+
+const corsHeaders = (request: Request): Headers => {
+  const headers = new Headers({ Vary: "Origin" });
+  const origin = request.headers.get("Origin");
+  if (origin && ALLOWED_ORIGINS.has(origin)) {
+    headers.set("Access-Control-Allow-Origin", origin);
+  }
+  return headers;
+};
+
+const cachedResponse = async (
+  request: Request,
+  ctx: WorkerContext,
+  body: ArrayBuffer | string | undefined,
+  status: number
+): Promise<Response> => {
+  const headers = corsHeaders(request);
+  headers.set("Cache-Control", CACHE_CONTROL);
+  if (status === 200) {
+    headers.set("Content-Type", "application/x-protobuf");
+  }
+  const response = new Response(body, { status, headers });
+  ctx.waitUntil(edgeCache().put(request.url, response.clone()));
+  return response;
+};
+
+const handleGet = async (request: Request, env: Env, ctx: WorkerContext): Promise<Response> => {
+  const tile = parseTile(new URL(request.url).pathname);
+  if (!tile) {
+    return new Response("Not found", { status: 404, headers: corsHeaders(request) });
+  }
+
+  const cached = await edgeCache().match(request.url);
+  if (cached) {
+    const headers = new Headers(cached.headers);
+    corsHeaders(request).forEach((value, key) => headers.set(key, value));
+    return new Response(cached.body, { status: cached.status, headers });
+  }
+
+  const archive = new PMTiles(new R2Source(env), sharedCache, nativeDecompress);
+  const header = await archive.getHeader();
+  if (tile.z < header.minZoom || tile.z > header.maxZoom) {
+    return cachedResponse(request, ctx, undefined, 204);
+  }
+  if (header.tileType !== TileType.Mvt) {
+    return cachedResponse(request, ctx, "Archive is not MVT", 400);
+  }
+
+  const data = await archive.getZxy(tile.z, tile.x, tile.y);
+  return data ? cachedResponse(request, ctx, data.data, 200) : cachedResponse(request, ctx, undefined, 204);
+};
+
+export default {
+  // Mirrors the official Protomaps worker shape:
+  // https://github.com/protomaps/PMTiles/tree/main/serverless/cloudflare
+  async fetch(request: Request, env: Env, ctx: WorkerContext): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return new Response(undefined, { status: 204, headers: corsHeaders(request) });
+    }
+    if (request.method !== "GET") {
+      return new Response("Method not allowed", { status: 405, headers: corsHeaders(request) });
+    }
+    try {
+      return await handleGet(request, env, ctx);
+    } catch (error: unknown) {
+      if (error instanceof KeyNotFoundError) {
+        return new Response("Archive not found", { status: 404, headers: corsHeaders(request) });
+      }
+      throw error;
+    }
+  }
+};

--- a/docs/superpowers/spikes/map-stack/worker/wrangler.toml
+++ b/docs/superpowers/spikes/map-stack/worker/wrangler.toml
@@ -1,0 +1,7 @@
+name = "map-spike-tiles"
+main = "tiles.ts"
+compatibility_date = "2026-07-01"
+
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "seichijunrei-assets-dev"


### PR DESCRIPTION
Refs #237

## What

**S0.4 地图栈选型:ADR + 风险验证 spike。** X1 既定方向(MapLibre GL + Protomaps pmtiles on R2,Mapbox 禁用)经完整调研与可运行 spike 验证后确认。

- `docs/adr/0001-map-stack-maplibre-protomaps.md` — 简版决策记录,依 spec 建立 `docs/adr/` 目录(修复 report C「无统一 ADR 目录」缺口)
- `docs/superpowers/specs/2026-07-11-map-stack-adr.md` — 调研全文:引擎/tile 供应双层决策矩阵(8 维加权)、被 block 五 story(S1.4/S1.5/S2.2/S5.2/S6.2)+ 离线伏笔(S3.6/S3.10)的需求映射、分阶段策略(静态卡→交互→离线)、实测体积/成本账、风险表、全部来源链接
- `docs/superpowers/spikes/map-stack/` — 独立 Vite+TS spike(**不依赖 apps/web**,自带 npm lockfile,不入 pnpm workspace)

## 决策要点

| 层 | 决定 |
|---|---|
| 引擎 | MapLibre GL JS v5(BSD-3,无 key,无按 load 计费) |
| Tile 供应 | Protomaps 日构建 → `pmtiles extract` 日本区域 → **自托管 R2**;OpenFreeMap 为应急后备;MapTiler 不采(free tier 禁商用);Google 被离线需求一票否决 |
| 服务形状 | edge worker 新增 `/tiles/{z}/{x}/{y}.mvt` ZXY 端点(Protomaps 官方 worker 逻辑,与现有 `/img/*` proxy+cache 同构) |
| 静态层 | 插画+SVG 秒出 → idle 时 non-interactive GL 静默 hydrate → 点击升格;任何 tile 故障停留插画层 |
| 离线 | 同一 PMTiles 基建:SW 预取 ZXY / `FileSource` 区域包(pmtiles 内建) |
| 日语 | `@protomaps/basemaps` `lang:'ja'` + MapLibre 内建 CJK |

**成本实测**:宇治·京都 z0-15 extract = 20.4MB/25s;日本全域 z15 估算 ≤2.4GB → **R2 免费层内,存储 $0,egress $0**。

## Spike 验证(真 Chrome QA 全过)

- 静态卡三态渐进 + 故障停留插画层(S0.4 AC3 语义)✅
- 飞出覆盖区 → 纯背景色,零碎 tile(AC2 语义)✅
- 离线 FileSource(Blob→全离线渲染,Walk mode 伏笔)✅
- `/tiles/*` worker on 本地 R2 模拟(wrangler `--local`,无需真桶):in-bbox 200(71,463B protobuf)/out-of-coverage 204/CORS ✅;浏览器 worker 模式实测 6 tile 全 200 ✅
- 日文标注(明星町一丁目/宇治市/志津川…)✅;console 零错误零警告 ✅
- 无 WebGL 的 headless 环境按 D4 停留插画层(实证降级链;E2E 需 SwiftShader 浏览器)

运行方式见 spike README(`npm ci && npm run dev`;worker:`npm run worker:seed && npm run worker:dev`)。

## Scope & Secrets

- **不碰产品代码**:apps/、workers/、根 worker/、根 wrangler.toml 零改动(apps/web 由 S0.2 并行建设)。apps/web 内 demo route + 生产 `[[r2_buckets]]` + `perf-mobile-cold` 正式测量 = S0.2 合流后的后续接线(见 issue #237 评论)
- **零 secret**:全程无 API key(这正是选型卖点之一);spike 的 wrangler 仅 `--local` 模拟
- spike 的 `index.html` 受根 `.gitignore` 的 `*.html` 规则误伤,已在 spike 局部 .gitignore 加 `!index.html` 反选(未动根配置)

🤖 Generated with [Claude Code](https://claude.com/claude-code)