### PR TITLE
S2.8: workers/users service — route save/list oRPC + Neon Auth JWT (enabler)

### DIFF
--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -27,6 +27,8 @@ on:
         required: false
       R2_SECRET_ACCESS_KEY:
         required: false
+      NEON_AUTH_JWKS_URL:
+        required: false
 jobs:
   deploy:
     name: Deploy
@@ -79,6 +81,7 @@ jobs:
           secrets: ${{ inputs.worker_secrets }}
         env:
           DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+          NEON_AUTH_JWKS_URL: ${{ secrets.NEON_AUTH_JWKS_URL }}
       - name: Smoke
         env:
           COMPONENT: ${{ inputs.component }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       catalog: ${{ steps.f.outputs.catalog }}
+      users: ${{ steps.f.outputs.users }}
       agent: ${{ steps.f.outputs.agent }}
       frontend: ${{ steps.f.outputs.frontend }}
       web: ${{ steps.f.outputs.web }}
@@ -37,6 +38,7 @@ jobs:
           filters: |
             contract: ['packages/contract/**']
             catalog: ['workers/catalog/**', 'packages/contract/**']
+            users: ['workers/users/**', 'packages/contract/**']
             agent: ['apps/agent/**', 'packages/contract/**']
             frontend: ['frontend/**']
             web: ['apps/web/**']
@@ -62,6 +64,14 @@ jobs:
     with:
       component: catalog
 
+  ci-users:
+    name: Users CI
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.users == 'true' }}
+    uses: ./.github/workflows/_ts-ci.yml
+    with:
+      component: users
+
   contract-openapi-drift:
     name: Contract OpenAPI drift
     runs-on: ubuntu-latest
@@ -77,8 +87,8 @@ jobs:
         working-directory: packages/contract
       - name: Verify committed OpenAPI is current
         run: |
-          git add -A packages/contract/openapi.json
-          git diff --cached --exit-code -- packages/contract/openapi.json
+          git add -A packages/contract/openapi.json packages/contract/users-openapi.json
+          git diff --cached --exit-code -- packages/contract/openapi.json packages/contract/users-openapi.json
 
   ci-frontend:
     name: Frontend CI
@@ -237,9 +247,30 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     concurrency: deploy-web-staging
 
+  deploy-users-staging:
+    name: Deploy users staging
+    needs: [deploy-staging, ci-users]
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/_deploy-component.yml
+    with:
+      component: users
+      environment: staging
+      pulumi_stack: staging
+      working_directory: workers/users
+      run_pulumi: false
+      worker_secrets: |
+        DATABASE_URL
+        NEON_AUTH_JWKS_URL
+    secrets:
+      NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      NEON_AUTH_JWKS_URL: ${{ secrets.NEON_AUTH_JWKS_URL }}
+    concurrency: deploy-users-staging
+
   post-staging:
     name: Post-deploy (staging)
-    needs: [deploy-staging, deploy-web-staging]
+    needs: [deploy-staging, deploy-web-staging, deploy-users-staging]
     uses: ./.github/workflows/_post-deploy-test.yml
     with:
       environment: staging
@@ -283,9 +314,29 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     concurrency: deploy-web-prod
 
+  deploy-users-prod:
+    name: Deploy users production
+    needs: [post-staging, deploy-prod]
+    uses: ./.github/workflows/_deploy-component.yml
+    with:
+      component: users
+      environment: production
+      pulumi_stack: prod
+      working_directory: workers/users
+      run_pulumi: false
+      worker_secrets: |
+        DATABASE_URL
+        NEON_AUTH_JWKS_URL
+    secrets:
+      NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      NEON_AUTH_JWKS_URL: ${{ secrets.NEON_AUTH_JWKS_URL }}
+    concurrency: deploy-users-prod
+
   post-prod:
     name: Post-deploy (production)
-    needs: [deploy-prod, deploy-web-prod]
+    needs: [deploy-prod, deploy-web-prod, deploy-users-prod]
     uses: ./.github/workflows/_post-deploy-test.yml
     with:
       environment: production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,23 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.SUPABASE_DB_URL }}
 
+      # ── Deploy users Worker (before root — root's USERS [[services]] binding depends on it) ──
+      - name: Deploy users Worker
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.79.0"
+          workingDirectory: workers/users
+          command: deploy
+          environment: production
+          secrets: |
+            DATABASE_URL
+            NEON_AUTH_JWKS_URL
+        env:
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+          NEON_AUTH_JWKS_URL: ${{ secrets.NEON_AUTH_JWKS_URL }}
+
       # ── Verify Dockerfile exists before root deploy ──
       - run: test -f Dockerfile
 

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ backend/tests/eval/results/agent_openai-mimo-*
 !catalog/src/lib/
 !workers/catalog/src/lib/
 !workers/catalog/src/lib/**
+
+# Users TS service source — re-include (root lib/ rule is too broad)
+!workers/users/src/lib/
+!workers/users/src/lib/**

--- a/db/migrations/20260713000001_user_routes.sql
+++ b/db/migrations/20260713000001_user_routes.sql
@@ -1,0 +1,10 @@
+-- S2.8 evolves routes into the Users service's saved-route shape. session_id is
+-- retained for the future flow that claims anonymous routes after authentication.
+ALTER TABLE routes ADD COLUMN IF NOT EXISTS user_id TEXT;
+ALTER TABLE routes ADD COLUMN IF NOT EXISTS title TEXT;
+ALTER TABLE routes ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'saved', 'completed'));
+ALTER TABLE routes ADD COLUMN IF NOT EXISTS saved_at TIMESTAMPTZ;
+ALTER TABLE routes ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+CREATE INDEX IF NOT EXISTS idx_routes_user ON routes (user_id);
+DROP TRIGGER IF EXISTS trg_routes_updated_at ON routes;
+CREATE TRIGGER trg_routes_updated_at BEFORE UPDATE ON routes FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,2 +1,3 @@
-h1:BFboR5htY8XyegInA0OR2tY9xLeahgnjVNeqAgtKZnY=
+h1:UHyZaTfFdu8vJBWxyW8+OUaXlviTaFMKokvBr9q87/c=
 20260623000001_init.sql h1:j96dtVbOQB/5eNuug4tZpdgURdZ5h0Zh4Vka7/dy1A0=
+20260713000001_user_routes.sql h1:th9ag/cdiRp9plYQraVBGIuRXeH4g5R3XvCuGZeFx8Q=

--- a/packages/contract/scripts/emit-openapi.ts
+++ b/packages/contract/scripts/emit-openapi.ts
@@ -13,30 +13,36 @@ import { dirname, join } from "node:path";
 import { OpenAPIGenerator } from "@orpc/openapi";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { catalogContract } from "../src/contract.js";
+import { usersContract } from "../src/users-contract.js";
 
 const generator = new OpenAPIGenerator({
   schemaConverters: [new ZodToJsonSchemaConverter()],
 });
 
-const spec = await generator.generate(catalogContract, {
-  info: {
+async function emitOpenApi(
+  contract: Parameters<OpenAPIGenerator["generate"]>[0],
+  filename: string,
+  info: { title: string; version: string; description: string },
+): Promise<void> {
+  const spec = await generator.generate(contract, { info });
+  const outPath = join(dirname(fileURLToPath(import.meta.url)), "..", filename);
+  writeFileSync(outPath, `${JSON.stringify(spec, null, 2)}\n`, "utf8");
+  const methods = Object.keys(contract);
+  const schemaNames = Object.keys(spec.components?.schemas ?? {});
+  process.stdout.write(`Wrote ${outPath}\n`);
+  process.stdout.write(`Methods: ${methods.join(", ")}\n`);
+  process.stdout.write(`Schemas: ${schemaNames.join(", ") || "(inlined)"}\n`);
+}
+
+await emitOpenApi(catalogContract, "openapi.json", {
     title: "Animichi Catalog Service",
     version: "0.1.0",
     description:
       "Read methods of the TS Catalog service, consumed by the Python Agent service.",
-  },
 });
 
-const outPath = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "..",
-  "openapi.json",
-);
-
-writeFileSync(outPath, `${JSON.stringify(spec, null, 2)}\n`, "utf8");
-
-const methods = Object.keys(catalogContract);
-const schemaNames = Object.keys(spec.components?.schemas ?? {});
-process.stdout.write(`Wrote ${outPath}\n`);
-process.stdout.write(`Methods: ${methods.join(", ")}\n`);
-process.stdout.write(`Schemas: ${schemaNames.join(", ") || "(inlined)"}\n`);
+await emitOpenApi(usersContract, "users-openapi.json", {
+  title: "Animichi Users Service",
+  version: "0.1.0",
+  description: "User-domain routes of the TS Users service, consumed by apps/web.",
+});

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -7,3 +7,4 @@
 export * from "./models.js";
 export * from "./contract.js";
 export * from "./errors.js";
+export * from "./users-contract.js";

--- a/packages/contract/src/users-contract.ts
+++ b/packages/contract/src/users-contract.ts
@@ -90,7 +90,7 @@ export type UserRoute = z.infer<typeof UserRoute>;
 export const SaveRouteInput = z.object({
   id: z.uuid().optional(),
   title: z.string().min(1).max(200),
-  point_ids: z.array(z.string()).max(500),
+  point_ids: z.array(z.string().max(128)).max(500),
   status: RouteStatus.default("saved"),
 });
 /** Inferred save-route input. */

