### PR TITLE
feat(ci): per-PR preview environments — CF preview URLs + Neon branch-per-PR + auto-teardown

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,286 @@
+# Standalone, event-driven opt-in workflow (like codeql.yml), outside the
+# ci.yml/deploy.yml caller-reusable layering. Refs #305.
+# Add the `preview` label to create or update a preview; synchronize only
+# redeploys PRs that remain labeled, while closed always sweeps orphaned state.
+# Catalog uploads are globally serialized because versions upload inherits the
+# latest secret version; interleaving PRs could otherwise pair code and DB wrong.
+# Dedicated preview Workers prevent secret inheritance from poisoning staging
+# or production Workers.
+name: PR preview
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened, closed]
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    if: >-
+      github.event.action != 'closed' &&
+      contains(github.event.pull_request.labels.*.name, 'preview') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+    concurrency:
+      # Keep secret-put and upload adjacent across all PRs.
+      group: preview-cf-upload
+      cancel-in-progress: false
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up toolchain
+        uses: ./.github/actions/setup
+
+      - name: Preflight
+        env:
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          if [ -z "$NEON_PROJECT_ID" ]; then
+            echo "::error::NEON_PROJECT_ID is unset. Configure it with: gh variable set NEON_PROJECT_ID --body <project-id>"
+            exit 1
+          fi
+
+      - name: Resolve workers.dev subdomain
+        id: subdomain
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          SUBDOMAIN=$(curl -sfS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/subdomain" | jq -r '.result.subdomain')
+          if [ -z "$SUBDOMAIN" ] || [ "$SUBDOMAIN" = "null" ]; then
+            echo '::error::Cloudflare workers.dev subdomain is empty or null'
+            exit 1
+          fi
+          echo "subdomain=$SUBDOMAIN" >> "$GITHUB_OUTPUT"
+
+      - name: Create or reuse Neon preview branch
+        id: neon
+        uses: neondatabase/create-branch-action@72ed4f69a12b6be9c16aebfad893f6a21e9aba8b # v6.4.0
+        with:
+          api_key: ${{ secrets.NEON_API_KEY }}
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: preview/pr-${{ github.event.pull_request.number }}
+          database: ${{ vars.NEON_DATABASE_NAME || 'neondb' }}
+          role: ${{ vars.NEON_ROLE_NAME || 'neondb_owner' }}
+
+      - name: Mask connection strings
+        env:
+          DIRECT_URL: ${{ steps.neon.outputs.db_url }}
+          POOLED_URL: ${{ steps.neon.outputs.db_url_pooled }}
+        run: |
+          echo "::add-mask::$DIRECT_URL"
+          echo "::add-mask::$POOLED_URL"
+
+      - name: Migrate preview branch (atlas)
+        env:
+          DATABASE_URL: ${{ steps.neon.outputs.db_url }}
+        run: |
+          curl -sSfL "https://release.ariga.io/atlas/atlas-community-linux-amd64-v0.30.0" -o /usr/local/bin/atlas
+          chmod +x /usr/local/bin/atlas
+          atlas migrate apply --dir "file://db/migrations" --url "$DATABASE_URL" --revisions-schema public
+
+      - name: Upload catalog preview version
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DB_URL_POOLED: ${{ steps.neon.outputs.db_url_pooled }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -o pipefail
+          if ! pnpm --filter catalog exec wrangler versions list --env preview >/dev/null 2>&1; then
+            # One-time routeless Worker creation; subsequent runs upload versions only.
+            pnpm --filter catalog exec wrangler deploy --env preview
+          fi
+          printf '%s' "$DB_URL_POOLED" | pnpm --filter catalog exec wrangler versions secret put DATABASE_URL --env preview
+          pnpm --filter catalog exec wrangler versions upload --env preview --preview-alias "pr-${PR_NUMBER}" | tee "$RUNNER_TEMP/catalog-upload.log"
+
+      - name: Build web
+        run: pnpm --filter web build
+
+      - name: Upload web preview version
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -o pipefail
+          if ! pnpm --filter web exec wrangler versions list --env preview >/dev/null 2>&1; then
+            # One-time routeless Worker creation; subsequent runs upload versions only.
+            pnpm --filter web exec wrangler deploy --env preview
+          fi
+          pnpm --filter web exec wrangler versions upload --env preview --preview-alias "pr-${PR_NUMBER}" | tee "$RUNNER_TEMP/web-upload.log"
+
+      - name: Derive preview facts
+        id: urls
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SUBDOMAIN: ${{ steps.subdomain.outputs.subdomain }}
+          CREATED: ${{ steps.neon.outputs.created }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          CATALOG_STABLE="https://pr-${PR_NUMBER}-catalog-preview.${SUBDOMAIN}.workers.dev"
+          WEB_STABLE="https://pr-${PR_NUMBER}-animichi-web-preview.${SUBDOMAIN}.workers.dev"
+          CATALOG_VERSIONED=$(awk 'match($0, /https:\/\/[^[:space:]]+\.workers\.dev/) { print substr($0, RSTART, RLENGTH) }' "$RUNNER_TEMP/catalog-upload.log" | sort -u | awk -v s="$CATALOG_STABLE" '$0 != s' | head -n 1)
+          WEB_VERSIONED=$(awk 'match($0, /https:\/\/[^[:space:]]+\.workers\.dev/) { print substr($0, RSTART, RLENGTH) }' "$RUNNER_TEMP/web-upload.log" | sort -u | awk -v s="$WEB_STABLE" '$0 != s' | head -n 1)
+          if [ -z "$CATALOG_VERSIONED" ]; then
+            echo '::error::wrangler versions upload printed no preview URL for catalog'
+            exit 1
+          fi
+          if [ -z "$WEB_VERSIONED" ]; then
+            echo '::error::wrangler versions upload printed no preview URL for web'
+            exit 1
+          fi
+          if [ "$CREATED" = "true" ]; then
+            BRANCH_STATE='created'
+          else
+            BRANCH_STATE='reused'
+          fi
+          SHORT_SHA=$(printf '%.7s' "$HEAD_SHA")
+          {
+            echo "catalog_stable=$CATALOG_STABLE"
+            echo "web_stable=$WEB_STABLE"
+            echo "catalog_versioned=$CATALOG_VERSIONED"
+            echo "web_versioned=$WEB_VERSIONED"
+            echo "branch_state=$BRANCH_STATE"
+            echo "short_sha=$SHORT_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upsert PR comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          CATALOG_STABLE: ${{ steps.urls.outputs.catalog_stable }}
+          WEB_STABLE: ${{ steps.urls.outputs.web_stable }}
+          CATALOG_VERSIONED: ${{ steps.urls.outputs.catalog_versioned }}
+          WEB_VERSIONED: ${{ steps.urls.outputs.web_versioned }}
+          BRANCH_STATE: ${{ steps.urls.outputs.branch_state }}
+          SHORT_SHA: ${{ steps.urls.outputs.short_sha }}
+          NEON_BRANCH: preview/pr-${{ github.event.pull_request.number }}
+          BRANCH_ID: ${{ steps.neon.outputs.branch_id }}
+        run: |
+          BODY=$(printf '%s\n' \
+            '<!-- animichi-preview-status -->' \
+            '## Preview environment' \
+            '' \
+            "- Catalog stable alias: $CATALOG_STABLE" \
+            "- Web stable alias: $WEB_STABLE" \
+            "- Catalog version for this commit: $CATALOG_VERSIONED" \
+            "- Web version for this commit: $WEB_VERSIONED" \
+            "- Neon branch: \`$NEON_BRANCH\` ($BRANCH_STATE, id \`$BRANCH_ID\`)" \
+            "- Head commit: \`$SHORT_SHA\`" \
+            '' \
+            'Close the PR to tear this down automatically.')
+          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[] | select(.body | contains("<!-- animichi-preview-status -->")) | .id' | head -n 1)
+          if [ -n "$COMMENT_ID" ]; then
+            jq -n --arg body "$BODY" '{body:$body}' | gh api --method PATCH "repos/$REPO/issues/comments/$COMMENT_ID" --input -
+          else
+            jq -n --arg body "$BODY" '{body:$body}' | gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" --input -
+          fi
+
+      - name: Job summary
+        env:
+          CATALOG_STABLE: ${{ steps.urls.outputs.catalog_stable }}
+          WEB_STABLE: ${{ steps.urls.outputs.web_stable }}
+          CATALOG_VERSIONED: ${{ steps.urls.outputs.catalog_versioned }}
+          WEB_VERSIONED: ${{ steps.urls.outputs.web_versioned }}
+          BRANCH_STATE: ${{ steps.urls.outputs.branch_state }}
+          SHORT_SHA: ${{ steps.urls.outputs.short_sha }}
+          NEON_BRANCH: preview/pr-${{ github.event.pull_request.number }}
+          BRANCH_ID: ${{ steps.neon.outputs.branch_id }}
+        run: |
+          {
+            echo '## Preview environment'
+            echo
+            echo "- Catalog stable alias: $CATALOG_STABLE"
+            echo "- Web stable alias: $WEB_STABLE"
+            echo "- Catalog version for this commit: $CATALOG_VERSIONED"
+            echo "- Web version for this commit: $WEB_VERSIONED"
+            echo "- Neon branch: \`$NEON_BRANCH\` ($BRANCH_STATE, id \`$BRANCH_ID\`)"
+            echo "- Head commit: \`$SHORT_SHA\`"
+            echo
+            echo 'Close the PR to tear this down automatically.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  teardown:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Name-guard + existence check
+        id: guard
+        env:
+          BRANCH_NAME: preview/pr-${{ github.event.pull_request.number }}
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          case "$BRANCH_NAME" in
+            preview/pr-[0-9]*) ;;
+            *) echo "::error::Refusing unsafe branch name: $BRANCH_NAME"; exit 1 ;;
+          esac
+          PR_SUFFIX=${BRANCH_NAME#preview/pr-}
+          case "$PR_SUFFIX" in
+            ''|*[!0-9]*) echo "::error::Refusing non-numeric PR branch: $BRANCH_NAME"; exit 1 ;;
+          esac
+          # Belt-and-braces protection for canonical long-lived branch names.
+          case "$BRANCH_NAME" in
+            main|master|production|staging|development)
+              echo "::error::Refusing protected branch name: $BRANCH_NAME"
+              exit 1
+              ;;
+          esac
+          if [ -z "$NEON_PROJECT_ID" ]; then
+            echo 'exists=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BRANCHES_JSON=$(curl -sfS -H "Authorization: Bearer $NEON_API_KEY" "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches")
+          if printf '%s' "$BRANCHES_JSON" | jq -r '.branches[].name' | grep -Fxq -- "$BRANCH_NAME"; then
+            echo 'exists=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'exists=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Delete Neon branch
+        if: steps.guard.outputs.exists == 'true'
+        uses: neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776 # v3.2.1
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: preview/pr-${{ github.event.pull_request.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
+      - name: Mark PR comment torn down
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BRANCH_NAME: preview/pr-${{ github.event.pull_request.number }}
+        run: |
+          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[] | select(.body | contains("<!-- animichi-preview-status -->")) | .id' | head -n 1)
+          if [ -z "$COMMENT_ID" ]; then
+            echo 'No preview status comment found; nothing to update.'
+            exit 0
+          fi
+          BODY=$(printf '%s\n' \
+            '<!-- animichi-preview-status -->' \
+            '## Preview environment torn down' \
+            '' \
+            "Neon branch \`$BRANCH_NAME\` deleted (or already absent). CF preview versions are routeless and expire from relevance; re-label after reopen to recreate.")
+          jq -n --arg body "$BODY" '{body:$body}' | gh api --method PATCH "repos/$REPO/issues/comments/$COMMENT_ID" --input -

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,8 @@
 # Standalone, event-driven opt-in workflow (like codeql.yml), outside the
 # ci.yml/deploy.yml caller-reusable layering. Refs #305.
-# Add the `preview` label to create or update a preview; synchronize only
-# redeploys PRs that remain labeled, while closed always sweeps orphaned state.
+# Add the `preview` label to create or update a preview; synchronize only redeploys
+# PRs that remain labeled. Removing it tears down immediately; closed always sweeps
+# label-independently so orphans cannot survive. Fork PRs never build, so teardown is fork-gated.
 # Catalog uploads are globally serialized because versions upload inherits the
 # latest secret version; interleaving PRs could otherwise pair code and DB wrong.
 # Dedicated preview Workers prevent secret inheritance from poisoning staging
@@ -10,7 +11,7 @@ name: PR preview
 
 on:
   pull_request:
-    types: [labeled, synchronize, reopened, closed]
+    types: [labeled, unlabeled, synchronize, reopened, closed]
 
 permissions:
   contents: read
@@ -26,6 +27,7 @@ jobs:
   preview:
     if: >-
       github.event.action != 'closed' &&
+      github.event.action != 'unlabeled' &&
       contains(github.event.pull_request.labels.*.name, 'preview') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
@@ -218,7 +220,10 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   teardown:
-    if: github.event.action == 'closed'
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action == 'closed' ||
+       (github.event.action == 'unlabeled' && github.event.label.name == 'preview'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -248,8 +253,8 @@ jobs:
               ;;
           esac
           if [ -z "$NEON_PROJECT_ID" ]; then
-            echo 'exists=false' >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::NEON_PROJECT_ID is unset; cannot verify or delete the preview Neon branch. Set it with: gh variable set NEON_PROJECT_ID --body <project-id> (see docs/ops/preview.md). If a branch was already created it must be removed manually via: neonctl branches delete $BRANCH_NAME --project-id <project-id>"
+            exit 1
           fi
           BRANCHES_JSON=$(curl -sfS -H "Authorization: Bearer $NEON_API_KEY" "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches")
           if printf '%s' "$BRANCHES_JSON" | jq -r '.branches[].name' | grep -Fxq -- "$BRANCH_NAME"; then

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -11,7 +11,6 @@
   "env": {
     "staging": { "name": "animichi-web-staging" },
     "production": { "name": "animichi-web" },
-    // Per-PR preview (issue #305): routeless worker, reached only via version/alias preview URLs.
     "preview": { "name": "animichi-web-preview", "workers_dev": false, "preview_urls": true }
   }
 }

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -10,6 +10,8 @@
   },
   "env": {
     "staging": { "name": "animichi-web-staging" },
-    "production": { "name": "animichi-web" }
+    "production": { "name": "animichi-web" },
+    // Per-PR preview (issue #305): routeless worker, reached only via version/alias preview URLs.
+    "preview": { "name": "animichi-web-preview", "workers_dev": false, "preview_urls": true }
   }
 }

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -11,5 +11,6 @@ Use this directory for:
 Current canonical docs:
 - `deployment.md` — Cloudflare Workers + Containers deployment runbook (topology, auth flow, env boundaries, rollback)
 - `cloudflare-hardening.md` — WAF rate limiting, prompt-injection filtering, rollback for edge rules
+- `preview.md` — per-PR preview environments (label-gated CF preview URLs + Neon branch-per-PR + auto-teardown)
 
 Keep iteration task trackers, progress logs, and findings under `docs/iterations/`.

--- a/docs/ops/preview.md
+++ b/docs/ops/preview.md
@@ -38,7 +38,7 @@ Wait for the **Preview environment** PR comment. Stable aliases follow these for
 - `https://pr-<N>-animichi-web-preview.<subdomain>.workers.dev`
 
 Each push to the labeled PR refreshes both previews and updates the comment. Close or merge the
-PR to tear down the Neon branch automatically.
+PR, or remove the `preview` label, to tear down the Neon branch automatically.
 
 ## Costs and quotas
 
@@ -57,6 +57,15 @@ only the 1,000 most recent preview aliases. Undeployed versions have no runtime 
 - Preview automation never targets staging or production Workers, or the default Neon branch.
 - Connection strings are masked and passed only through step environment variables and stdin; they
   are never written to logs, files, or artifacts.
+
+### Teardown residue
+
+The Neon branch is deleted when the PR closes or the `preview` label is removed. The Cloudflare
+preview aliases are not deleted because Wrangler has no alias-deletion primitive. The catalog alias
+therefore returns 5xx errors after its Neon database disappears, while the web alias continues to
+serve a static shell. These stale aliases are harmless, secret-free shells tied to closed PRs: the
+database secret has no live backing branch. Cloudflare retains only the 1,000 most recent preview
+aliases, so they age out naturally.
 
 ## Troubleshooting
 

--- a/docs/ops/preview.md
+++ b/docs/ops/preview.md
@@ -1,0 +1,67 @@
+# Per-PR preview environments
+
+## What it is
+
+Adding the `preview` label to an internal pull request creates a temporary environment with:
+
+- Cloudflare Worker preview URLs for the catalog API and web app.
+- A Neon branch named `preview/pr-<N>` with Atlas migrations applied.
+- A sticky PR comment containing stable aliases and per-commit preview URLs.
+
+Closing or merging the PR automatically deletes its Neon branch.
+
+## One-time setup
+
+Set the Neon project ID as a repository variable:
+
+```sh
+gh variable set NEON_PROJECT_ID --body <project-id>
+```
+
+Find the project ID in Neon Console under **Project settings**, or run `neonctl projects list`.
+Projects that do not use the defaults can also set `NEON_DATABASE_NAME` and `NEON_ROLE_NAME`;
+the workflow otherwise uses `neondb` and `neondb_owner`.
+
+Ensure the repository has a `preview` label. The first labeled run bootstraps the routeless
+`catalog-preview` and `animichi-web-preview` Workers with a one-time
+`wrangler deploy --env preview`. Later runs only upload undeployed versions.
+
+## Daily use
+
+```sh
+gh pr edit <n> --add-label preview
+```
+
+Wait for the **Preview environment** PR comment. Stable aliases follow these forms:
+
+- `https://pr-<N>-catalog-preview.<subdomain>.workers.dev`
+- `https://pr-<N>-animichi-web-preview.<subdomain>.workers.dev`
+
+Each push to the labeled PR refreshes both previews and updates the comment. Close or merge the
+PR to tear down the Neon branch automatically.
+
+## Costs and quotas
+
+Neon branches count toward the project branch cap. The free plan defaults to 10 branches including
+the default branch, allowing roughly nine concurrent previews. Storage is copy-on-write delta, and
+compute autosuspends after the project's configured idle period. The branch is deleted on PR close.
+
+Cloudflare `versions upload` is free, and preview URLs are served on `workers.dev`. Cloudflare keeps
+only the 1,000 most recent preview aliases. Undeployed versions have no runtime cost. Keep the
+`preview` label only on PRs that need a live environment.
+
+## Guardrails
+
+- Teardown only deletes names matching `preview/pr-<N>`, with an additional denylist for `main`,
+  `master`, `production`, `staging`, and `development`.
+- Preview automation never targets staging or production Workers, or the default Neon branch.
+- Connection strings are masked and passed only through step environment variables and stdin; they
+  are never written to logs, files, or artifacts.
+
+## Troubleshooting
+
+- **Atlas fails:** verify `NEON_DATABASE_NAME` and `NEON_ROLE_NAME` for the project.
+- **The label is present but no run starts:** only `labeled`, `synchronize`, and `reopened` events
+  create or update previews. Push another commit or remove and re-add the label.
+- **Atlas reports migration hash drift after a rebase:** close and reopen the PR to delete the old
+  branch and create a fresh one.

--- a/workers/catalog/wrangler.toml
+++ b/workers/catalog/wrangler.toml
@@ -64,3 +64,19 @@ ENVIRONMENT = "production"
 [[env.production.r2_buckets]]
 binding = "MEDIA_BUCKET"
 bucket_name = "catalog-media"
+
+# Per-PR preview environment (issue #305). Routeless: CI deploys only the
+# one-time bootstrap that creates the Worker; previews are undeployed versions
+# reached through preview URLs. DATABASE_URL is injected per version from the
+# Neon branch preview/pr-<N> by .github/workflows/preview.yml.
+[env.preview]
+name = "catalog-preview"
+workers_dev = false
+preview_urls = true
+
+[env.preview.vars]
+ENVIRONMENT = "preview"
+
+[[env.preview.r2_buckets]]
+binding = "MEDIA_BUCKET"
+bucket_name = "catalog-media-staging" # reuse staging cache; previews are ephemeral


### PR DESCRIPTION
## Summary

Per-PR preview environments v2 (Refs #305): label a PR `preview` → CI creates a Neon branch `preview/pr-<N>` (atlas-migrated), uploads **routeless** Cloudflare Worker versions for `workers/catalog` + `apps/web`, and posts one self-updating PR comment with stable preview URLs. Closing/merging the PR deletes the Neon branch automatically.

New standalone workflow `.github/workflows/preview.yml` — `ci.yml` / `deploy.yml` / `_deploy-component.yml` (#324) untouched.

## Design

- **Trigger / opt-in gate**: `pull_request: [labeled, synchronize, reopened, closed]`; the preview job runs only when the PR carries the `preview` label AND is same-repo (fork guard). `opened` is deliberately not in the trigger list — unlabeled PRs never start a run.
- **Isolation (why a dedicated `env.preview`)**: top-level worker names equal production (`catalog`, `animichi-web`). A `versions secret put` against those would be inherited by the next real deploy — preview therefore gets dedicated routeless workers `catalog-preview` / `animichi-web-preview` (`workers_dev = false`, `preview_urls = true`), so staging/production secret chains are never touched.
- **Per-version DB wiring**: `versions secret put DATABASE_URL` (Neon pooled URL via stdin) then `versions upload --preview-alias pr-<N>` — the uploaded version snapshots the secret; the alias gives a stable URL across pushes. Cross-PR races on secret inheritance are prevented by a global job concurrency group (`preview-cf-upload`, queued not cancelled).
- **Idempotency**: Neon `create-branch-action` reuses an existing `preview/pr-<N>`; atlas applies only pending migrations; the PR comment is upserted by hidden marker (`<!-- animichi-preview-status -->`); re-running any event converges.
- **Teardown**: on `closed` (merged or not, labeled or not — always sweeps), with **name-guard assertions**: branch must match `preview/pr-<digits>` (numeric suffix re-checked) plus an explicit denylist (`main/master/production/staging/development`) before any delete; existence is verified against the Neon API first (API failures fail the job loudly instead of silently skipping the delete).
- **Secret hygiene**: connection strings exist only in step `env` + stdin, are `add-mask`ed defensively, and never appear in logs, files, or artifacts. `NEON_PROJECT_ID` is read from a repo **variable** (fail-fast preflight if unset) — nothing hardcoded.
- **Bootstrap**: first-ever run per surface creates the routeless worker via a guarded one-time `wrangler deploy --env preview` (probe: `versions list`), then it's versions-upload only.

### Trigger-condition trace (label gate self-check)

| Event | preview job | teardown job |
|---|---|---|
| PR opened, no label | no run (opened not in types) | no run |
| `preview` label added | **runs** | skip |
| other label added | skipped by `if` | skip |
| push to labeled PR (synchronize) | **runs** | skip |
| push to unlabeled PR | skipped by `if` | skip |
| label removed, then pushes | skipped (stale preview stays until close) | skip |
| reopened with label | **runs** (recreates after prior teardown) | skip |
| closed / merged (any label state) | skipped | **runs** (existence-checked, no-op if branch absent) |
| fork PR labeled | skipped (head-repo guard) | close still sweeps (no-op) |

## Gates (run locally by the lead)

- `actionlint` — zero findings (file + whole tree), shellcheck integration active
- `zizmor` v1.26.1 — zero findings (pedantic residue = `undocumented-permissions` help-level only, suppressed in CI's default persona too)
- `pnpm --filter catalog exec wrangler deploy --dry-run --env preview` — config + bundle valid (R2 `catalog-media-staging`, `ENVIRONMENT=preview`)
- `pnpm --filter web build` + `wrangler deploy --dry-run --env preview` — assets binding valid
- `pnpm --filter catalog test:worker` — 13 files / 109 tests green (wrangler.toml change is regression-free)
- Flag existence verified against lockfile wrangler 4.103.0: `--preview-alias`, `versions secret put`
- No real deploys and no real Neon branches were created during development — all live execution is left to CI.

---

## ⚠️ FIRST-RUN COST / QUOTA NOTES — READ BEFORE ENABLING

**Neon**
- Each labeled PR = **one Neon branch** (`preview/pr-<N>`). Branches count toward the project branch cap — **free plan default is 10 branches including the default branch, i.e. ~9 concurrent previews**. Branch storage is copy-on-write delta; preview compute autosuspends after the project's idle setting and its compute time counts toward plan compute hours. Branches are deleted on PR close; a leaked branch (e.g. teardown run cancelled) can be removed with `neonctl branches delete preview/pr-<N>`.

**Cloudflare**
- `wrangler versions upload` is free; previews are served on `workers.dev` and hold no routes — **no runtime cost while idle** and zero impact on staging/production traffic. Only the 1,000 most recent preview aliases are retained. One-time bootstrap creates two extra (routeless) workers: `catalog-preview`, `animichi-web-preview`.

**Keep the `preview` label only on PRs that actually need a live environment.**

## First trial run (suggested: on this very PR)

1. One-time: set the Neon project id repo variable (find it in Neon Console → Project settings, or `neonctl projects list`):
   ```sh
   gh variable set NEON_PROJECT_ID --repo lifeodyssey/animichi --body "<neon-project-id>"
   ```
   If the project's database/role differ from Neon defaults (`neondb` / `neondb_owner`), also set `NEON_DATABASE_NAME` / `NEON_ROLE_NAME` variables.
2. Label this PR: `gh pr edit <this-pr> --add-label preview` and watch the "PR preview" run. First run bootstraps the two routeless workers.
3. Expect the **Preview environment** comment with `https://pr-<N>-catalog-preview.<subdomain>.workers.dev` (+ web). Sanity: `curl <catalog-url>/healthz` → `{"status":"ok","service":"catalog","env":"preview"}`.
4. Push any commit → same alias URL serves the new version; comment updates in place.
5. Close (don't merge) → teardown deletes `preview/pr-<N>` (verify in Neon console) and flips the comment to "torn down". Reopen + it recreates on the next labeled/synchronize event.

Docs: `docs/ops/preview.md`.

## Post-review hardening (Codex xhigh) — applied in `f92327c`

Core three defenses (delete name-guard, prod-poison isolation, secret hygiene) reviewed **green by both sides, zero security holes**; the four P1s were calibration, now hardened:

1. **teardown fork-gated (NOT label-gated).** Unconditional close-sweep is the load-bearing anti-orphan design — a label gate would leak previews in the "label→build→unlabel→close" path, so it stays label-independent. Added only a fork gate: fork PRs never build a preview (preview job is same-repo-guarded), so teardown safely skips them.
2. **`unlabeled` now tears down.** Removing the `preview` label proactively deletes the secret-bearing preview (Neon branch) instead of leaving it alive until close.
3. **Missing `NEON_PROJECT_ID` in teardown → loud `exit 1`** (was silent `exists=false` that could mask a leaked branch), symmetric with the preview job's preflight.
4. **CF preview-alias residue documented.** Wrangler has no alias-delete primitive; the stale alias is a harmless, secret-free shell (catalog 5xx once its Neon DB is gone, web static shell) that ages out at Cloudflare's 1000-alias cap. Doc-fallback in `docs/ops/preview.md`.

### Follow-ups (non-blocking, tracked here)
- **atlas binary has no checksum verification** — reuses the existing `_deploy-component.yml` download pattern; repo-wide concern, fix once across both workflows.
- **preview reuses the staging R2 bucket** (`catalog-media-staging`) — low risk, cache-only and rebuildable; give previews their own bucket if isolation is later wanted.
- **branch-name rename TOCTOU** in the existence-check→delete window — only exploitable with Neon project privileges (already game-over if an attacker has those).

Refs #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

