### PR TITLE
feat(edge): local JWT verification + Neon Auth dual-issuer readiness (no cutover)

### DIFF
--- a/docs/ops/cloudflare-hardening.md
+++ b/docs/ops/cloudflare-hardening.md
@@ -36,7 +36,7 @@ Two credential types, both validated at the Worker edge:
 
 | Credential | Format | Validation |
 |---|---|---|
-| Human JWT | `Bearer <supabase_jwt>` | `validateJwt()` calls Supabase `/auth/v1/user` with `SUPABASE_ANON_KEY` |
+| Human JWT | `Bearer <supabase_jwt>` | `authenticate()` verifies the signature locally against the Supabase JWKS (ES256/RS256 via jose `createRemoteJWKSet`), checking issuer/audience/exp — no `/auth/v1/user` round-trip. Flag-gated Neon Auth (EdDSA) issuer is off by default. |
 | Agent API key | `Bearer sk_<hex>` | `validateApiKey()` SHA-256 hashes the key, looks up `api_keys` table via Supabase REST with `SUPABASE_SERVICE_ROLE_KEY` |
 
 On success the Worker sets `X-User-Id` and `X-User-Type`, deletes the `Authorization` header, and forwards to the container. The container never sees raw bearer tokens.
@@ -45,9 +45,9 @@ On success the Worker sets `X-User-Id` and `X-User-Type`, deletes the `Authoriza
 
 | Variable | Boundary | Notes |
 |---|---|---|
-| `SUPABASE_URL` | Worker-only | Used for JWT validation and API-key lookup |
-| `SUPABASE_ANON_KEY` | Worker-only | Passed as `apikey` header to Supabase auth |
+| `SUPABASE_URL` | Worker-only | JWKS fetch (`/auth/v1/.well-known/jwks.json`) for local JWT verification + `api_keys` lookup |
 | `SUPABASE_SERVICE_ROLE_KEY` | Worker-only | Used for `api_keys` table lookup |
+| `NEON_AUTH_ENABLED` / `NEON_AUTH_JWKS_URL` / `NEON_AUTH_ISSUER` | Worker-only (optional) | Dual-issuer readiness — Neon Auth EdDSA JWKS verification; absent or `false` ⇒ Neon path off (default) |
 | `SUPABASE_DB_URL` | Container-only | Direct Postgres connection for asyncpg |
 | `GEMINI_API_KEY` | Container-only | LLM provider credential |
 | `ANITABI_API_URL` | Container-only | Pilgrimage data API |
@@ -62,7 +62,7 @@ The full container env allowlist is defined in `worker/worker.js` as `CONTAINER_
 ## Current Trust Boundary
 
 - Browser and API clients talk only to the Worker hostname
-- Worker-only auth secrets stay at the edge: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
+- Worker-only auth secrets stay at the edge: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` (+ optional `NEON_AUTH_*`); the edge JWT path verifies against the public Supabase JWKS, so no `SUPABASE_ANON_KEY` is needed there
 - Container runtime receives only its explicit allowlist from `worker/worker.js`
 - Backend auth trust starts from `X-User-Id` and `X-User-Type`, not from raw bearer tokens
 

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -42,18 +42,19 @@ The deployment target stays intentionally thin. The Worker owns routing and edge
 | Layer | Responsibility | Secrets/config it should see |
 |---|---|---|
 | Frontend build | Static export only | `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` |
-| Worker edge | Route match, JWT/API-key auth, identity injection | `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` |
+| Worker edge | Route match, JWT/API-key auth, identity injection | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` (+ optional `NEON_AUTH_*`) |
 | Container runtime | Backend service, DB, model/provider calls | `SUPABASE_DB_URL`, `GEMINI_API_KEY`, `ANITABI_API_URL`, `CORS_ALLOWED_ORIGIN`, optional observability keys |
 
 Current hardening rule: the Worker strips the raw `Authorization` header before proxying and forwards only trusted `X-User-Id` / `X-User-Type` identity headers to the container.
 
 ## Auth Flow
 
-Worker auth is implemented in `worker/worker.js`:
+Worker auth is implemented in `worker/auth.ts`:
 
-- JWT flow: `validateJwt()` calls `SUPABASE_URL/auth/v1/user` with `SUPABASE_ANON_KEY`
-- API key flow: `validateApiKey()` hashes the presented `sk_*` token and looks it up through Supabase REST using `SUPABASE_SERVICE_ROLE_KEY`
-- Forwarding flow: the Worker injects `X-User-Id` and `X-User-Type`, deletes `Authorization`, and proxies the request to `CONTAINER`
+- JWT flow: `authenticate()` verifies the token signature locally against the issuer JWKS (jose `createRemoteJWKSet`, cached per isolate) — no per-request `/auth/v1/user` round-trip. Supabase tokens verify as ES256/RS256 against `SUPABASE_URL/auth/v1/.well-known/jwks.json` (issuer `SUPABASE_URL/auth/v1`, audience `authenticated`, `exp` checked); the injected `X-User-Id` is the token `sub`.
+- Dual-issuer readiness: a flag-gated Neon Auth (Better Auth, EdDSA) verification path exists but is OFF by default — active only when `NEON_AUTH_ENABLED=true` and both `NEON_AUTH_JWKS_URL` and `NEON_AUTH_ISSUER` are set. Tokens route by `alg`/`iss`, so Supabase and Neon issuers coexist without a cutover.
+- API key flow: `authenticate()` hashes the presented `sk_*` token and looks it up through Supabase REST using `SUPABASE_SERVICE_ROLE_KEY` (unchanged)
+- Forwarding flow: the Worker injects `X-User-Id` and `X-User-Type`, deletes `Authorization`, and proxies the request to `CONTAINER` (unchanged)
 
 Auth expectations:
 