--- a/packages/contract/src/users-contract.ts
+++ b/packages/contract/src/users-contract.ts
@@ -1,0 +1,117 @@
+/** Self-contained models, errors, and oRPC contract for the Users service. */
+
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+
+/** Users error category semantics; categories never cross the wire. */
+export const UsersErrorCategory = z.enum(["user_actionable", "retryable", "system"]);
+/** Inferred Users error category. */
+export type UsersErrorCategory = z.infer<typeof UsersErrorCategory>;
+
+/** Data carried when a saved route does not exist. */
+export const RouteNotFoundData = z.object({ route_id: z.string() });
+/** Inferred route-not-found data. */
+export type RouteNotFoundData = z.infer<typeof RouteNotFoundData>;
+
+/** Data carried when a saved route belongs to another user. */
+export const RouteNotOwnedData = z.object({ route_id: z.string() });
+/** Inferred route-not-owned data. */
+export type RouteNotOwnedData = z.infer<typeof RouteNotOwnedData>;
+
+type UsersErrorDefItem = {
+  readonly status: number;
+  readonly category: UsersErrorCategory;
+  readonly message: string;
+  readonly data: z.ZodType<unknown>;
+};
+
+/** Users error registry with registry-only categories kept out of oRPC responses. */
+export const USERS_ERROR_DEFS = {
+  ROUTE_NOT_FOUND: {
+    status: 404,
+    category: "user_actionable",
+    message: "No such saved route",
+    data: RouteNotFoundData,
+  },
+  ROUTE_NOT_OWNED: {
+    status: 403,
+    category: "user_actionable",
+    message: "Route belongs to another user",
+    data: RouteNotOwnedData,
+  },
+} as const satisfies Record<string, UsersErrorDefItem>;
+
+/** Users error registry type. */
+export type UsersErrorDefs = typeof USERS_ERROR_DEFS;
+/** Users error code union. */
+export type UsersErrorCode = keyof UsersErrorDefs;
+
+type UsersErrorMapItem<Code extends UsersErrorCode> = {
+  status: UsersErrorDefs[Code]["status"];
+  message: UsersErrorDefs[Code]["message"];
+  data: UsersErrorDefs[Code]["data"];
+};
+type UsersErrorMap<Code extends UsersErrorCode> = {
+  [Key in Code]: UsersErrorMapItem<Key>;
+};
+
+function usersErrorEntry<Code extends UsersErrorCode>(
+  code: Code,
+): readonly [Code, UsersErrorMapItem<Code>] {
+  const { status, message, data } = USERS_ERROR_DEFS[code];
+  return [code, { status, message, data }];
+}
+
+/** Pick oRPC error entries while dropping registry-only category metadata. */
+export function pickUsersErrors<const Code extends UsersErrorCode>(
+  codes: readonly Code[],
+): UsersErrorMap<Code> {
+  return Object.fromEntries(codes.map(usersErrorEntry)) as UsersErrorMap<Code>;
+}
+
+/** Lifecycle status for a user-owned route. */
+export const RouteStatus = z.enum(["draft", "saved", "completed"]);
+/** Inferred route lifecycle status. */
+export type RouteStatus = z.infer<typeof RouteStatus>;
+
+/** User-owned route returned by the Users service. */
+export const UserRoute = z.object({
+  id: z.uuid(),
+  title: z.string(),
+  point_ids: z.array(z.string()),
+  status: RouteStatus,
+  saved_at: z.string().nullable(),
+  updated_at: z.string(),
+});
+/** Inferred user-owned route. */
+export type UserRoute = z.infer<typeof UserRoute>;
+
+/** Input for creating or updating a user-owned route. */
+export const SaveRouteInput = z.object({
+  id: z.uuid().optional(),
+  title: z.string().min(1).max(200),
+  point_ids: z.array(z.string()).max(500),
+  status: RouteStatus.default("saved"),
+});
+/** Inferred save-route input. */
+export type SaveRouteInput = z.infer<typeof SaveRouteInput>;
+
+/** Result returned when listing the caller's routes. */
+export const ListRoutesResult = z.object({ routes: z.array(UserRoute) });
+/** Inferred list-routes result. */
+export type ListRoutesResult = z.infer<typeof ListRoutesResult>;
+
+/** oRPC contract for authenticated user-route operations. */
+export const usersContract = {
+  listRoutes: oc
+    .route({ method: "GET", path: "/v1/users/routes", summary: "List the caller's saved routes" })
+    .output(ListRoutesResult),
+  saveRoute: oc
+    .route({ method: "POST", path: "/v1/users/routes", summary: "Create or update a saved route" })
+    .input(SaveRouteInput)
+    .errors(pickUsersErrors(["ROUTE_NOT_FOUND", "ROUTE_NOT_OWNED"]))
+    .output(UserRoute),
+};
+
+/** Users oRPC contract type. */
+export type UsersContract = typeof usersContract;

--- a/packages/contract/users-openapi.json
+++ b/packages/contract/users-openapi.json
@@ -1,0 +1,326 @@
+{
+  "info": {
+    "title": "Animichi Users Service",
+    "version": "0.1.0",
+    "description": "User-domain routes of the TS Users service, consumed by apps/web."
+  },
+  "openapi": "3.1.1",
+  "paths": {
+    "/v1/users/routes": {
+      "get": {
+        "operationId": "listRoutes",
+        "summary": "List the caller's saved routes",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "routes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "point_ids": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "status": {
+                            "enum": [
+                              "draft",
+                              "saved",
+                              "completed"
+                            ],
+                            "type": "string"
+                          },
+                          "saved_at": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "point_ids",
+                          "status",
+                          "saved_at",
+                          "updated_at"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "routes"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "saveRoute",
+        "summary": "Create or update a saved route",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200
+                  },
+                  "point_ids": {
+                    "type": "array",
+                    "maxItems": 500,
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "status": {
+                    "enum": [
+                      "draft",
+                      "saved",
+                      "completed"
+                    ],
+                    "type": "string",
+                    "default": "saved"
+                  }
+                },
+                "required": [
+                  "title",
+                  "point_ids"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "point_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "status": {
+                      "enum": [
+                        "draft",
+                        "saved",
+                        "completed"
+                      ],
+                      "type": "string"
+                    },
+                    "saved_at": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "point_ids",
+                    "status",
+                    "saved_at",
+                    "updated_at"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "ROUTE_NOT_OWNED"
+                        },
+                        "status": {
+                          "const": 403
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "Route belongs to another user"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "route_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "route_id"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "ROUTE_NOT_FOUND"
+                        },
+                        "status": {
+                          "const": 404
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "No such saved route"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "route_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "route_id"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/contract/users-openapi.json
+++ b/packages/contract/users-openapi.json
@@ -101,7 +101,8 @@
                     "type": "array",
                     "maxItems": 500,
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 128
                     }
                   },
                   "status": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,6 +375,61 @@ importers:
         specifier: ^4.103.0
         version: 4.103.0(@cloudflare/workers-types@4.20260623.1)
 
+  workers/users:
+    dependencies:
+      '@neondatabase/serverless':
+        specifier: ^1.1.0
+        version: 1.1.0
+      '@orpc/openapi':
+        specifier: 1.14.6
+        version: 1.14.6(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.0)
+      '@orpc/server':
+        specifier: 1.14.6
+        version: 1.14.6(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.0)
+      '@seichijunrei/contract':
+        specifier: workspace:*
+        version: link:../../packages/contract
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@cloudflare/workers-types@4.20260623.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+      hono:
+        specifier: '>=4.12.16'
+        version: 4.12.27
+      jose:
+        specifier: ^6.0.11
+        version: 6.2.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.16.19
+        version: 0.16.19(@cloudflare/workers-types@4.20260623.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)
+      '@cloudflare/workers-types':
+        specifier: ^4.20251001.0
+        version: 4.20260623.1
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
+      '@vitest/coverage-istanbul':
+        specifier: 4.1.9
+        version: 4.1.9(vitest@4.1.9)
+      eslint:
+        specifier: ^10.5.0
+        version: 10.5.0(jiti@2.7.0)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.62.0
+        version: 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      wrangler:
+        specifier: ^4.103.0
+        version: 4.110.0(@cloudflare/workers-types@4.20260623.1)
+
 packages:
 
   '@adobe/css-tools@4.5.0':
