### PR TITLE
test(agent): SD-3① cross-DB regression lock + web_search exception gap (S1.7 infra slice)

### DIFF
--- a/apps/agent/agent/agents/web_tools.py
+++ b/apps/agent/agent/agents/web_tools.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import asyncio
 from typing import cast
 
+import httpx
+from ddgs.exceptions import DDGSException
 from pydantic_ai import RunContext
 from pydantic_ai.common_tools.duckduckgo import (
     DuckDuckGoResult,
@@ -26,6 +28,13 @@ from agent.agents.runtime_deps import RuntimeDeps
 from agent.agents.translation import TranslationResult, translate_title
 
 _ddg_tool = duckduckgo_search_tool(max_results=5)
+_SEARCH_ERRORS: tuple[type[Exception], ...] = (
+    TimeoutError,
+    OSError,
+    RuntimeError,
+    httpx.HTTPError,
+    DDGSException,
+)
 
 
 async def _run_ddg_search(query: str) -> list[DuckDuckGoResult]:
@@ -88,7 +97,7 @@ async def web_search(
         raw_results = await asyncio.wait_for(
             _run_configured_search(ctx.deps, query), timeout=10.0
         )
-    except (TimeoutError, OSError, RuntimeError) as exc:
+    except _SEARCH_ERRORS as exc:
         return f"Search failed for '{query}': {exc}"
     if not raw_results:
         return f"No results found for: {query}"

--- a/apps/agent/agent/tests/db_doubles.py
+++ b/apps/agent/agent/tests/db_doubles.py
@@ -1,0 +1,23 @@
+"""Shared Supabase-client test doubles."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from agent.infrastructure.supabase.client import SupabaseClient
+
+
+def build_persistence_supabase_double() -> MagicMock:
+    """Build a Supabase double with RuntimeAPI persistence sinks wired.
+
+    Wires only the shared persistence writes; callers set their own read doubles.
+    """
+    db = MagicMock(spec=SupabaseClient)
+    db.session.upsert_session = AsyncMock()
+    db.session.upsert_conversation = AsyncMock()
+    db.session.update_conversation_title = AsyncMock()
+    db.user_memory.get_user_memory = AsyncMock(return_value=None)
+    db.user_memory.upsert_user_memory = AsyncMock()
+    db.routes.save_route = AsyncMock(return_value="route-1")
+    db.pool.fetch = AsyncMock(return_value=[])
+    return db

--- a/apps/agent/agent/tests/integration/test_selected_route_no_cross_db.py
+++ b/apps/agent/agent/tests/integration/test_selected_route_no_cross_db.py
@@ -1,0 +1,93 @@
+"""Lock SD-3(1) / issue #273 against selected-route cross-DB reads.
+
+Before #294, ``db.points.get_points_by_ids`` surfaced stale Supabase rows here.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.agents.catalog_adapter import build_search_payload
+from agent.clients.catalog_client import PilgrimagePoint
+from agent.infrastructure.session.memory import InMemorySessionStore
+from agent.infrastructure.supabase.client import SupabaseClient
+from agent.interfaces.public_api import PublicAPIRequest, RuntimeAPI
+from agent.interfaces.schemas import PublicAPIResponse
+from agent.tests.eval.mock_catalog_client import FIXTURE_POINTS, MockCatalogClient
+
+
+def _catalog_points() -> list[PilgrimagePoint]:
+    return [point.model_copy(deep=True) for point in FIXTURE_POINTS["115908"][:2]]
+
+
+@pytest.fixture
+def divergent_db() -> MagicMock:
+    db = MagicMock(spec=SupabaseClient)
+    db.points.get_points_by_ids = AsyncMock(
+        return_value=[
+            {
+                "id": "p004",
+                "name": "STALE-SUPABASE-p004",
+                "latitude": 0.0,
+                "longitude": 0.0,
+            },
+            {
+                "id": "p005",
+                "name": "STALE-SUPABASE-p005",
+                "latitude": 1.0,
+                "longitude": 1.0,
+            },
+        ]
+    )
+    db.session.upsert_session = AsyncMock()
+    db.session.upsert_conversation = AsyncMock()
+    db.user_memory.get_user_memory = AsyncMock(return_value=None)
+    db.user_memory.upsert_user_memory = AsyncMock()
+    db.session.update_conversation_title = AsyncMock()
+    db.routes.save_route = AsyncMock(return_value="route-1")
+    db.pool.fetch = AsyncMock(return_value=[])
+    return db
+
+
+@pytest.fixture
+async def selected_response(divergent_db: MagicMock) -> PublicAPIResponse:
+    api = RuntimeAPI(
+        divergent_db,
+        session_store=InMemorySessionStore(),
+        catalog=MockCatalogClient(),
+    )
+    return await api.handle(
+        PublicAPIRequest(selected_point_ids=["p004", "p005"], locale="ja")
+    )
+
+
+def _response_rows(response: PublicAPIResponse) -> list[dict[str, object]]:
+    route = cast(dict[str, object], response.data["route"])
+    return cast(list[dict[str, object]], route["ordered_points"])
+
+
+async def test_selected_route_succeeds_with_catalog_points(
+    selected_response: PublicAPIResponse,
+) -> None:
+    assert selected_response.success is True
+    assert selected_response.intent == "plan_selected"
+    assert _response_rows(selected_response) == [
+        point.model_dump(mode="json") for point in _catalog_points()
+    ]
+
+
+async def test_selected_route_never_reads_stale_supabase(
+    divergent_db: MagicMock, selected_response: PublicAPIResponse
+) -> None:
+    assert "STALE-SUPABASE-" not in selected_response.model_dump_json()
+    divergent_db.points.get_points_by_ids.assert_not_awaited()
+
+
+async def test_selected_route_rows_match_same_session_search(
+    selected_response: PublicAPIResponse,
+) -> None:
+    search = build_search_payload(_catalog_points(), tool="search_bangumi")
+    assert _response_rows(selected_response) == search["rows"]

--- a/apps/agent/agent/tests/integration/test_selected_route_no_cross_db.py
+++ b/apps/agent/agent/tests/integration/test_selected_route_no_cross_db.py
@@ -13,10 +13,25 @@ import pytest
 from agent.agents.catalog_adapter import build_search_payload
 from agent.clients.catalog_client import PilgrimagePoint
 from agent.infrastructure.session.memory import InMemorySessionStore
-from agent.infrastructure.supabase.client import SupabaseClient
 from agent.interfaces.public_api import PublicAPIRequest, RuntimeAPI
 from agent.interfaces.schemas import PublicAPIResponse
+from agent.tests.db_doubles import build_persistence_supabase_double
 from agent.tests.eval.mock_catalog_client import FIXTURE_POINTS, MockCatalogClient
+
+_STALE_SUPABASE_ROWS = [
+    {
+        "id": "p004",
+        "name": "STALE-SUPABASE-p004",
+        "latitude": 0.0,
+        "longitude": 0.0,
+    },
+    {
+        "id": "p005",
+        "name": "STALE-SUPABASE-p005",
+        "latitude": 1.0,
+        "longitude": 1.0,
+    },
+]
 
 
 def _catalog_points() -> list[PilgrimagePoint]:
@@ -25,30 +40,8 @@ def _catalog_points() -> list[PilgrimagePoint]:
 
 @pytest.fixture
 def divergent_db() -> MagicMock:
-    db = MagicMock(spec=SupabaseClient)
-    db.points.get_points_by_ids = AsyncMock(
-        return_value=[
-            {
-                "id": "p004",
-                "name": "STALE-SUPABASE-p004",
-                "latitude": 0.0,
-                "longitude": 0.0,
-            },
-            {
-                "id": "p005",
-                "name": "STALE-SUPABASE-p005",
-                "latitude": 1.0,
-                "longitude": 1.0,
-            },
-        ]
-    )
-    db.session.upsert_session = AsyncMock()
-    db.session.upsert_conversation = AsyncMock()
-    db.user_memory.get_user_memory = AsyncMock(return_value=None)
-    db.user_memory.upsert_user_memory = AsyncMock()
-    db.session.update_conversation_title = AsyncMock()
-    db.routes.save_route = AsyncMock(return_value="route-1")
-    db.pool.fetch = AsyncMock(return_value=[])
+    db = build_persistence_supabase_double()
+    db.points.get_points_by_ids = AsyncMock(return_value=_STALE_SUPABASE_ROWS)
     return db
 
 
@@ -65,6 +58,7 @@ async def selected_response(divergent_db: MagicMock) -> PublicAPIResponse:
 
 
 def _response_rows(response: PublicAPIResponse) -> list[dict[str, object]]:
+    # Mirrors the PublicAPIResponse.data boundary type (schemas.py: data: dict[str, object]).
     route = cast(dict[str, object], response.data["route"])
     return cast(list[dict[str, object]], route["ordered_points"])
 

--- a/apps/agent/agent/tests/unit/test_public_api_pipeline.py
+++ b/apps/agent/agent/tests/unit/test_public_api_pipeline.py
@@ -8,12 +8,12 @@ import pytest
 
 from agent.agents.agent_result import AgentResult, StepRecord
 from agent.infrastructure.session.memory import InMemorySessionStore
-from agent.infrastructure.supabase.client import SupabaseClient
 from agent.interfaces.public_api import (
     PublicAPIRequest,
     RuntimeAPI,
     detect_language,
 )
+from agent.tests.db_doubles import build_persistence_supabase_double
 from agent.tests.unit.conftest_public_api import (
     install_mock_pipeline,
 )
@@ -29,17 +29,8 @@ def _mock_pipeline(monkeypatch):
 
 @pytest.fixture
 def mock_db():
-    db = MagicMock(spec=SupabaseClient)
-    pool = AsyncMock()
-    pool.fetch = AsyncMock(return_value=[])
-    db.pool = pool
+    db = build_persistence_supabase_double()
     db.points.search_points_by_location = AsyncMock(return_value=[])
-    db.user_memory.get_user_memory = AsyncMock(return_value=None)
-    db.session.upsert_session = AsyncMock()
-    db.session.upsert_conversation = AsyncMock()
-    db.user_memory.upsert_user_memory = AsyncMock()
-    db.session.update_conversation_title = AsyncMock()
-    db.routes.save_route = AsyncMock(return_value="route-1")
     return db
 
 

--- a/apps/agent/agent/tests/unit/test_web_tools_errors.py
+++ b/apps/agent/agent/tests/unit/test_web_tools_errors.py
@@ -1,0 +1,39 @@
+"""Exception handling tests for the web search tool."""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import httpx
+from ddgs.exceptions import RatelimitException
+from pydantic_ai import RunContext
+
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.web_tools import web_search
+
+
+def _ctx_with_error(exc: Exception) -> RunContext[RuntimeDeps]:
+    async def _raise(_query: str) -> list[object]:
+        raise exc
+
+    ctx = MagicMock()
+    ctx.deps = MagicMock(spec=RuntimeDeps)
+    ctx.deps.web_searcher = _raise
+    return cast(RunContext[RuntimeDeps], ctx)
+
+
+async def test_connect_timeout_returns_graceful_failure() -> None:
+    result = await web_search(
+        _ctx_with_error(httpx.ConnectTimeout("connect timed out")), query="query"
+    )
+
+    assert result.startswith("Search failed for")
+
+
+async def test_ddgs_rate_limit_returns_graceful_failure() -> None:
+    result = await web_search(
+        _ctx_with_error(RatelimitException("ratelimited")), query="query"
+    )
+
+    assert result.startswith("Search failed for")


### PR DESCRIPTION
Refs #273 (S1.7 — SD-3① infrastructure slice: selected_route same-session cross-DB mixed read)

## Verification finding (evidence-first)

The SD-3① core fix and the SD-28 dual-route unification are **already merged** in #294 (`fc5a884`, refined by `944fca1`/`3b05f72`). Verified in code:

- **Historical bug form** (pre-#294, `git show fc5a884^:apps/agent/agent/agents/selected_route.py`): the bypass required `db` to be a `SupabaseClient` and read `await db.points.get_points_by_ids(point_ids)` (Supabase) while same-session `search_bangumi`/`search_nearby` read Neon via CatalogClient — two databases forked 2026-06-23 with zero sync.
- **Current state**: `apps/agent/agent/agents/selected_route.py:22-50` is catalog-only (`catalog.route(...)` at line 38, no `db` parameter); `apps/agent/agent/interfaces/public_api.py:271-280` passes `catalog=self._catalog` only; the four data tools are catalog-only with a loud-fail `_require_catalog` guard (`apps/agent/agent/agents/pilgrimage_tools.py:35-43`).
- **SD-28 supplement**: route ordering already goes through the catalog `/route` endpoint (`workers/catalog/src/router.ts:51` → `src/lib/route.ts`); Python `route_optimizer.py` is deleted, guarded by `test_route_optimizer_is_retired_from_agent_imports` (`agent/tests/unit/test_selected_route.py:151-160`); ordering parity covered by `agent/tests/integration/test_dual_route_parity.py`.

What was **missing** was an end-to-end regression that re-stages the divergent-database scenario and proves the mixed read is dead at the `RuntimeAPI.handle` level. That is this PR.

## Changes

1. **`agent/tests/integration/test_selected_route_no_cross_db.py`** (new) — stages the old mixed-read: a `SupabaseClient` double whose `points.get_points_by_ids` returns divergent rows (same ids `p004`/`p005`, stale names/coords) alongside a `MockCatalogClient`, driven through the real `RuntimeAPI.handle(selected_point_ids=...)`. Asserts:
   - response route rows == catalog fixture dumps, field-by-field (catalog fidelity);
   - `"STALE-SUPABASE-"` markers appear nowhere in the serialized response AND `db.points.get_points_by_ids` is never awaited (mixed read unreachable);
   - rows == `build_search_payload(...)["rows"]` (bypass matches same-session search exactly);
   - `PublicAPIResponse` contract unchanged (existing shape: `success`/`intent`/`data.route.ordered_points`).

2. **`agent/agents/web_tools.py` + `agent/tests/unit/test_web_tools_errors.py`** — #323 leftover: `except (TimeoutError, OSError, RuntimeError)` missed `httpx.ConnectTimeout` (derives from `httpx.HTTPError`, not builtins `TimeoutError`) and `ddgs.exceptions.DDGSException`, so a transient search failure aborted the whole agent run. Now a typed `_SEARCH_ERRORS` tuple includes both; graceful return string unchanged. Tests cover `httpx.ConnectTimeout` and `ddgs` `RatelimitException`.

## Regression proof (mixed read reproduces → no longer reproduces)

Mutation check: temporarily re-introducing a Supabase point read on the bypass branch of `public_api.py` makes `test_selected_route_never_reads_stale_supabase` **fail**; reverting it, all tests pass. The historical implementation (`db.points.get_points_by_ids`) would fail all three assertions under this staging.

## Gates (run locally)

- `make lint` — ruff check + format: clean (232 files)
- `make typecheck` — mypy strict: clean (104 files)
- `make test` — 923 passed, coverage 83.96% (floor 82)
- Targeted no-Docker integration: `test_selected_route_no_cross_db.py` + `test_dual_route_parity.py` — 4 passed (local Docker unavailable; full integration suite runs in CI)

## Recorded leftovers (out of this slice, for SD-3③/④ tracking)

Residual same-session Supabase catalog-table readers still exist outside the selected-route path — recorded on #273:
- clarify enrichment is DB-first with Supabase write-through (`agent/agents/tools.py:50-70,126-146`)
- title-translation DB fallback (`agent/agents/translation.py:138`, via `web_tools.py:136` when no `title_translator` injected)
- interface routes `/v1/bangumi/popular|{id}/guide|nearby` and `/v1/search/preview` read Supabase points/bangumi (`agent/interfaces/routes/bangumi.py:31,44,48,133`, `agent/interfaces/routes/search_preview.py:59,75-76`)
- `agent/agents/sql_agent.py` (Supabase SQL generator) has no remaining production caller except a constants import — dead-code candidate (F4-adjacent)

Implementation: Codex (gpt-5.6-sol) under Fable 5 lead; gates and review by lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
