### PR TITLE
fix(eval): repair LocaleMatch measurement + query-first reply-language policy

### DIFF
--- a/apps/agent/agent/agents/pilgrimage_agent.py
+++ b/apps/agent/agent/agents/pilgrimage_agent.py
@@ -32,6 +32,7 @@ from agent.agents.runtime_models import (
     RouteResponseModel,
     SearchResponseModel,
 )
+from agent.utils.language import resolve_reply_language
 
 COMPACT_THRESHOLD = 40  # ~5 turns × 8 messages/turn
 _KEEP_RECENT = 8  # Keep latest turn fully uncompressed
@@ -309,11 +310,15 @@ def _inject_session_context(ctx: RunContext[RuntimeDeps]) -> str:
     """Inject locale enforcement and current session state for multi-turn."""
     parts: list[str] = []
 
-    # Locale enforcement — respond in the user's query language, with
-    # browser locale as fallback when query language is unclear
-    lang = _LOCALE_NAMES.get(ctx.deps.locale, "Japanese")
+    # Locale enforcement — query language first, browser locale as fallback
+    # (SD-17 (3)). A direct order beats "the language the user writes in":
+    # DeepSeek drifts to Chinese for English users under the soft phrasing.
+    target = resolve_reply_language(ctx.deps.query, ctx.deps.locale)
+    lang = _LOCALE_NAMES.get(target, "Japanese")
     parts.append(
-        f"Respond in the language the user writes in. If unclear, default to {lang}."
+        f"Respond in {lang}. Proper nouns (anime titles, station and place "
+        f"names) may stay in their original script, but write all prose "
+        f"in {lang}."
     )
 
     state = ctx.deps.tool_state

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -7,7 +7,6 @@ session management in ``session_facade``, and persistence in ``persistence``.
 from __future__ import annotations
 
 import asyncio
-import re
 from time import perf_counter
 from typing import cast
 from uuid import uuid4
@@ -56,13 +55,13 @@ from agent.interfaces.session_facade import (
     extract_context_delta,
     normalize_session_state,
 )
+from agent.utils.language import detect_language
 
 __all__ = [
     "PublicAPIError",
     "PublicAPIRequest",
     "PublicAPIResponse",
     "RuntimeAPI",
-    "detect_language",
     "handle_public_request",
 ]
 