@@ -82,10 +83,10 @@ Default bind settings:
 Required at deploy time:
 
 - `SUPABASE_URL`
-- `SUPABASE_ANON_KEY`
 - `SUPABASE_SERVICE_ROLE_KEY`
+- optional: `NEON_AUTH_ENABLED`, `NEON_AUTH_JWKS_URL`, `NEON_AUTH_ISSUER` (dual-issuer readiness; leave unset to keep the Neon path off)
 
-These secrets stay in the Worker environment and are not forwarded into the container runtime.
+These secrets stay in the Worker environment and are not forwarded into the container runtime. `SUPABASE_ANON_KEY` is no longer required at the edge — the JWT path verifies against the public Supabase JWKS and sends no `apikey` header.
 
 ### Container runtime
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build:frontend": "pnpm --filter ./frontend run build",
     "deploy": "pnpm run build:frontend && npx wrangler deploy",
-    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts"
+    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",
-    "hono": "^4.9.10"
+    "hono": "^4.9.10",
+    "jose": "^6.2.3"
   },
   "pnpm": {
     "overrides": {
@@ -27,5 +28,9 @@
       "@vitest/expect": "4.1.9",
       "@vitest/spy": "4.1.9"
     }
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260623.1",
+    "@types/node": "^26.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,16 @@ importers:
       hono:
         specifier: '>=4.12.16'
         version: 4.12.27
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260623.1
+        version: 4.20260623.1
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
 
   apps/web:
     dependencies:
@@ -34,7 +44,7 @@ importers:
         version: 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start':
         specifier: ^1.168.27
-        version: 1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       animal-island-ui-tailwind:
         specifier: ^1.0.16
         version: 1.0.16(a9fad26973e5ea2f6d915e0f2906791d)
@@ -50,10 +60,10 @@ importers:
         version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
       '@tailwindcss/vite':
         specifier: ^4.3.2
-        version: 4.3.2(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.2(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/nitro-v2-vite-plugin':
         specifier: ^1.155.0
-        version: 1.155.0(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260623.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.0.3)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.155.0(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260623.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.0.3)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -65,7 +75,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 5.2.0(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/coverage-istanbul':
         specifier: 4.1.9
         version: 4.1.9(vitest@4.1.9)
@@ -86,10 +96,10 @@ importers:
         version: 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^7.3.6
-        version: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
         specifier: ^4.110.0
         version: 4.110.0(@cloudflare/workers-types@4.20260623.1)
@@ -122,7 +132,7 @@ importers:
         version: 3.2.2(react@19.2.7)
       '@opennextjs/cloudflare':
         specifier: ^1.19.8
-        version: 1.19.11(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(wrangler@4.110.0)
+        version: 1.19.11(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(wrangler@4.110.0(@cloudflare/workers-types@4.20260623.1))
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -370,7 +380,7 @@ importers:
         version: 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
         specifier: ^4.103.0
         version: 4.103.0(@cloudflare/workers-types@4.20260623.1)
@@ -3710,6 +3720,9 @@ packages:
 
   '@types/node@25.9.4':
     resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
+
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -7770,6 +7783,9 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -9307,7 +9323,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 4.20260623.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler: 4.104.0(@cloudflare/workers-types@4.20260623.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -9818,6 +9834,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.4
 
+  '@inquirer/confirm@6.1.1(@types/node@26.1.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
+    optionalDependencies:
+      '@types/node': 26.1.1
+    optional: true
+
   '@inquirer/core@11.2.1(@types/node@25.9.4)':
     dependencies:
       '@inquirer/ansi': 2.0.7
@@ -9830,11 +9854,29 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.4
 
+  '@inquirer/core@11.2.1(@types/node@26.1.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 26.1.1
+    optional: true
+
   '@inquirer/figures@2.0.7': {}
 
   '@inquirer/type@4.0.7(@types/node@25.9.4)':
     optionalDependencies:
       '@types/node': 25.9.4
+
+  '@inquirer/type@4.0.7(@types/node@26.1.1)':
+    optionalDependencies:
+      '@types/node': 26.1.1
+    optional: true
 
   '@ioredis/commands@1.10.0': {}
 
@@ -10106,7 +10148,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opennextjs/cloudflare@1.19.11(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(wrangler@4.110.0)':
+  '@opennextjs/cloudflare@1.19.11(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(wrangler@4.110.0(@cloudflare/workers-types@4.20260623.1))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
@@ -11594,20 +11636,20 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.1
 
-  '@tailwindcss/vite@4.3.2(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.2(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.2
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@tanstack/history@1.162.0': {}
 
-  '@tanstack/nitro-v2-vite-plugin@1.155.0(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260623.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.0.3)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/nitro-v2-vite-plugin@1.155.0(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260623.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.0.3)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      nitropack: 2.13.4(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260623.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.0.3)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      nitropack: 2.13.4(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260623.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.0.3)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       pathe: 2.0.3
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11663,14 +11705,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@tanstack/react-start-rsc@0.1.26(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.26(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-core': 1.171.14
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.13
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.16
       '@tanstack/start-storage-context': 1.167.16
       pathe: 2.0.3
@@ -11700,21 +11742,21 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start-client': 1.168.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/react-start-rsc': 0.1.26(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/react-start-rsc': 0.1.26(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.13
-      '@tanstack/start-plugin-core': 1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.16
       pathe: 2.0.3
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -11762,7 +11804,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/template': 7.29.7
@@ -11771,11 +11813,11 @@ snapshots:
       '@tanstack/router-generator': 1.167.18
       '@tanstack/router-utils': 1.162.2
       chokidar: 5.0.0
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -11808,14 +11850,14 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.14
       '@tanstack/router-generator': 1.167.18
-      '@tanstack/router-plugin': 1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/router-plugin': 1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-server-core': 1.169.16
       exsolve: 1.1.0
@@ -11827,11 +11869,11 @@ snapshots:
       srvx: 0.11.21
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      vitefu: 1.1.3(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitefu: 1.1.3(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
       zod: 4.4.3
     optionalDependencies:
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -12008,6 +12050,10 @@ snapshots:
   '@types/node@25.9.4':
     dependencies:
       undici-types: 7.24.6
+
+  '@types/node@26.1.1':
+    dependencies:
+      undici-types: 8.3.0
 
   '@types/pg@8.20.0':
     dependencies:
@@ -12319,7 +12365,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -12327,7 +12373,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12348,7 +12394,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -12364,7 +12410,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -12375,24 +12421,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.14.6(@types/node@25.9.4)(typescript@5.9.3)
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.9(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.14.6(@types/node@25.9.4)(typescript@5.9.3)
-      vite: 8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
-
   '@vitest/mocker@4.1.9(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
@@ -12401,6 +12429,24 @@ snapshots:
     optionalDependencies:
       msw: 2.14.6(@types/node@25.9.4)(typescript@6.0.3)
       vite: 8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.9(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@26.1.1)(typescript@5.9.3)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.9(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@26.1.1)(typescript@5.9.3)
+      vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -13394,7 +13440,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -13427,7 +13473,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -13441,7 +13487,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15139,32 +15185,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3):
-    dependencies:
-      '@inquirer/confirm': 6.1.1(@types/node@25.9.4)
-      '@mswjs/interceptors': 0.41.9
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.14.2
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.7.0
-      until-async: 3.0.2
-      yargs: 17.7.3
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
   msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 6.1.1(@types/node@25.9.4)
@@ -15189,6 +15209,32 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
+
+  msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.1.1(@types/node@26.1.1)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.7.0
+      until-async: 3.0.2
+      yargs: 17.7.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
 
   mute-stream@3.0.0: {}
 
@@ -15226,7 +15272,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.13.4(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260623.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.0.3)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
+  nitropack@2.13.4(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260623.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.0.3)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.2)
@@ -15291,7 +15337,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.127.0)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.127.0)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       unplugin-utils: 0.3.2
       unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260623.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)))(ioredis@5.11.1)
       untyped: 2.0.0
@@ -16821,6 +16867,8 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  undici-types@8.3.0: {}
+
   undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
@@ -16841,7 +16889,7 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unimport@6.3.0(esbuild@0.28.1)(oxc-parser@0.127.0)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
+  unimport@6.3.0(esbuild@0.28.1)(oxc-parser@0.127.0)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       acorn: 8.17.0
       escape-string-regexp: 5.0.0
@@ -16855,7 +16903,7 @@ snapshots:
       scule: 1.3.0
       strip-literal: 3.1.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       unplugin-utils: 0.3.2
     optionalDependencies:
       oxc-parser: 0.127.0
@@ -16916,7 +16964,7 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
+  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
@@ -16925,7 +16973,7 @@ snapshots:
       esbuild: 0.28.1
       rolldown: 1.0.3
       rollup: 4.62.2
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
   unrs-resolver@1.12.2:
     dependencies:
@@ -17058,7 +17106,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -17067,7 +17115,7 @@ snapshots:
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 25.9.4
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
@@ -17091,9 +17139,25 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
     optionalDependencies:
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      '@types/node': 26.1.1
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.49.0
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  vitefu@1.1.3(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
   vitest-axe@0.1.0(vitest@4.1.9):
     dependencies:
@@ -17104,68 +17168,6 @@ snapshots:
       lodash-es: 4.18.1
       redent: 3.0.0
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
-
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 25.9.4
-      '@vitest/coverage-istanbul': 4.1.9(vitest@4.1.9)
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
-      jsdom: 29.1.1(@noble/hashes@1.8.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 25.9.4
-      '@vitest/coverage-istanbul': 4.1.9(vitest@4.1.9)
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
-      jsdom: 29.1.1(@noble/hashes@1.8.0)
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
@@ -17192,6 +17194,68 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.4
+      '@vitest/coverage-istanbul': 4.1.9(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      jsdom: 29.1.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.1
+      '@vitest/coverage-istanbul': 4.1.9(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      jsdom: 29.1.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.1
       '@vitest/coverage-istanbul': 4.1.9(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
       jsdom: 29.1.1(@noble/hashes@1.8.0)

--- a/worker/auth-neon.test.ts
+++ b/worker/auth-neon.test.ts
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { authenticate } from "./auth.ts";
+
+const BASE_ENV = { SUPABASE_URL: "https://sb-neon-base.example.test", SUPABASE_SERVICE_ROLE_KEY: "service" };
+
+function stubFetch(handler: (url: string, init?: RequestInit) => Response, urls: string[] = []): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    urls.push(String(input));
+    return handler(String(input), init);
+  }) as unknown as typeof fetch;
+}
+
+function bearer(token: string): Request {
+  return new Request("https://app-neon.example.test/v1/chat", { headers: { Authorization: `Bearer ${token}` } });
+}
+
+async function fixture(alg: "EdDSA" | "ES256", issuer: string, audience = issuer, exp: string | number = "15m") {
+  const { publicKey, privateKey } = await generateKeyPair(alg, { extractable: true });
+  const jwk = { ...await exportJWK(publicKey), kid: `fake-${alg.toLowerCase()}-key` };
+  const token = await new SignJWT({ email: "fake@example.test" }).setProtectedHeader({ alg, kid: jwk.kid })
+    .setIssuer(issuer).setAudience(audience).setSubject("fake-neon-user").setIssuedAt().setExpirationTime(exp).sign(privateKey);
+  return { jwk, token };
+}
+
+function jwks(jwk: JsonWebKey): Response {
+  return new Response(JSON.stringify({ keys: [jwk] }), { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+function neonEnv(host: string) {
+  return { ...BASE_ENV, NEON_AUTH_ENABLED: "true", NEON_AUTH_JWKS_URL: `${host}/.well-known/jwks.json`, NEON_AUTH_ISSUER: host };
+}
+
+test("flag absent rejects EdDSA without fetching Neon JWKS", async () => {
+  const host = "https://neon-absent.example.test";
+  const { token } = await fixture("EdDSA", host);
+  const urls: string[] = [];
+  const r = await authenticate(bearer(token), BASE_ENV, stubFetch(() => new Response("", { status: 500 }), urls));
+  assert.deepEqual(r, { ok: false });
+  assert.equal(urls.includes(`${host}/.well-known/jwks.json`), false);
+});
+
+test("false flag rejects EdDSA without fetching Neon JWKS", async () => {
+  const host = "https://neon-disabled.example.test";
+  const { token } = await fixture("EdDSA", host);
+  const urls: string[] = [];
+  const env = { ...neonEnv(host), NEON_AUTH_ENABLED: "false" };
+  const r = await authenticate(bearer(token), env, stubFetch(() => new Response("", { status: 500 }), urls));
+  assert.deepEqual(r, { ok: false });
+  assert.equal(urls.includes(env.NEON_AUTH_JWKS_URL), false);
+});
+
+test("enabled Neon accepts a valid EdDSA token", async () => {
+  const host = "https://neon-valid.example.test";
+  const { jwk, token } = await fixture("EdDSA", host);
+  const r = await authenticate(bearer(token), neonEnv(host), stubFetch(() => jwks(jwk)));
+  assert.deepEqual(r, { ok: true, userId: "fake-neon-user", userType: "human" });
+});
+
+test("enabled Neon rejects wrong issuer", async () => {
+  const host = "https://neon-wrong-issuer.example.test";
+  const { jwk, token } = await fixture("EdDSA", "https://neon-other-issuer.example.test", host);
+  const r = await authenticate(bearer(token), neonEnv(host), stubFetch(() => jwks(jwk)));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("enabled Neon rejects expired token", async () => {
+  const host = "https://neon-expired.example.test";
+  const { jwk, token } = await fixture("EdDSA", host, host, Math.floor(Date.now() / 1000) - 60);
+  const r = await authenticate(bearer(token), neonEnv(host), stubFetch(() => jwks(jwk)));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("enabled Neon rejects wrong audience", async () => {
+  const host = "https://neon-wrong-audience.example.test";
+  const { jwk, token } = await fixture("EdDSA", host, "https://neon-other-audience.example.test");
+  const r = await authenticate(bearer(token), neonEnv(host), stubFetch(() => jwks(jwk)));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("enabled Neon rejects signature from another key", async () => {
+  const host = "https://neon-bad-signature.example.test";
+  const trusted = await fixture("EdDSA", host);
+  const untrusted = await fixture("EdDSA", host);
+  const r = await authenticate(bearer(untrusted.token), neonEnv(host), stubFetch(() => jwks(trusted.jwk)));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("enabled Neon coexists with Supabase", async () => {
+  const neonHost = "https://neon-dual.example.test";
+  const sbHost = "https://sb-dual.example.test";
+  const neon = await fixture("EdDSA", neonHost);
+  const sb = await fixture("ES256", `${sbHost}/auth/v1`, "authenticated", "1h");
+  const env = { ...neonEnv(neonHost), SUPABASE_URL: sbHost };
+  const urls: string[] = [];
+  const fetcher = stubFetch((url) => jwks(url === env.NEON_AUTH_JWKS_URL ? neon.jwk : sb.jwk), urls);
+  const sbResult = await authenticate(bearer(sb.token), env, fetcher);
+  const neonResult = await authenticate(bearer(neon.token), env, fetcher);
+  assert.deepEqual(sbResult, { ok: true, userId: "fake-neon-user", userType: "human" });
+  assert.deepEqual(neonResult, { ok: true, userId: "fake-neon-user", userType: "human" });
+  assert.deepEqual(urls, [`${sbHost}/auth/v1/.well-known/jwks.json`, env.NEON_AUTH_JWKS_URL]);
+});
+
+test("enabled Neon without JWKS URL rejects without throwing", async () => {
+  const host = "https://neon-missing-jwks.example.test";
+  const { token } = await fixture("EdDSA", host);
+  const env = { ...BASE_ENV, NEON_AUTH_ENABLED: "true", NEON_AUTH_ISSUER: host };
+  const r = await authenticate(bearer(token), env, stubFetch(() => new Response("", { status: 500 })));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("sk_ token still uses api_keys when Neon is enabled", async () => {
+  const host = "https://neon-api-key.example.test";
+  const r = await authenticate(bearer("sk_fake_neon"), neonEnv(host), stubFetch((url) =>
+    url.includes("select=user_id") ? new Response(JSON.stringify([{ user_id: "fake-agent" }]), { status: 200 }) : new Response("", { status: 200 })));
+  assert.deepEqual(r, { ok: true, userId: "fake-agent", userType: "agent" });
+});

--- a/worker/auth.test.ts
+++ b/worker/auth.test.ts
@@ -16,11 +16,11 @@ function bearer(token: string): Request {
   return new Request("https://app.example.test/v1/chat", { headers: { Authorization: `Bearer ${token}` } });
 }
 
-async function esFixture(host: string, issuer = `${host}/auth/v1`, exp: string | number = "1h") {
+async function esFixture(host: string, issuer = `${host}/auth/v1`, exp: string | number = "1h", aud = "authenticated") {
   const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
   const jwk = { ...await exportJWK(publicKey), kid: "fake-es-key" };
   const token = await new SignJWT({}).setProtectedHeader({ alg: "ES256", kid: jwk.kid })
-    .setIssuer(issuer).setAudience("authenticated").setSubject("fake-user").setIssuedAt().setExpirationTime(exp).sign(privateKey);
+    .setIssuer(issuer).setAudience(aud).setSubject("fake-user").setIssuedAt().setExpirationTime(exp).sign(privateKey);
   return { jwk, token };
 }
 
@@ -72,6 +72,13 @@ test("wrong Supabase issuer is rejected", async () => {
   assert.deepEqual(r, { ok: false });
 });
 
+test("wrong Supabase audience is rejected", async () => {
+  const host = "https://sb-wrong-aud.example.test";
+  const { jwk, token } = await esFixture(host, undefined, "1h", "wrong-aud");
+  const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
+  assert.deepEqual(r, { ok: false });
+});
+
 test("ES256 token signed by another key is rejected", async () => {
   const host = "https://sb-bad-signature.example.test";
   const trusted = await esFixture(host);
@@ -80,12 +87,27 @@ test("ES256 token signed by another key is rejected", async () => {
   assert.deepEqual(r, { ok: false });
 });
 
-test("HS256 token is rejected", async () => {
+test("HS256 token is rejected even with a healthy JWKS", async () => {
   const host = "https://sb-hs256.example.test";
-  const token = await new SignJWT({}).setProtectedHeader({ alg: "HS256", kid: "fake-hs-key" })
+  const { publicKey } = await generateKeyPair("ES256", { extractable: true });
+  const jwk = { ...await exportJWK(publicKey), kid: "fake-es-key" };
+  const token = await new SignJWT({}).setProtectedHeader({ alg: "HS256", kid: jwk.kid })
     .setIssuer(`${host}/auth/v1`).setAudience("authenticated").setSubject("fake-user").setIssuedAt().setExpirationTime("1h")
     .sign(new TextEncoder().encode("fake-secret-with-at-least-32-bytes"));
-  const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => new Response("", { status: 500 })));
+  const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("EdDSA token is rejected by the Supabase algorithm allowlist", async () => {
+  // Guards verifySupabase's algorithms allowlist: this signature verifies against the
+  // served OKP JWKS, so rejection is due ONLY to EdDSA not being allow-listed.
+  // Removing `algorithms: ["ES256","RS256"]` from verifySupabase turns THIS test red.
+  const host = "https://sb-eddsa-confusion.example.test";
+  const { publicKey, privateKey } = await generateKeyPair("EdDSA", { extractable: true });
+  const jwk = { ...await exportJWK(publicKey), kid: "fake-okp-key" };
+  const token = await new SignJWT({}).setProtectedHeader({ alg: "EdDSA", kid: jwk.kid })
+    .setIssuer(`${host}/auth/v1`).setAudience("authenticated").setSubject("fake-user").setIssuedAt().setExpirationTime("1h").sign(privateKey);
+  const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
   assert.deepEqual(r, { ok: false });
 });
 

--- a/worker/auth.test.ts
+++ b/worker/auth.test.ts
@@ -1,51 +1,95 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { authenticate } from "./auth.ts";
 
-const ENV = {
-  SUPABASE_URL: "https://x.supabase.co",
-  SUPABASE_ANON_KEY: "anon",
-  SUPABASE_SERVICE_ROLE_KEY: "service",
-};
+const ENV = { SUPABASE_URL: "https://sb-base.example.test", SUPABASE_SERVICE_ROLE_KEY: "service" };
 
-function stubFetch(handler: (url: string, init?: RequestInit) => Response): typeof fetch {
-  return (async (input: RequestInfo | URL, init?: RequestInit) =>
-    handler(String(input), init)) as unknown as typeof fetch;
+function stubFetch(handler: (url: string, init?: RequestInit) => Response, urls: string[] = []): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    urls.push(String(input));
+    return handler(String(input), init);
+  }) as unknown as typeof fetch;
 }
 
 function bearer(token: string): Request {
-  return new Request("https://app/v1/chat", { headers: { Authorization: `Bearer ${token}` } });
+  return new Request("https://app.example.test/v1/chat", { headers: { Authorization: `Bearer ${token}` } });
+}
+
+async function esFixture(host: string, issuer = `${host}/auth/v1`, exp: string | number = "1h") {
+  const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+  const jwk = { ...await exportJWK(publicKey), kid: "fake-es-key" };
+  const token = await new SignJWT({}).setProtectedHeader({ alg: "ES256", kid: jwk.kid })
+    .setIssuer(issuer).setAudience("authenticated").setSubject("fake-user").setIssuedAt().setExpirationTime(exp).sign(privateKey);
+  return { jwk, token };
+}
+
+function jwks(jwk: JsonWebKey): Response {
+  return new Response(JSON.stringify({ keys: [jwk] }), { status: 200, headers: { "Content-Type": "application/json" } });
 }
 
 test("no Authorization header -> {ok:false}", async () => {
-  const r = await authenticate(new Request("https://app/v1/chat"), ENV, stubFetch(() => new Response("", { status: 200 })));
-  assert.deepEqual(r, { ok: false });
-});
-
-test("valid JWT -> human + userId from /auth/v1/user", async () => {
-  const r = await authenticate(bearer("jwt-token"), ENV, stubFetch((url) => {
-    assert.ok(url.endsWith("/auth/v1/user"));
-    return new Response(JSON.stringify({ id: "user-123" }), { status: 200 });
-  }));
-  assert.deepEqual(r, { ok: true, userId: "user-123", userType: "human" });
-});
-
-test("invalid JWT (upstream !ok) -> {ok:false}", async () => {
-  const r = await authenticate(bearer("bad"), ENV, stubFetch(() => new Response("", { status: 401 })));
+  const r = await authenticate(new Request("https://app.example.test/v1/chat"), ENV, stubFetch(() => new Response("", { status: 200 })));
   assert.deepEqual(r, { ok: false });
 });
 
 test("valid sk_ key -> agent + userId from api_keys", async () => {
-  const r = await authenticate(bearer("sk_live_abc"), ENV, stubFetch((url) => {
+  const r = await authenticate(bearer("sk_fake_valid"), ENV, stubFetch((url) => {
     if (url.includes("/rest/v1/api_keys") && url.includes("select=user_id"))
-      return new Response(JSON.stringify([{ user_id: "agent-9" }]), { status: 200 });
-    return new Response("", { status: 200 }); // PATCH last_used_at best-effort
+      return new Response(JSON.stringify([{ user_id: "fake-agent" }]), { status: 200 });
+    return new Response("", { status: 200 });
   }));
-  assert.deepEqual(r, { ok: true, userId: "agent-9", userType: "agent" });
+  assert.deepEqual(r, { ok: true, userId: "fake-agent", userType: "agent" });
 });
 
 test("unknown sk_ key (no rows) -> {ok:false}", async () => {
-  const r = await authenticate(bearer("sk_nope"), ENV, stubFetch((url) =>
+  const r = await authenticate(bearer("sk_fake_unknown"), ENV, stubFetch((url) =>
     url.includes("/rest/v1/api_keys") ? new Response("[]", { status: 200 }) : new Response("", { status: 200 })));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("valid ES256 token verifies locally", async () => {
+  const host = "https://sb-valid.example.test";
+  const { jwk, token } = await esFixture(host);
+  const urls: string[] = [];
+  const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk), urls));
+  assert.deepEqual(r, { ok: true, userId: "fake-user", userType: "human" });
+  assert.deepEqual(urls, [`${host}/auth/v1/.well-known/jwks.json`]);
+  assert.equal(urls.some((url) => url.endsWith("/auth/v1/user")), false);
+});
+
+test("expired ES256 token is rejected", async () => {
+  const host = "https://sb-expired.example.test";
+  const { jwk, token } = await esFixture(host, `${host}/auth/v1`, Math.floor(Date.now() / 1000) - 60);
+  const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("wrong Supabase issuer is rejected", async () => {
+  const host = "https://sb-wrong-issuer.example.test";
+  const { jwk, token } = await esFixture(host, "https://sb-other-issuer.example.test/auth/v1");
+  const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("ES256 token signed by another key is rejected", async () => {
+  const host = "https://sb-bad-signature.example.test";
+  const trusted = await esFixture(host);
+  const untrusted = await esFixture(host);
+  const r = await authenticate(bearer(untrusted.token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(trusted.jwk)));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("HS256 token is rejected", async () => {
+  const host = "https://sb-hs256.example.test";
+  const token = await new SignJWT({}).setProtectedHeader({ alg: "HS256", kid: "fake-hs-key" })
+    .setIssuer(`${host}/auth/v1`).setAudience("authenticated").setSubject("fake-user").setIssuedAt().setExpirationTime("1h")
+    .sign(new TextEncoder().encode("fake-secret-with-at-least-32-bytes"));
+  const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => new Response("", { status: 500 })));
+  assert.deepEqual(r, { ok: false });
+});
+
+test("garbage token is rejected", async () => {
+  const r = await authenticate(bearer("not-a-jwt"), { ...ENV, SUPABASE_URL: "https://sb-garbage.example.test" }, stubFetch(() => new Response("", { status: 500 })));
   assert.deepEqual(r, { ok: false });
 });

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -1,23 +1,70 @@
 /// <reference types="@cloudflare/workers-types" />
 
+import { createRemoteJWKSet, customFetch, decodeJwt, decodeProtectedHeader, jwtVerify } from "jose";
+
 export type AuthResult =
   | { ok: true; userId: string; userType: "human" | "agent" }
   | { ok: false };
 
 export interface AuthEnv {
   SUPABASE_URL: string;
-  SUPABASE_ANON_KEY: string;
   SUPABASE_SERVICE_ROLE_KEY: string;
+  NEON_AUTH_ENABLED?: string;
+  NEON_AUTH_JWKS_URL?: string;
+  NEON_AUTH_ISSUER?: string;
 }
 
-async function verifyJwt(token: string, env: AuthEnv, f: typeof fetch): Promise<{ ok: true; userId: string } | { ok: false }> {
+const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+function remoteJwks(url: string, f: typeof fetch): ReturnType<typeof createRemoteJWKSet> {
+  const cached = jwksCache.get(url);
+  if (cached) return cached;
+  const jwks = createRemoteJWKSet(new URL(url), { [customFetch]: f });
+  jwksCache.set(url, jwks);
+  return jwks;
+}
+
+function human(sub: unknown): AuthResult {
+  return typeof sub === "string" && sub.length > 0
+    ? { ok: true, userId: sub, userType: "human" }
+    : { ok: false };
+}
+
+async function verifySupabase(token: string, env: AuthEnv, f: typeof fetch): Promise<AuthResult> {
   try {
-    const resp = await f(`${env.SUPABASE_URL}/auth/v1/user`, {
-      headers: { Authorization: `Bearer ${token}`, apikey: env.SUPABASE_ANON_KEY },
+    const jwks = remoteJwks(`${env.SUPABASE_URL}/auth/v1/.well-known/jwks.json`, f);
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: `${env.SUPABASE_URL}/auth/v1`, audience: "authenticated", algorithms: ["ES256", "RS256"],
     });
-    if (!resp.ok) return { ok: false };
-    const user = (await resp.json()) as { id?: string };
-    return user.id ? { ok: true, userId: user.id } : { ok: false };
+    return human(payload.sub);
+  } catch {
+    return { ok: false };
+  }
+}
+
+async function verifyNeon(token: string, env: AuthEnv, f: typeof fetch): Promise<AuthResult> {
+  try {
+    const issuer = env.NEON_AUTH_ISSUER ?? "";
+    const jwks = remoteJwks(env.NEON_AUTH_JWKS_URL ?? "", f);
+    const { payload } = await jwtVerify(token, jwks, { issuer, audience: issuer, algorithms: ["EdDSA"] });
+    return human(payload.sub);
+  } catch {
+    return { ok: false };
+  }
+}
+
+function neonEnabled(env: AuthEnv): boolean {
+  return env.NEON_AUTH_ENABLED === "true"
+    && typeof env.NEON_AUTH_JWKS_URL === "string" && env.NEON_AUTH_JWKS_URL.length > 0
+    && typeof env.NEON_AUTH_ISSUER === "string" && env.NEON_AUTH_ISSUER.length > 0;
+}
+
+async function verifyJwt(token: string, env: AuthEnv, f: typeof fetch): Promise<AuthResult> {
+  try {
+    const header = decodeProtectedHeader(token);
+    const payload = decodeJwt(token);
+    const useNeon = neonEnabled(env) && (header.alg === "EdDSA" || payload.iss === env.NEON_AUTH_ISSUER);
+    return useNeon ? await verifyNeon(token, env, f) : await verifySupabase(token, env, f);
   } catch {
     return { ok: false };
   }
@@ -51,7 +98,7 @@ async function verifyApiKey(rawKey: string, env: AuthEnv, f: typeof fetch, ctx?:
   }
 }
 
-/** Authenticate a /v1 request: `sk_*` -> api_keys (agent), else JWT -> /auth/v1/user (human). */
+/** Authenticate a /v1 request: `sk_*` -> api_keys (agent), else JWT -> issuer JWKS (human). */
 export async function authenticate(request: Request, env: AuthEnv, fetchImpl: typeof fetch = fetch, ctx?: ExecutionContext): Promise<AuthResult> {
   const header = request.headers.get("Authorization") ?? "";
   if (!header.startsWith("Bearer ")) return { ok: false };
@@ -61,6 +108,5 @@ export async function authenticate(request: Request, env: AuthEnv, fetchImpl: ty
     const r = await verifyApiKey(token, env, fetchImpl, ctx);
     return r.ok ? { ok: true, userId: r.userId, userType: "agent" } : { ok: false };
   }
-  const r = await verifyJwt(token, env, fetchImpl);
-  return r.ok ? { ok: true, userId: r.userId, userType: "human" } : { ok: false };
+  return verifyJwt(token, env, fetchImpl);
 }


### PR DESCRIPTION
## What

Edge auth infrastructure slice (F9 + Neon dual-issuer readiness, **no cutover**):

1. **Supabase JWT verification is now local.** `worker/auth.ts` verifies user JWTs against the project JWKS (`jose` `createRemoteJWKSet`, cached per isolate, refetch-on-unknown-kid) instead of a network round-trip to `${SUPABASE_URL}/auth/v1/user` on every authed `/v1/*` request.
2. **Neon Auth (Better Auth) issuer path added, default OFF.** Flag-gated EdDSA verification with kid/iss/aud/exp checks. Tokens are routed by characteristics (header `alg` / `iss` claim): Neon tokens verify against the Neon JWKS, Supabase tokens against the Supabase JWKS — both issuers coexist while the flag is on.
3. `sk_` API-key path: untouched (byte-identical).

## F9 premise verification (done live before implementation, values not committed)

The F9 assumption "Supabase supports asymmetric JWT" was marked [unverified]. Verified against the production project:

- `GET $SUPABASE_URL/auth/v1/.well-known/jwks.json` → HTTP 200 with one active **ES256 (P-256 EC)** signing key.
- A freshly minted user access token has header `{"alg":"ES256","kid":"<matches the JWKS key>"}` and payload `iss = $SUPABASE_URL/auth/v1`, `aud = "authenticated"`, `sub = <user UUID>` (identical to the `id` the old `/auth/v1/user` endpoint returned), ~1h expiry.

**Conclusion: the project signs with asymmetric ES256 today → Plan 1 (local JWKS verification) implemented.** The HS256-shared-secret fallback plan was not needed. HS256 is deliberately excluded from the accepted algorithms (key-confusion guard); legacy HS256 service/anon API keys were never valid on this path.

## Default behavior: zero change

- With today's production env (no `NEON_AUTH_*` vars set), the Neon path is unreachable code — flag defaults to off in code, no config change needed to merge safely.
- `/v1/*` accept/reject semantics, 401 body, and forwarded `X-User-Id`/`X-User-Type` header contract are unchanged. `userId` comes from the token `sub`, which equals the previous `/auth/v1/user` `id`.
- One known tradeoff to disclose (inherent to local verification, industry standard for edge JWT checks): server-side revocation (user deleted/banned, session signed out) is no longer caught mid-lifetime; a revoked token stays valid up to its remaining `exp` (≤1h). Previously the per-request introspection caught it immediately.

## Design notes

- Routing rule: a non-`sk_` bearer token goes to the Neon verifier iff `NEON_AUTH_ENABLED === "true"` AND `NEON_AUTH_JWKS_URL` AND `NEON_AUTH_ISSUER` are set AND (unverified header `alg === "EdDSA"` OR unverified `iss === NEON_AUTH_ISSUER`). Everything else goes to the Supabase verifier. Cross-verification is impossible by construction (per-issuer algorithm allowlists + separate JWKS).
- Supabase verify: `iss = ${SUPABASE_URL}/auth/v1`, `aud = "authenticated"`, algorithms `["ES256","RS256"]`.
- Neon verify: `iss = aud = NEON_AUTH_ISSUER`, algorithms `["EdDSA"]` (kid-resolved via JWKS; 15-min tokens covered by the standard exp check). Shape per `docs/ops/auth-migration-neon.md` §5.
- JWKS fetches go through the existing injected-fetch seam (`jose` `customFetch`), so tests stub the JWKS endpoints with locally generated keypairs — zero real network in the suite.
- `AuthEnv` no longer declares `SUPABASE_ANON_KEY` (only the removed introspection call used it). The Worker secret itself is NOT removed — other consumers (frontend) still use it.

## Tests (16 → 30, all green)

| File | Cases | Covers |
|---|---|---|
| `worker/entry.test.ts` | 11 (unchanged) | routing/header-stripping regression |
| `worker/auth.test.ts` | 9 | no-header, sk_ valid/unknown (regression), valid ES256 local verify (asserts JWKS fetched and `/auth/v1/user` NOT called), expired, wrong iss, wrong signing key, HS256 rejected, garbage token |
| `worker/auth-neon.test.ts` | 10 (new) | flag absent/false (Neon JWKS never fetched), valid EdDSA accept, wrong iss, wrong aud, expired, wrong key, dual-issuer coexistence (each token verified only against its own JWKS), missing JWKS URL no-throw, sk_ regression with flag on |

All token/JWKS fixtures are locally generated per test (`generateKeyPair`/`SignJWT`), unique fake `.example.test` hosts per case, zero real hostnames/ids/secrets anywhere.

## Gates

- `pnpm run test:worker`: **30/30 pass** (Node 24).
- `tsc --noEmit --strict` (es2022 / bundler resolution / workers-types + node): **0 errors**.
- Suppression/`any` grep across changed files: clean (no `any`, no `eslint-disable`, no `@ts-*` suppressions).
- eslint: the repo defines no lint surface for `worker/` (frontend flat config ignores files outside its base path; no typescript-eslint in the workspace). CI parity gate for this directory is `test:worker`.

## Integration notes (for the wrangler.toml owner — no toml change required to merge)

This PR intentionally does not touch `wrangler.toml`. The code treats missing vars as "Neon path off", so merging is safe with zero config changes. At cutover (S0.6/S0.8) add to the Worker env (values operator-side only, never committed):

- `NEON_AUTH_ENABLED = "true"` — flips the dual-issuer routing on
- `NEON_AUTH_JWKS_URL` — `<neon auth base URL>/.well-known/jwks.json`
- `NEON_AUTH_ISSUER` — the Neon Auth base URL (checked as both `iss` and `aud`)

Dependency changes at workspace root: `jose` ^6.2.3 (runtime), `@cloudflare/workers-types` + `@types/node` (dev, for the tsc gate).

## Deferred to cutover (S0.6/S0.8 — out of scope here)

- Set the three `NEON_AUTH_*` vars and flip the flag.
- apps/web login UI on the Better Auth client SDK; retire `scripts/qa_auth.py` / `qa_login.sh` with the Supabase login path.
- Supabase retirement checklist in `docs/ops/auth-migration-neon.md` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