@@ -13394,7 +13449,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -13427,7 +13482,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -13441,7 +13496,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -4,6 +4,7 @@ import { authenticate as realAuthenticate, type AuthResult } from "./auth.ts";
 
 export interface Env {
   CATALOG: { fetch: (req: Request) => Promise<Response> };
+  USERS: { fetch: (req: Request) => Promise<Response> };
   CONTAINER: DurableObjectNamespace;
   SUPABASE_URL: string;
   SUPABASE_ANON_KEY: string;
@@ -80,6 +81,12 @@ export function createWorkerApp(deps: {
     c.env.CONTAINER.get(c.env.CONTAINER.idFromName("default")).fetch(c.req.raw),
   );
   app.all("/img/*", (c) => handleImageProxy(c.req.raw, c.executionCtx));
+  // Hono runs the first matching handler in registration order.
+  // /v1/users/* bypasses the container entirely: the users service verifies the
+  // Neon Auth JWT itself (jose JWKS), so the edge passes Authorization through
+  // untouched. Different trust model from the container /v1/* path — do not
+  // funnel this through authenticate()/forwardV1.
+  app.all("/v1/users/*", (c) => c.env.USERS.fetch(c.req.raw));
   app.all("/v1/*", async (c) => {
     if (isPublicV1(new URL(c.req.url).pathname)) return forwardV1(c.env, c.req.raw);
     const auth = await authenticate(c.req.raw, c.env, c.executionCtx);

--- a/worker/entry.test.ts
+++ b/worker/entry.test.ts
@@ -111,3 +111,34 @@ test("client-forged X-User-Id is stripped on PUBLIC route too", async () => {
   await app.request("/v1/bangumi/popular", { headers: { "X-User-Id": "forged" } }, envWithContainer(cap), stubCtx);
   assert.equal(cap.req?.headers.get("X-User-Id"), null);
 });
+
+test("/v1/users/routes -> USERS with Authorization intact, no container or auth", async () => {
+  let authCalled = false;
+  let containerHit = false;
+  let received: Request | undefined;
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => { authCalled = true; return { ok: false }; } });
+  const env = {
+    USERS: { fetch: async (req: Request) => { received = req; return new Response("users"); } },
+    CONTAINER: {
+      idFromName: () => "id",
+      get: () => ({ fetch: async () => { containerHit = true; return new Response("container"); } }),
+    },
+  } as never;
+  const res = await app.request("/v1/users/routes", { headers: { Authorization: "Bearer x" } }, env, stubCtx);
+  assert.equal(await res.text(), "users");
+  assert.equal(received?.headers.get("Authorization"), "Bearer x");
+  assert.equal(containerHit, false);
+  assert.equal(authCalled, false);
+});
+
+test("/v1/users/routes bypasses a rejecting authenticate stub", async () => {
+  let received = false;
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => ({ ok: false }) });
+  const env = {
+    USERS: { fetch: async () => { received = true; return new Response("users"); } },
+  } as never;
+  const res = await app.request("/v1/users/routes", {}, env, stubCtx);
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), "users");
+  assert.equal(received, true);
+});

--- a/workers/users/.dev.vars.example
+++ b/workers/users/.dev.vars.example
@@ -1,0 +1,3 @@
+# Local `wrangler dev` values. Copy to `.dev.vars` (git-ignored).
+DATABASE_URL=postgresql://postgres:postgres@localhost:54322/postgres
+NEON_AUTH_JWKS_URL=https://neon-auth.example.invalid/neondb/auth/.well-known/jwks.json

--- a/workers/users/.gitignore
+++ b/workers/users/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.wrangler/
+*.log
+.dev.vars
+coverage/

--- a/workers/users/AGENTS.md
+++ b/workers/users/AGENTS.md
@@ -1,0 +1,52 @@
+# workers/users — AGENTS.md
+
+TypeScript Cloudflare Worker: the **user-domain data service** (saved routes today; the
+anonymous-claim flow and more user data later). Owns user-scoped rows in Neon; reached ONLY via the
+root Worker's `USERS` service binding at `/v1/users/*` — no public route of its own.
+Root guide: `../../AGENTS.md`. Template sibling: `../catalog/AGENTS.md`.
+
+## Commands (from `workers/users/`)
+
+- pnpm. `pnpm run dev` (`wrangler dev`, local) — never `wrangler deploy` (hook `block-local-deploy`).
+- `pnpm test` / `pnpm run test:worker` (`vitest-pool-workers`) · `pnpm run typecheck` (`tsc --noEmit`).
+
+## Trust model (S2.8 — DIFFERENT from the container `/v1/*` path)
+
+- Every `/v1/users/*` request must carry a **Neon Auth JWT** as `Authorization: Bearer`. This
+  service verifies it ITSELF with jose: `createRemoteJWKSet` against `env.NEON_AUTH_JWKS_URL`
+  (cached per URL — never refetched per request), EdDSA only, `iss` == `aud` == the JWKS URL minus
+  `/.well-known/jwks.json`. `sub` becomes the row-scoping `user_id`.
+- No valid JWT → flat **401**. Anonymous access is NEVER allowed here (do not conflate with Chat's
+  anonymous `/v1/*` model). Cross-user access to an owned row → defined **403** `ROUTE_NOT_OWNED`
+  (rejected here, not silently at the DB layer).
+- The edge Worker passes `Authorization` through untouched; it does not pre-authenticate this path.
+
+## Stack + workerd gotchas (mirrors catalog — read `../catalog/AGENTS.md` for the long form)
+
+- Hono + oRPC; contract source of truth = `packages/contract/src/users-contract.ts`
+  (error registry mirror: `src/lib/errors.ts` — keep in lockstep).
+- **Drizzle is typing only** (`src/db/schema.ts`); every query goes through the raw `sql` tagged
+  template via the minimal `DbExecutor` (`execute` only). The fluent builder hangs under
+  workerd + neon-http.
+- **Arrays**: interpolating a JS array in the `sql` template expands to a tuple (`($1,$2)`; empty
+  → invalid `()`). Bind arrays as ONE param: `${sql.param(arr)}::text[]` (see `src/api/routes.ts`).
+- **timestamptz** returns raw strings under workerd → normalize `new Date(v).toISOString()` at the
+  boundary.
+- zod value imports only at the contract/handler boundary; internals `import type` from
+  `@seichijunrei/contract`.
+
+## Config / secrets
+
+- `wrangler.toml` `[vars]` holds ENVIRONMENT only. `DATABASE_URL` + `NEON_AUTH_JWKS_URL` are
+  secrets (`.dev.vars` locally — see `.dev.vars.example`; `wrangler secret put` / deploy-lane env
+  in CI). Never commit real Neon URLs or project ids.
+- Envs: `[env.staging]` = `users-staging`, `[env.production]` = `users` (routeless; binding-only).
+- DB schema changes ride `db/migrations/` (atlas, timestamped files + `atlas migrate hash`).
+
+## Tests
+
+TDD via `vitest-pool-workers` (`test/*.worker.test.ts`, ≤200 lines each). JWTs are minted in-test
+(Ed25519 + `createLocalJWKSet`) and injected through `createUsersApp({ getKey, makeDb })`; the fake
+executor renders queries with `PgDialect.sqlToQuery` — no drizzle-internals guessing. Real-DB
+round-trips (neon-http array/timestamptz serialization) are NOT covered here yet — verify against a
+real Postgres before building on top (leftover from S2.8).

--- a/workers/users/eslint.config.mjs
+++ b/workers/users/eslint.config.mjs
@@ -1,0 +1,19 @@
+// @ts-check
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  { ignores: ["node_modules/**", ".wrangler/**", "dist/**", "coverage/**", "eslint.config.mjs", "vitest.config.ts"] },
+  js.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: { parserOptions: { project: true, tsconfigRootDir: import.meta.dirname } },
+    rules: {
+      complexity: ["error", 10],
+      "max-depth": ["error", 2],
+      "max-lines-per-function": ["error", { max: 50, skipBlankLines: true, skipComments: true }],
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+    },
+  },
+);

--- a/workers/users/package.json
+++ b/workers/users/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "users",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Animichi Users service — user-domain routes over Neon (Hono + oRPC + jose)",
+  "scripts": {
+    "dev": "wrangler dev",
+    "test": "npm run test:worker",
+    "test:worker": "vitest run --config vitest.config.ts --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@neondatabase/serverless": "^1.1.0",
+    "@orpc/openapi": "1.14.6",
+    "@orpc/server": "1.14.6",
+    "@seichijunrei/contract": "workspace:*",
+    "drizzle-orm": "^0.45.2",
+    "hono": "^4.9.10",
+    "jose": "^6.0.11",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.16.19",
+    "@cloudflare/workers-types": "^4.20251001.0",
+    "@eslint/js": "^10.0.1",
+    "@vitest/coverage-istanbul": "4.1.9",
+    "eslint": "^10.5.0",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.62.0",
+    "vitest": "^4.1.0",
+    "wrangler": "^4.103.0"
+  }
+}