@@ -98,22 +97,6 @@ def default_catalog_client() -> CatalogClient:
     client to route through; production injects one explicitly via the lifespan.
     """
     return CatalogClient(base_url=get_settings().catalog_api_url)
-
-
-_CJK_RE = re.compile(r"[\u4e00-\u9fff]")
-_KANA_RE = re.compile(r"[\u3040-\u30ff]")
-
-
-def detect_language(text: str) -> str:
-    """Detect whether *text* is Chinese, Japanese, or English.
-
-    Heuristic: kana → ja, CJK only → zh, else → en.
-    """
-    if _KANA_RE.search(text):
-        return "ja"
-    if _CJK_RE.search(text):
-        return "zh"
-    return "en"
 
 
 class RuntimeAPI:

--- a/apps/agent/agent/tests/eval/baselines/agent_l4_trajectory_openai-deepseek-v4-pro-https---api.deepseek.com.json
+++ b/apps/agent/agent/tests/eval/baselines/agent_l4_trajectory_openai-deepseek-v4-pro-https---api.deepseek.com.json
@@ -13,7 +13,7 @@
     "tool_f1": 0.7818282312925173,
     "route_order_correct": 0.7678571428571429,
     "data_keys_present": 0.7839285714285714,
-    "locale_match": 0.4857142857142857,
+    "locale_match": 0.8571,
     "step_efficiency": 0.8772441893424038
   },
   "cases": {
@@ -86,7 +86,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_zh_002": {
@@ -95,7 +95,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_zh_003": {
@@ -104,7 +104,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_zh_004": {
@@ -113,7 +113,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_zh_005": {
@@ -122,7 +122,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_zh_006": {
@@ -131,7 +131,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_en_001": {
@@ -140,7 +140,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_en_002": {
@@ -149,7 +149,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_en_003": {
@@ -158,7 +158,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_en_004": {
@@ -167,7 +167,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_en_005": {
@@ -176,7 +176,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_en_006": {
@@ -185,7 +185,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_en_007": {
@@ -194,7 +194,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A2_ja_001": {
@@ -230,7 +230,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A2_zh_002": {
@@ -239,7 +239,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A2_zh_003": {
@@ -248,7 +248,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A2_en_001": {
@@ -257,7 +257,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A2_en_002": {
@@ -266,7 +266,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A2_ja_004": {
@@ -284,7 +284,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A3_ja_001": {
@@ -329,7 +329,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "A3_zh_002": {
@@ -347,7 +347,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "A3_zh_004": {
@@ -365,7 +365,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "A3_en_001": {
@@ -374,7 +374,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.2857142857142857
     },
     "A3_en_002": {
@@ -392,7 +392,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "A3_en_004": {
@@ -410,7 +410,7 @@
       "tool_f1": 0.4,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.2222222222222222
     },
     "A4_ja_001": {
@@ -527,7 +527,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.2
     },
     "A5_ja_004": {
@@ -563,7 +563,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A6_en_001": {
@@ -572,7 +572,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A6_en_002": {
@@ -581,7 +581,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A7_zh_001": {
@@ -590,7 +590,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A7_zh_002": {
@@ -599,7 +599,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A7_zh_003": {
@@ -608,7 +608,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A7_zh_004": {
@@ -626,7 +626,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A7_en_002": {
@@ -635,7 +635,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A7_en_003": {
@@ -653,7 +653,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A7_zh_005": {
@@ -671,7 +671,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A7_zh_006": {
@@ -680,7 +680,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A7_en_006": {
@@ -689,7 +689,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A8_ja_001": {
@@ -788,7 +788,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A9_zh_002": {
@@ -797,7 +797,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A9_zh_003": {
@@ -806,7 +806,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A9_zh_004": {
@@ -824,7 +824,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A9_zh_006": {
@@ -833,7 +833,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A9_zh_007": {
@@ -842,7 +842,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A9_zh_008": {
@@ -851,7 +851,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A9_zh_009": {
@@ -860,7 +860,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 1.0,
+      "locale_match": 0.0,
       "step_efficiency": 1.0
     },
     "A9_zh_010": {
@@ -878,7 +878,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A10_en_002": {
@@ -896,7 +896,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A10_en_004": {
@@ -914,7 +914,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A10_en_006": {
@@ -923,7 +923,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A10_en_007": {
@@ -932,7 +932,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A10_en_008": {
@@ -950,7 +950,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A10_en_010": {
@@ -959,7 +959,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "B1_ja_004": {
@@ -1004,7 +1004,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.3333333333333333
     },
     "B1_zh_002": {
@@ -1013,7 +1013,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.125
     },
     "B1_zh_003": {
@@ -1040,7 +1040,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.2
     },
     "B1_zh_006": {
@@ -1076,7 +1076,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "B1_en_005": {
@@ -1184,7 +1184,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "B2_zh_005": {
@@ -1229,7 +1229,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.3333333333333333
     },
     "B2_en_005": {
@@ -1274,7 +1274,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.14285714285714285
     },
     "B3_zh_004": {
@@ -1283,7 +1283,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.25
     },
     "B3_zh_005": {
@@ -1310,7 +1310,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.2
     },
     "B3_en_004": {
@@ -1328,7 +1328,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.2
     },
     "B4_ja_001": {
@@ -1364,7 +1364,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "B4_zh_002": {
@@ -1382,7 +1382,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "B4_en_001": {
@@ -1391,7 +1391,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "B4_en_002": {
@@ -1454,7 +1454,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C1_zh_002": {
@@ -1463,7 +1463,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C1_zh_003": {
@@ -1472,7 +1472,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C1_zh_004": {
@@ -1481,7 +1481,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "C1_en_001": {
@@ -1625,7 +1625,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C3_zh_004": {
@@ -1634,7 +1634,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C3_en_001": {
@@ -1652,7 +1652,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C3_en_003": {
@@ -1661,7 +1661,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C3_en_004": {
@@ -1670,7 +1670,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C4_ja_001": {
@@ -1805,7 +1805,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D1_zh_002": {
@@ -1814,7 +1814,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D1_zh_003": {
@@ -1868,7 +1868,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D1_en_003": {
@@ -1877,7 +1877,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D1_en_004": {
@@ -1895,7 +1895,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D1_en_006": {
@@ -1904,7 +1904,7 @@
       "tool_f1": 0.4,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.75
     },
     "D1_en_007": {
@@ -1976,7 +1976,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D2_zh_003": {
@@ -1985,7 +1985,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D2_zh_004": {
@@ -2003,7 +2003,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D2_en_001": {
@@ -2021,7 +2021,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D2_en_003": {
@@ -2030,7 +2030,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D2_en_004": {
@@ -2084,7 +2084,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D3_zh_002": {
@@ -2093,7 +2093,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D3_en_001": {
@@ -2102,7 +2102,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D3_en_002": {
@@ -2111,7 +2111,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D3_en_003": {
@@ -2120,7 +2120,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D4_ja_001": {
@@ -2147,7 +2147,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D4_zh_002": {
@@ -2165,7 +2165,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "D4_en_002": {
@@ -2174,7 +2174,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.75
     },
     "D4_zh_003": {
@@ -2183,7 +2183,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E1_ja_001": {
@@ -2228,7 +2228,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E1_zh_003": {
@@ -2237,7 +2237,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E1_en_001": {
@@ -2246,7 +2246,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E1_en_002": {
@@ -2255,7 +2255,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E1_en_003": {
@@ -2264,7 +2264,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E1_en_004": {
@@ -2273,7 +2273,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E2_ja_001": {
@@ -2309,7 +2309,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E2_zh_003": {
@@ -2318,7 +2318,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E2_en_001": {
@@ -2336,7 +2336,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E2_en_003": {
@@ -2345,7 +2345,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E2_en_004": {
@@ -2354,7 +2354,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E3_ja_001": {
@@ -2381,7 +2381,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E3_en_001": {
@@ -2399,7 +2399,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E4_ja_001": {
@@ -2435,7 +2435,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "E4_en_002": {
@@ -2444,7 +2444,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F1_ja_001": {
@@ -2489,7 +2489,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F1_zh_002": {
@@ -2498,7 +2498,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F1_zh_003": {
@@ -2525,7 +2525,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F1_en_002": {
@@ -2534,7 +2534,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F1_en_003": {
@@ -2552,7 +2552,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F2_ja_001": {
@@ -2597,7 +2597,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F2_zh_003": {
@@ -2624,7 +2624,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F2_en_002": {
@@ -2633,7 +2633,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F2_en_003": {
@@ -2696,7 +2696,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F3_en_002": {
@@ -2705,7 +2705,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "F3_en_003": {
@@ -2768,7 +2768,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G1_zh_002": {
@@ -2786,7 +2786,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G1_zh_004": {
@@ -2822,7 +2822,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G1_en_004": {
@@ -2894,7 +2894,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G2_zh_002": {
@@ -3011,7 +3011,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G3_zh_002": {
@@ -3020,7 +3020,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G3_zh_003": {
@@ -3029,7 +3029,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G3_zh_004": {
@@ -3038,7 +3038,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G3_en_001": {
@@ -3047,7 +3047,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G3_en_002": {
@@ -3056,7 +3056,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G3_en_003": {
@@ -3164,7 +3164,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G5_zh_002": {
@@ -3182,7 +3182,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G5_en_002": {
@@ -3227,7 +3227,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "G6_en_001": {
@@ -3335,7 +3335,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "H2_ja_001": {
@@ -3371,7 +3371,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "H2_zh_002": {
@@ -3389,7 +3389,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "H2_zh_004": {
@@ -3461,7 +3461,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "H3_zh_002": {
@@ -3470,7 +3470,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "H3_en_001": {
@@ -3524,7 +3524,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "H4_zh_002": {
@@ -3542,7 +3542,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "H4_en_001": {
@@ -3569,7 +3569,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I1_zh_002": {
@@ -3578,7 +3578,7 @@
       "tool_f1": 0.6666666666666666,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I1_zh_006": {
@@ -3587,7 +3587,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "I1_zh_007": {
@@ -3596,7 +3596,7 @@
       "tool_f1": 0.4,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.4
     },
     "I1_zh_009": {
@@ -3614,7 +3614,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I2_en_002": {
@@ -3623,7 +3623,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I2_en_003": {
@@ -3641,7 +3641,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I2_en_005": {
@@ -3650,7 +3650,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I2_en_006": {
@@ -3659,7 +3659,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I2_en_007": {
@@ -3668,7 +3668,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I2_en_008": {
@@ -3677,7 +3677,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I3_en_003": {
@@ -3686,7 +3686,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "I3_en_005": {
@@ -3695,7 +3695,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "I4_ja_001": {
@@ -3722,7 +3722,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I4_zh_002": {
@@ -3731,7 +3731,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I4_en_001": {
@@ -3767,7 +3767,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I5_ja_001": {
@@ -3794,7 +3794,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I5_zh_002": {
@@ -3803,7 +3803,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I5_en_001": {
@@ -3839,7 +3839,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 1.0,
+      "locale_match": 0.0,
       "step_efficiency": 1.0
     },
     "I6_zh_001": {
@@ -3857,7 +3857,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I6_en_001": {
@@ -3875,7 +3875,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I6_ja_003": {
@@ -3884,7 +3884,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 1.0,
+      "locale_match": 0.0,
       "step_efficiency": 1.0
     },
     "I6_zh_003": {
@@ -3893,7 +3893,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I7_ja_001": {
@@ -3920,7 +3920,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I7_zh_002": {
@@ -3929,7 +3929,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I7_en_001": {
@@ -3938,7 +3938,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I7_en_002": {
@@ -3947,7 +3947,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I8_ja_001": {
@@ -4019,7 +4019,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "J1_en_002": {
@@ -4037,7 +4037,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "J1_zh_003": {
@@ -4073,7 +4073,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "J2_zh_002": {
@@ -4082,7 +4082,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "J2_en_001": {
@@ -4091,7 +4091,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "J2_en_002": {
@@ -4109,7 +4109,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "J2_en_004": {
@@ -4118,7 +4118,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "J3_ja_001": {
@@ -4145,7 +4145,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "J3_zh_002": {
@@ -4163,7 +4163,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "J4_ja_001": {
@@ -4190,7 +4190,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "J4_zh_002": {
@@ -4199,7 +4199,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "J4_en_001": {
@@ -4208,7 +4208,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "J4_en_002": {
@@ -4217,7 +4217,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "J5_ja_001": {
@@ -4244,7 +4244,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "J5_zh_002": {
@@ -4253,7 +4253,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "J5_en_001": {
@@ -4370,7 +4370,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 1.0,
+      "locale_match": 0.0,
       "step_efficiency": 0.5
     },
     "K3_zh_001": {
@@ -4379,7 +4379,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.25
     },
     "K3_en_001": {
@@ -4451,7 +4451,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "L1_en_001": {
@@ -4478,7 +4478,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "L2_ja_001": {
@@ -4514,7 +4514,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "L2_en_001": {
@@ -4523,7 +4523,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "L2_en_002": {
@@ -4541,7 +4541,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "L3_ja_001": {
@@ -4550,7 +4550,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 1.0,
-      "locale_match": 1.0,
+      "locale_match": 0.0,
       "step_efficiency": 0.3333333333333333
     },
     "L3_ja_002": {
@@ -4568,7 +4568,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "L3_en_001": {
@@ -4604,7 +4604,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "L4_en_001": {
@@ -4613,7 +4613,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "L4_en_002": {
@@ -4631,7 +4631,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_zh_007": {
@@ -4640,7 +4640,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A1_en_008": {
@@ -4694,7 +4694,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "D1_ja_008": {
@@ -4721,7 +4721,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I4_ja_003": {
@@ -4739,7 +4739,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I4_en_004": {
@@ -4757,7 +4757,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A7_en_007": {
@@ -4766,7 +4766,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "B4_zh_004": {
@@ -4793,7 +4793,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I1_zh_011": {
@@ -4802,7 +4802,7 @@
       "tool_f1": 0.5,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.4
     },
     "I1_zh_012": {
@@ -4820,7 +4820,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "I2_en_010": {
@@ -4829,7 +4829,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A4_ja_004": {
@@ -4865,7 +4865,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C3_zh_005": {
@@ -4874,7 +4874,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C3_en_005": {
@@ -4883,7 +4883,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A2_zh_004": {
@@ -4892,7 +4892,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "B_remake_zh_001": {
@@ -4901,7 +4901,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "B_remake_ja_001": {
@@ -4919,7 +4919,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "A_remake_zh_001": {
@@ -4928,7 +4928,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A_remake_zh_002": {
@@ -4937,7 +4937,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "B_multisn_ja_001": {
@@ -4955,7 +4955,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "B_multisn_en_001": {
@@ -4964,7 +4964,7 @@
       "tool_f1": 0.0,
       "route_order_correct": 0.0,
       "data_keys_present": 0.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.5
     },
     "A_multisn_ja_001": {
@@ -4991,7 +4991,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "B_sameseries_ja_001": {
@@ -5018,7 +5018,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "A_sameseries_en_001": {
@@ -5027,7 +5027,7 @@
       "tool_f1": 1.0,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 1.0
     },
     "C_multisn_zh_001": {
@@ -5036,7 +5036,7 @@
       "tool_f1": 0.8,
       "route_order_correct": 1.0,
       "data_keys_present": 1.0,
-      "locale_match": 0.0,
+      "locale_match": 1.0,
       "step_efficiency": 0.6666666666666666
     },
     "GINJ1_ja_001": {

--- a/apps/agent/agent/tests/eval/evaluators.py
+++ b/apps/agent/agent/tests/eval/evaluators.py
@@ -35,7 +35,7 @@ from pydantic_ai.settings import ModelSettings
 from pydantic_evals.evaluators import Evaluator, EvaluatorContext, LLMJudge
 
 from agent.agents.agent_result import AgentResult
-from agent.interfaces.public_api import detect_language
+from agent.utils.language import detect_language, resolve_reply_language
 
 # ── Case types (shared with the dataset builder) ─────────────────────
 
@@ -188,13 +188,18 @@ class DataKeysPresent(Evaluator[AgentInput, AgentResult, AgentExpected]):
 
 
 class LocaleMatch(Evaluator[AgentInput, AgentResult, AgentExpected]):
-    """L1: 1.0 if the reply language matches the requested locale."""
+    """L1: 1.0 if the reply language matches the expected reply language.
+
+    Expected = query language when its script is unambiguous, else the case
+    locale (SD-17 (3) — same policy the agent instruction enforces).
+    """
 
     def evaluate(self, ctx: _Ctx) -> Mapping[str, float]:
         message = ctx.output.message
         if not message:
             return {"locale_match": 0.0}
-        matched = detect_language(message) == ctx.inputs.locale
+        expected = resolve_reply_language(ctx.inputs.query, ctx.inputs.locale)
+        matched = detect_language(message) == expected
         return {"locale_match": 1.0 if matched else 0.0}
 
 

--- a/apps/agent/agent/tests/unit/test_eval_evaluators_component.py
+++ b/apps/agent/agent/tests/unit/test_eval_evaluators_component.py
@@ -65,11 +65,22 @@ def test_locale_match_scores_message_language(
 ) -> None:
     output = QAResponseModel(intent="general_qa", message=message)
     evaluator_ctx = ctx(
-        AgentInput(query="q", locale=locale),
+        AgentInput(query="", locale=locale),
         result(steps(), output),
         AgentExpected(["general_qa"]),
     )
     assert dict(LocaleMatch().evaluate(evaluator_ctx)) == expected
+
+
+def test_locale_match_query_language_beats_locale() -> None:
+    """SD-17 (3): an unambiguous query language overrides the browser locale."""
+    output = QAResponseModel(intent="general_qa", message="これは日本語です")
+    evaluator_ctx = ctx(
+        AgentInput(query="君の名は。の聖地", locale="zh"),
+        result(steps(), output),
+        AgentExpected(["general_qa"]),
+    )
+    assert dict(LocaleMatch().evaluate(evaluator_ctx)) == {"locale_match": 1.0}
 
 
 @pytest.mark.parametrize(

--- a/apps/agent/agent/tests/unit/test_language.py
+++ b/apps/agent/agent/tests/unit/test_language.py
@@ -1,0 +1,98 @@
+"""Unit tests for script-based language detection.
+
+Samples mirror real agent outputs from the 2026-07-11 eval baseline run —
+the exact shapes the previous single-char detector misclassified.
+"""
+
+from __future__ import annotations
+
+from agent.utils.language import detect_language, resolve_reply_language
+
+
+class TestDetectLanguagePlain:
+    def test_chinese_template(self) -> None:
+        assert detect_language("找到了3处圣地。") == "zh"
+
+    def test_japanese_template(self) -> None:
+        assert detect_language("3件の聖地が見つかりました。") == "ja"
+
+    def test_english_template(self) -> None:
+        assert detect_language("Found 3 pilgrimage spots.") == "en"
+
+    def test_japanese_sentence(self) -> None:
+        assert detect_language("東京の聖地を探しています") == "ja"
+
+    def test_empty_string_is_english(self) -> None:
+        assert detect_language("") == "en"
+
+
+class TestDetectLanguageContaminated:
+    """Correct-language prose quoting foreign proper nouns must not flip."""
+
+    def test_chinese_prose_quoting_kana_title(self) -> None:
+        text = "《你的名字》（君の名は。）的圣地主要分布在东京新宿·四谷地区。"
+        assert detect_language(text) == "zh"
+
+    def test_chinese_prose_with_japanese_place_names(self) -> None:
+        text = "为你找到了吹响悠风号（響け！ユーフォニアム）的圣地：宇治桥（宇治橋）。"
+        assert detect_language(text) == "zh"
+
+    def test_english_prose_quoting_kana_title(self) -> None:
+        text = "Here are the pilgrimage spots for **Your Name (君の名は。)**!"
+        assert detect_language(text) == "en"
+
+    def test_english_prose_with_kanji_only_names(self) -> None:
+        text = "Visit the Suga Shrine stairs (須賀神社) in Yotsuya, Tokyo."
+        assert detect_language(text) == "en"
+
+    def test_english_prose_with_cjk_heavy_table(self) -> None:
+        text = (
+            "Here are the **Weathering with You (天気の子)** spots:\n"
+            "| # | Spot | Episode |\n"
+            "| 1 | 代々木会館跡 | Ep 1 |\n"
+            "| 2 | 新宿駅南口 | Ep 2 |"
+        )
+        assert detect_language(text) == "en"
+
+    def test_japanese_prose_quoting_chinese_translation(self) -> None:
+        text = "「響け！ユーフォニアム」（吹响悠风号）の聖地巡礼スポットを3件見つけました。"
+        assert detect_language(text) == "ja"
+
+    def test_chinese_prose_with_single_stray_kana(self) -> None:
+        assert detect_language("从千駄ヶ谷站出发，步行约10分钟。") == "zh"
+
+
+class TestResolveReplyLanguage:
+    def test_clear_japanese_query_wins_over_locale(self) -> None:
+        assert resolve_reply_language("君の名は。の聖地", "zh") == "ja"
+
+    def test_clear_chinese_query_wins_over_locale(self) -> None:
+        assert resolve_reply_language("你的名字的圣地", "ja") == "zh"
+
+    def test_simplified_han_marks_chinese(self) -> None:
+        assert resolve_reply_language("灌篮高手的取景地", "ja") == "zh"
+
+    def test_pure_latin_query_wins_over_locale(self) -> None:
+        assert resolve_reply_language("Your Name pilgrimage", "ja") == "en"
+
+    def test_zh_tail_beats_kana_in_pasted_title(self) -> None:
+        assert resolve_reply_language("ぼっち・ざ・ろっく的圣地", "zh") == "zh"
+
+    def test_japanese_query_with_latin_title_defers_to_locale(self) -> None:
+        assert resolve_reply_language("THE FIRST SLAM DUNKの聖地巡礼", "ja") == "ja"
+
+    def test_mixed_pasted_title_plus_english_defers_to_locale(self) -> None:
+        assert resolve_reply_language("天気の子 anime pilgrimage", "en") == "en"
+
+    def test_ambiguous_single_han_defers_to_locale(self) -> None:
+        assert resolve_reply_language("鬼", "ja") == "ja"
+        assert resolve_reply_language("花", "zh") == "zh"
+
+    def test_shinjitai_marks_japanese(self) -> None:
+        assert resolve_reply_language("天気", "zh") == "ja"
+
+    def test_empty_query_defers_to_locale(self) -> None:
+        assert resolve_reply_language("", "ja") == "ja"
+
+    def test_quoted_title_does_not_vote(self) -> None:
+        assert resolve_reply_language("《你的名字》の聖地", "en") == "ja"

--- a/apps/agent/agent/tests/unit/test_pilgrimage_agent.py
+++ b/apps/agent/agent/tests/unit/test_pilgrimage_agent.py
@@ -225,6 +225,8 @@ class TestSessionContextInjection:
         from agent.agents.pilgrimage_agent import _inject_session_context
 
         ctx = MagicMock()
+        ctx.deps.query = ""
+        ctx.deps.locale = "ja"
         ctx.deps.tool_state = {
             "search_bangumi": {
                 "row_count": 76,
@@ -240,15 +242,28 @@ class TestSessionContextInjection:
 
         ctx = MagicMock()
         ctx.deps.tool_state = {}
+        ctx.deps.query = ""
         ctx.deps.locale = "ja"
         result = _inject_session_context(ctx)
-        assert "default to Japanese" in result
+        assert "Respond in Japanese." in result
         assert "Current anime" not in result
+
+    def test_query_language_overrides_locale_directive(self) -> None:
+        from agent.agents.pilgrimage_agent import _inject_session_context
+
+        ctx = MagicMock()
+        ctx.deps.tool_state = {}
+        ctx.deps.query = "你的名字的圣地"
+        ctx.deps.locale = "ja"
+        result = _inject_session_context(ctx)
+        assert "Respond in Simplified Chinese." in result
 
     def test_injects_resolve_context(self) -> None:
         from agent.agents.pilgrimage_agent import _inject_session_context
 
         ctx = MagicMock()
+        ctx.deps.query = ""
+        ctx.deps.locale = "ja"
         ctx.deps.tool_state = {
             "resolve_anime": {"title": "君の名は。", "bangumi_id": "160209"}
         }

--- a/apps/agent/agent/tests/unit/test_public_api_pipeline.py
+++ b/apps/agent/agent/tests/unit/test_public_api_pipeline.py
@@ -11,7 +11,6 @@ from agent.infrastructure.session.memory import InMemorySessionStore
 from agent.interfaces.public_api import (
     PublicAPIRequest,
     RuntimeAPI,
-    detect_language,
 )
 from agent.tests.db_doubles import build_persistence_supabase_double
 from agent.tests.unit.conftest_public_api import (
@@ -284,23 +283,6 @@ class TestSelectedPointIdsBypass:
         assert captured["catalog"] is api._catalog
         assert response.intent == "plan_selected"
         assert response.ui == {"component": "RoutePlannerWizard"}
-
-
-class TestDetectLanguage:
-    def test_detect_chinese(self) -> None:
-        assert detect_language("找到了3处圣地。") == "zh"
-
-    def test_detect_japanese(self) -> None:
-        assert detect_language("3件の聖地が見つかりました。") == "ja"
-
-    def test_detect_english(self) -> None:
-        assert detect_language("Found 3 pilgrimage spots.") == "en"
-
-    def test_mixed_cjk_with_kana_is_japanese(self) -> None:
-        assert detect_language("東京の聖地を探しています") == "ja"
-
-    def test_empty_string_is_english(self) -> None:
-        assert detect_language("") == "en"
 
 
 class TestTranslationGate:

--- a/apps/agent/agent/utils/language.py
+++ b/apps/agent/agent/utils/language.py
@@ -1,0 +1,99 @@
+"""Script-based language detection for user queries and agent replies.
+
+Shared by the eval ``LocaleMatch`` evaluator, the agent's reply-language
+directive, and the interface-layer translation gate. Pilgrimage content
+necessarily quotes Japanese proper nouns (anime titles, station names), so
+naive first-CJK-char detection misreads correct Chinese/English prose as
+Japanese; these helpers strip quoted spans first and judge the prose that
+remains.
+"""
+
+from __future__ import annotations
+
+import re
+
+_KANA_RE = re.compile(r"[぀-ヿ]")
+_HAN_RE = re.compile(r"[一-鿿]")
+_LATIN_RE = re.compile(r"[A-Za-z]")
+_QUOTED_RE = re.compile(r"[「『《【（(\[].*?[」』》】）)\]]")
+_TABLE_ROW_RE = re.compile(r"^\s*\|.*$", re.MULTILINE)
+_BOLD_RE = re.compile(r"\*\*.*?\*\*")
+
+# Han forms used in Simplified Chinese but not in Japanese, and vice versa.
+# ponytail: curated high-frequency subsets, not exhaustive — han-only text
+# with no hit stays ambiguous and callers fall back to the browser locale.
+_ZH_ONLY_HAN = frozenset(
+    "你您们吗哪说请这谁么为发圣别觉话张爱见时动众龙线轻风节实过还进选篮"
+)
+_JA_ONLY_HAN = frozenset("気駅発楽対仮険絵覧様帰応変辺売読働囲図団戦歳庁観")
+
+
+def _strip_quoted(text: str) -> str:
+    """Drop quoted spans, bold spans, and table rows (proper-noun carriers)."""
+    text = _TABLE_ROW_RE.sub(" ", text)
+    text = _BOLD_RE.sub(" ", text)
+    previous = None
+    while previous != text:
+        previous = text
+        text = _QUOTED_RE.sub(" ", text)
+    return text
+
+
+def _core_text(text: str) -> str:
+    """Prose with quoted proper nouns removed; raw text when nothing remains."""
+    core = _strip_quoted(text)
+    if _KANA_RE.search(core) or _HAN_RE.search(core) or _LATIN_RE.search(core):
+        return core
+    return text
+
+
+def _script_counts(text: str) -> tuple[int, int, int]:
+    """(kana, han, latin) character counts of *text*."""
+    kana = len(_KANA_RE.findall(text))
+    han = len(_HAN_RE.findall(text))
+    latin = len(_LATIN_RE.findall(text))
+    return kana, han, latin
+
+
+def detect_language(text: str) -> str:
+    """Detect the prose language of *text*: ``ja``, ``zh``, or ``en``.
+
+    Quoted anime titles and place names are ignored, so a Chinese or English
+    reply that cites Japanese proper nouns is not misread as Japanese.
+    """
+    kana, han, latin = _script_counts(_core_text(text))
+    total = kana + han + latin
+    if total == 0:
+        return "en"
+    if kana >= 2:
+        return "ja"
+    if han / total >= 0.30:
+        return "zh"
+    return "en"
+
+
+def resolve_reply_language(query: str, locale: str) -> str:
+    """Language the reply should use: query language first, locale fallback.
+
+    Implements SD-17 (3): the current turn's text decides when its script is
+    unambiguous; mixed-language and undecidable queries defer to *locale*.
+    """
+    core = _core_text(query)
+    kana, han, latin = _script_counts(core)
+    cjk = kana + han
+    if cjk == 0:
+        return "en" if latin else locale
+    if latin / (cjk + latin) >= 0.5:
+        return locale
+    return _cjk_language(core, kana) or locale
+
+
+def _cjk_language(core: str, kana: int) -> str | None:
+    """Classify CJK-dominant prose by distinctive scripts; None if ambiguous."""
+    if any(char in _ZH_ONLY_HAN for char in core):
+        return "zh"
+    if kana:
+        return "ja"
+    if any(char in _JA_ONLY_HAN for char in core):
+        return "ja"
+    return None


### PR DESCRIPTION
## What

`LocaleMatch 48.6%` (the #1 B-段 target from #304) was mostly the measuring stick lying, not the agent. This PR fixes the measurement, aligns the metric's ground truth with the SD-17 ③ policy, strengthens the agent's locale directive, and applies a baseline erratum (v1.2) — same offline-recompute method as the v1.1 RouteOrderCorrect erratum.

## Root cause (three layers)

**1. Detector bug (dominant — 73% of failures were false).** `detect_language` used first-match single-char search: any kana → `ja`, else any han → `zh`. Pilgrimage replies necessarily quote Japanese proper nouns, so correct zh/en prose was misread:

> 《你的名字》（**君の名は。**）的圣地主要分布在东京新宿·四谷地区…  ← perfect Chinese, judged "ja"

Of 288 scored failures: **211 false fails** (zh 110/110 — ALL zh "failures" were artifacts; en 101) plus **9 false passes** (real drift hidden by quoted kana). The bizarre `en→zh ×51` in the original report was English prose whose only CJK was kanji-only place names.

**2. Wrong expectation semantics.** The evaluator expected the browser `locale`, but the dataset's own J-family is literally `path: "query_lang_ne_locale"` and SD-17 ③ says current-turn text first, locale fallback. Evaluator and agent instruction now share one policy function — metric semantics and product semantics can no longer diverge (the IntentMatch lesson, structurally prevented).

**3. The real defect (now visible): en 66.5%.** DeepSeek answers **English users in Chinese** (56×) or Japanese (11×) — its native-language drift, the opposite of the "everything collapses to Japanese" headline. zh (97.8%) and ja (94.9%) are healthy.

## Changes

- **`agent/utils/language.py` (new)** — `detect_language`: strips quoted spans (「」『』《》【】（）()[]）, markdown table rows, and bold spans (the proper-noun carriers), then classifies remaining prose by script ratios (kana ≥ 2 → ja; han share ≥ 0.30 → zh; else en). `resolve_reply_language(query, locale)`: query-first policy — pure-latin → en; mixed pasted-title+foreign-words → locale; simplified-only han (你说圣选篮…) → zh; kana → ja; shinjitai-only han (気駅発楽…) → ja; undecidable → locale.
- **`evaluators.py`** — `LocaleMatch` expects `resolve_reply_language(query, locale)`, detects with the fixed detector.
- **`pilgrimage_agent.py`** — injected directive names the resolved target directly ("Respond in English. Proper nouns … may stay in their original script"), replacing the soft phrasing DeepSeek ignored.
- **`public_api.py`** — old detector removed; the translation gate now imports the fixed one. Production side effect: the gate stops firing **spurious LLM translation calls** on correct replies that merely quote Japanese place names (most zh/en responses previously took a pointless translate round-trip).
- **Baseline erratum v1.2** — offline recompute over the stored run's 560 messages: `locale_match` **48.6% → 85.7%** (213 flips to pass, 5 to fail). Zero LLM spend.
- **Tests** — new `test_language.py` (22 cases, samples mirror real misclassified outputs from the baseline run); pilgrimage-agent/evaluator-component tests updated for the new directive + semantics.

## Calibration evidence (all offline, zero LLM cost)

Detector + policy calibrated against all 560 stored messages and 647 queries; every residual failure was eyeballed and confirmed to be genuine wrong-language prose:

| | old metric | corrected metric |
|---|---|---|
| overall | 48.6% | **85.7%** |
| ja | 100% (9 false passes) | 94.9% |
| zh | 35.8% | 97.8% |
| en | 15.6% | 66.5% ← real target |

Remaining true failures: en→zh 56, en→ja 11, ja→zh 9, zh→ja 4.

## Gates

- `pytest` unit: **943 passed**, coverage 84.15% (floor 82%)
- `mypy` strict: 107 files clean
- `ruff check` + `format`: clean

## Validation route for the agent-side directive

The measurement fix is fully validated offline (above). The **directive change** (en drift) needs a live eval run to confirm — lands with the next trajectory-tier run (DeepSeek ~¥10, or free on Agnes if the provider probe pans out). The updated baseline keeps the regression gate honest either way.

## Adjacent findings (out of scope, not fixed here)

- `K3_ja_001` (`selected_empty_ids`): empty selection did not error gracefully — routed into a full zh search response (dispatch truthiness bug?).
- `L3_ja_001` (`empty_input`): empty query produced a hallucinated route plan in zh.
- The production translation gate targets browser `locale`; arguably it should target `resolve_reply_language(request.text, locale)` — product decision, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)