--- a/workers/users/src/api/routes.ts
+++ b/workers/users/src/api/routes.ts
@@ -1,0 +1,110 @@
+import type {
+  ListRoutesResult,
+  RouteStatus,
+  SaveRouteInput,
+  UserRoute,
+} from "@seichijunrei/contract";
+import { sql } from "drizzle-orm";
+import type { DbExecutor } from "../db/client";
+import { routeNotFound, routeNotOwned } from "../lib/errors";
+
+type RecordRow = Record<string, unknown>;
+
+function isRecord(value: unknown): value is RecordRow {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStatus(value: unknown): value is RouteStatus {
+  return value === "draft" || value === "saved" || value === "completed";
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+    ? value
+    : [];
+}
+
+function iso(value: unknown): string {
+  if (typeof value !== "string" && !(value instanceof Date)) throw new Error("invalid timestamp row");
+  return new Date(value).toISOString();
+}
+
+function nullableIso(value: unknown): string | null {
+  return value === null ? null : iso(value);
+}
+
+/** Narrow and normalize one raw database row into the public route model. */
+function toUserRoute(value: unknown): UserRoute {
+  if (!isRecord(value)) throw new Error("invalid route row");
+  const { id, title, status } = value;
+  if (typeof id !== "string" || typeof title !== "string" || !isStatus(status)) {
+    throw new Error("invalid route row");
+  }
+  return {
+    id, title, status, point_ids: strings(value.point_ids),
+    saved_at: nullableIso(value.saved_at), updated_at: iso(value.updated_at),
+  };
+}
+
+/** List routes owned by a user, newest update first. */
+export async function listRoutes(db: DbExecutor, userId: string): Promise<ListRoutesResult> {
+  const result = await db.execute(sql`
+    SELECT id, title, point_ids, status, saved_at, updated_at
+    FROM routes WHERE user_id = ${userId} ORDER BY updated_at DESC
+  `);
+  return { routes: result.rows.map(toUserRoute) };
+}
+
+async function createRoute(
+  db: DbExecutor,
+  userId: string,
+  input: SaveRouteInput,
+): Promise<UserRoute> {
+  const result = await db.execute(sql`
+    INSERT INTO routes (user_id, title, point_ids, status, saved_at)
+    VALUES (${userId}, ${input.title}, ${sql.param(input.point_ids)}::text[], ${input.status},
+      CASE WHEN ${input.status} = 'draft' THEN NULL ELSE NOW() END)
+    RETURNING id, title, point_ids, status, saved_at, updated_at
+  `);
+  return toUserRoute(result.rows[0]);
+}
+
+function ownerFrom(value: unknown): string | null | undefined {
+  if (!isRecord(value)) return undefined;
+  return typeof value.user_id === "string" || value.user_id === null
+    ? value.user_id
+    : undefined;
+}
+
+async function assertOwner(db: DbExecutor, userId: string, routeId: string): Promise<void> {
+  const result = await db.execute(sql`SELECT user_id FROM routes WHERE id = ${routeId}`);
+  if (result.rows.length === 0) throw routeNotFound(routeId);
+  if (ownerFrom(result.rows[0]) !== userId) throw routeNotOwned(routeId);
+}
+
+async function updateRoute(
+  db: DbExecutor,
+  userId: string,
+  input: SaveRouteInput & { id: string },
+): Promise<UserRoute> {
+  await assertOwner(db, userId, input.id);
+  const result = await db.execute(sql`
+    UPDATE routes SET title = ${input.title}, point_ids = ${sql.param(input.point_ids)}::text[],
+      status = ${input.status}, saved_at = CASE WHEN ${input.status} = 'draft'
+        THEN NULL ELSE COALESCE(saved_at, NOW()) END
+    WHERE id = ${input.id}
+    RETURNING id, title, point_ids, status, saved_at, updated_at
+  `);
+  return toUserRoute(result.rows[0]);
+}
+
+/** Create a route or update it after explicit ownership validation. */
+export async function saveRoute(
+  db: DbExecutor,
+  userId: string,
+  input: SaveRouteInput,
+): Promise<UserRoute> {
+  return input.id
+    ? updateRoute(db, userId, { ...input, id: input.id })
+    : createRoute(db, userId, input);
+}

--- a/workers/users/src/api/routes.ts
+++ b/workers/users/src/api/routes.ts
@@ -37,11 +37,12 @@ function nullableIso(value: unknown): string | null {
 function toUserRoute(value: unknown): UserRoute {
   if (!isRecord(value)) throw new Error("invalid route row");
   const { id, title, status } = value;
-  if (typeof id !== "string" || typeof title !== "string" || !isStatus(status)) {
+  if (typeof id !== "string" || !isStatus(status)) {
     throw new Error("invalid route row");
   }
+  const safeTitle = typeof title === "string" ? title : "";
   return {
-    id, title, status, point_ids: strings(value.point_ids),
+    id, title: safeTitle, status, point_ids: strings(value.point_ids),
     saved_at: nullableIso(value.saved_at), updated_at: iso(value.updated_at),
   };
 }
@@ -82,6 +83,11 @@ async function assertOwner(db: DbExecutor, userId: string, routeId: string): Pro
   if (ownerFrom(result.rows[0]) !== userId) throw routeNotOwned(routeId);
 }
 
+function updatedRoute(rows: unknown[], routeId: string): UserRoute {
+  if (rows.length === 0) throw routeNotOwned(routeId);
+  return toUserRoute(rows[0]);
+}
+
 async function updateRoute(
   db: DbExecutor,
   userId: string,
@@ -92,10 +98,10 @@ async function updateRoute(
     UPDATE routes SET title = ${input.title}, point_ids = ${sql.param(input.point_ids)}::text[],
       status = ${input.status}, saved_at = CASE WHEN ${input.status} = 'draft'
         THEN NULL ELSE COALESCE(saved_at, NOW()) END
-    WHERE id = ${input.id}
+    WHERE id = ${input.id} AND user_id = ${userId}
     RETURNING id, title, point_ids, status, saved_at, updated_at
   `);
-  return toUserRoute(result.rows[0]);
+  return updatedRoute(result.rows, input.id);
 }
 
 /** Create a route or update it after explicit ownership validation. */

--- a/workers/users/src/auth/jwt.ts
+++ b/workers/users/src/auth/jwt.ts
@@ -1,0 +1,48 @@
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  type JWTVerifyGetKey,
+} from "jose";
+
+const JWKS_SUFFIX = "/.well-known/jwks.json";
+const remoteKeys = new Map<string, JWTVerifyGetKey>();
+
+/** Derive the Neon Auth issuer/audience base URL from its JWKS URL. */
+export function issuerFromJwksUrl(jwksUrl: string): string {
+  return jwksUrl.endsWith(JWKS_SUFFIX) ? jwksUrl.slice(0, -JWKS_SUFFIX.length) : jwksUrl;
+}
+
+function cachedRemote(url: string): JWTVerifyGetKey {
+  const cached = remoteKeys.get(url);
+  if (cached) return cached;
+  const key = createRemoteJWKSet(new URL(url));
+  remoteKeys.set(url, key);
+  return key;
+}
+
+function bearerToken(authorization: string | null): string | null {
+  if (!authorization?.startsWith("Bearer ")) return null;
+  const token = authorization.slice("Bearer ".length);
+  return token.length > 0 ? token : null;
+}
+
+/** Verify an EdDSA Neon Auth bearer and return its non-empty subject. */
+export async function verifyBearer(
+  authorization: string | null,
+  jwksUrl: string,
+  getKey?: JWTVerifyGetKey,
+): Promise<{ userId: string } | null> {
+  const token = bearerToken(authorization);
+  if (!token) return null;
+  try {
+    const base = issuerFromJwksUrl(jwksUrl);
+    const { payload } = await jwtVerify(token, getKey ?? cachedRemote(jwksUrl), {
+      algorithms: ["EdDSA"], issuer: base, audience: base,
+    });
+    return typeof payload.sub === "string" && payload.sub.length > 0
+      ? { userId: payload.sub }
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/workers/users/src/db/client.ts
+++ b/workers/users/src/db/client.ts
@@ -1,0 +1,16 @@
+import { neon } from "@neondatabase/serverless";
+import { drizzle, type NeonHttpDatabase } from "drizzle-orm/neon-http";
+import type { SQL } from "drizzle-orm";
+import * as schema from "./schema";
+
+/** Typed Drizzle database; queries still use only the raw SQL executor. */
+export type UsersDb = NeonHttpDatabase<typeof schema>;
+/** Minimal executor shared by production Drizzle and test fakes. */
+export interface DbExecutor {
+  execute: (query: SQL) => Promise<{ rows: unknown[] }>;
+}
+
+/** Create the Neon HTTP-backed Users database. */
+export function makeDb(connStr: string): UsersDb {
+  return drizzle(neon(connStr), { schema });
+}

--- a/workers/users/src/db/schema.ts
+++ b/workers/users/src/db/schema.ts
@@ -1,0 +1,39 @@
+import {
+  customType,
+  integer,
+  jsonb,
+  pgTable,
+  real,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+/** PostGIS geography typing for the legacy route origin column. */
+const geography = customType<{ data: string; driverData: string }>({
+  dataType() {
+    return "geography(Point,4326)";
+  },
+});
+
+/**
+ * Typing only — queries go through the raw sql tagged template (workerd
+ * gotcha); this schema is also the future atlas-provider-drizzle source.
+ */
+export const routes = pgTable("routes", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  sessionId: text("session_id"),
+  bangumiId: text("bangumi_id"),
+  originStation: text("origin_station"),
+  originLocation: geography("origin_location"),
+  pointIds: text("point_ids").array().notNull(),
+  totalDistance: real("total_distance"),
+  totalDuration: integer("total_duration"),
+  routeData: jsonb("route_data"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+  userId: text("user_id"),
+  title: text("title"),
+  status: text("status").notNull().default("draft"),
+  savedAt: timestamp("saved_at", { withTimezone: true }),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/workers/users/src/index.ts
+++ b/workers/users/src/index.ts
@@ -1,0 +1,76 @@
+import { OpenAPIHandler } from "@orpc/openapi/fetch";
+import { Hono } from "hono";
+import type { JWTVerifyGetKey } from "jose";
+import { verifyBearer } from "./auth/jwt";
+import { makeDb as realMakeDb, type DbExecutor } from "./db/client";
+import { usersRouter } from "./router";
+
+/** Users Worker bindings. Secrets are supplied outside wrangler vars. */
+export interface Env {
+  ENVIRONMENT?: string;
+  HYPERDRIVE?: { connectionString: string };
+  DATABASE_URL?: string;
+  NEON_AUTH_JWKS_URL?: string;
+}
+
+/** Injectable boundaries used by workerd tests. */
+export interface UsersAppDeps {
+  getKey?: JWTVerifyGetKey;
+  makeDb?: (connStr: string) => DbExecutor;
+}
+
+const dbPools = new Map<string, DbExecutor>();
+
+function connectionString(env: Env): string | undefined {
+  return env.HYPERDRIVE?.connectionString ?? env.DATABASE_URL;
+}
+
+function realDbFor(connStr: string): DbExecutor {
+  const cached = dbPools.get(connStr);
+  if (cached) return cached;
+  const db = realMakeDb(connStr);
+  dbPools.set(connStr, db);
+  return db;
+}
+
+function dbFor(connStr: string, factory?: UsersAppDeps["makeDb"]): DbExecutor {
+  return factory ? factory(connStr) : realDbFor(connStr);
+}
+
+/** Clear cached real Neon clients; neon-http owns no persistent sockets. */
+export function closeDbPools(): void {
+  dbPools.clear();
+}
+
+const unauthorized = {
+  error: { code: "unauthorized", message: "Valid credentials required." },
+};
+
+/** Create an independently injectable Users Hono application. */
+export function createUsersApp(deps: UsersAppDeps = {}): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  const apiHandler = new OpenAPIHandler(usersRouter);
+  app.get("/healthz", (c) => c.json({
+    status: "ok", service: "users", env: c.env.ENVIRONMENT ?? "unknown",
+  }));
+  app.use("/v1/users/*", async (c, next) => {
+    const authUrl = c.env.NEON_AUTH_JWKS_URL;
+    if (!authUrl) return c.json({ error: "users auth not configured" }, 503);
+    const auth = await verifyBearer(
+      c.req.header("Authorization") ?? null, authUrl, deps.getKey,
+    );
+    if (!auth) return c.json(unauthorized, 401);
+    const connStr = connectionString(c.env);
+    if (!connStr) return c.json({ error: "users database not configured" }, 503);
+    const { matched, response } = await apiHandler.handle(c.req.raw, {
+      context: { db: dbFor(connStr, deps.makeDb), userId: auth.userId },
+    });
+    if (matched) return c.newResponse(response.body, response);
+    await next();
+  });
+  return app;
+}
+
+export default createUsersApp();
+export { usersRouter };
+export type { UsersRouter } from "./router";

--- a/workers/users/src/lib/errors.ts
+++ b/workers/users/src/lib/errors.ts
@@ -1,0 +1,37 @@
+import { ORPCError } from "@orpc/server";
+
+/** Data carried by both user-route lookup failures. */
+export interface RouteErrorData { route_id: string }
+
+/**
+ * No-zod Worker mirror of USERS_ERROR_DEFS. Keep status, category, and message
+ * in lockstep with packages/contract/src/users-contract.ts.
+ */
+export const USERS_ERRORS = {
+  ROUTE_NOT_FOUND: {
+    status: 404, category: "user_actionable", message: "No such saved route",
+  },
+  ROUTE_NOT_OWNED: {
+    status: 403, category: "user_actionable", message: "Route belongs to another user",
+  },
+} as const;
+
+/** Construct a defined route-not-found oRPC error. */
+export function routeNotFound(
+  routeId: string,
+): ORPCError<"ROUTE_NOT_FOUND", RouteErrorData> {
+  const def = USERS_ERRORS.ROUTE_NOT_FOUND;
+  return new ORPCError("ROUTE_NOT_FOUND", {
+    defined: true, status: def.status, message: def.message, data: { route_id: routeId },
+  });
+}
+
+/** Construct a defined route-not-owned oRPC error. */
+export function routeNotOwned(
+  routeId: string,
+): ORPCError<"ROUTE_NOT_OWNED", RouteErrorData> {
+  const def = USERS_ERRORS.ROUTE_NOT_OWNED;
+  return new ORPCError("ROUTE_NOT_OWNED", {
+    defined: true, status: def.status, message: def.message, data: { route_id: routeId },
+  });
+}

--- a/workers/users/src/router.ts
+++ b/workers/users/src/router.ts
@@ -1,0 +1,21 @@
+import { usersContract } from "@seichijunrei/contract";
+import { implement } from "@orpc/server";
+import { listRoutes as listHandler, saveRoute as saveHandler } from "./api/routes";
+import type { DbExecutor } from "./db/client";
+
+/** Per-request dependencies established by authentication middleware. */
+export interface UsersContext { db: DbExecutor; userId: string }
+
+const os = implement(usersContract).$context<UsersContext>();
+
+const listRoutes = os.listRoutes.handler(async ({ context }) =>
+  listHandler(context.db, context.userId),
+);
+const saveRoute = os.saveRoute.handler(async ({ input, context }) =>
+  saveHandler(context.db, context.userId, input),
+);
+
+/** Users service oRPC implementation. */
+export const usersRouter = { listRoutes, saveRoute };
+/** Users router type. */
+export type UsersRouter = typeof usersRouter;

--- a/workers/users/test/auth.worker.test.ts
+++ b/workers/users/test/auth.worker.test.ts
@@ -1,0 +1,70 @@
+import { generateKeyPair, SignJWT } from "jose";
+import { describe, expect, it } from "vitest";
+import { createUsersApp } from "../src/index";
+import { authTools, BASE, fakeDb, TEST_ENV } from "./helpers";
+
+const unauthorized = {
+  error: { code: "unauthorized", message: "Valid credentials required." },
+};
+
+async function request(token?: string, env = TEST_ENV): Promise<Response> {
+  const auth = await authTools();
+  const { db } = fakeDb();
+  const app = createUsersApp({ getKey: auth.getKey, makeDb: () => db });
+  const headers: Record<string, string> = token === undefined ? {} : { Authorization: token };
+  return app.request("/v1/users/routes", { headers }, env);
+}
+
+async function expectUnauthorized(token?: string): Promise<void> {
+  const response = await request(token);
+  expect(response.status).toBe(401);
+  expect(await response.json()).toEqual(unauthorized);
+}
+
+describe("Users Worker auth boundary", () => {
+  it("rejects a missing Authorization header", () => expectUnauthorized());
+  it("rejects an empty bearer", () => expectUnauthorized("Bearer "));
+  it("rejects a garbage token", () => expectUnauthorized("Bearer garbage"));
+
+  it("rejects an expired token", async () => {
+    const { makeJwt } = await authTools();
+    await expectUnauthorized(`Bearer ${await makeJwt({ sub: "user-a", exp: 1 })}`);
+  });
+
+  it("rejects the wrong issuer", async () => {
+    const { makeJwt } = await authTools();
+    await expectUnauthorized(`Bearer ${await makeJwt({ sub: "user-a", iss: "https://wrong.invalid" })}`);
+  });
+
+  it("rejects the wrong audience", async () => {
+    const { makeJwt } = await authTools();
+    await expectUnauthorized(`Bearer ${await makeJwt({ sub: "user-a", aud: "https://wrong.invalid" })}`);
+  });
+
+  it("rejects a token signed by another key", async () => {
+    const { privateKey } = await generateKeyPair("EdDSA", { extractable: true });
+    const token = await new SignJWT({}).setProtectedHeader({ alg: "EdDSA", kid: "test-key" })
+      .setSubject("user-a").setIssuer(BASE).setAudience(BASE).setExpirationTime("15m").sign(privateKey);
+    const validResolver = (await authTools()).getKey;
+    const response = await createUsersApp({ getKey: validResolver, makeDb: () => fakeDb().db })
+      .request("/v1/users/routes", { headers: { Authorization: `Bearer ${token}` } }, TEST_ENV);
+    expect(response.status).toBe(401);
+  });
+
+  it("accepts a valid token", async () => {
+    const { makeJwt } = await authTools();
+    expect((await request(`Bearer ${await makeJwt({ sub: "user-a" })}`)).status).toBe(200);
+  });
+
+  it("serves health without authentication", async () => {
+    const response = await createUsersApp().request("/healthz", {}, { ENVIRONMENT: "test" });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ status: "ok", service: "users" });
+  });
+
+  it("returns 503 when auth is unconfigured", async () => {
+    const response = await request(undefined, { ENVIRONMENT: "test", DATABASE_URL: "postgresql://fake" });
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "users auth not configured" });
+  });
+});

--- a/workers/users/test/helpers.ts
+++ b/workers/users/test/helpers.ts
@@ -114,7 +114,8 @@ export function fakeDb(seed: FakeRouteRow[] = []): { db: DbExecutor; rows: FakeR
       return Promise.resolve({ rows: [row] });
     }
     if (text.includes("update routes")) {
-      const row = rows.find((item) => item.id === values.at(-1));
+      const [id, userId] = values.slice(-2);
+      const row = rows.find((item) => item.id === id && item.user_id === userId);
       if (!row) return Promise.resolve({ rows: [] });
       updateRow(row, values);
       return Promise.resolve({ rows: [row] });

--- a/workers/users/test/helpers.ts
+++ b/workers/users/test/helpers.ts
@@ -1,0 +1,128 @@
+import type { RouteStatus } from "@seichijunrei/contract";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import {
+  createLocalJWKSet,
+  exportJWK,
+  generateKeyPair,
+  SignJWT,
+  type JWTVerifyGetKey,
+} from "jose";
+import type { DbExecutor } from "../src/db/client";
+import type { Env } from "../src/index";
+
+/** Test Neon Auth issuer/audience. */
+export const BASE = "https://auth.test.invalid/neondb/auth";
+/** Test Neon Auth JWKS endpoint. */
+export const JWKS_URL = `${BASE}/.well-known/jwks.json`;
+/** Complete configured Worker environment for tests. */
+export const TEST_ENV: Env = {
+  ENVIRONMENT: "test",
+  NEON_AUTH_JWKS_URL: JWKS_URL,
+  DATABASE_URL: "postgresql://fake",
+};
+
+interface JwtOptions { sub: string; iss?: string; aud?: string; exp?: number }
+/** Shared JWT tools initialized once per worker isolate. */
+export interface AuthTools {
+  getKey: JWTVerifyGetKey;
+  makeJwt: (options: JwtOptions) => Promise<string>;
+}
+
+let authToolsPromise: Promise<AuthTools> | undefined;
+
+async function createAuthTools(): Promise<AuthTools> {
+  const { privateKey, publicKey } = await generateKeyPair("EdDSA", { extractable: true });
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = "test-key";
+  const getKey = createLocalJWKSet({ keys: [jwk] });
+  const makeJwt = (options: JwtOptions): Promise<string> => new SignJWT({})
+    .setProtectedHeader({ alg: "EdDSA", kid: "test-key" })
+    .setSubject(options.sub)
+    .setIssuer(options.iss ?? BASE)
+    .setAudience(options.aud ?? BASE)
+    .setExpirationTime(options.exp ?? Math.floor(Date.now() / 1000) + 900)
+    .sign(privateKey);
+  return { getKey, makeJwt };
+}
+
+/** Return the isolate's one-time Ed25519 test fixture. */
+export function authTools(): Promise<AuthTools> {
+  authToolsPromise ??= createAuthTools();
+  return authToolsPromise;
+}
+
+/** Mutable row representation owned by the reusable fake executor. */
+export interface FakeRouteRow {
+  id: string;
+  user_id: string | null;
+  title: string;
+  point_ids: string[];
+  status: RouteStatus;
+  saved_at: string | null;
+  updated_at: string;
+}
+
+const NOW = "2026-07-13T04:00:00.000Z";
+const NEW_ID = "00000000-0000-4000-8000-000000000001";
+const dialect = new PgDialect();
+
+function rendered(query: SQL): { text: string; values: unknown[] } {
+  const { sql: text, params: values } = dialect.sqlToQuery(query);
+  return { text: text.toLowerCase(), values };
+}
+
+function routeStatus(value: unknown): RouteStatus {
+  return value === "draft" || value === "completed" ? value : "saved";
+}
+
+function insertRow(values: unknown[]): FakeRouteRow {
+  const status = routeStatus(values[3]);
+  return {
+    id: NEW_ID,
+    user_id: typeof values[0] === "string" ? values[0] : null,
+    title: typeof values[1] === "string" ? values[1] : "",
+    point_ids: Array.isArray(values[2]) ? values[2].filter((v): v is string => typeof v === "string") : [],
+    status,
+    saved_at: status === "draft" ? null : NOW,
+    updated_at: NOW,
+  };
+}
+
+function updateRow(row: FakeRouteRow, values: unknown[]): void {
+  row.title = typeof values[0] === "string" ? values[0] : row.title;
+  row.point_ids = Array.isArray(values[1])
+    ? values[1].filter((v): v is string => typeof v === "string")
+    : row.point_ids;
+  row.status = routeStatus(values[2]);
+  row.saved_at = row.status === "draft" ? null : row.saved_at ?? NOW;
+  row.updated_at = NOW;
+}
+
+/** In-memory raw-SQL executor matching list, owner, insert, and update queries. */
+export function fakeDb(seed: FakeRouteRow[] = []): { db: DbExecutor; rows: FakeRouteRow[] } {
+  const rows = [...seed];
+  const execute = (query: SQL): Promise<{ rows: unknown[] }> => {
+    const { text, values } = rendered(query);
+    if (text.includes("select user_id")) {
+      const row = rows.find((item) => item.id === values[0]);
+      return Promise.resolve({ rows: row ? [{ user_id: row.user_id }] : [] });
+    }
+    if (text.includes("insert into routes")) {
+      const row = insertRow(values);
+      rows.push(row);
+      return Promise.resolve({ rows: [row] });
+    }
+    if (text.includes("update routes")) {
+      const row = rows.find((item) => item.id === values.at(-1));
+      if (!row) return Promise.resolve({ rows: [] });
+      updateRow(row, values);
+      return Promise.resolve({ rows: [row] });
+    }
+    const userId = values[0];
+    const matches = rows.filter((item) => item.user_id === userId);
+    matches.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    return Promise.resolve({ rows: matches });
+  };
+  return { db: { execute }, rows };
+}

--- a/workers/users/test/routes-api.worker.test.ts
+++ b/workers/users/test/routes-api.worker.test.ts
@@ -1,0 +1,63 @@
+import type { SaveRouteInput } from "@seichijunrei/contract";
+import { ORPCError } from "@orpc/server";
+import { describe, expect, it } from "vitest";
+import { listRoutes, saveRoute } from "../src/api/routes";
+import { fakeDb, type FakeRouteRow } from "./helpers";
+
+const ID = "00000000-0000-4000-8000-000000000009";
+const RAW = "2026-07-13 12:34:56+00";
+
+function row(overrides: Partial<FakeRouteRow> = {}): FakeRouteRow {
+  return {
+    id: ID, user_id: "user-a", title: "Tokyo", point_ids: ["p1"],
+    status: "saved", saved_at: RAW, updated_at: RAW, ...overrides,
+  };
+}
+
+async function caught(input: SaveRouteInput): Promise<ORPCError<string, unknown>> {
+  try {
+    await saveRoute(fakeDb([row({ user_id: "user-b" })]).db, "user-a", input);
+  } catch (error) {
+    expect(error).toBeInstanceOf(ORPCError);
+    return error as ORPCError<string, unknown>;
+  }
+  throw new Error("expected saveRoute to reject");
+}
+
+describe("user routes handlers", () => {
+  it("lists an empty store", async () => {
+    expect(await listRoutes(fakeDb().db, "user-a")).toEqual({ routes: [] });
+  });
+
+  it("creates a saved route with normalized timestamps", async () => {
+    const result = await saveRoute(fakeDb().db, "user-a", {
+      title: "Tokyo", point_ids: ["p1"], status: "saved",
+    });
+    expect(result).toMatchObject({ title: "Tokyo", status: "saved", point_ids: ["p1"] });
+    expect(result.saved_at).toBe("2026-07-13T04:00:00.000Z");
+    expect(result.updated_at).toBe("2026-07-13T04:00:00.000Z");
+  });
+
+  it("creates a draft with no saved timestamp", async () => {
+    const result = await saveRoute(fakeDb().db, "user-a", {
+      title: "Draft", point_ids: [], status: "draft",
+    });
+    expect(result.saved_at).toBeNull();
+  });
+
+  it("throws ROUTE_NOT_FOUND for an unknown update id", async () => {
+    const error = await caught({ id: "00000000-0000-4000-8000-000000000008", title: "X", point_ids: [], status: "saved" });
+    expect(error).toMatchObject({ code: "ROUTE_NOT_FOUND", status: 404, defined: true });
+  });
+
+  it("throws ROUTE_NOT_OWNED for another user's route", async () => {
+    const error = await caught({ id: ID, title: "X", point_ids: [], status: "saved" });
+    expect(error).toMatchObject({ code: "ROUTE_NOT_OWNED", status: 403, defined: true });
+  });
+
+  it("normalizes raw workerd timestamp strings while listing", async () => {
+    const result = await listRoutes(fakeDb([row()]).db, "user-a");
+    expect(result.routes[0]?.saved_at).toBe("2026-07-13T12:34:56.000Z");
+    expect(result.routes[0]?.updated_at).toBe("2026-07-13T12:34:56.000Z");
+  });
+});

--- a/workers/users/test/routes-api.worker.test.ts
+++ b/workers/users/test/routes-api.worker.test.ts
@@ -1,11 +1,17 @@
 import type { SaveRouteInput } from "@seichijunrei/contract";
 import { ORPCError } from "@orpc/server";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 import { listRoutes, saveRoute } from "../src/api/routes";
+import type { DbExecutor } from "../src/db/client";
 import { fakeDb, type FakeRouteRow } from "./helpers";
 
 const ID = "00000000-0000-4000-8000-000000000009";
 const RAW = "2026-07-13 12:34:56+00";
+const UPDATE_INPUT: SaveRouteInput = {
+  id: ID, title: "X", point_ids: [], status: "saved",
+};
 
 function row(overrides: Partial<FakeRouteRow> = {}): FakeRouteRow {
   return {
@@ -14,9 +20,12 @@ function row(overrides: Partial<FakeRouteRow> = {}): FakeRouteRow {
   };
 }
 
-async function caught(input: SaveRouteInput): Promise<ORPCError<string, unknown>> {
+async function caught(
+  input: SaveRouteInput,
+  db: DbExecutor = fakeDb([row({ user_id: "user-b" })]).db,
+): Promise<ORPCError<string, unknown>> {
   try {
-    await saveRoute(fakeDb([row({ user_id: "user-b" })]).db, "user-a", input);
+    await saveRoute(db, "user-a", input);
   } catch (error) {
     expect(error).toBeInstanceOf(ORPCError);
     return error as ORPCError<string, unknown>;
@@ -59,5 +68,36 @@ describe("user routes handlers", () => {
     const result = await listRoutes(fakeDb([row()]).db, "user-a");
     expect(result.routes[0]?.saved_at).toBe("2026-07-13T12:34:56.000Z");
     expect(result.routes[0]?.updated_at).toBe("2026-07-13T12:34:56.000Z");
+  });
+});
+
+describe("atomic route updates", () => {
+  it("throws ROUTE_NOT_OWNED when an owned update loses the race", async () => {
+    const inlineDb: DbExecutor = { execute: (query) => {
+      const rendered = new PgDialect().sqlToQuery(query);
+      if (rendered.sql.toLowerCase().includes("select user_id")) {
+        return Promise.resolve({ rows: [{ user_id: "user-a" }] });
+      }
+      return Promise.resolve({ rows: [] });
+    } };
+    const error = await caught(UPDATE_INPUT, inlineDb);
+    expect(error).toMatchObject({ code: "ROUTE_NOT_OWNED", status: 403, defined: true });
+  });
+
+  it("includes user_id in the atomic update predicate", async () => {
+    let updateQuery: SQL | undefined;
+    const inlineDb: DbExecutor = { execute: (query) => {
+      const rendered = new PgDialect().sqlToQuery(query);
+      if (rendered.sql.toLowerCase().includes("select user_id")) {
+        return Promise.resolve({ rows: [{ user_id: "user-a" }] });
+      }
+      updateQuery = query;
+      return Promise.resolve({ rows: [] });
+    } };
+    await caught(UPDATE_INPUT, inlineDb);
+    if (!updateQuery) throw new Error("expected update query");
+    const rendered = new PgDialect().sqlToQuery(updateQuery);
+    expect(rendered.sql).toContain("user_id");
+    expect(rendered.params).toContain("user-a");
   });
 });

--- a/workers/users/test/worker.worker.test.ts
+++ b/workers/users/test/worker.worker.test.ts
@@ -1,0 +1,66 @@
+import { UserRoute } from "@seichijunrei/contract";
+import { describe, expect, it } from "vitest";
+import { createUsersApp } from "../src/index";
+import { authTools, fakeDb, TEST_ENV } from "./helpers";
+
+async function setup() {
+  const auth = await authTools();
+  const store = fakeDb();
+  const app = createUsersApp({ getKey: auth.getKey, makeDb: () => store.db });
+  const token = await auth.makeJwt({ sub: "user-a" });
+  return { app, auth, headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" } };
+}
+
+function save(app: Awaited<ReturnType<typeof setup>>["app"], headers: Record<string, string>, body: unknown) {
+  return app.request("/v1/users/routes", {
+    method: "POST", headers, body: JSON.stringify(body),
+  }, TEST_ENV);
+}
+
+describe("Users Worker routes wire", () => {
+  it("saves then lists a route for the same JWT subject", async () => {
+    const { app, headers } = await setup();
+    const created = await save(app, headers, { title: "Tokyo", point_ids: ["p1"] });
+    expect(created.status).toBe(200);
+    const route: unknown = await created.json();
+    expect(UserRoute.safeParse(route).success).toBe(true);
+    const listed = await app.request("/v1/users/routes", { headers }, TEST_ENV);
+    expect(await listed.json()).toMatchObject({ routes: [{ title: "Tokyo" }] });
+  });
+
+  it.each([
+    [{ point_ids: [] }, "missing title"],
+    [{ title: "", point_ids: [] }, "empty title"],
+    [{ title: "X", point_ids: Array.from({ length: 501 }, (_, i) => String(i)) }, "501 points"],
+    [{ title: "X", point_ids: [], status: "invalid" }, "bad status"],
+  ])("returns 400 for %s (%s)", async (body, _label) => {
+    const { app, headers } = await setup();
+    expect((await save(app, headers, body)).status).toBe(400);
+  });
+
+  it("serializes the defined ownership error for a cross-user update", async () => {
+    const { app, auth, headers } = await setup();
+    const created = await save(app, headers, { title: "A", point_ids: [] });
+    const route: unknown = await created.json();
+    const parsed = UserRoute.parse(route);
+    const userB = await auth.makeJwt({ sub: "user-b" });
+    const response = await save(app, {
+      Authorization: `Bearer ${userB}`, "content-type": "application/json",
+    }, { id: parsed.id, title: "B", point_ids: [] });
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      defined: true, code: "ROUTE_NOT_OWNED", status: 403,
+      message: "Route belongs to another user", data: { route_id: parsed.id },
+    });
+  });
+
+  it("returns 503 when the database is unconfigured", async () => {
+    const { app, auth } = await setup();
+    const token = await auth.makeJwt({ sub: "user-a" });
+    const response = await app.request("/v1/users/routes", {
+      headers: { Authorization: `Bearer ${token}` },
+    }, { ENVIRONMENT: "test", NEON_AUTH_JWKS_URL: TEST_ENV.NEON_AUTH_JWKS_URL });
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "users database not configured" });
+  });
+});

--- a/workers/users/tsconfig.json
+++ b/workers/users/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers/types"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/workers/users/vitest.config.ts
+++ b/workers/users/vitest.config.ts
@@ -1,0 +1,16 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+/** Worker-runtime tests and coverage for the Users service. */
+export default defineConfig({
+  plugins: [cloudflareTest({ wrangler: { configPath: "./wrangler.toml" } })],
+  test: {
+    include: ["test/**/*.worker.test.ts"],
+    coverage: {
+      provider: "istanbul",
+      include: ["src/**/*.ts"],
+      reporter: ["text", "lcov"],
+      thresholds: { lines: 60, functions: 60, statements: 60, branches: 50 },
+    },
+  },
+});

--- a/workers/users/wrangler.toml
+++ b/workers/users/wrangler.toml
@@ -1,5 +1,7 @@
 name = "users"
 main = "src/index.ts"
+# No public workers.dev host — reached only via the root Worker USERS service binding.
+workers_dev = false
 compatibility_date = "2025-09-23"
 compatibility_flags = ["nodejs_compat"]
 
@@ -13,12 +15,14 @@ ENVIRONMENT = "development"
 
 [env.staging]
 name = "users-staging"
+workers_dev = false
 
 [env.staging.vars]
 ENVIRONMENT = "staging"
 
 [env.production]
 name = "users"
+workers_dev = false
 
 [env.production.vars]
 ENVIRONMENT = "production"

--- a/workers/users/wrangler.toml
+++ b/workers/users/wrangler.toml
@@ -1,0 +1,24 @@
+name = "users"
+main = "src/index.ts"
+compatibility_date = "2025-09-23"
+compatibility_flags = ["nodejs_compat"]
+
+[observability]
+enabled = true
+
+# Keep vars to ENVIRONMENT only. Tests assert unconfigured auth/database 503s;
+# local dev uses .dev.vars and production uses `wrangler secret put`.
+[vars]
+ENVIRONMENT = "development"
+
+[env.staging]
+name = "users-staging"
+
+[env.staging.vars]
+ENVIRONMENT = "staging"
+
+[env.production]
+name = "users"
+
+[env.production.vars]
+ENVIRONMENT = "production"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -62,6 +62,11 @@ binding = "ASSETS"
 binding = "CATALOG"
 service = "catalog"
 
+# Users service for authenticated user-domain routes.
+[[services]]
+binding = "USERS"
+service = "users"
+
 [[containers]]
 class_name = "RuntimeContainer"
 image = "./Dockerfile"
@@ -107,6 +112,10 @@ binding = "ASSETS"
 binding = "CATALOG"
 service = "catalog"
 
+[[env.production.services]]
+binding = "USERS"
+service = "users"
+
 [[env.production.containers]]
 class_name = "RuntimeContainer"
 image = "./Dockerfile"
@@ -134,6 +143,10 @@ binding = "ASSETS"
 [[env.staging.services]]
 binding = "CATALOG"
 service = "catalog-staging"
+
+[[env.staging.services]]
+binding = "USERS"
+service = "users-staging"
 
 [[env.staging.containers]]
 class_name = "RuntimeContainer"


### PR DESCRIPTION
S2.8 enabler: stands up the `workers/users` TypeScript service (mirroring `workers/catalog`) with route **save/list** oRPC + **Neon Auth JWT verification**, wired end-to-end: contract → Neon migration → service → edge routing → CI/deploy lanes.

Refs #289

## AC coverage

| AC (issue #289) | Type | Status | Test |
|---|---|---|---|
| Save → visible in list via `/v1/users/routes` | integration | ✅ (worker-wire level, injected DB) | `workers/users/test/worker.worker.test.ts` "saves then lists a route for the same JWT subject" |
| Empty list returns `[]` without erroring | unit | ✅ | `workers/users/test/routes-api.worker.test.ts` "lists an empty store" |
| Cross-user access rejected 403 by the service (not silently at Neon) | integration | ✅ | wire: "serializes the defined ownership error for a cross-user update" + handler: "throws ROUTE_NOT_OWNED" |
| Anonymous-session claim endpoint | integration | ⏳ deferred (see Leftovers) | — |
| Auth boundary: no valid JWT → flat 401, never anonymous | unit | ✅ | `workers/users/test/auth.worker.test.ts` (10 cases: missing/empty/garbage/expired/wrong-iss/wrong-aud/foreign-key/valid/healthz/unconfigured) |
| CI/deploy wiring: `ci-users` runs on `workers/users/**`; deploy step ordered before the root Worker | integration | ✅ (this PR's CI run exercises `ci-users`) | `.github/workflows/ci.yml` + `deploy.yml` |

Quality ratchet: every shipped AC has a test in this diff (`ac_total == ac_with_test` for the 5 in-scope ACs).

## What's in here

- **`packages/contract/src/users-contract.ts`** (new; catalog surface untouched): `RouteStatus` / `UserRoute` / `SaveRouteInput` / `ListRoutesResult`, users error registry (`ROUTE_NOT_FOUND` 404, `ROUTE_NOT_OWNED` 403) + `pickUsersErrors`, oRPC `GET|POST /v1/users/routes`. `emit-openapi` now also emits a committed, drift-guarded `users-openapi.json`; `openapi.json` (catalog) is byte-identical.
- **`db/migrations/20260713000001_user_routes.sql`**: evolves the existing `routes` table (old Python-agent shape) — adds `user_id`, `title`, `status` (`draft|saved|completed` CHECK), `saved_at`, `updated_at` (+trigger, +index). `session_id` retained on purpose: it is exactly what the future claim flow needs. `atlas.sum` regenerated (atlas v0.30.0, `migrate validate` clean).
- **`workers/users/`**: Hono + oRPC + Drizzle-typing-only/raw-`sql`-queries, per catalog. JWT: jose `createRemoteJWKSet` against `env.NEON_AUTH_JWKS_URL` (cached per URL), EdDSA-only, `iss` == `aud` == JWKS base; failure → flat 401 with the edge's unauthorized envelope. `[env.staging]`=`users-staging`, `[env.production]`=`users`, routeless (service-binding only). 23 workerd tests; coverage 78/70/86/80 vs 60/60/60/50 floors.
- **Edge**: `worker/app.ts` routes `/v1/users/*` to the `USERS` service binding registered *before* the generic `/v1/*` handler; Authorization passes through untouched (users verifies itself — deliberately different trust model from the container path). Root `wrangler.toml` gains the `USERS` binding for top-level/production/staging.
- **CI/deploy**: `ci-users` lane (`_ts-ci.yml`), users deploy jobs serialized **after catalog** (shared atlas dir never applied concurrently) and **before the root Worker** in the manual `deploy.yml`. `_deploy-component.yml` gains an optional `NEON_AUTH_JWKS_URL` secret (additive; existing callers unaffected).

## Review-caught bug worth knowing about

Interpolating a JS array straight into drizzle's `sql` template expands it into a tuple — `VALUES ($1, $2, ($3, $4), $5)`, and an empty array renders invalid `()`. Against real Postgres the INSERT/UPDATE would fail. Fixed by binding arrays as one parameter: `${sql.param(arr)}::text[]` (documented in `workers/users/AGENTS.md`).

## 🚨 OWNER ACTION required before this reaches main

**Set the GitHub Actions repo secret `NEON_AUTH_JWKS_URL`** (value = `$NEON_AUTH_BASE_URL/.well-known/jwks.json`, see `docs/ops/auth-migration-neon.md`). Without it, `deploy-users-staging` will fail on the first main push. `NEON_DATABASE_URL` already exists (catalog uses it).

## Coordination

This PR **owns root `wrangler.toml` + `worker/app.ts`/`entry.ts` edits for this batch** (per lead assignment); `worker/auth.ts` is deliberately untouched (owned by the auth-cutover lead). If a `[vars]`/binding conflict lands, this PR's version of those files wins.

## Gates (all run locally, Node 24)

| Gate | Result |
|---|---|
| `workers/users`: tsc / eslint(strict, 0 warn) / `test:worker` | ✅ / ✅ / 23 passed, thresholds met |
| `workers/catalog`: tsc / eslint / `test:worker` (regression) | ✅ / ✅ / 109 passed |
| root `pnpm run test:worker` (edge) | 18 passed (2 new `/v1/users/*` cases) |
| `packages/contract`: tsc / `emit:openapi` idempotent (2 runs, no diff; catalog spec byte-identical) | ✅ |
| `actionlint` (all workflows) | ✅ |
| `atlas migrate validate` | ✅ |

## Leftovers (follow-up stories)

- **Claim endpoint** (`/v1/users/routes/claim`) + anonymous-session write path: deferred with the S1.7 save-trigger + apps/web login integration; the schema (retained `session_id`) and the auth middleware are already claim-ready.
- **Delete** route oRPC (in the spec's list/save/delete trio) — not needed by the current UI slice.
- **`apps/web` client wrappers** (`src/lib/data/routes.ts`, `claimAnonymousRoutes.ts`) — land with the web slice that consumes them.
- **Real-DB spike coverage**: neon-http array/timestamptz serialization is exercised only via fakes here; a `pg`-driver spike (catalog-style) should verify against real Postgres before further build-out.
- **Agent-side consumption**: the Python agent does not (and per SD-2 must not) gain data endpoints; if the agent ever needs saved-route context it consumes this service's contract in a later story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
