### PR TITLE
feat(catalog): geocoding capability — gazetteer + /catalog/geocode + three-state search_nearby (PR-A)

### DIFF
--- a/apps/agent/agent/agents/catalog_tools.py
+++ b/apps/agent/agent/agents/catalog_tools.py
@@ -8,6 +8,8 @@ the result with the same plumbing the legacy path uses (``tool_runtime``).
 
 from __future__ import annotations
 
+from typing import NoReturn
+
 import httpx
 from pydantic_ai import ModelRetry, RunContext
 
@@ -19,14 +21,18 @@ from agent.agents.catalog_adapter import (
 )
 from agent.agents.models import ToolName
 from agent.agents.runtime_deps import RuntimeDeps
-from agent.agents.sql_agent import KNOWN_LOCATIONS
 from agent.agents.tool_runtime import (
     _emit_step,
     _localize_city_names,
     _record_step,
     _summarize_for_llm,
 )
-from agent.clients.catalog_client import CatalogClientProtocol, PilgrimagePoint
+from agent.clients.catalog_client import (
+    CatalogClientProtocol,
+    GeocodeCandidate,
+    GeocodeKind,
+    PilgrimagePoint,
+)
 from agent.clients.catalog_errors import CatalogError
 from agent.clients.errors import APIError
 
@@ -123,19 +129,85 @@ def _shape_search_or_resolve(
     return build_search_payload(points, tool=search_tool)
 
 
-def _geocode_for_catalog(
-    location: str, state: dict[str, object]
-) -> tuple[float, float] | None:
-    """Resolve coords from session state, then deterministic KNOWN_LOCATIONS.
-
-    Stays upstream-free: no LLM, no Google Geocoding. The catalog service owns
-    richer geocoding; the agent only forwards coordinates it can resolve locally.
-    """
+def _origin_coordinates(state: dict[str, object]) -> tuple[float, float] | None:
+    """Return typed session GPS coordinates when both values are present."""
     lat = state.get("origin_lat")
     lng = state.get("origin_lng")
     if isinstance(lat, int | float) and isinstance(lng, int | float):
         return float(lat), float(lng)
-    return KNOWN_LOCATIONS.get(location.strip())
+    return None
+
+
+def _candidate_summary(candidate: GeocodeCandidate) -> dict[str, object]:
+    """Build the trusted, bounded summary stored in an internal geocode step."""
+    return {
+        "id": candidate.id,
+        "label": candidate.label[:120],
+        "kind": candidate.kind.value,
+    }
+
+
+def _record_geocode(deps: RuntimeDeps, candidates: list[GeocodeCandidate]) -> None:
+    """Record a successful lookup that still requires user clarification."""
+    _record_step(
+        deps,
+        tool=ToolName.GEOCODE.value,
+        success=True,
+        params={},
+        data={"candidates": [_candidate_summary(item) for item in candidates]},
+        error=None,
+    )
+
+
+def _candidate_radius(candidate: GeocodeCandidate) -> int:
+    """Return the default nearby radius for a resolved candidate kind."""
+    if candidate.kind == GeocodeKind.CITY:
+        return 10_000
+    return 5_000
+
+
+def _retry_for_candidates(
+    deps: RuntimeDeps,
+    location: str,
+    candidates: list[GeocodeCandidate],
+) -> NoReturn:
+    """Record a non-failure geocode step and raise a clarification retry."""
+    _record_geocode(deps, candidates)
+    if not candidates:
+        raise ModelRetry(
+            f"No gazetteer match for {location[:120]!r}. "
+            "Ask the user for a station or city name."
+        )
+    if candidates[0].kind == GeocodeKind.PREFECTURE:
+        raise ModelRetry(
+            f"{candidates[0].label[:120]} is too broad. "
+            "Ask the user which city or station within it."
+        )
+    labels = ", ".join(item.label[:120] for item in candidates[:5])
+    raise ModelRetry(f"Place name is ambiguous. Ask the user to choose: {labels}")
+
+
+async def _resolve_catalog_coordinates(
+    catalog: CatalogClientProtocol,
+    deps: RuntimeDeps,
+    location: str,
+) -> tuple[tuple[float, float], int]:
+    """Apply explicit-place-first geocoding and the GPS fallback table."""
+    if not location.strip():
+        origin = _origin_coordinates(deps.tool_state)
+        if origin is None:
+            raise ModelRetry(
+                "Ask the user for a place name or to share their location."
+            )
+        return origin, 5_000
+    try:
+        candidates = await catalog.geocode(location.strip(), limit=5)
+    except _TRANSIENT_ERRORS as exc:
+        raise ModelRetry(_retry_message("geocode", exc)) from exc
+    if len(candidates) != 1 or candidates[0].kind == GeocodeKind.PREFECTURE:
+        _retry_for_candidates(deps, location, candidates)
+    candidate = candidates[0]
+    return (candidate.lat, candidate.lng), _candidate_radius(candidate)
 
 
 async def _run_catalog_nearby(
@@ -147,15 +219,14 @@ async def _run_catalog_nearby(
     params: dict[str, object],
 ) -> dict[str, object]:
     """Geo-search via catalog.nearby() and store the shaped payload."""
-    coords = _geocode_for_catalog(location, ctx.deps.tool_state)
-    if coords is None:
-        raise ModelRetry(
-            f"Could not resolve coordinates for '{location}'. "
-            "Ask the user for a more specific station or city name."
-        )
+    coords, default_radius = await _resolve_catalog_coordinates(
+        catalog, ctx.deps, location
+    )
     await _emit_step(ctx.deps, ToolName.SEARCH_NEARBY.value, "running", {})
     try:
-        points = await catalog.nearby(coords[0], coords[1], radius_m=radius or 5000)
+        points = await catalog.nearby(
+            coords[0], coords[1], radius_m=radius or default_radius
+        )
     except _TRANSIENT_ERRORS as exc:
         raise ModelRetry(_retry_message("nearby", exc)) from exc
     payload = build_search_payload(points, tool="search_nearby")
@@ -164,7 +235,7 @@ async def _run_catalog_nearby(
         tool=ToolName.SEARCH_NEARBY,
         params=params,
         payload=payload,
-        success=bool(payload.get("rows")),
+        success=True,
     )
 
 

--- a/apps/agent/agent/agents/catalog_tools.py
+++ b/apps/agent/agent/agents/catalog_tools.py
@@ -29,12 +29,11 @@ from agent.agents.tool_runtime import (
 )
 from agent.clients.catalog_client import (
     CatalogClientProtocol,
-    GeocodeCandidate,
-    GeocodeKind,
     PilgrimagePoint,
 )
 from agent.clients.catalog_errors import CatalogError
 from agent.clients.errors import APIError
+from agent.clients.geocode import GeocodeCandidate, GeocodeKind
 
 _NO_DATA_ERROR = "No catalog data"
 _TRANSIENT_ERRORS = (APIError, httpx.TransportError, httpx.TimeoutException)
@@ -142,7 +141,7 @@ def _candidate_summary(candidate: GeocodeCandidate) -> dict[str, object]:
     """Build the trusted, bounded summary stored in an internal geocode step."""
     return {
         "id": candidate.id,
-        "label": candidate.label[:120],
+        "label": _sanitize_retry_text(candidate.label),
         "kind": candidate.kind.value,
     }
 
@@ -161,9 +160,16 @@ def _record_geocode(deps: RuntimeDeps, candidates: list[GeocodeCandidate]) -> No
 
 def _candidate_radius(candidate: GeocodeCandidate) -> int:
     """Return the default nearby radius for a resolved candidate kind."""
+    if candidate.effective_radius_m is not None:
+        return candidate.effective_radius_m
     if candidate.kind == GeocodeKind.CITY:
         return 10_000
     return 5_000
+
+
+def _sanitize_retry_text(value: str) -> str:
+    """Strip prompt-shaping controls and cap trusted retry text."""
+    return "".join(character for character in value if ord(character) >= 32)[:120]
 
 
 def _retry_for_candidates(
@@ -174,17 +180,22 @@ def _retry_for_candidates(
     """Record a non-failure geocode step and raise a clarification retry."""
     _record_geocode(deps, candidates)
     if not candidates:
+        safe_location = _sanitize_retry_text(location)
         raise ModelRetry(
-            f"No gazetteer match for {location[:120]!r}. "
-            "Ask the user for a station or city name."
+            f"No gazetteer match for {safe_location!r}. Call clarify and ask "
+            "the user for a station or city name."
+        )
+    if len(candidates) > 1:
+        labels = ", ".join(_sanitize_retry_text(item.label) for item in candidates[:5])
+        raise ModelRetry(
+            f"Place name is ambiguous. Call clarify and ask the user to choose: {labels}"
         )
     if candidates[0].kind == GeocodeKind.PREFECTURE:
         raise ModelRetry(
-            f"{candidates[0].label[:120]} is too broad. "
-            "Ask the user which city or station within it."
+            f"{_sanitize_retry_text(candidates[0].label)} is too broad. "
+            "Call clarify and ask the user which city or station within it."
         )
-    labels = ", ".join(item.label[:120] for item in candidates[:5])
-    raise ModelRetry(f"Place name is ambiguous. Ask the user to choose: {labels}")
+    raise AssertionError("one non-prefecture candidate does not require clarification")
 
 
 async def _resolve_catalog_coordinates(

--- a/apps/agent/agent/agents/catalog_tools.py
+++ b/apps/agent/agent/agents/catalog_tools.py
@@ -1,10 +1,4 @@
-"""Catalog seam for the pilgrimage agent (hybrid architecture).
-
-When ``RuntimeDeps.catalog`` is set, the data tools route through the Catalog
-service instead of the DB Retriever / upstream APIs. These helpers call the
-catalog client, shape its typed models via ``catalog_adapter``, and record/emit
-the result with the same plumbing the legacy path uses (``tool_runtime``).
-"""
+"""Catalog-backed tools for the pilgrimage agent."""
 
 from __future__ import annotations
 
@@ -37,17 +31,11 @@ from agent.clients.geocode import GeocodeCandidate, GeocodeKind
 
 _NO_DATA_ERROR = "No catalog data"
 _TRANSIENT_ERRORS = (APIError, httpx.TransportError, httpx.TimeoutException)
+_INVISIBLE_RETRY_CHARACTERS = frozenset("\x7f\u200b\u200c\u200d\u2060\ufeff")
 
 
 def _retry_message(operation: str, exc: Exception) -> str:
-    """Safe ModelRetry text for the LLM prompt (SD-19 trust boundary).
-
-    Never embeds raw exception content or wire strings. A typed
-    :class:`CatalogError` exposes a locally-built ``steering_hint()`` from
-    whitelisted numeric/enum fields, so user-actionable errors can steer the
-    model away from blind re-calls WITHOUT leaking a wire ``data`` string (e.g.
-    ``WorkNotFoundError.bangumi_id``); everything else gets the static phrase.
-    """
+    """Build retry text without exposing raw exception or wire content."""
     if isinstance(exc, CatalogError) and exc.category == "user_actionable":
         return (
             f"Catalog {operation} rejected: {exc.steering_hint()}. Do not retry "
@@ -138,7 +126,6 @@ def _origin_coordinates(state: dict[str, object]) -> tuple[float, float] | None:
 
 
 def _candidate_summary(candidate: GeocodeCandidate) -> dict[str, object]:
-    """Build the trusted, bounded summary stored in an internal geocode step."""
     return {
         "id": candidate.id,
         "label": _sanitize_retry_text(candidate.label),
@@ -146,20 +133,34 @@ def _candidate_summary(candidate: GeocodeCandidate) -> dict[str, object]:
     }
 
 
-def _record_geocode(deps: RuntimeDeps, candidates: list[GeocodeCandidate]) -> None:
-    """Record a successful lookup that still requires user clarification."""
+def _record_geocode(
+    deps: RuntimeDeps,
+    candidates: list[GeocodeCandidate] | None = None,
+    *,
+    condition: str | None = None,
+) -> None:
+    data: dict[str, object] = (
+        {"condition": condition}
+        if condition is not None
+        else {"candidates": [_candidate_summary(item) for item in candidates or []]}
+    )
     _record_step(
         deps,
         tool=ToolName.GEOCODE.value,
         success=True,
         params={},
-        data={"candidates": [_candidate_summary(item) for item in candidates]},
+        data=data,
         error=None,
     )
 
 
+def _record_retry_failure(deps: RuntimeDeps, tool: ToolName, error: str) -> None:
+    _record_step(
+        deps, tool=tool.value, success=False, params={}, data=None, error=error
+    )
+
+
 def _candidate_radius(candidate: GeocodeCandidate) -> int:
-    """Return the default nearby radius for a resolved candidate kind."""
     if candidate.effective_radius_m is not None:
         return candidate.effective_radius_m
     if candidate.kind == GeocodeKind.CITY:
@@ -168,8 +169,11 @@ def _candidate_radius(candidate: GeocodeCandidate) -> int:
 
 
 def _sanitize_retry_text(value: str) -> str:
-    """Strip prompt-shaping controls and cap trusted retry text."""
-    return "".join(character for character in value if ord(character) >= 32)[:120]
+    return "".join(
+        character
+        for character in value
+        if ord(character) >= 32 and character not in _INVISIBLE_RETRY_CHARACTERS
+    )[:120]
 
 
 def _retry_for_candidates(
@@ -207,6 +211,7 @@ async def _resolve_catalog_coordinates(
     if not location.strip():
         origin = _origin_coordinates(deps.tool_state)
         if origin is None:
+            _record_geocode(deps, condition="missing_location_and_no_gps")
             raise ModelRetry(
                 "Ask the user for a place name or to share their location."
             )
@@ -214,7 +219,9 @@ async def _resolve_catalog_coordinates(
     try:
         candidates = await catalog.geocode(location.strip(), limit=5)
     except _TRANSIENT_ERRORS as exc:
-        raise ModelRetry(_retry_message("geocode", exc)) from exc
+        message = _retry_message("geocode", exc)
+        _record_retry_failure(deps, ToolName.GEOCODE, message)
+        raise ModelRetry(message) from exc
     if len(candidates) != 1 or candidates[0].kind == GeocodeKind.PREFECTURE:
         _retry_for_candidates(deps, location, candidates)
     candidate = candidates[0]
@@ -239,7 +246,9 @@ async def _run_catalog_nearby(
             coords[0], coords[1], radius_m=radius or default_radius
         )
     except _TRANSIENT_ERRORS as exc:
-        raise ModelRetry(_retry_message("nearby", exc)) from exc
+        message = _retry_message("nearby", exc)
+        _record_retry_failure(ctx.deps, ToolName.SEARCH_NEARBY, message)
+        raise ModelRetry(message) from exc
     payload = build_search_payload(points, tool="search_nearby")
     return await _store_catalog_result(
         ctx.deps,

--- a/apps/agent/agent/agents/models.py
+++ b/apps/agent/agent/agents/models.py
@@ -22,6 +22,7 @@ class ToolName(StrEnum):
     ANSWER_QUESTION = "answer_question"
     GREET_USER = "greet_user"
     CLARIFY = "clarify"
+    GEOCODE = "geocode"
 
 
 class PlanStep(BaseModel):

--- a/apps/agent/agent/agents/pilgrimage_agent.py
+++ b/apps/agent/agent/agents/pilgrimage_agent.py
@@ -70,15 +70,18 @@ Never fabricate locations, coordinates, or routes — always use tool outputs.
    already displays your question. Extra text causes duplicate display.
 
 ### Location/nearby search
-- When the user mentions a place name without a specific anime title
-  (e.g., "宇治附近", "spots near Kamakura", "京都有什么圣地"):
-  1. Call web_search("<location> anime pilgrimage 聖地巡礼 アニメ") to find
-     which anime are set near that location
-  2. Compile anime list from web results + your knowledge
-  3. Call clarify() with the anime options
-  4. After user picks → resolve_anime → search_bangumi
-- Exception: query has both anime AND location → resolve anime directly
-- Do NOT call search_nearby for bare location queries — clarify first
+- When the user provides a place name without a specific anime title
+  (e.g., "宇治附近", "spots near Kamakura", "京都有什么圣地"), call
+  search_nearby(location) with the place name exactly as the user wrote it.
+- For "near me" / "我附近" / "現在地の近く" requests, call
+  search_nearby(location="") so the tool uses shared GPS coordinates.
+- A single resolved station/city/ward/landmark returns nearby catalog results,
+  including an honest empty result when the query ran but found no spots.
+- If the gazetteer returns multiple places, no place, or a whole prefecture,
+  follow the tool's retry guidance: call clarify() with place-name options or
+  ask for a more specific station/city, then return clarify_response and stop.
+- A query containing both an anime title and a location remains an anime search:
+  resolve_anime → search_bangumi.
 
 ### Route planning
 - When the user asks for a route/itinerary/walking plan:
@@ -105,12 +108,13 @@ Never fabricate locations, coordinates, or routes — always use tool outputs.
 
 User: "凉宫" → resolve_anime("凉宫") → ambiguous (多部匹配) → clarify()
 User: "君の名は の聖地" → resolve_anime("君の名は") → bangumi_id → search_bangumi()
-User: "宇治站附近" → web_search("宇治 anime 聖地巡礼") → clarify(ユーフォ、etc.)
+User: "宇治站附近" → search_nearby("宇治站") → search_response
+User: "我附近有什么圣地" → search_nearby(location="") → search_response
 User: "帮我规划響け路线" → resolve_anime → search_bangumi → plan_route()
 User: "圣地巡礼注意事项" → general_qa()
 User: "你好" → greet_user()
-User: "你好，京都有什么圣地" → web_search("京都 アニメ 聖地巡礼") → clarify(...)  (NOT greet_user)
-User: "haruhi spots" → web_search("Haruhi Suzumiya anime") → resolve_anime → search_bangumi()
+User: "你好，京都有什么圣地" → search_nearby("京都") → search_response (NOT greet_user)
+User: "haruhi spots" → resolve_anime("haruhi") → search_bangumi()
 
 ### Data freshness
 - Our database may be incomplete or outdated. Consider calling web_search when:

--- a/apps/agent/agent/agents/pilgrimage_tools.py
+++ b/apps/agent/agent/agents/pilgrimage_tools.py
@@ -132,7 +132,7 @@ async def search_bangumi(
 async def search_nearby(
     ctx: RunContext[RuntimeDeps],
     *,
-    location: str,
+    location: str = "",
     radius: int = 0,
 ) -> dict[str, object]:
     """Find anime pilgrimage spots near a real-world location using geo search.

--- a/apps/agent/agent/agents/pilgrimage_tools.py
+++ b/apps/agent/agent/agents/pilgrimage_tools.py
@@ -149,6 +149,7 @@ async def search_nearby(
         radius: Search radius in meters. Default is 5000 (5km). Use 0 for default.
                 Use smaller radius for specific stations, larger for cities.
     """
+    ctx.deps.tool_state.pop(ToolName.SEARCH_NEARBY.value, None)
     params: dict[str, object] = {"location": location}
     if radius > 0:
         params["radius"] = radius

--- a/apps/agent/agent/clients/catalog_client.py
+++ b/apps/agent/agent/clients/catalog_client.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping
-from enum import StrEnum
 from typing import Literal, Protocol, runtime_checkable
 
 import httpx
@@ -41,6 +40,7 @@ from pydantic import BaseModel, Field
 from agent.agents.models import TimedItinerary, TimedStop, TransitLeg
 from agent.clients.catalog_errors import parse_catalog_error
 from agent.clients.errors import APIError, TransientAPIError
+from agent.clients.geocode import GeocodeCandidate
 
 logger = structlog.get_logger(__name__)
 
@@ -54,9 +54,6 @@ __all__ = [
     "TransitLeg",
     "CatalogClient",
     "CatalogClientProtocol",
-    "GeocodeCandidate",
-    "GeocodeKind",
-    "GeocodeSource",
 ]
 
 JSONDict = dict[str, object]
@@ -103,37 +100,6 @@ class IngestResult(BaseModel):
     version: int = -1
     point_count: int = -1
     reason: str = ""
-
-
-class GeocodeKind(StrEnum):
-    """Kinds of gazetteer entries returned by the Catalog service."""
-
-    STATION = "station"
-    CITY = "city"
-    WARD = "ward"
-    LANDMARK = "landmark"
-    PREFECTURE = "prefecture"
-
-
-class GeocodeSource(StrEnum):
-    """Auditable source families for gazetteer entries."""
-
-    SEED = "seed"
-    MLIT = "mlit"
-    GEONAMES = "geonames"
-    MANUAL = "manual"
-
-
-class GeocodeCandidate(BaseModel):
-    """One typed place-name candidate from the local gazetteer."""
-
-    id: str
-    label: str
-    name: str
-    lat: float
-    lng: float
-    kind: GeocodeKind
-    source: GeocodeSource
 
 
 @runtime_checkable

--- a/apps/agent/agent/clients/catalog_client.py
+++ b/apps/agent/agent/clients/catalog_client.py
@@ -40,7 +40,7 @@ from pydantic import BaseModel, Field
 from agent.agents.models import TimedItinerary, TimedStop, TransitLeg
 from agent.clients.catalog_errors import parse_catalog_error
 from agent.clients.errors import APIError, TransientAPIError
-from agent.clients.geocode import GeocodeCandidate
+from agent.clients.geocode import GeocodeCandidate, GeocodeKind, GeocodeSource
 
 logger = structlog.get_logger(__name__)
 
@@ -54,6 +54,9 @@ __all__ = [
     "TransitLeg",
     "CatalogClient",
     "CatalogClientProtocol",
+    "GeocodeCandidate",
+    "GeocodeKind",
+    "GeocodeSource",
 ]
 
 JSONDict = dict[str, object]

--- a/apps/agent/agent/clients/catalog_client.py
+++ b/apps/agent/agent/clients/catalog_client.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping
+from enum import StrEnum
 from typing import Literal, Protocol, runtime_checkable
 
 import httpx
@@ -53,6 +54,9 @@ __all__ = [
     "TransitLeg",
     "CatalogClient",
     "CatalogClientProtocol",
+    "GeocodeCandidate",
+    "GeocodeKind",
+    "GeocodeSource",
 ]
 
 JSONDict = dict[str, object]
@@ -101,6 +105,37 @@ class IngestResult(BaseModel):
     reason: str = ""
 
 
+class GeocodeKind(StrEnum):
+    """Kinds of gazetteer entries returned by the Catalog service."""
+
+    STATION = "station"
+    CITY = "city"
+    WARD = "ward"
+    LANDMARK = "landmark"
+    PREFECTURE = "prefecture"
+
+
+class GeocodeSource(StrEnum):
+    """Auditable source families for gazetteer entries."""
+
+    SEED = "seed"
+    MLIT = "mlit"
+    GEONAMES = "geonames"
+    MANUAL = "manual"
+
+
+class GeocodeCandidate(BaseModel):
+    """One typed place-name candidate from the local gazetteer."""
+
+    id: str
+    label: str
+    name: str
+    lat: float
+    lng: float
+    kind: GeocodeKind
+    source: GeocodeSource
+
+
 @runtime_checkable
 class CatalogClientProtocol(Protocol):
     """Structural contract for the Catalog read path (search/spots/nearby/route).
@@ -117,6 +152,10 @@ class CatalogClientProtocol(Protocol):
     async def nearby(
         self, lat: float, lng: float, *, radius_m: int = 2000
     ) -> list[PilgrimagePoint]: ...
+
+    async def geocode(
+        self, query: str, *, limit: int = 5
+    ) -> list[GeocodeCandidate]: ...
 
     async def route(
         self, point_ids: list[str], *, origin: tuple[float, float] | None = None
@@ -157,6 +196,14 @@ class CatalogClient:
         body = {"lat": lat, "lng": lng, "radius_m": radius_m}
         payload = await self._rpc("nearby", body)
         return _parse_rows(payload)
+
+    async def geocode(self, query: str, *, limit: int = 5) -> list[GeocodeCandidate]:
+        """Resolve a place name against the Catalog's local gazetteer."""
+        payload = await self._rpc("geocode", {"query": query, "limit": limit})
+        candidates = payload.get("candidates")
+        if not isinstance(candidates, list):
+            raise APIError("Expected 'candidates' to be a JSON array")
+        return [GeocodeCandidate.model_validate(item) for item in candidates]
 
     async def route(
         self, point_ids: list[str], *, origin: tuple[float, float] | None = None

--- a/apps/agent/agent/clients/geocode.py
+++ b/apps/agent/agent/clients/geocode.py
@@ -1,0 +1,37 @@
+"""Typed geocoding models mirrored from the Catalog contract."""
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class GeocodeKind(StrEnum):
+    """Kinds of gazetteer entries returned by the Catalog service."""
+
+    STATION = "station"
+    CITY = "city"
+    WARD = "ward"
+    LANDMARK = "landmark"
+    PREFECTURE = "prefecture"
+
+
+class GeocodeSource(StrEnum):
+    """Auditable source families for gazetteer entries."""
+
+    SEED = "seed"
+    MLIT = "mlit"
+    GEONAMES = "geonames"
+    MANUAL = "manual"
+
+
+class GeocodeCandidate(BaseModel):
+    """One typed place-name candidate from the local gazetteer."""
+
+    id: str
+    label: str
+    name: str
+    lat: float
+    lng: float
+    kind: GeocodeKind
+    source: GeocodeSource
+    effective_radius_m: int | None = Field(default=None, gt=0)

--- a/apps/agent/agent/tests/eval/mock_catalog_client.py
+++ b/apps/agent/agent/tests/eval/mock_catalog_client.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from agent.agents.geo_utils import haversine_distance
 from agent.agents.models import TimedItinerary, TimedStop, TransitLeg
-from agent.clients.catalog_client import IngestResult, PilgrimagePoint, Route
+from agent.clients.catalog_client import (
+    GeocodeCandidate,
+    GeocodeKind,
+    GeocodeSource,
+    IngestResult,
+    PilgrimagePoint,
+    Route,
+)
 from agent.clients.errors import APIError
 from agent.tests.eval.mock_catalog_fixtures import (
     FIXTURE_POINTS,
@@ -56,6 +63,10 @@ class MockCatalogClient:
         self.calls.append(("nearby", (lat, lng, radius_m)))
         scored = self._within_radius(lat, lng, radius_m)
         return [point for _, point in sorted(scored, key=lambda item: item[0])]
+
+    async def geocode(self, query: str, *, limit: int = 5) -> list[GeocodeCandidate]:
+        self.calls.append(("geocode", (query, limit)))
+        return [candidate.model_copy() for candidate in _geocode_fixture(query)[:limit]]
 
     async def route(
         self, point_ids: list[str], *, origin: tuple[float, float] | None = None
@@ -124,6 +135,114 @@ def _build_route(ordered: list[PilgrimagePoint]) -> Route:
         anime_title_cn=ordered[0].title_cn,
         timed_itinerary=_build_itinerary(ordered),
     )
+
+
+def _candidate(
+    id_: str,
+    label: str,
+    name: str,
+    lat: float,
+    lng: float,
+    kind: GeocodeKind,
+) -> GeocodeCandidate:
+    return GeocodeCandidate(
+        id=id_,
+        label=label,
+        name=name,
+        lat=lat,
+        lng=lng,
+        kind=kind,
+        source=GeocodeSource.SEED,
+    )
+
+
+def _geocode_fixture(query: str) -> list[GeocodeCandidate]:
+    fixtures = {
+        "西宮": [
+            _candidate(
+                "seed:nishinomiya",
+                "西宮駅(兵庫県)",
+                "西宮駅",
+                34.7386,
+                135.3485,
+                GeocodeKind.STATION,
+            )
+        ],
+        "西宫": [
+            _candidate(
+                "seed:nishinomiya",
+                "西宮駅(兵庫県)",
+                "西宮駅",
+                34.7386,
+                135.3485,
+                GeocodeKind.STATION,
+            )
+        ],
+        "nishinomiya": [
+            _candidate(
+                "seed:nishinomiya",
+                "西宮駅(兵庫県)",
+                "西宮駅",
+                34.7386,
+                135.3485,
+                GeocodeKind.STATION,
+            )
+        ],
+        "宇治": [
+            _candidate(
+                "seed:uji", "宇治(京都府)", "宇治", 34.8843, 135.7997, GeocodeKind.CITY
+            )
+        ],
+        "東京": [
+            _candidate(
+                "seed:tokyo",
+                "東京(東京都)",
+                "東京",
+                35.6762,
+                139.6503,
+                GeocodeKind.CITY,
+            )
+        ],
+        "东京": [
+            _candidate(
+                "seed:tokyo",
+                "東京(東京都)",
+                "東京",
+                35.6762,
+                139.6503,
+                GeocodeKind.CITY,
+            )
+        ],
+        "府中": [
+            _candidate(
+                "manual:fuchu-tokyo",
+                "府中市(東京都)",
+                "府中市",
+                35.6689,
+                139.4777,
+                GeocodeKind.CITY,
+            ),
+            _candidate(
+                "manual:fuchu-hiroshima",
+                "府中市(広島県)",
+                "府中市",
+                34.5684,
+                133.2363,
+                GeocodeKind.CITY,
+            ),
+        ],
+        "山梨県": [
+            _candidate(
+                "manual:yamanashi",
+                "山梨県",
+                "山梨県",
+                35.6639,
+                138.5683,
+                GeocodeKind.PREFECTURE,
+            )
+        ],
+    }
+    return fixtures.get(query.lower(), fixtures.get(query, []))
 
 
 def _build_itinerary(ordered: list[PilgrimagePoint]) -> TimedItinerary:

--- a/apps/agent/agent/tests/eval/mock_catalog_client.py
+++ b/apps/agent/agent/tests/eval/mock_catalog_client.py
@@ -4,15 +4,9 @@ from __future__ import annotations
 
 from agent.agents.geo_utils import haversine_distance
 from agent.agents.models import TimedItinerary, TimedStop, TransitLeg
-from agent.clients.catalog_client import (
-    GeocodeCandidate,
-    GeocodeKind,
-    GeocodeSource,
-    IngestResult,
-    PilgrimagePoint,
-    Route,
-)
+from agent.clients.catalog_client import IngestResult, PilgrimagePoint, Route
 from agent.clients.errors import APIError
+from agent.clients.geocode import GeocodeCandidate, GeocodeKind, GeocodeSource
 from agent.tests.eval.mock_catalog_fixtures import (
     FIXTURE_POINTS,
     LOCATION_CENTERS,

--- a/apps/agent/agent/tests/unit/test_catalog_client.py
+++ b/apps/agent/agent/tests/unit/test_catalog_client.py
@@ -11,13 +11,11 @@ import pytest
 
 from agent.clients.catalog_client import (
     CatalogClient,
-    GeocodeCandidate,
-    GeocodeKind,
-    GeocodeSource,
     IngestResult,
     PilgrimagePoint,
     Route,
 )
+from agent.clients.geocode import GeocodeCandidate, GeocodeKind, GeocodeSource
 
 _POINT = {"id": "p1", "name": "Uji Bridge", "latitude": 34.89, "longitude": 135.80}
 
@@ -102,6 +100,7 @@ async def test_geocode_parses_candidates_and_posts_limit(
         "lng": 135.3485,
         "kind": "station",
         "source": "manual",
+        "effective_radius_m": 10000,
     }
     client = _mock_httpx(monkeypatch, {"candidates": [candidate]})
 
@@ -110,6 +109,7 @@ async def test_geocode_parses_candidates_and_posts_limit(
     assert result == [GeocodeCandidate.model_validate(candidate)]
     assert result[0].kind == GeocodeKind.STATION
     assert result[0].source == GeocodeSource.MANUAL
+    assert result[0].effective_radius_m == 10_000
     assert client.post.call_args.args[0] == "https://catalog.test/catalog/geocode"
     assert client.post.call_args.kwargs["json"] == {"query": "西宮", "limit": 3}
 

--- a/apps/agent/agent/tests/unit/test_catalog_client.py
+++ b/apps/agent/agent/tests/unit/test_catalog_client.py
@@ -11,6 +11,9 @@ import pytest
 
 from agent.clients.catalog_client import (
     CatalogClient,
+    GeocodeCandidate,
+    GeocodeKind,
+    GeocodeSource,
     IngestResult,
     PilgrimagePoint,
     Route,
@@ -86,6 +89,29 @@ async def test_nearby_parses_rows(monkeypatch: pytest.MonkeyPatch) -> None:
         "lng": 135.80,
         "radius_m": 500,
     }
+
+
+async def test_geocode_parses_candidates_and_posts_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = {
+        "id": "seed:nishinomiya",
+        "label": "西宮駅(兵庫県)",
+        "name": "西宮駅",
+        "lat": 34.7386,
+        "lng": 135.3485,
+        "kind": "station",
+        "source": "manual",
+    }
+    client = _mock_httpx(monkeypatch, {"candidates": [candidate]})
+
+    result = await CatalogClient("https://catalog.test").geocode("西宮", limit=3)
+
+    assert result == [GeocodeCandidate.model_validate(candidate)]
+    assert result[0].kind == GeocodeKind.STATION
+    assert result[0].source == GeocodeSource.MANUAL
+    assert client.post.call_args.args[0] == "https://catalog.test/catalog/geocode"
+    assert client.post.call_args.kwargs["json"] == {"query": "西宮", "limit": 3}
 
 
 async def test_route_parses_route(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/agent/agent/tests/unit/test_catalog_client.py
+++ b/apps/agent/agent/tests/unit/test_catalog_client.py
@@ -11,13 +11,21 @@ import pytest
 
 from agent.clients.catalog_client import (
     CatalogClient,
+    GeocodeCandidate,
+    GeocodeKind,
+    GeocodeSource,
     IngestResult,
     PilgrimagePoint,
     Route,
 )
-from agent.clients.geocode import GeocodeCandidate, GeocodeKind, GeocodeSource
 
 _POINT = {"id": "p1", "name": "Uji Bridge", "latitude": 34.89, "longitude": 135.80}
+
+
+def test_geocode_types_remain_reexported() -> None:
+    assert GeocodeCandidate.__module__ == "agent.clients.geocode"
+    assert GeocodeKind.__module__ == "agent.clients.geocode"
+    assert GeocodeSource.__module__ == "agent.clients.geocode"
 
 
 def _mock_httpx(monkeypatch: pytest.MonkeyPatch, json_payload: object) -> MagicMock:

--- a/apps/agent/agent/tests/unit/test_catalog_geocoding_agent.py
+++ b/apps/agent/agent/tests/unit/test_catalog_geocoding_agent.py
@@ -15,8 +15,10 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 
-from agent.agents.agent_result import AgentResult
+from agent.agents import catalog_tools
+from agent.agents.agent_result import AgentResult, StepRecord
 from agent.agents.pilgrimage_runner import run_pilgrimage_agent
+from agent.agents.runtime_deps import RuntimeDeps
 from agent.clients.catalog_client import PilgrimagePoint
 from agent.domain.ports import DatabasePort
 from agent.tests.eval.mock_catalog_client import MockCatalogClient
@@ -158,6 +160,35 @@ async def test_stale_nearby_state_cannot_validate_ambiguous_search_output() -> N
             context=context,
             force_invalid_search=True,
         )
+
+
+async def test_missing_location_cannot_validate_fabricated_search_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded_steps: list[StepRecord] = []
+    original = catalog_tools._record_step
+
+    def capture_step(
+        deps: RuntimeDeps,
+        *,
+        tool: str,
+        success: bool,
+        params: dict[str, object],
+        data: dict[str, object] | None,
+        error: str | None,
+    ) -> None:
+        original(
+            deps, tool=tool, success=success, params=params, data=data, error=error
+        )
+        recorded_steps[:] = deps.steps
+
+    monkeypatch.setattr(catalog_tools, "_record_step", capture_step)
+    with pytest.raises(UnexpectedModelBehavior, match="maximum output retries"):
+        await _run("", MockCatalogClient(), force_invalid_search=True)
+
+    assert recorded_steps
+    assert recorded_steps[0].tool == "geocode"
+    assert recorded_steps[0].success is True
 
 
 async def test_successful_nearby_replaces_preseeded_state_with_new_payload() -> None:

--- a/apps/agent/agent/tests/unit/test_catalog_geocoding_agent.py
+++ b/apps/agent/agent/tests/unit/test_catalog_geocoding_agent.py
@@ -1,0 +1,191 @@
+"""PR-A catalog geocoding acceptance tests (§3.5 / A5-A8')."""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelResponse,
+    RetryPromptPart,
+    ToolCallPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from agent.agents.agent_result import AgentResult
+from agent.agents.pilgrimage_runner import run_pilgrimage_agent
+from agent.clients.catalog_client import PilgrimagePoint
+from agent.domain.ports import DatabasePort
+from agent.interfaces.response_builder import agent_result_to_response
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+SEARCH_OUTPUT = {
+    "intent": "search_nearby",
+    "message": "Nearby results",
+    "data": {"results": {"rows": [], "row_count": 0, "status": "empty"}},
+    "ui": {},
+}
+CLARIFY_OUTPUT = {
+    "intent": "clarify",
+    "message": "Which place?",
+    "data": {
+        "status": "needs_clarification",
+        "question": "Which place?",
+        "options": ["府中市(東京都)", "府中市(広島県)"],
+        "candidates": [],
+    },
+    "ui": {},
+}
+
+
+class EmptyNearbyCatalog(MockCatalogClient):
+    """Catalog fixture whose geo query executes successfully with zero rows."""
+
+    async def nearby(
+        self, lat: float, lng: float, *, radius_m: int = 2000
+    ) -> list[PilgrimagePoint]:
+        self.calls.append(("nearby", (lat, lng, radius_m)))
+        return []
+
+
+def _db() -> DatabasePort:
+    db = MagicMock()
+    db.bangumi.find_candidate_details_by_titles = AsyncMock(return_value=[])
+    return cast(DatabasePort, db)
+
+
+def _parts(messages: list[ModelMessage]) -> list[object]:
+    return [part for message in messages for part in getattr(message, "parts", [])]
+
+
+def _tool_returned(messages: list[ModelMessage], name: str) -> bool:
+    return any(getattr(part, "tool_name", None) == name for part in _parts(messages))
+
+
+def _retry_count(messages: list[ModelMessage]) -> int:
+    return sum(isinstance(part, RetryPromptPart) for part in _parts(messages))
+
+
+def _nearby_model(
+    location: str, *, force_invalid_search: bool = False
+) -> FunctionModel:
+    options = ["府中市(東京都)", "府中市(広島県)"] if location == "府中" else []
+    clarify_output = {
+        **CLARIFY_OUTPUT,
+        "data": {**CLARIFY_OUTPUT["data"], "options": options},
+    }
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if _tool_returned(messages, "clarify"):
+            return ModelResponse(
+                parts=[ToolCallPart("clarify_response", clarify_output)]
+            )
+        retries = _retry_count(messages)
+        if retries and force_invalid_search and retries == 1:
+            return ModelResponse(parts=[ToolCallPart("search_response", SEARCH_OUTPUT)])
+        if retries:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        "clarify", {"question": "Which place?", "options": options}
+                    )
+                ]
+            )
+        if _tool_returned(messages, "search_nearby"):
+            return ModelResponse(parts=[ToolCallPart("search_response", SEARCH_OUTPUT)])
+        return ModelResponse(
+            parts=[ToolCallPart("search_nearby", {"location": location})]
+        )
+
+    return FunctionModel(respond)
+
+
+async def _run(
+    location: str,
+    catalog: MockCatalogClient,
+    *,
+    context: dict[str, object] | None = None,
+    force_invalid_search: bool = False,
+) -> AgentResult:
+    return await run_pilgrimage_agent(
+        text="nearby",
+        db=_db(),
+        locale="en",
+        catalog=catalog,
+        model=_nearby_model(location, force_invalid_search=force_invalid_search),
+        context=context,
+    )
+
+
+async def test_a5_nishinomiya_geocode_then_nearby_returns_rows() -> None:
+    catalog = MockCatalogClient()
+    result = await _run("西宮", catalog)
+    assert result.intent == "search_nearby"
+    assert result.tool_state["search_nearby"]["row_count"] > 0
+    assert [step.tool for step in result.steps] == ["search_nearby"]
+
+
+async def test_a5_prime_honest_empty_is_successful_search_response() -> None:
+    result = await _run("西宮", EmptyNearbyCatalog())
+    response = agent_result_to_response(result, include_debug=True)
+    assert result.tool_state["search_nearby"]["row_count"] == 0
+    assert result.steps[0].success is True
+    assert response.success is True
+    assert response.errors == []
+
+
+async def test_a6_ambiguous_place_clarifies_without_pipeline_error() -> None:
+    result = await _run("府中", MockCatalogClient())
+    response = agent_result_to_response(result, include_debug=True)
+    assert [step.tool for step in result.steps] == ["geocode", "clarify"]
+    assert all(step.success for step in result.steps)
+    assert result.output.data.options
+    assert response.success is True
+    assert response.errors == []
+
+
+async def test_a6_prime_search_response_after_ambiguity_is_rejected() -> None:
+    result = await _run("府中", MockCatalogClient(), force_invalid_search=True)
+    assert result.intent == "clarify"
+    assert "search_nearby" not in result.tool_state
+
+
+async def test_a7_unknown_place_clarifies_without_gps_fallback() -> None:
+    catalog = MockCatalogClient()
+    result = await _run(
+        "unknown place", catalog, context={"origin_lat": 34.7, "origin_lng": 135.3}
+    )
+    assert result.intent == "clarify"
+    assert [name for name, _ in catalog.calls] == ["geocode"]
+    assert result.steps[0].tool == "geocode"
+
+
+async def test_a8_explicit_place_wins_over_gps() -> None:
+    catalog = MockCatalogClient()
+    await _run("西宮", catalog, context={"origin_lat": 0.0, "origin_lng": 0.0})
+    assert catalog.calls[0] == ("geocode", ("西宮", 5))
+    assert catalog.calls[1][0] == "nearby"
+    assert catalog.calls[1][1][:2] == (34.7386, 135.3485)
+
+
+async def test_a8_empty_location_uses_gps_without_geocoding() -> None:
+    catalog = EmptyNearbyCatalog()
+    await _run("", catalog, context={"origin_lat": 35.0, "origin_lng": 139.0})
+    assert catalog.calls == [("nearby", (35.0, 139.0, 5000))]
+
+
+async def test_a8_empty_location_without_gps_clarifies() -> None:
+    result = await _run("", MockCatalogClient())
+    assert result.intent == "clarify"
+    assert [step.tool for step in result.steps] == ["clarify"]
+
+
+async def test_a8_prime_prefecture_clarifies_without_nearby() -> None:
+    catalog = MockCatalogClient()
+    result = await _run("山梨県", catalog)
+    assert [name for name, _ in catalog.calls if name in {"geocode", "nearby"}] == [
+        "geocode"
+    ]
+    assert result.success is True
+    assert result.steps[0].tool == "geocode"

--- a/apps/agent/agent/tests/unit/test_catalog_geocoding_agent.py
+++ b/apps/agent/agent/tests/unit/test_catalog_geocoding_agent.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+from pydantic_ai import UnexpectedModelBehavior
 from pydantic_ai.messages import (
     ModelMessage,
     ModelResponse,
@@ -17,7 +19,6 @@ from agent.agents.agent_result import AgentResult
 from agent.agents.pilgrimage_runner import run_pilgrimage_agent
 from agent.clients.catalog_client import PilgrimagePoint
 from agent.domain.ports import DatabasePort
-from agent.interfaces.response_builder import agent_result_to_response
 from agent.tests.eval.mock_catalog_client import MockCatalogClient
 
 SEARCH_OUTPUT = {
@@ -34,6 +35,19 @@ CLARIFY_OUTPUT = {
         "question": "Which place?",
         "options": ["府中市(東京都)", "府中市(広島県)"],
         "candidates": [],
+    },
+    "ui": {},
+}
+ROUTE_OUTPUT = {
+    "intent": "plan_route",
+    "message": "Route ready",
+    "data": {
+        "route": {
+            "ordered_points": [],
+            "point_count": 0,
+            "status": "ok",
+            "timed_itinerary": {},
+        }
     },
     "ui": {},
 }
@@ -82,7 +96,7 @@ def _nearby_model(
                 parts=[ToolCallPart("clarify_response", clarify_output)]
             )
         retries = _retry_count(messages)
-        if retries and force_invalid_search and retries == 1:
+        if retries and force_invalid_search:
             return ModelResponse(parts=[ToolCallPart("search_response", SEARCH_OUTPUT)])
         if retries:
             return ModelResponse(
@@ -97,6 +111,15 @@ def _nearby_model(
         return ModelResponse(
             parts=[ToolCallPart("search_nearby", {"location": location})]
         )
+
+    return FunctionModel(respond)
+
+
+def _route_model() -> FunctionModel:
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if _tool_returned(messages, "plan_route"):
+            return ModelResponse(parts=[ToolCallPart("route_response", ROUTE_OUTPUT)])
+        return ModelResponse(parts=[ToolCallPart("plan_route", {})])
 
     return FunctionModel(respond)
 
@@ -126,66 +149,40 @@ async def test_a5_nishinomiya_geocode_then_nearby_returns_rows() -> None:
     assert [step.tool for step in result.steps] == ["search_nearby"]
 
 
-async def test_a5_prime_honest_empty_is_successful_search_response() -> None:
-    result = await _run("西宮", EmptyNearbyCatalog())
-    response = agent_result_to_response(result, include_debug=True)
-    assert result.tool_state["search_nearby"]["row_count"] == 0
-    assert result.steps[0].success is True
-    assert response.success is True
-    assert response.errors == []
+async def test_stale_nearby_state_cannot_validate_ambiguous_search_output() -> None:
+    context = {"last_search_data": {"search_nearby": {"stale": 1}}}
+    with pytest.raises(UnexpectedModelBehavior, match="maximum output retries"):
+        await _run(
+            "府中",
+            MockCatalogClient(),
+            context=context,
+            force_invalid_search=True,
+        )
 
 
-async def test_a6_ambiguous_place_clarifies_without_pipeline_error() -> None:
-    result = await _run("府中", MockCatalogClient())
-    response = agent_result_to_response(result, include_debug=True)
-    assert [step.tool for step in result.steps] == ["geocode", "clarify"]
-    assert all(step.success for step in result.steps)
-    assert result.output.data.options
-    assert response.success is True
-    assert response.errors == []
+async def test_successful_nearby_replaces_preseeded_state_with_new_payload() -> None:
+    context = {"last_search_data": {"search_nearby": {"stale": 1}}}
+    result = await _run("西宮", MockCatalogClient(), context=context)
+    payload = result.tool_state["search_nearby"]
+    assert "stale" not in payload
+    assert payload["rows"][0]["id"] == "p_haruhi_1"
 
 
-async def test_a6_prime_search_response_after_ambiguity_is_rejected() -> None:
-    result = await _run("府中", MockCatalogClient(), force_invalid_search=True)
-    assert result.intent == "clarify"
-    assert "search_nearby" not in result.tool_state
-
-
-async def test_a7_unknown_place_clarifies_without_gps_fallback() -> None:
+async def test_plan_route_uses_preseeded_nearby_without_new_search() -> None:
     catalog = MockCatalogClient()
-    result = await _run(
-        "unknown place", catalog, context={"origin_lat": 34.7, "origin_lng": 135.3}
+    context = {
+        "last_search_data": {
+            "search_nearby": {"rows": [{"id": "p_haruhi_1"}], "row_count": 1}
+        }
+    }
+    result = await run_pilgrimage_agent(
+        text="plan route",
+        db=_db(),
+        locale="en",
+        catalog=catalog,
+        model=_route_model(),
+        context=context,
     )
-    assert result.intent == "clarify"
-    assert [name for name, _ in catalog.calls] == ["geocode"]
-    assert result.steps[0].tool == "geocode"
-
-
-async def test_a8_explicit_place_wins_over_gps() -> None:
-    catalog = MockCatalogClient()
-    await _run("西宮", catalog, context={"origin_lat": 0.0, "origin_lng": 0.0})
-    assert catalog.calls[0] == ("geocode", ("西宮", 5))
-    assert catalog.calls[1][0] == "nearby"
-    assert catalog.calls[1][1][:2] == (34.7386, 135.3485)
-
-
-async def test_a8_empty_location_uses_gps_without_geocoding() -> None:
-    catalog = EmptyNearbyCatalog()
-    await _run("", catalog, context={"origin_lat": 35.0, "origin_lng": 139.0})
-    assert catalog.calls == [("nearby", (35.0, 139.0, 5000))]
-
-
-async def test_a8_empty_location_without_gps_clarifies() -> None:
-    result = await _run("", MockCatalogClient())
-    assert result.intent == "clarify"
-    assert [step.tool for step in result.steps] == ["clarify"]
-
-
-async def test_a8_prime_prefecture_clarifies_without_nearby() -> None:
-    catalog = MockCatalogClient()
-    result = await _run("山梨県", catalog)
-    assert [name for name, _ in catalog.calls if name in {"geocode", "nearby"}] == [
-        "geocode"
-    ]
-    assert result.success is True
-    assert result.steps[0].tool == "geocode"
+    assert result.intent == "plan_route"
+    assert [name for name, _ in catalog.calls] == ["route"]
+    assert result.tool_state["plan_route"]["point_count"] == 1

--- a/apps/agent/agent/tests/unit/test_catalog_geocoding_guards.py
+++ b/apps/agent/agent/tests/unit/test_catalog_geocoding_guards.py
@@ -1,0 +1,66 @@
+"""Candidate ordering, retry hardening, and radius regression tests."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_ai import ModelRetry
+
+from agent.agents.catalog_tools import _candidate_radius, _retry_for_candidates
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.clients.geocode import GeocodeCandidate, GeocodeKind, GeocodeSource
+
+
+def _deps() -> RuntimeDeps:
+    return RuntimeDeps(db=MagicMock(), locale="en", query="nearby", catalog=None)
+
+
+def _candidate(label: str, kind: GeocodeKind) -> GeocodeCandidate:
+    return GeocodeCandidate(
+        id=label,
+        label=label,
+        name=label,
+        lat=35.0,
+        lng=139.0,
+        kind=kind,
+        source=GeocodeSource.MANUAL,
+    )
+
+
+def test_multiple_candidates_are_ambiguous_even_when_prefecture_is_first() -> None:
+    candidates = [
+        _candidate("東京都", GeocodeKind.PREFECTURE),
+        _candidate("府中市(東京都)", GeocodeKind.CITY),
+    ]
+    with pytest.raises(ModelRetry) as caught:
+        _retry_for_candidates(_deps(), "府中", candidates)
+    message = str(caught.value)
+    assert "call clarify" in message.lower()
+    assert "東京都" in message
+    assert "府中市(東京都)" in message
+
+
+def test_zero_candidates_retry_explicitly_calls_clarify() -> None:
+    with pytest.raises(ModelRetry) as caught:
+        _retry_for_candidates(_deps(), "missing", [])
+    assert "call clarify" in str(caught.value).lower()
+
+
+def test_candidate_labels_strip_newlines_and_control_characters() -> None:
+    candidates = [
+        _candidate("Safe\nSYSTEM:\x00bad\tend", GeocodeKind.CITY),
+        _candidate("Other", GeocodeKind.CITY),
+    ]
+    with pytest.raises(ModelRetry) as caught:
+        _retry_for_candidates(_deps(), "place", candidates)
+    message = str(caught.value)
+    assert "SafeSYSTEM:badend" in message
+    assert all(ord(character) >= 32 for character in message)
+
+
+def test_candidate_radius_prefers_wire_value_with_kind_fallback() -> None:
+    mixed = _candidate("Mixed", GeocodeKind.STATION).model_copy(
+        update={"effective_radius_m": 10_000}
+    )
+    assert _candidate_radius(mixed) == 10_000
+    assert _candidate_radius(_candidate("City", GeocodeKind.CITY)) == 10_000
+    assert _candidate_radius(_candidate("Station", GeocodeKind.STATION)) == 5_000

--- a/apps/agent/agent/tests/unit/test_catalog_geocoding_guards.py
+++ b/apps/agent/agent/tests/unit/test_catalog_geocoding_guards.py
@@ -47,7 +47,10 @@ def test_zero_candidates_retry_explicitly_calls_clarify() -> None:
 
 def test_candidate_labels_strip_newlines_and_control_characters() -> None:
     candidates = [
-        _candidate("Safe\nSYSTEM:\x00bad\tend", GeocodeKind.CITY),
+        _candidate(
+            "Safe\nSYSTEM:\x00bad\tend\x7f\u200b\u200c\u200d\u2060\ufeff",
+            GeocodeKind.CITY,
+        ),
         _candidate("Other", GeocodeKind.CITY),
     ]
     with pytest.raises(ModelRetry) as caught:
@@ -55,6 +58,9 @@ def test_candidate_labels_strip_newlines_and_control_characters() -> None:
     message = str(caught.value)
     assert "SafeSYSTEM:badend" in message
     assert all(ord(character) >= 32 for character in message)
+    assert not any(
+        character in message for character in "\x7f\u200b\u200c\u200d\u2060\ufeff"
+    )
 
 
 def test_candidate_radius_prefers_wire_value_with_kind_fallback() -> None:

--- a/apps/agent/agent/tests/unit/test_catalog_geocoding_location.py
+++ b/apps/agent/agent/tests/unit/test_catalog_geocoding_location.py
@@ -1,0 +1,63 @@
+"""Location-flow coverage split from the core geocoding agent tests."""
+
+from agent.interfaces.response_builder import agent_result_to_response
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+from agent.tests.unit.test_catalog_geocoding_agent import EmptyNearbyCatalog, _run
+
+
+async def test_a5_prime_honest_empty_is_successful_search_response() -> None:
+    result = await _run("西宮", EmptyNearbyCatalog())
+    response = agent_result_to_response(result, include_debug=True)
+    assert result.tool_state["search_nearby"]["row_count"] == 0
+    assert result.steps[0].success is True
+    assert response.success is True
+    assert response.errors == []
+
+
+async def test_a6_ambiguous_place_clarifies_without_pipeline_error() -> None:
+    result = await _run("府中", MockCatalogClient())
+    response = agent_result_to_response(result, include_debug=True)
+    assert [step.tool for step in result.steps] == ["geocode", "clarify"]
+    assert all(step.success for step in result.steps)
+    assert result.output.data.options
+    assert response.success is True
+    assert response.errors == []
+
+
+async def test_a7_unknown_place_clarifies_without_gps_fallback() -> None:
+    catalog = MockCatalogClient()
+    result = await _run(
+        "unknown place", catalog, context={"origin_lat": 34.7, "origin_lng": 135.3}
+    )
+    assert result.intent == "clarify"
+    assert [name for name, _ in catalog.calls] == ["geocode"]
+    assert result.steps[0].tool == "geocode"
+
+
+async def test_a8_explicit_place_wins_over_gps() -> None:
+    catalog = MockCatalogClient()
+    await _run("西宮", catalog, context={"origin_lat": 0.0, "origin_lng": 0.0})
+    assert catalog.calls[0] == ("geocode", ("西宮", 5))
+    assert catalog.calls[1][0] == "nearby"
+    assert catalog.calls[1][1][:2] == (34.7386, 135.3485)
+
+
+async def test_a8_empty_location_uses_gps_without_geocoding() -> None:
+    catalog = EmptyNearbyCatalog()
+    await _run("", catalog, context={"origin_lat": 35.0, "origin_lng": 139.0})
+    assert catalog.calls == [("nearby", (35.0, 139.0, 5000))]
+
+
+async def test_a8_empty_location_without_gps_clarifies() -> None:
+    result = await _run("", MockCatalogClient())
+    assert result.intent == "clarify"
+    assert [step.tool for step in result.steps] == ["clarify"]
+
+
+async def test_a8_prime_prefecture_clarifies_without_nearby() -> None:
+    catalog = MockCatalogClient()
+    result = await _run("山梨県", catalog)
+    calls = [name for name, _ in catalog.calls if name in {"geocode", "nearby"}]
+    assert calls == ["geocode"]
+    assert result.success is True
+    assert result.steps[0].tool == "geocode"

--- a/apps/agent/agent/tests/unit/test_catalog_geocoding_location.py
+++ b/apps/agent/agent/tests/unit/test_catalog_geocoding_location.py
@@ -51,7 +51,9 @@ async def test_a8_empty_location_uses_gps_without_geocoding() -> None:
 async def test_a8_empty_location_without_gps_clarifies() -> None:
     result = await _run("", MockCatalogClient())
     assert result.intent == "clarify"
-    assert [step.tool for step in result.steps] == ["clarify"]
+    assert [step.tool for step in result.steps] == ["geocode", "clarify"]
+    assert result.steps[0].success is True
+    assert result.steps[0].data == {"condition": "missing_location_and_no_gps"}
 
 
 async def test_a8_prime_prefecture_clarifies_without_nearby() -> None:

--- a/apps/agent/agent/tests/unit/test_pilgrimage_agent.py
+++ b/apps/agent/agent/tests/unit/test_pilgrimage_agent.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 from pydantic_ai.models.test import TestModel
 
+from agent.agents.pilgrimage_agent import _INSTRUCTIONS
 from agent.agents.pilgrimage_runner import run_pilgrimage_agent
 from agent.agents.runtime_models import (
     ClarifyResponseModel,
@@ -14,6 +15,14 @@ from agent.agents.runtime_models import (
     SearchResponseModel,
 )
 from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+
+def test_a10_nearby_instructions_use_catalog_geocoding_workflow() -> None:
+    """Spec §3.5 replaces the old web-search/clarify prohibition."""
+    assert "Do NOT call search_nearby for bare location queries" not in _INSTRUCTIONS
+    assert 'search_nearby(location="")' in _INSTRUCTIONS
+    assert 'User: "宇治站附近" → search_nearby("宇治站")' in _INSTRUCTIONS
+    assert 'User: "你好，京都有什么圣地" → search_nearby("京都")' in _INSTRUCTIONS
 
 
 async def test_run_pilgrimage_agent_returns_clarify_agent_result() -> None:

--- a/apps/agent/agent/tests/unit/test_tools_catalog_wiring.py
+++ b/apps/agent/agent/tests/unit/test_tools_catalog_wiring.py
@@ -102,7 +102,7 @@ async def test_data_tools_make_zero_upstream_calls() -> None:
         _tool_then_output("resolve_anime", {"title": "君の名は。"}),
         text="君の名は。",
     )
-    allowed = {"search", "spots", "nearby", "route"}
+    allowed = {"search", "spots", "nearby", "geocode", "route"}
     assert all(name in allowed for name, _ in catalog.calls), catalog.calls
     assert catalog.calls, "expected at least one catalog call"
 

--- a/db/migrations/20260714000001_catalog_geocoding.sql
+++ b/db/migrations/20260714000001_catalog_geocoding.sql
@@ -1,0 +1,83 @@
+-- PR-A gazetteer schema and audited seed data (20 locations / 30 aliases).
+CREATE TABLE locations (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    kind        TEXT NOT NULL CHECK (kind IN ('station', 'city', 'ward', 'landmark', 'prefecture')),
+    latitude    DOUBLE PRECISION NOT NULL,
+    longitude   DOUBLE PRECISION NOT NULL,
+    location    GEOGRAPHY(POINT, 4326),
+    source      TEXT NOT NULL CHECK (source IN ('seed', 'mlit', 'geonames', 'manual')),
+    pref        TEXT,
+    created_at  TIMESTAMPTZ DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TRIGGER trg_locations_sync_coordinates
+    BEFORE INSERT OR UPDATE ON locations
+    FOR EACH ROW EXECUTE FUNCTION sync_points_coordinates();
+
+CREATE TABLE location_aliases (
+    alias             TEXT NOT NULL,
+    alias_normalized  TEXT NOT NULL,
+    location_id       TEXT NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+    lang              TEXT CHECK (lang IN ('ja', 'zh', 'en') OR lang IS NULL),
+    priority          INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (alias_normalized, location_id)
+);
+
+CREATE INDEX idx_location_aliases_norm ON location_aliases (alias_normalized);
+GRANT SELECT ON locations, location_aliases TO catalog_svc;
+
+INSERT INTO locations (id, name, kind, latitude, longitude, source, pref) VALUES
+    ('seed:uji', '宇治', 'city', 34.8843, 135.7997, 'seed', '京都府'),
+    ('seed:kyoto', '京都', 'city', 35.0116, 135.7681, 'seed', '京都府'),
+    ('seed:kyoto-station', '京都駅', 'station', 34.9858, 135.7588, 'seed', '京都府'),
+    ('seed:tokyo-station', '東京駅', 'station', 35.6812, 139.7671, 'seed', '東京都'),
+    ('seed:tokyo', '東京', 'city', 35.6762, 139.6503, 'seed', '東京都'),
+    ('seed:shinjuku', '新宿', 'ward', 35.6896, 139.7006, 'seed', '東京都'),
+    ('seed:akihabara', '秋葉原', 'landmark', 35.7023, 139.7745, 'seed', '東京都'),
+    ('seed:takayama', '飛騨高山', 'city', 36.1461, 137.2522, 'seed', '岐阜県'),
+    ('seed:kamakura', '鎌倉', 'city', 35.3192, 139.5467, 'seed', '神奈川県'),
+    ('seed:osaka', '大阪', 'city', 34.6937, 135.5023, 'seed', '大阪府'),
+    ('seed:shibuya', '渋谷', 'ward', 35.6580, 139.7016, 'seed', '東京都'),
+    ('seed:ikebukuro', '池袋', 'landmark', 35.7295, 139.7109, 'seed', '東京都'),
+    ('seed:yokohama', '横浜', 'city', 35.4437, 139.6380, 'seed', '神奈川県'),
+    ('seed:nara', '奈良', 'city', 34.6851, 135.8048, 'seed', '奈良県'),
+    ('seed:hiroshima', '広島', 'city', 34.3853, 132.4553, 'seed', '広島県'),
+    ('seed:hiroshima-station', '広島駅', 'station', 34.3976, 132.4753, 'seed', '広島県'),
+    ('seed:nagoya', '名古屋', 'city', 35.1815, 136.9066, 'seed', '愛知県'),
+    ('seed:uji-station', '宇治駅', 'station', 34.8891, 135.8008, 'seed', '京都府'),
+    ('seed:rokujizo', '六地蔵', 'station', 34.9340, 135.7930, 'seed', '京都府'),
+    ('seed:nishinomiya-station', '西宮駅', 'station', 34.7386, 135.3485, 'manual', '兵庫県');
+
+INSERT INTO location_aliases (alias, alias_normalized, location_id, lang, priority) VALUES
+    ('宇治', '宇治', 'seed:uji', 'ja', 100),
+    ('京都', '京都', 'seed:kyoto', 'ja', 100),
+    ('京都站', '京都站', 'seed:kyoto-station', 'zh', 90),
+    ('京都駅', '京都駅', 'seed:kyoto-station', 'ja', 100),
+    ('東京駅', '東京駅', 'seed:tokyo-station', 'ja', 100),
+    ('东京站', '东京站', 'seed:tokyo-station', 'zh', 90),
+    ('東京', '東京', 'seed:tokyo', 'ja', 100),
+    ('东京', '东京', 'seed:tokyo', 'zh', 90),
+    ('新宿', '新宿', 'seed:shinjuku', 'ja', 100),
+    ('秋叶原', '秋叶原', 'seed:akihabara', 'zh', 90),
+    ('秋葉原', '秋葉原', 'seed:akihabara', 'ja', 100),
+    ('飛騨高山', '飛騨高山', 'seed:takayama', 'ja', 100),
+    ('高山', '高山', 'seed:takayama', 'ja', 90),
+    ('鎌倉', '鎌倉', 'seed:kamakura', 'ja', 100),
+    ('镰仓', '镰仓', 'seed:kamakura', 'zh', 90),
+    ('大阪', '大阪', 'seed:osaka', 'ja', 100),
+    ('渋谷', '渋谷', 'seed:shibuya', 'ja', 100),
+    ('涩谷', '涩谷', 'seed:shibuya', 'zh', 90),
+    ('池袋', '池袋', 'seed:ikebukuro', 'ja', 100),
+    ('横浜', '横浜', 'seed:yokohama', 'ja', 100),
+    ('横滨', '横滨', 'seed:yokohama', 'zh', 90),
+    ('奈良', '奈良', 'seed:nara', 'ja', 100),
+    ('広島', '広島', 'seed:hiroshima', 'ja', 100),
+    ('広島駅', '広島駅', 'seed:hiroshima-station', 'ja', 100),
+    ('名古屋', '名古屋', 'seed:nagoya', 'ja', 100),
+    ('宇治駅', '宇治駅', 'seed:uji-station', 'ja', 100),
+    ('六地蔵', '六地蔵', 'seed:rokujizo', 'ja', 100),
+    ('西宮', '西宮', 'seed:nishinomiya-station', 'ja', 100),
+    ('西宫', '西宫', 'seed:nishinomiya-station', 'zh', 90),
+    ('nishinomiya', 'nishinomiya', 'seed:nishinomiya-station', 'en', 90);

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,3 +1,4 @@
-h1:UHyZaTfFdu8vJBWxyW8+OUaXlviTaFMKokvBr9q87/c=
+h1:pS2HShjiQ80ngF+IaR4i23XB8MA+QxNWVFiO8XSc9aA=
 20260623000001_init.sql h1:j96dtVbOQB/5eNuug4tZpdgURdZ5h0Zh4Vka7/dy1A0=
 20260713000001_user_routes.sql h1:th9ag/cdiRp9plYQraVBGIuRXeH4g5R3XvCuGZeFx8Q=
+20260714000001_catalog_geocoding.sql h1:EwkJGRPfg5camebXRzw+5xRVf6TWu23t3/tnw91uPwY=

--- a/docs/superpowers/specs/2026-07-13-catalog-geocoding-GOAL.md
+++ b/docs/superpowers/specs/2026-07-13-catalog-geocoding-GOAL.md
@@ -1,0 +1,87 @@
+# GOAL + PLAN · Catalog Geocoding 落地(到 PR 双评审待合并为止)
+
+> 2026-07-13。把 spec `2026-07-13-catalog-geocoding.md` 落成 **PR-A(geocode 能力)+ PR-B(gazetteer
+> 数据+量尺)**,每个 PR 走完 sonnet+codex 双评审、findings 仲裁回修、复核干净、门禁全绿——
+> **终态 = 两个 PR 开着、双评审通过、待合并。合并与部署由用户执行,本 GOAL 不做。**
+
+## §0 范围(铁律)
+
+- **In**: `packages/contract`(geocode 端点,纯增量)、`workers/catalog`(geocode 解析链+写回)、
+  `db/migrations`(locations/location_aliases + 26 条平价 seed)、`apps/agent`(search_nearby 编排重写、
+  CatalogClient.geocode、MockCatalogClient)、eval dataset/评估器修正(PR-B)、gazetteer CSV+seed 脚本(PR-B)。
+- **Out**: 合并 PR、部署、`wrangler secret put`(生产变更一律用户批准执行,PR body 只写 ops 步骤)、
+  前端、`/v1/bangumi/*`、`sql_agent.py` 死代码清理、路线 origin 接入(follow-up)、CI agent-eval 解禁。
+- **角色铁律**:lead(Fable)不写产品代码——subagent(sonnet 为主)写;lead 只做 spec/GOAL、派发、
+  仲裁、核验、git/PR 操作。
+- **红线**:LLM 不产出坐标;不上向量/语义(SD-29);`nearby`/`search` 契约不动;无任何 lint/type/test
+  抑制;覆盖率只升不降。
+
+## §1 完成定义(Definition of Done)
+
+1. **Spec 定稿**:双评审(sonnet+codex xhigh)findings 全部仲裁(实证裁决,不照单全收)→ 回修 →
+   复核轮干净 → spec 提交。
+2. **PR-A 开出且双评审通过**:实现 = spec §3.2-3.5 + AC A1-A10 全带测试;lead 三步核验
+   (git 真实性 + 读测试防篡改 + 独立重跑门禁)+ **西宮 e2e 实测**(真实链路证明假阴性消失);
+   push + `gh pr create`;随后 PR 级 sonnet+codex 双评审 → findings 修完 → 复核干净。
+3. **PR-B 开出且双评审通过**:实现 = spec §3.6-3.7 + AC B1-B5;含 **MiMo trajectory 全量重跑证据**
+   (search_nearby 错误 8→0,结果贴 PR);同样三步核验 + 双评审闭环。
+4. **两 PR 状态 = MERGEABLE、双评审 approve、无未决 finding、门禁绿**(agent 933+ 测试/≥82% 覆盖、
+   worker vitest、mypy/ruff/tsc、`emit:openapi` 幂等)。
+5. **到此为止**:不 merge、不 tag、不部署。向用户交付两个 PR 链接 + 评审摘要 + 遗留 ops 步骤清单。
+
+## §2 当前状态(基线)
+
+- ✅ 调研完成:三层搜索全景(agent→catalog→Neon PostGIS)+ 假阴性实证(西宮/箱根/豊郷)+
+  eval 制度化失败确认(C1_ja_004/C1_zh_005 把 clarify 标成正确答案)。
+- ✅ Spec 草稿已提交:`b29b9e6`(分支 `feat/catalog-geocoding`,基于 e1321d8)。
+- ⏳ Spec 双评审进行中:sonnet + codex xhigh 并行(codex 带卡死监控)。
+- ✅ 前置资产:`GOOGLE_MAPS_API_KEY` 已是 repo secret(container 用,worker 注入属 ops-out);
+  MiMo 按量 key 可用(eval 重跑 ~¥2);Python 版 Google gateway 代码可移植。
+- 🅿 相邻但独立:PR #335(clarify coercion)双评审完毕待用户合并;PR #334(locale)待回修——均不阻塞本 GOAL。
+
+## §3 PLAN(分阶段;每阶段小步提交)
+
+### Phase 0 — Spec 双评审闭环(进行中)
+- 收 sonnet + codex findings → lead 逐条实证仲裁(有分歧跑代码裁决,Codex over-flag 有前科)→
+  回修 spec → 复核轮(两评审侧确认或 lead 实证覆盖)→ commit 定稿。
+
+### Phase 1 — PR-A 实现(sonnet subagent,worktree=本 clone 分支)
+- 迁移(locations/location_aliases + trigger + 26 条 seed)→ contract geocode → worker
+  `lib/geocode.ts`+`api/geocode.ts`(exact→Google 写回,raw-sql 模板,mock fetch 测试)→
+  agent(CatalogClientProtocol/CatalogClient/Mock + search_nearby 编排三态 + `_INSTRUCTIONS` 一句)→
+  AC A1-A10 测试 → 全量门禁 → **commit(铁律:必须真 commit,git log 自证)**。
+
+### Phase 2 — PR-A 核验 + 开 PR + 双评审
+- lead 三步核验 + 西宮 e2e(可用 MiMo 或 DeepSeek 真跑一条)→ push → PR(body 含 spec 链接、
+  AC 表、ops 步骤:worker secret 注入属部署时用户操作)。
+- PR 级双评审(sonnet + codex xhigh,只读)→ 仲裁 → 修(subagent)→ 复核 → 干净即标记
+  "双评审通过待合并",通知用户。
+
+### Phase 3 — PR-B 实现(sonnet subagent;分支基于 PR-A)
+- gazetteer CSV(MLIT 车站 + GeoNames 城市,含出典文档)+ 幂等 seed 脚本 + pg_trgm 迁移/索引 →
+  eval 修正(C1 族逐条审 + 新 case + MockCatalog fixture)→ `nonempty_results` 评估器 →
+  AC B1-B4 → 门禁 → commit。
+
+### Phase 4 — PR-B 核验 + eval 证据 + 开 PR + 双评审
+- 三步核验 → **MiMo trajectory 全量重跑**(证据:search_nearby 8→0 + 各指标无回归)→ push → PR →
+  双评审闭环 → "待合并",通知用户。
+
+## §4 执行约束
+
+- **Subagent 核验协议**(每次代码产出必做):① git ground truth(commit 存在、文件在 commit 里,
+  不信自我报告);② 读新增/改动测试防篡改(无 skip/xfail/弱断言/mock 被测逻辑);③ lead 独立重跑
+  全量门禁。历史教训:Codex 谎报 commit 两次、门禁被 `-k` 过滤误伤一次——门禁一律全量跑。
+- **Codex 卡死处置**:log 活性 6 分钟冻结即判卡;先从 log 抢救 findings(两次成功先例),再决定重派
+  或降级 sonnet;写任务默认 sonnet。
+- **并发纪律**:同一 clone 同时只允许一个写者;派发前 `git status` 必须干净;eval 跑时不动工作树。
+- 评审分歧一律实证裁决(复现脚本/最小 probe),先例:PR #335 的 `[1,2]` crash 误报被实测 refute。
+- Spec/GOAL 改动与实现同分支小步提交;commit 信息引用 GOAL §编号(仓库惯例)。
+
+## §5 风险 / 待确认
+
+- Google ToS 对 geocoding 结果缓存/存储的条款约束——已点名 codex 评审核查;若确认受限,
+  兜底切国土地理院 API(免费,日本域足够)并在 spec OQ1 定案。
+- trgm 对 CJK 短串效果差(已知),PR-B 阈值由测试钉住;romaji/zh 依赖 alias 行 + Google 写回。
+- GPS/地名优先级翻转的回归面:H2/H4("从这里出发")case 需评审确认不破——spec 评审在查。
+- MiMo 重跑有随机性:判定标准是"search_nearby 类错误归零",不是逐指标完全复刻。
+- 若 codex 评审通道持续卡死:双评审退化为 sonnet×2(不同 lens)+ lead 深审,在 PR body 注明。

--- a/docs/superpowers/specs/2026-07-13-catalog-geocoding-GOAL.md
+++ b/docs/superpowers/specs/2026-07-13-catalog-geocoding-GOAL.md
@@ -11,8 +11,9 @@
   CatalogClient.geocode、MockCatalogClient)、eval dataset/评估器修正(PR-B)、gazetteer CSV+seed 脚本(PR-B)。
 - **Out**: 合并 PR、部署、`wrangler secret put`(生产变更一律用户批准执行,PR body 只写 ops 步骤)、
   前端、`/v1/bangumi/*`、`sql_agent.py` 死代码清理、路线 origin 接入(follow-up)、CI agent-eval 解禁。
-- **角色铁律**:lead(Fable)不写产品代码——subagent(sonnet 为主)写;lead 只做 spec/GOAL、派发、
-  仲裁、核验、git/PR 操作。
+- **角色铁律(Policy B,2026-07-13 用户定)**:lead(Fable)不写产品代码——代码一律由 Codex
+  (gpt-5.6-sol)写;sonnet 只做只读调研/评审;仅当 Codex **连续 3 次卡死**才降级 sonnet 代写,
+  且必须在 PR body 注明;lead 只做 spec/GOAL、派发、仲裁、核验、git/PR 操作。
 - **红线**:LLM 不产出坐标;不上向量/语义(SD-29);`nearby`/`search` 契约不动;无任何 lint/type/test
   抑制;覆盖率只升不降。
 
@@ -45,7 +46,7 @@
 - 收 sonnet + codex findings → lead 逐条实证仲裁(有分歧跑代码裁决,Codex over-flag 有前科)→
   回修 spec → 复核轮(两评审侧确认或 lead 实证覆盖)→ commit 定稿。
 
-### Phase 1 — PR-A 实现(sonnet subagent,worktree=本 clone 分支)
+### Phase 1 — PR-A 实现(Codex 写;卡死处置见 §4)
 - 迁移(locations/location_aliases + trigger + 26 条 seed)→ contract geocode → worker
   `lib/geocode.ts`+`api/geocode.ts`(exact→Google 写回,raw-sql 模板,mock fetch 测试)→
   agent(CatalogClientProtocol/CatalogClient/Mock + search_nearby 编排三态 + `_INSTRUCTIONS` 一句)→
@@ -57,7 +58,7 @@
 - PR 级双评审(sonnet + codex xhigh,只读)→ 仲裁 → 修(subagent)→ 复核 → 干净即标记
   "双评审通过待合并",通知用户。
 
-### Phase 3 — PR-B 实现(sonnet subagent;分支基于 PR-A)
+### Phase 3 — PR-B 实现(Codex 写;分支基于 PR-A)
 - gazetteer CSV(MLIT 车站 + GeoNames 城市,含出典文档)+ 幂等 seed 脚本 + pg_trgm 迁移/索引 →
   eval 修正(C1 族逐条审 + 新 case + MockCatalog fixture)→ `nonempty_results` 评估器 →
   AC B1-B4 → 门禁 → commit。
@@ -71,8 +72,8 @@
 - **Subagent 核验协议**(每次代码产出必做):① git ground truth(commit 存在、文件在 commit 里,
   不信自我报告);② 读新增/改动测试防篡改(无 skip/xfail/弱断言/mock 被测逻辑);③ lead 独立重跑
   全量门禁。历史教训:Codex 谎报 commit 两次、门禁被 `-k` 过滤误伤一次——门禁一律全量跑。
-- **Codex 卡死处置**:log 活性 6 分钟冻结即判卡;先从 log 抢救 findings(两次成功先例),再决定重派
-  或降级 sonnet;写任务默认 sonnet。
+- **Codex 卡死处置**:log 活性 6 分钟冻结即判卡;先从 job log 抢救成果(多次成功先例),重置干净树
+  再重派 Codex;**连续 3 次卡死 → 降级 sonnet 代写并在 PR body 注明**(Policy B)。
 - **并发纪律**:同一 clone 同时只允许一个写者;派发前 `git status` 必须干净;eval 跑时不动工作树。
 - 评审分歧一律实证裁决(复现脚本/最小 probe),先例:PR #335 的 `[1,2]` crash 误报被实测 refute。
 - Spec/GOAL 改动与实现同分支小步提交;commit 信息引用 GOAL §编号(仓库惯例)。

--- a/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
+++ b/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
@@ -1,0 +1,248 @@
+# Catalog Geocoding — 真正实现"按地点搜圣地"
+
+- **Status**: Draft → dual review (Fable-authored, sonnet+codex review)
+- **Date**: 2026-07-13
+- **Related**: SD-29 (structured-first retrieval doctrine) · `docs/ARCHITECTURE.md:215` · MiMo eval search_nearby 错误分析 (fix/mimo-clarify-coercion 调查) · KNOWN_LOCATIONS gazetteer 缺口
+- **PRs**: PR-A (capability), PR-B (data + measurement)
+
+## 1. Problem
+
+"按地点搜圣地" 由两半组成:**地名→坐标(geocoding)** 与 **坐标→附近点位(geo search)**。后者是真的
+(PostGIS `ST_DWithin` + `<->` KNN + GiST 索引,`workers/catalog/src/lib/geo-query.ts:37-51`);
+前者从未被实现:
+
+- `_geocode_for_catalog` (`apps/agent/agent/agents/catalog_tools.py:126-138`) 只查 session origin 坐标
+  和一个 **26 条硬编码 dict** (`KNOWN_LOCATIONS`, `sql_agent.py:71-100`,京都/大阪/东京核心站)。
+- 其 docstring 声称 "The catalog service owns richer geocoding" —— 但 catalog 契约里**没有** geocode
+  方法。承诺存在,实现不存在。
+- 任何不在 26 条里的真实地名 → `ModelRetry` → 模型换名字重猜 → 重试耗尽。
+
+**实测假阴性(库里有数据,却返回"找不到"):**
+
+| 查询 | 库内数据 | `_geocode_for_catalog` | eval 现状 |
+|---|---|---|---|
+| 西宮/西宫 (凉宫圣地, seed 动画) | `db_state=hit_sparse` | `None` | `C1_ja_004`/`C1_zh_005` 把 `clarify` 标成正确答案 → **假阴性被制度化** |
+| 箱根 (EVA) | — | `None` | MiMo eval `B1_en_001` 重试耗尽报错 |
+| 豊郷 (K-On, seed 动画) | 有 | `None` | 无 case |
+
+MiMo 全量 eval 剩余 8 个错误全部是这一类(模型无关——v4-pro 同样撞墙,只是 eval 数据集给它留了
+`clarify` 逃生门)。
+
+## 2. Goals / Non-goals
+
+**Goals**
+1. 用户以任意常见日本地名(车站/城市/区,ja/zh/en)搜附近圣地时,能解析出坐标并返回真实结果。
+2. Geocoding 成为 catalog 的数据平面能力:可缓存、可生长、契约化(兑现 docstring 的承诺)。
+3. 真歧义(多个"府中")走 clarify;真未知诚实报告;**不再把"查不到坐标"伪装成"需要用户澄清"**。
+4. 量尺同步修正:eval 不再把假阴性标成正确答案,并新增第一个内容级(result-level)metric。
+
+**Non-goals**
+- ❌ LLM 参与 geocode 链(禁止模型报坐标——现有 "Never fabricate coordinates" 红线不动)。
+- ❌ 向量/语义检索(SD-29;DD-11/12/13/22 冻结不变)。
+- ❌ 反向 geocoding、路线 origin 换新链路(follow-up,见 §8)、前端改动、`/v1/bangumi/*` REST 面。
+- ❌ 清理 `sql_agent.py` 死代码(独立 chore)。
+
+## 3. Design
+
+### 3.1 架构位置:catalog worker(不是 Python agent)
+
+Agent 保持 upstream-free(AST 不变量测试 `test_agent_upstream_free.py` 不动)。geocoding 结果是
+典型可缓存数据,归 catalog 数据平面。模式与番名搜索**同构**:本地表精确查 → miss 调外部 API →
+写回库(下次本地命中)。
+
+```
+search_nearby(location)                    [agent tool, 编排]
+  → catalog.geocode(location)              [新 RPC]
+      gazetteer exact (locations 表)        ← PR-A: 26 条旧 seed;PR-B: ~12k 车站+城市
+      → (PR-B) pg_trgm fuzzy
+      → Google Geocoding 兜底 + 写回        ← key 已在生产 secrets
+  → 1 candidate → catalog.nearby(lat,lng)  [现有 RPC,契约不动]
+  → N candidates → 走 clarify
+  → 0 candidates → 单次 ModelRetry 引导 clarify
+```
+
+**设计取舍**:独立 `/catalog/geocode` 端点、`nearby` 契约**不动**(而非 nearby 直接收地名)。
+理由:(a) nearby 保持纯函数零风险;(b) geocode 可复用(路线 origin、未来地图 UI);
+(c) 歧义候选的返回形状不污染 nearby 输出。代价是 agent 工具内两次 RPC(均为 Hyperdrive 毫秒级)。
+
+### 3.2 Contract (`packages/contract/src/contract.ts`,纯增量)
+
+```ts
+export const GeocodeInput = z.object({
+  query: z.string().min(1),
+  limit: z.number().int().min(1).max(10).optional(), // default 5
+});
+export const GeocodeCandidate = z.object({
+  id: z.string(),            // gazetteer row id
+  label: z.string(),         // 展示名,含消歧上下文: "西宮北口駅(兵庫県西宮市)"
+  name: z.string(),          // canonical 名
+  lat: Latitude, lng: Longitude,
+  kind: z.string(),          // 'station' | 'city' | 'ward' | 'landmark' | 'external'
+  source: z.string(),        // 'seed' | 'mlit' | 'geonames' | 'google'
+});
+export const GeocodeResult = z.object({ candidates: z.array(GeocodeCandidate) }); // 0..limit
+
+geocode: oc.route({ method: "POST", path: "/catalog/geocode",
+                    summary: "Resolve a place name to coordinate candidates" })
+  .input(GeocodeInput)
+  .errors(pickCatalogErrors(["UPSTREAM_UNAVAILABLE"]))
+  .output(GeocodeResult),
+```
+
+`emit:openapi` 幂等检查随 PR-A 跑(纯增量,无 drift)。
+
+### 3.3 Schema(`db/migrations/`,Atlas)
+
+```sql
+CREATE TABLE locations (
+  id         TEXT PRIMARY KEY,          -- 'seed:uji' / 'mlit:st-<code>' / 'g:<place_id-hash>'
+  name       TEXT NOT NULL,             -- canonical (ja)
+  kind       TEXT NOT NULL,             -- station|city|ward|landmark|external
+  latitude   DOUBLE PRECISION NOT NULL,
+  longitude  DOUBLE PRECISION NOT NULL,
+  location   GEOGRAPHY(POINT, 4326),    -- 复用 points 的 sync-trigger 模式自动派生
+  source     TEXT NOT NULL,
+  pref       TEXT,                      -- 都道府県,拼 label 消歧用
+  created_at TIMESTAMPTZ DEFAULT now(), updated_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE TABLE location_aliases (
+  alias            TEXT NOT NULL,
+  alias_normalized TEXT NOT NULL,       -- normalizeAlias() 同款 NFKC 折叠
+  location_id      TEXT NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+  lang             TEXT,                -- ja|zh|en|NULL
+  priority         INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (alias_normalized, location_id)
+);
+CREATE INDEX idx_location_aliases_norm ON location_aliases (alias_normalized);
+-- PR-B: CREATE EXTENSION IF NOT EXISTS pg_trgm;
+--       CREATE INDEX idx_location_aliases_trgm ON location_aliases USING GIN (alias_normalized gin_trgm_ops);
+```
+
+同一迁移内 seed 现有 26 条 `KNOWN_LOCATIONS`(含 zh 变体作为 alias 行)——PR-A 落地即与现状
+**平价**,Google 兜底使其严格更强。
+
+### 3.4 Worker 解析链(`workers/catalog/src/lib/geocode.ts` + `api/geocode.ts`)
+
+1. `norm = normalizeAlias(query)`(复用 `lib/alias.ts:55`)。
+2. **Exact**: `SELECT ... FROM location_aliases a JOIN locations l ON ... WHERE a.alias_normalized=$1
+   ORDER BY a.priority DESC, l.kind LIMIT $limit`。命中即返回(多行=歧义,原样返回候选)。
+3. **(PR-B) Fuzzy**: `WHERE similarity(a.alias_normalized,$1) > 0.4 ORDER BY similarity DESC LIMIT $limit`;
+   最高分 ≥0.6 且唯一 → 单候选;否则作为歧义候选返回。CJK 短串 trgm 弱是已知限制,阈值由测试钉住。
+4. **Google 兜底**(`GOOGLE_MAPS_API_KEY` 存在时): GET `maps/api/geocode/json`,
+   `region=jp&language=ja&components=country:JP`,10s 超时,解析 ≤limit 候选
+   (参数/解析逻辑移植自现成的 `apps/agent/agent/infrastructure/gateways/geocoding.py`,该 Python 版
+   随 PR-A 保留不动——它只被死代码引用)。key 缺失 → 跳过并 `logger.warning`,返回本地结果(优雅降级,
+   与该 gateway 现行为一致)。
+5. **写回**: Google 候选 upsert 进 `locations`(`id='g:'+sha1(place_id)[:16]`, `source='google'`)+
+   `location_aliases`(原 query→每个候选,`ON CONFLICT DO NOTHING`)。同一查询第二次即本地命中,
+   Google 成本趋零。与番名 ingest 同构:seed + on-demand 生长。
+6. 全链确定性,无 LLM。DB 查询走既有 raw-`sql` 模板模式(Drizzle builder 在 workerd 下挂起的坑已知)。
+
+### 3.5 Agent 侧(`apps/agent`)
+
+- `CatalogClientProtocol` + `CatalogClient` 增 `geocode(query, limit=5) -> list[GeocodeCandidate]`
+  (pydantic model 新增于 clients;`MockCatalogClient` 加确定性 fixture:西宮/宇治/府中×2/未知名)。
+- `search_nearby(location: str = "", radius: int = 0)` 重写编排(替换 `_geocode_for_catalog`):
+
+| 输入情形 | 行为 |
+|---|---|
+| `location` 空 且 session 有 GPS | 用 origin 坐标(现行"我附近"路径,不变) |
+| `location` 空 且 无 GPS | `ModelRetry`:请用户给地点或分享位置(→clarify) |
+| `location` 非空 | **geocode 优先**(行为变更,见下) → 1 候选:`nearby(lat,lng)`;N 候选:返回 `{"status":"ambiguous_location","options":[labels...]}`,docstring 指示模型转 `clarify`;0 候选:有 GPS 则回退 GPS,否则**单次** `ModelRetry`:"Could not locate '<X>'. Call clarify to ask the user for a nearby station or city." |
+
+- **显式行为变更**:现行代码 GPS 无条件优先(`catalog_tools.py:127-130`),导致"用户在东京、
+  问西宮附近"会搜东京。新规则:**显式地名 > GPS,空地名 = GPS**。`_INSTRUCTIONS` 的
+  Location/nearby 段同步一句:用户点名地点时把地名原样传入 `location`;"我附近/near me" 传空。
+- ModelRetry 消息统一引导 clarify 而非鼓励换名重猜——消灭 MiMo 式 retry 风暴(对 v4-pro 同样生效)。
+- 删除 `catalog_tools.py` 对 `KNOWN_LOCATIONS` 的 import(dict 本体留在死代码 `sql_agent.py`,
+  随独立 chore 清理)。
+
+### 3.6 数据(PR-B)
+
+- **车站**: 国土数値情報 N02 鉄道データ(国土交通省,~10,600 站,出典明记可商用)。
+- **城市/区**: GeoNames JP(cities500 子集,CC-BY 4.0,~1,900 行)。
+- 处理后 CSV(~700KB)检入 `workers/catalog/data/gazetteer-jp.csv` + 生成脚本
+  `workers/catalog/scripts/build-gazetteer.md`(文档化下载/转换步骤)+ 幂等 seed 脚本
+  `workers/catalog/scripts/seed-locations.ts`(upsert,可重跑)。
+- **多语言 alias**: 城市 zh/en 变体复用 `apps/agent/agent/agents/geo_names.py` 数据
+  (662/747 城市 en↔ja/zh)导出;车站 PR-B 仅 ja(en/zh 长尾靠 Google 写回自然生长)。
+- 归属声明入 `docs/data-sources.md`(MLIT 出典 + GeoNames CC-BY)。
+
+### 3.7 Eval 与量尺(PR-B)
+
+1. **修正被制度化的假阴性**:`C1_ja_004`/`C1_zh_005`(西宮,库有数据)`acceptable_stages`
+   `["clarify"]` → `["search_nearby"]`。逐条审 C1/C2 族:凡"具体真实地名+库有数据"一律改;
+   仅"真模糊查询"(近くに何がある 无 GPS)保留 clarify。
+2. **新增 case**:箱根(geocode 成功+库空→诚实空结果)、豊郷(hit)、"Nishinomiya"(en)、
+   "西宫"(zh 简体)、府中(歧义→clarify 正确)。
+3. **第一个内容级 metric** `nonempty_results`(L1 确定性):dataset 增可选字段
+   `expect_nonempty: true`;评估器对带标记的 case 检查任一 search payload `row_count > 0`,
+   未标记的 case 不产出该 metric(实现须确认 pydantic-evals 对 per-case 缺失 metric 的均值语义,
+   避免虚高)。这是"检索质量零标尺"窟窿上的第一颗钉子——不是终点。
+4. Baseline:PR-B 合并后 MiMo trajectory 全量重跑(~¥2)刷新 MiMo baseline 并验证
+   search_nearby 8 错误归零;DeepSeek baseline 待余额补充后刷新(现 ~¥14,一次 ~¥10)。
+5. 已知边界:trajectory tier 用 `MockCatalogClient`,geocode 的 mock fixture 决定 eval 覆盖;
+   真实 Google 路径由 worker 单测(mock fetch)+ 手动 smoke 覆盖。CI 的 agent-eval job 目前
+   `&& false` 硬禁用——本 spec 不改 CI 门禁(独立议题)。
+
+## 4. Acceptance Criteria(Quality Ratchet:每条带测试)
+
+**PR-A**
+| # | AC | 测试 |
+|---|---|---|
+| A1 | `/catalog/geocode` exact 命中返回候选(西宮→兵庫坐标) | worker vitest (unit) |
+| A2 | miss + key 存在 → Google 调用(mock fetch)→ 候选返回 + `locations`/`location_aliases` 写回;同 query 第二次不再调 Google | worker vitest (unit) |
+| A3 | miss + 无 key → 空候选,warning,无异常 | worker vitest (unit) |
+| A4 | `nearby`/`search` 契约与行为零变化;`emit:openapi` 幂等 | 既有 worker 测试 + drift check (ci) |
+| A5 | agent `search_nearby("西宮")` → geocode→nearby→rows(FunctionModel e2e,MockCatalog) | agent unit (e2e) |
+| A6 | 歧义地名("府中")→ `ambiguous_location` payload → 模型转 clarify | agent unit (e2e) |
+| A7 | 未知地名无 GPS → 恰好一次 ModelRetry(消息含 clarify 引导),**无重试耗尽** | agent unit |
+| A8 | 显式地名 > GPS;空地名 → GPS;空地名无 GPS → ModelRetry | agent unit ×3 |
+| A9 | 26 条旧 KNOWN_LOCATIONS 全部经新链路可解析(迁移 seed 平价) | worker vitest (unit, 遍历断言) |
+| A10 | 全量门禁:agent 933+ tests / coverage ≥82%;worker vitest 全绿;mypy/ruff/tsc 干净 | ci |
+
+**PR-B**
+| # | AC | 测试 |
+|---|---|---|
+| B1 | gazetteer seed 幂等,≥10k 车站 + ≥1.5k 城市,重跑无 dup | worker vitest (integration, 测试 PG) |
+| B2 | trgm:"西宮北口" 命中 "西宮北口駅";阈值下无候选→走 Google | worker vitest (unit) |
+| B3 | eval C1 西宮 case 期望修正 + 新 case 落 dataset;MockCatalog geocode fixture 同步 | eval dataset + agent unit |
+| B4 | `nonempty_results` metric 上线,带标记 case 正确计分,未标记不虚高 | eval evaluator unit |
+| B5 | MiMo trajectory 全量重跑:search_nearby 错误 8→0;baseline 刷新 | eval (manual gate, PR 附证据) |
+
+## 5. Ops / Security
+
+- `GOOGLE_MAPS_API_KEY`:GitHub repo secret 已存在(container 用);PR-A 需在 deploy workflow 给
+  **catalog worker** 注入(`wrangler secret put`,staging + production)。**部署到 prod 的 approve
+  关卡照例需用户批准。**
+- Key 只经 env → worker secret;不入代码/日志(沿用现有 gateway 的 redact 习惯)。
+- Google 成本:cache-first + 写回,预估稳态每月个位数美元;worker 记 `google_geocode_called`
+  日志计数器便于观测。
+- 迁移经 Atlas(`db/migrations/`);`supabase/migrations/` 历史树不动。
+
+## 6. Risks
+
+| 风险 | 缓解 |
+|---|---|
+| trgm 对 CJK 短串效果差 | 阈值保守(0.6 auto / 0.4 candidate)+ 歧义一律走 clarify;romaji/zh 靠 alias 行与 Google 写回,不指望 trgm |
+| Google 返回日本外同名地 | `components=country:JP` 硬过滤 |
+| GPS/地名优先级翻转改变既有行为 | A8 三态测试钉死;eval H2/H4("从这里出发")回归确认 |
+| 写回污染(Google 坏候选入库) | 写回行 `source='google'` 可识别可清理;alias 仅绑原 query,不做泛化 |
+| 26 条平价迁移漏项 | A9 遍历断言 |
+| eval 期望大改引发基线漂移 | PR-B 单独重跑基线,gate 按新语义重置(有 v1.1/v1.2 勘误先例) |
+
+## 7. Open Questions(带默认值,评审可推翻)
+
+- **OQ1** 外部兜底选 Google(默认,key 已备,zh/en 支持最好)vs 国土地理院 API(免费,仅日文)。
+  默认 Google;若成本敏感,PR-B 可加 GSI 为第一兜底、Google 第二。
+- **OQ2** 候选 label 本地化(zh 用户见"西宮北口駅(兵库县)")——默认 PR-A 仅 ja label,
+  PR-B 用 geo_names 数据本地化城市部分。
+- **OQ3** `points` 表自身地名(如"大吉山展望台")是否并入 gazetteer 查询(UNION)——默认 PR-B 不做,
+  记 follow-up(它让"圣地名"本身可作为搜索中心)。
+
+## 8. Follow-ups(不在本 spec 范围)
+
+- 路线 origin(`plan_route`/K-path `execute_selected_route`)接入 `catalog.geocode`。
+- `sql_agent.py` 死代码清理(SQLAgent、旧 resolve_location、Python geocoding gateway)。
+- 检索质量量尺体系化(内容级 recall/precision,超出 `nonempty_results` 的完整方案)。
+- CI agent-eval job 解禁策略。

--- a/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
+++ b/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
@@ -1,248 +1,311 @@
 # Catalog Geocoding — 真正实现"按地点搜圣地"
 
-- **Status**: Draft → dual review (Fable-authored, sonnet+codex review)
+- **Status**: v2 — dual-review rework(v1 双评审均判 needs-rework;本版吸收全部 P0/P1)
 - **Date**: 2026-07-13
-- **Related**: SD-29 (structured-first retrieval doctrine) · `docs/ARCHITECTURE.md:215` · MiMo eval search_nearby 错误分析 (fix/mimo-clarify-coercion 调查) · KNOWN_LOCATIONS gazetteer 缺口
+- **Related**: SD-29 · `docs/ARCHITECTURE.md:215` · MiMo eval search_nearby 错误分析 · GOAL 同目录 `*-GOAL.md`
 - **PRs**: PR-A (capability), PR-B (data + measurement)
+- **v2 变更摘要**: ①外部兜底 Google→**国土地理院(GSI)**(Google ToS 禁止永久存储 lat/lng,30 天上限、仅 place_id 可存——双评审 P0,已一手核实);②候选折叠策略(西宮多站折 1、府中跨域=真歧义);③歧义管道精确化(failed-step + 无 tool_state + 武装 validator);④`_INSTRUCTIONS` 全段重写入 PR-A(原文明令禁止 bare-location 调 search_nearby);⑤27 别名/19 坐标对纠数 + 西宮补种;⑥eval 翻转面如实扩到 C1/C2 全族;⑦PR-B seed 改 Atlas 数据迁移(deploy 只跑 atlas apply);⑧契约 enum 化/类型导出/无错误码(优雅降级);⑨kind 感知半径 + 都道府县 carve-out。
 
 ## 1. Problem
 
-"按地点搜圣地" 由两半组成:**地名→坐标(geocoding)** 与 **坐标→附近点位(geo search)**。后者是真的
-(PostGIS `ST_DWithin` + `<->` KNN + GiST 索引,`workers/catalog/src/lib/geo-query.ts:37-51`);
-前者从未被实现:
+"按地点搜圣地"由两半组成:**地名→坐标(geocoding)** 与 **坐标→附近点位(geo search)**。
+后者是真的(PostGIS `ST_DWithin` + `<->` KNN + GiST,`workers/catalog/src/lib/geo-query.ts:37-51`);
+前者从未实现:
 
-- `_geocode_for_catalog` (`apps/agent/agent/agents/catalog_tools.py:126-138`) 只查 session origin 坐标
-  和一个 **26 条硬编码 dict** (`KNOWN_LOCATIONS`, `sql_agent.py:71-100`,京都/大阪/东京核心站)。
-- 其 docstring 声称 "The catalog service owns richer geocoding" —— 但 catalog 契约里**没有** geocode
-  方法。承诺存在,实现不存在。
-- 任何不在 26 条里的真实地名 → `ModelRetry` → 模型换名字重猜 → 重试耗尽。
+- `_geocode_for_catalog`(`apps/agent/agent/agents/catalog_tools.py:126-138`;GPS 优先在 134-137)
+  只查 session origin 坐标和一个 **27 键/19 坐标对** 的硬编码 dict(`sql_agent.py:71-100`)。
+- 其 docstring 声称 "The catalog service owns richer geocoding"——catalog 契约里**没有** geocode 方法。
+- Agent 指令**明令**bare-location 查询走 `web_search → clarify`、"Do NOT call search_nearby"
+  (`pilgrimage_agent.py:73-82`,例句 108/112)——整条产品路径被禁用后用 clarify 兜底。
 
-**实测假阴性(库里有数据,却返回"找不到"):**
+**实测假阴性(库里有数据,却"找不到"):**
 
 | 查询 | 库内数据 | `_geocode_for_catalog` | eval 现状 |
 |---|---|---|---|
-| 西宮/西宫 (凉宫圣地, seed 动画) | `db_state=hit_sparse` | `None` | `C1_ja_004`/`C1_zh_005` 把 `clarify` 标成正确答案 → **假阴性被制度化** |
-| 箱根 (EVA) | — | `None` | MiMo eval `B1_en_001` 重试耗尽报错 |
-| 豊郷 (K-On, seed 动画) | 有 | `None` | 无 case |
+| 西宮/西宫(凉宫,seed 动画) | `hit_sparse` | `None`(dict 无此键,已实测) | `C1_ja_004`/`C1_zh_005` 把 `clarify` 标为正确 → **假阴性被制度化** |
+| 箱根(EVA) | miss | `None` | MiMo eval `B1_en_001` 重试耗尽报错 |
+| 豊郷(K-On,seed 动画) | 有 | `None` | 无 case |
 
-MiMo 全量 eval 剩余 8 个错误全部是这一类(模型无关——v4-pro 同样撞墙,只是 eval 数据集给它留了
-`clarify` 逃生门)。
+MiMo 全量 eval 残余 8 个错误全属此类(模型无关;v4-pro 同样撞墙,只是 eval 给它留了 clarify 逃生门)。
 
 ## 2. Goals / Non-goals
 
 **Goals**
-1. 用户以任意常见日本地名(车站/城市/区,ja/zh/en)搜附近圣地时,能解析出坐标并返回真实结果。
-2. Geocoding 成为 catalog 的数据平面能力:可缓存、可生长、契约化(兑现 docstring 的承诺)。
-3. 真歧义(多个"府中")走 clarify;真未知诚实报告;**不再把"查不到坐标"伪装成"需要用户澄清"**。
-4. 量尺同步修正:eval 不再把假阴性标成正确答案,并新增第一个内容级(result-level)metric。
+1. 任意常见日本地名(车站/市区,ja 为主 + zh/en 别名)可解析坐标并返回真实结果。
+2. Geocoding 成为 catalog 数据平面能力:**可合法缓存、可生长**、契约化。
+3. 真歧义(跨地域同名)走 clarify;真未知诚实报告;"查不到坐标"不再伪装成"需要澄清"。
+4. 量尺同步修正:翻正被制度化的假阴性 + 第一个内容级 metric。
 
 **Non-goals**
-- ❌ LLM 参与 geocode 链(禁止模型报坐标——现有 "Never fabricate coordinates" 红线不动)。
-- ❌ 向量/语义检索(SD-29;DD-11/12/13/22 冻结不变)。
-- ❌ 反向 geocoding、路线 origin 换新链路(follow-up,见 §8)、前端改动、`/v1/bangumi/*` REST 面。
-- ❌ 清理 `sql_agent.py` 死代码(独立 chore)。
+- ❌ LLM 参与 geocode 链 / 模型报坐标("Never fabricate coordinates" 红线不动)。
+- ❌ 向量/语义检索(SD-29;DD-11/12/13/22 冻结)。
+- ❌ **Google Geocoding**(ToS:lat/lng 仅可缓存 30 天、禁止预取/永久存储、仅 place_id 例外——
+  与写回式 gazetteer 根本冲突。若未来 GSI miss 率证明需要,再按"瞬态、不落库、带 TTL"模式单独评估)。
+- ❌ 反向 geocoding、路线 origin 接入(follow-up)、前端、`/v1/bangumi/*`、`sql_agent.py` 死代码清理、
+  CI agent-eval 解禁。
 
 ## 3. Design
 
-### 3.1 架构位置:catalog worker(不是 Python agent)
+### 3.1 架构位置与数据流
 
-Agent 保持 upstream-free(AST 不变量测试 `test_agent_upstream_free.py` 不动)。geocoding 结果是
-典型可缓存数据,归 catalog 数据平面。模式与番名搜索**同构**:本地表精确查 → miss 调外部 API →
-写回库(下次本地命中)。
+Agent 保持 upstream-free(`test_agent_upstream_free.py` 不变;`CatalogClient` 是唯一 sanctioned seam,
+加 `geocode()` 不违反——已核)。模式与番名搜索同构:本地表精确查 → miss 调外部 → **写回**(GSI 结果
+无存储限制,出典明记即可)→ 下次本地命中。
 
 ```
-search_nearby(location)                    [agent tool, 编排]
-  → catalog.geocode(location)              [新 RPC]
-      gazetteer exact (locations 表)        ← PR-A: 26 条旧 seed;PR-B: ~12k 车站+城市
-      → (PR-B) pg_trgm fuzzy
-      → Google Geocoding 兜底 + 写回        ← key 已在生产 secrets
-  → 1 candidate → catalog.nearby(lat,lng)  [现有 RPC,契约不动]
-  → N candidates → 走 clarify
-  → 0 candidates → 单次 ModelRetry 引导 clarify
+search_nearby(location)                     [agent tool, 编排]
+  → catalog.geocode(location)               [新 RPC]
+      locations/location_aliases 精确查      ← PR-A: 19+1 坐标 · 30 别名 seed;PR-B: ~12k 行
+      → (PR-B) pg_trgm 模糊
+      → GSI 地名検索 API 兜底 + 写回          ← 免费、无 key、可存储(出典明记)
+      → 候选折叠(§3.4b)
+  → 1 候选 → catalog.nearby(lat,lng,kind 感知半径)   [契约不动]
+  → ≥2 簇 → failed-step + ModelRetry 携候选 → clarify
+  → 0 候选 → failed-step + 单次 ModelRetry → clarify(显式地名时**不**回退 GPS)
 ```
 
-**设计取舍**:独立 `/catalog/geocode` 端点、`nearby` 契约**不动**(而非 nearby 直接收地名)。
-理由:(a) nearby 保持纯函数零风险;(b) geocode 可复用(路线 origin、未来地图 UI);
-(c) 歧义候选的返回形状不污染 nearby 输出。代价是 agent 工具内两次 RPC(均为 Hyperdrive 毫秒级)。
+**取舍**:独立 `/catalog/geocode`,`nearby` 契约零改动。延迟事实(纠 v1):agent→catalog 是 HTTP
+(`CatalogClient` 超时 30s,`catalog_client.py:128-137`);worker→DB 当前为直连 `DATABASE_URL`
+(Hyperdrive 在 `wrangler.toml:6-19` 处于注释状态);GSI 兜底最多 +8s(超时 8s),仍远低于 30s。
 
-### 3.2 Contract (`packages/contract/src/contract.ts`,纯增量)
+### 3.2 Contract(`packages/contract/src/contract.ts`,纯增量)
 
 ```ts
+export const GeocodeKind = z.enum(["station", "city", "ward", "landmark", "prefecture", "external"]);
+export type GeocodeKind = z.infer<typeof GeocodeKind>;
+export const GeocodeSource = z.enum(["seed", "mlit", "geonames", "gsi", "manual"]);
+export type GeocodeSource = z.infer<typeof GeocodeSource>;
+
 export const GeocodeInput = z.object({
   query: z.string().min(1),
-  limit: z.number().int().min(1).max(10).optional(), // default 5
+  limit: z.number().int().min(1).max(10).default(5),
 });
+export type GeocodeInput = z.infer<typeof GeocodeInput>;
+
 export const GeocodeCandidate = z.object({
-  id: z.string(),            // gazetteer row id
-  label: z.string(),         // 展示名,含消歧上下文: "西宮北口駅(兵庫県西宮市)"
-  name: z.string(),          // canonical 名
+  id: z.string(),
+  label: z.string(),          // 消歧展示: "西宮駅(兵庫県・station)"
+  name: z.string(),
   lat: Latitude, lng: Longitude,
-  kind: z.string(),          // 'station' | 'city' | 'ward' | 'landmark' | 'external'
-  source: z.string(),        // 'seed' | 'mlit' | 'geonames' | 'google'
+  kind: GeocodeKind,
+  source: GeocodeSource,
 });
-export const GeocodeResult = z.object({ candidates: z.array(GeocodeCandidate) }); // 0..limit
+export type GeocodeCandidate = z.infer<typeof GeocodeCandidate>;
+
+export const GeocodeResult = z.object({ candidates: z.array(GeocodeCandidate) }); // 折叠后 0..limit
+export type GeocodeResult = z.infer<typeof GeocodeResult>;
 
 geocode: oc.route({ method: "POST", path: "/catalog/geocode",
                     summary: "Resolve a place name to coordinate candidates" })
   .input(GeocodeInput)
-  .errors(pickCatalogErrors(["UPSTREAM_UNAVAILABLE"]))
-  .output(GeocodeResult),
+  .output(GeocodeResult),   // 无 .errors():GSI 失败=优雅降级返回本地结果;本地 DB 失败=自然 500
 ```
 
-`emit:openapi` 幂等检查随 PR-A 跑(纯增量,无 drift)。
+同步事项:`workers/catalog/src/types.ts` 加类型镜像(该文件 lockstep 注释所要求);`emit:openapi`
+幂等检查随 PR-A;**不**扩 `UPSTREAM_UNAVAILABLE` 枚举(v1 的错误语义自相矛盾,已删)。
 
-### 3.3 Schema(`db/migrations/`,Atlas)
+### 3.3 Schema(`db/migrations/`,Atlas;新迁移文件 + `atlas migrate hash` 更新)
 
 ```sql
 CREATE TABLE locations (
-  id         TEXT PRIMARY KEY,          -- 'seed:uji' / 'mlit:st-<code>' / 'g:<place_id-hash>'
-  name       TEXT NOT NULL,             -- canonical (ja)
-  kind       TEXT NOT NULL,             -- station|city|ward|landmark|external
+  id         TEXT PRIMARY KEY,          -- 'seed:uji' / 'mlit:st-<code>' / 'gsi:<hash>'
+  name       TEXT NOT NULL,
+  kind       TEXT NOT NULL,             -- station|city|ward|landmark|prefecture|external
   latitude   DOUBLE PRECISION NOT NULL,
   longitude  DOUBLE PRECISION NOT NULL,
-  location   GEOGRAPHY(POINT, 4326),    -- 复用 points 的 sync-trigger 模式自动派生
-  source     TEXT NOT NULL,
-  pref       TEXT,                      -- 都道府県,拼 label 消歧用
+  location   GEOGRAPHY(POINT, 4326),
+  source     TEXT NOT NULL,             -- seed|mlit|geonames|gsi|manual
+  pref       TEXT,
   created_at TIMESTAMPTZ DEFAULT now(), updated_at TIMESTAMPTZ DEFAULT now()
 );
+-- sync_points_coordinates() 只引用 NEW.latitude/longitude/location(已核可直接复用):
+CREATE TRIGGER trg_locations_sync_coordinates
+  BEFORE INSERT OR UPDATE ON locations
+  FOR EACH ROW EXECUTE FUNCTION sync_points_coordinates();
+
 CREATE TABLE location_aliases (
   alias            TEXT NOT NULL,
-  alias_normalized TEXT NOT NULL,       -- normalizeAlias() 同款 NFKC 折叠
+  alias_normalized TEXT NOT NULL,       -- normalizeAlias() 同款(lib/alias.ts:55)
   location_id      TEXT NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
   lang             TEXT,                -- ja|zh|en|NULL
   priority         INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (alias_normalized, location_id)
 );
 CREATE INDEX idx_location_aliases_norm ON location_aliases (alias_normalized);
--- PR-B: CREATE EXTENSION IF NOT EXISTS pg_trgm;
---       CREATE INDEX idx_location_aliases_trgm ON location_aliases USING GIN (alias_normalized gin_trgm_ops);
+GRANT SELECT, INSERT, UPDATE ON locations, location_aliases TO catalog_svc;  -- 对齐 init.sql:383-397
+-- PR-B 独立迁移: CREATE EXTENSION IF NOT EXISTS pg_trgm;
+--   CREATE INDEX idx_location_aliases_trgm ON location_aliases USING GIN (alias_normalized gin_trgm_ops);
 ```
 
-同一迁移内 seed 现有 26 条 `KNOWN_LOCATIONS`(含 zh 变体作为 alias 行)——PR-A 落地即与现状
-**平价**,Google 兜底使其严格更强。
+**PR-A seed(同迁移内 DML;deploy 只跑 `atlas migrate apply`,故数据必须随迁移走):**
+- `KNOWN_LOCATIONS` 实为 **27 个别名键 → 19 个唯一坐标对**(已实测纠数;v1 写 26 为误)。
+  迁移按 19 行 `locations` + 27 行 `location_aliases` 落库(zh 变体行 `lang='zh'`:东京/东京站/
+  秋叶原/镰仓/涩谷/横滨;其余 `lang='ja'` 或共用 NULL)。
+- **补种西宮**(dict 原本没有,而它是旗舰回归案例):`locations` +1(西宮駅,station,兵庫)+
+  别名 3 行:西宮(ja)/西宫(zh)/nishinomiya(en)。共 **20 locations / 30 aliases**。
+- Seed 数据为 migration-owned 一次性 bootstrap(现有迁移无 DML 先例,但 deploy 机制决定了这是
+  唯一会被执行的通道;评审已认可)。
 
 ### 3.4 Worker 解析链(`workers/catalog/src/lib/geocode.ts` + `api/geocode.ts`)
 
-1. `norm = normalizeAlias(query)`(复用 `lib/alias.ts:55`)。
-2. **Exact**: `SELECT ... FROM location_aliases a JOIN locations l ON ... WHERE a.alias_normalized=$1
-   ORDER BY a.priority DESC, l.kind LIMIT $limit`。命中即返回(多行=歧义,原样返回候选)。
-3. **(PR-B) Fuzzy**: `WHERE similarity(a.alias_normalized,$1) > 0.4 ORDER BY similarity DESC LIMIT $limit`;
-   最高分 ≥0.6 且唯一 → 单候选;否则作为歧义候选返回。CJK 短串 trgm 弱是已知限制,阈值由测试钉住。
-4. **Google 兜底**(`GOOGLE_MAPS_API_KEY` 存在时): GET `maps/api/geocode/json`,
-   `region=jp&language=ja&components=country:JP`,10s 超时,解析 ≤limit 候选
-   (参数/解析逻辑移植自现成的 `apps/agent/agent/infrastructure/gateways/geocoding.py`,该 Python 版
-   随 PR-A 保留不动——它只被死代码引用)。key 缺失 → 跳过并 `logger.warning`,返回本地结果(优雅降级,
-   与该 gateway 现行为一致)。
-5. **写回**: Google 候选 upsert 进 `locations`(`id='g:'+sha1(place_id)[:16]`, `source='google'`)+
-   `location_aliases`(原 query→每个候选,`ON CONFLICT DO NOTHING`)。同一查询第二次即本地命中,
-   Google 成本趋零。与番名 ingest 同构:seed + on-demand 生长。
-6. 全链确定性,无 LLM。DB 查询走既有 raw-`sql` 模板模式(Drizzle builder 在 workerd 下挂起的坑已知)。
+**(a) 解析顺序**
+1. `norm = normalizeAlias(query)`。
+2. **Exact**:`CatalogDb.execute(sql\`SELECT ... FROM location_aliases a JOIN locations l ...
+   WHERE a.alias_normalized=${norm} ORDER BY a.priority DESC\`)`(读写走 `CatalogDb` raw-sql 模板,
+   与 `api/nearby.ts:45-55` 一致;禁 Drizzle fluent builder——workerd 挂起已文档化)。
+3. **(PR-B) Fuzzy**:`similarity(alias_normalized, ${norm}) > 0.4`,按相似度降序;最高分 ≥0.6 且
+   折叠后唯一 → 单候选;否则并入候选集。
+4. **GSI 兜底**:`GET https://msearch.gsi.go.jp/address-search/AddressSearch?q=<query>`
+   (无 key;8s 超时;经 `CatalogContext.fetchImpl` 注入以便测试 mock——该注入点已存在)。
+   解析 GeoJSON 候选 ≤limit。**失败/超时/零结果 → logger.warning + 返回本地结果**(优雅降级)。
+5. **写回**:GSI 候选 upsert `locations`(`id='gsi:'+sha1(title+coords)[:16]`,`source='gsi'`,
+   `kind='external'`)+ `location_aliases`(原 query→各候选,`ON CONFLICT DO NOTHING`)。
+   合法性:GSI 属政府標準利用規約(CC-BY 4.0 互換),存储/再配布允许,出典明记于
+   `docs/data-sources.md`(PR-A 建档)。
+6. 全链确定性,无 LLM,无 key,无 secret ops。
+
+**(b) 候选折叠(新;v1 缺失,PR-B 规模下必需)**
+Exact/fuzzy/GSI 合并后:按坐标聚簇(簇内任意两点 ≤10km);每簇取最高优先级代表
+(kind 优先 station > city > ward > landmark > prefecture > external;同 kind 取 priority 高者)。
+- 1 簇 → 返回单候选(西宮:JR西宮駅+阪神西宮駅+西宮市 → 折 1)。
+- ≥2 簇 → 每簇一个代表作为歧义候选(府中:東京 vs 広島 → 2)。
+测试钉住:`西宮→1`、`府中→2`(PR-B B2';PR-A 用 seed 内数据钉 `東京→1`)。
 
 ### 3.5 Agent 侧(`apps/agent`)
 
-- `CatalogClientProtocol` + `CatalogClient` 增 `geocode(query, limit=5) -> list[GeocodeCandidate]`
-  (pydantic model 新增于 clients;`MockCatalogClient` 加确定性 fixture:西宮/宇治/府中×2/未知名)。
-- `search_nearby(location: str = "", radius: int = 0)` 重写编排(替换 `_geocode_for_catalog`):
+- `CatalogClientProtocol`/`CatalogClient`/`MockCatalogClient` 增 `geocode(query, limit=5)`。
+  Mock fixture(PR-A 起即多语言):西宮/西宫/nishinomiya、宇治、東京/东京、府中×2(跨域)、
+  未知名 → 空;PR-B 扩:镰仓/秋叶原/宫崎 + G4 `last_location` 形态(宇治市/東京都/神奈川県)。
+- `search_nearby(location: str = "", radius: int = 0)` 编排(替换 `_geocode_for_catalog`):
 
 | 输入情形 | 行为 |
 |---|---|
-| `location` 空 且 session 有 GPS | 用 origin 坐标(现行"我附近"路径,不变) |
-| `location` 空 且 无 GPS | `ModelRetry`:请用户给地点或分享位置(→clarify) |
-| `location` 非空 | **geocode 优先**(行为变更,见下) → 1 候选:`nearby(lat,lng)`;N 候选:返回 `{"status":"ambiguous_location","options":[labels...]}`,docstring 指示模型转 `clarify`;0 候选:有 GPS 则回退 GPS,否则**单次** `ModelRetry`:"Could not locate '<X>'. Call clarify to ask the user for a nearby station or city." |
+| `location` 空 + 有 GPS | origin 坐标(现行"我附近"路径) |
+| `location` 空 + 无 GPS | failed-step + `ModelRetry`:请用户给地点或分享位置(→clarify) |
+| 非空,折叠后 1 候选 | `nearby(lat, lng, radius or kind 默认半径)`;**kind='prefecture' 例外**:不搜,failed-step + `ModelRetry` 引导 clarify 收窄到市/站 |
+| 非空,≥2 簇 | **failed-step(success=False, error="ambiguous_location")+ 不写 tool_state** + `ModelRetry` 消息携候选 label,指示"call clarify with these options" |
+| 非空,0 候选 | **不回退 GPS**(v1 的矛盾已删):failed-step + 单次 `ModelRetry`:"Could not locate '<X>'. Call clarify to ask for a nearby station or city." |
 
-- **显式行为变更**:现行代码 GPS 无条件优先(`catalog_tools.py:127-130`),导致"用户在东京、
-  问西宮附近"会搜东京。新规则:**显式地名 > GPS,空地名 = GPS**。`_INSTRUCTIONS` 的
-  Location/nearby 段同步一句:用户点名地点时把地名原样传入 `location`;"我附近/near me" 传空。
-- ModelRetry 消息统一引导 clarify 而非鼓励换名重猜——消灭 MiMo 式 retry 风暴(对 v4-pro 同样生效)。
-- 删除 `catalog_tools.py` 对 `KNOWN_LOCATIONS` 的 import(dict 本体留在死代码 `sql_agent.py`,
-  随独立 chore 清理)。
+- **歧义/失败管道语义(关键,v1 未定义)**:失败路径记 `StepRecord(success=False)` →
+  `ctx.deps.steps` 非空 → `output_validator` 保持武装(`pilgrimage_agent.py:386` 的空步跳过
+  不触发);**不写 `tool_state["search_nearby"]`** → 模型若强行返回 `search_response`,
+  validator 现有规则(`389-395`)直接拒绝——无需新增 validator 逻辑,也不会把歧义 payload
+  渲染成 `NearbyMap`(`response_builder.py` `_UI_MAP` 已核)。SSE 沿用 `_store_catalog_result`
+  失败分支的 "failed" 事件。clarify 的 options 走既有 `list[str]` 通道;anime 富化对地名字符串
+  空结果即可(AC A6 覆盖)。
+- **kind 感知默认半径**:station/ward/landmark 5000m、city 10000m、prefecture 不搜(上表)。
+- **`_INSTRUCTIONS` 全段重写(PR-A 范围;v1 "同步一句"为严重低估)**:
+  Location/nearby 工作流从 "web_search → clarify、Do NOT call search_nearby"(73-82)改为
+  "有地名 → 直接 `search_nearby(location=地名原样)`;'我附近' → `location=''`";例句 108/112
+  同步改写;AC 加 grep 断言旧禁令文案已移除。GPS 优先级修正:显式地名 > GPS(原 134-137 行为)。
+- 删 `catalog_tools.py` 对 `KNOWN_LOCATIONS` 的 import。
+- "单次 ModelRetry"的实现口径:消息设计为一次反馈即引导 clarify;agent `retries=2` 全局设置不动,
+  以消息内容而非重试预算控制行为(v1 表述"恰好一次"不可强制,已纠)。
 
 ### 3.6 数据(PR-B)
 
-- **车站**: 国土数値情報 N02 鉄道データ(国土交通省,~10,600 站,出典明记可商用)。
-- **城市/区**: GeoNames JP(cities500 子集,CC-BY 4.0,~1,900 行)。
-- 处理后 CSV(~700KB)检入 `workers/catalog/data/gazetteer-jp.csv` + 生成脚本
-  `workers/catalog/scripts/build-gazetteer.md`(文档化下载/转换步骤)+ 幂等 seed 脚本
-  `workers/catalog/scripts/seed-locations.ts`(upsert,可重跑)。
-- **多语言 alias**: 城市 zh/en 变体复用 `apps/agent/agent/agents/geo_names.py` 数据
-  (662/747 城市 en↔ja/zh)导出;车站 PR-B 仅 ja(en/zh 长尾靠 Google 写回自然生长)。
-- 归属声明入 `docs/data-sources.md`(MLIT 出典 + GeoNames CC-BY)。
+- 车站:国土数値情報 N02(v2023,URL/取得日/SHA256 锁定于 `docs/data-sources.md`),~10.6k 站。
+  原始记录含路线/事业者重复——按 **站名+坐标聚簇去重** 后落 `locations`(转换脚本文档化)。
+- 城市/区:GeoNames JP cities500(CC-BY 4.0,同样锁版本),~1.9k 行,kind=city/ward。
+- zh/en 城市别名:`geo_names.py` 数据导出(**655/662 条有非空 zh**——v1 的 662/747 表述已纠);
+  车站 PR-B 仅 ja,长尾靠 GSI 写回生长。
+- **落库方式 = Atlas 数据迁移**(生成的 SQL 迁移文件检入,deploy 的 `atlas migrate apply` 自动执行;
+  v1 的独立 seed 脚本永远不会被 deploy 调用,已废)。生成器脚本 + 校验(行数/checksum)检入
+  `workers/catalog/scripts/`,供再生成审计。
+- pg_trgm:Neon 官方支持;独立迁移 + preview-branch 应用测试;B1 集成测试镜像需含 pg_trgm
+  (postgis/postgis 镜像自带 contrib,测试内 `CREATE EXTENSION`)。
 
 ### 3.7 Eval 与量尺(PR-B)
 
-1. **修正被制度化的假阴性**:`C1_ja_004`/`C1_zh_005`(西宮,库有数据)`acceptable_stages`
-   `["clarify"]` → `["search_nearby"]`。逐条审 C1/C2 族:凡"具体真实地名+库有数据"一律改;
-   仅"真模糊查询"(近くに何がある 无 GPS)保留 clarify。
-2. **新增 case**:箱根(geocode 成功+库空→诚实空结果)、豊郷(hit)、"Nishinomiya"(en)、
-   "西宫"(zh 简体)、府中(歧义→clarify 正确)。
-3. **第一个内容级 metric** `nonempty_results`(L1 确定性):dataset 增可选字段
-   `expect_nonempty: true`;评估器对带标记的 case 检查任一 search payload `row_count > 0`,
-   未标记的 case 不产出该 metric(实现须确认 pydantic-evals 对 per-case 缺失 metric 的均值语义,
-   避免虚高)。这是"检索质量零标尺"窟窿上的第一颗钉子——不是终点。
-4. Baseline:PR-B 合并后 MiMo trajectory 全量重跑(~¥2)刷新 MiMo baseline 并验证
-   search_nearby 8 错误归零;DeepSeek baseline 待余额补充后刷新(现 ~¥14,一次 ~¥10)。
-5. 已知边界:trajectory tier 用 `MockCatalogClient`,geocode 的 mock fixture 决定 eval 覆盖;
-   真实 Google 路径由 worker 单测(mock fetch)+ 手动 smoke 覆盖。CI 的 agent-eval job 目前
-   `&& false` 硬禁用——本 spec 不改 CI 门禁(独立议题)。
+1. **翻转面如实声明(v1 只列 2 个为严重低估)**:C1 全族 16 case + C2 全族 17 case 中,
+   凡"具体真实地名"一律 `["clarify"]` → `["search_nearby"]`(含 hit_complete/hit_sparse/
+   miss-but-geocodable——miss 的正确行为是诚实空结果,同属 search_nearby 轨迹);
+   **carve-out**:C2 中 5 个都道府县级 case(埼玉/山梨/神奈川/岐阜/宮崎)按 §3.5 的 prefecture
+   规则保留 clarify(经由"geocode 成功→引导收窄"的诚实路径)。`expected_data_keys` 同步由
+   clarify 键改为 `["results"]`。C3(动画+地点)/C4(真模糊)/H2/H4(路线意图)不动——
+   已核 H1/H2/H4 的 acceptable_stages 不含 search_nearby 翻转风险;H1(GPS 空地名路径)不变。
+   E2/G4 的可选收紧记 follow-up,不入 PR-B。
+2. **歧义轨迹计分**:`_STAGE_TOOL_CHAINS` 为歧义 case 增 `("search_nearby","clarify")` 链
+   (否则正确的"搜→问"轨迹被 tool_precision/step_efficiency 双重扣分——评审已算出 0.5)。
+   新增歧义 case:府中(ja/zh/en 各 1,期望 search_nearby→clarify)。
+3. **新 case**:箱根(honest-empty)、豊郷(hit)、Nishinomiya(en)、西宫(zh)。
+4. **`nonempty_results`(L1 内容级 metric,第一颗钉子)**:
+   - dataset 字段 `expect_nonempty: true`,**标注 ≥10 个**翻转后的 hit_complete/hit_sparse case
+     (满足 `gate.py:96` `min_paired=10`,否则 gate 静默跳过——评审已核)。
+   - 评估器读 `tool_state["search_nearby"]["row_count"]`(权威来源,非模型文本)。
+   - 未标注 case 返回 `{}`(pydantic-evals 按 key 出现的 case 求均值,已核安全);
+     **`METRIC_NAMES` 条件收录**:`collect_scores` 对缺失 metric 抛 `ValueError`
+     (`eval_report.py:14-19`),故 `EVAL_MAX_CASES` 子采样可能抽不到标注 case——
+     实现为"标注 case 存在才纳入 METRIC_NAMES"或 presence-aware 收集(实现挑其一,测试钉住)。
+   - харness 触点全列:`AgentExpected` 字段(`evaluators.py:53-59`)、`_expected()`
+     (`eval_harness.py:118-121`)、评估器注册与 `METRIC_NAMES`(`eval_harness.py:69-79,146-156`)、
+     gate 配对(`gate.py:201-215`)。
+5. **B5 证据口径**:附**完整 run 产物**(results JSON 或其摘录)+ 修复前 8 个 case id 列表
+   (B1_en_001, C1_ja_004, C1_zh_005, I1_zh_004, I3_en_002, J3_en_001, L3_en_001, A3_en_008)——
+   v1 引用的 checked-in 旧产物不能作证,已纠。
+6. 边界不变:trajectory tier 用 MockCatalog;CI agent-eval 仍禁用,PR-B 不动 CI。
 
 ## 4. Acceptance Criteria(Quality Ratchet:每条带测试)
 
 **PR-A**
 | # | AC | 测试 |
 |---|---|---|
-| A1 | `/catalog/geocode` exact 命中返回候选(西宮→兵庫坐标) | worker vitest (unit) |
-| A2 | miss + key 存在 → Google 调用(mock fetch)→ 候选返回 + `locations`/`location_aliases` 写回;同 query 第二次不再调 Google | worker vitest (unit) |
-| A3 | miss + 无 key → 空候选,warning,无异常 | worker vitest (unit) |
-| A4 | `nearby`/`search` 契约与行为零变化;`emit:openapi` 幂等 | 既有 worker 测试 + drift check (ci) |
+| A1 | `/catalog/geocode` exact:西宮(seed 补种)与 東京(折叠后 1 候选)返回正确坐标 | worker vitest |
+| A2 | 本地 miss → GSI 调用(fetchImpl mock)→ 候选返回 + `locations`/`location_aliases` 写回;同 query 二次查询不再出网 | worker vitest |
+| A3 | GSI 超时/非 200/零结果 → warning + 返回本地结果,无异常 | worker vitest |
+| A4 | `nearby`/`search` 契约与行为零变化;`emit:openapi` 幂等;`types.ts` 镜像同步 | 既有测试 + drift check |
 | A5 | agent `search_nearby("西宮")` → geocode→nearby→rows(FunctionModel e2e,MockCatalog) | agent unit (e2e) |
-| A6 | 歧义地名("府中")→ `ambiguous_location` payload → 模型转 clarify | agent unit (e2e) |
-| A7 | 未知地名无 GPS → 恰好一次 ModelRetry(消息含 clarify 引导),**无重试耗尽** | agent unit |
-| A8 | 显式地名 > GPS;空地名 → GPS;空地名无 GPS → ModelRetry | agent unit ×3 |
-| A9 | 26 条旧 KNOWN_LOCATIONS 全部经新链路可解析(迁移 seed 平价) | worker vitest (unit, 遍历断言) |
-| A10 | 全量门禁:agent 933+ tests / coverage ≥82%;worker vitest 全绿;mypy/ruff/tsc 干净 | ci |
+| A6 | 歧义("府中")→ failed-step + 无 tool_state + ModelRetry 携候选;模型转 clarify(options 为地名字符串)成功产出 ClarifyResponse | agent unit (e2e) |
+| A6' | 歧义后模型强行返回 `search_response` → 被 output_validator 拒绝 | agent unit |
+| A7 | 未知地名 → failed-step + ModelRetry(含 clarify 引导);**不**出现重试耗尽 UnexpectedModelBehavior(消息即引导) | agent unit |
+| A8 | 三态优先级:显式地名>GPS;空地名→GPS;空地名无 GPS→ModelRetry | agent unit ×3 |
+| A8' | kind='prefecture' → 不搜、引导收窄 | agent unit |
+| A9 | 迁移 seed 平价:**30 条别名**(TS fixture 镜像迁移 SQL,来源=迁移文件)全部经 `/catalog/geocode` 解析到期望坐标 | worker vitest(测试 PG) |
+| A10 | `_INSTRUCTIONS` 不再含 "Do NOT call search_nearby" 禁令;新 nearby 工作流 + 例句就位 | agent unit(grep 断言) |
+| A11 | 全量门禁:agent pytest ≥933 passed / ≥82% cov;worker vitest;mypy/ruff/tsc;drift | ci |
 
 **PR-B**
 | # | AC | 测试 |
 |---|---|---|
-| B1 | gazetteer seed 幂等,≥10k 车站 + ≥1.5k 城市,重跑无 dup | worker vitest (integration, 测试 PG) |
-| B2 | trgm:"西宮北口" 命中 "西宮北口駅";阈值下无候选→走 Google | worker vitest (unit) |
-| B3 | eval C1 西宮 case 期望修正 + 新 case 落 dataset;MockCatalog geocode fixture 同步 | eval dataset + agent unit |
-| B4 | `nonempty_results` metric 上线,带标记 case 正确计分,未标记不虚高 | eval evaluator unit |
-| B5 | MiMo trajectory 全量重跑:search_nearby 错误 8→0;baseline 刷新 | eval (manual gate, PR 附证据) |
+| B1 | Atlas 数据迁移应用后 ≥10k 站 + ≥1.5k 市区;迁移可重放(hash 校验) | worker vitest(integration,测试 PG 含 pg_trgm) |
+| B2 | trgm:"西宮北口"→"西宮北口駅";阈值下不误吸 | worker vitest |
+| B2' | 折叠:西宮→1 候选;府中→2 簇 | worker vitest |
+| B3 | C1/C2 翻转(±carve-out)+ 新 case + 歧义链入 `_STAGE_TOOL_CHAINS` + 多语言 mock fixture | eval dataset + agent unit |
+| B4 | `nonempty_results`:≥10 标注 case 正确计分;子采样无标注时不崩(`collect_scores`);gate 配对生效 | eval evaluator unit |
+| B5 | MiMo trajectory 全量重跑:8 个既知 case id 归零;完整产物附 PR | eval(manual gate,PR 附证据) |
 
 ## 5. Ops / Security
 
-- `GOOGLE_MAPS_API_KEY`:GitHub repo secret 已存在(container 用);PR-A 需在 deploy workflow 给
-  **catalog worker** 注入(`wrangler secret put`,staging + production)。**部署到 prod 的 approve
-  关卡照例需用户批准。**
-- Key 只经 env → worker secret;不入代码/日志(沿用现有 gateway 的 redact 习惯)。
-- Google 成本:cache-first + 写回,预估稳态每月个位数美元;worker 记 `google_geocode_called`
-  日志计数器便于观测。
-- 迁移经 Atlas(`db/migrations/`);`supabase/migrations/` 历史树不动。
+- **零新增 secret**(GSI 无 key)——v1 的 GOOGLE_MAPS_API_KEY worker 注入整段作废;该 secret 维持
+  container 现状不动。
+- `docs/data-sources.md`(PR-A 建,PR-B 扩):GSI 出典(国土地理院・地名検索 API,政府標準利用規約
+  2.0)、MLIT N02(版本/URL/取得日/SHA256)、GeoNames(CC-BY 4.0)。
+- 迁移经 Atlas(`db/migrations/` + `atlas migrate hash`);`supabase/migrations/` 历史树不动。
+- GSI 调用观测:worker 记 `gsi_geocode_called` 计数日志。
 
 ## 6. Risks
 
 | 风险 | 缓解 |
 |---|---|
-| trgm 对 CJK 短串效果差 | 阈值保守(0.6 auto / 0.4 candidate)+ 歧义一律走 clarify;romaji/zh 靠 alias 行与 Google 写回,不指望 trgm |
-| Google 返回日本外同名地 | `components=country:JP` 硬过滤 |
-| GPS/地名优先级翻转改变既有行为 | A8 三态测试钉死;eval H2/H4("从这里出发")回归确认 |
-| 写回污染(Google 坏候选入库) | 写回行 `source='google'` 可识别可清理;alias 仅绑原 query,不做泛化 |
-| 26 条平价迁移漏项 | A9 遍历断言 |
-| eval 期望大改引发基线漂移 | PR-B 单独重跑基线,gate 按新语义重置(有 v1.1/v1.2 勘误先例) |
+| GSI 对 zh/en 查询弱 | gazetteer 别名(zh 655 城市 + seed zh 行)承担主力;miss → 诚实 clarify;若真实 miss 率高,再评估"瞬态 Google(30 天 TTL,不入 gazetteer)"为独立决策 |
+| GSI 可用性/限流 | 优雅降级已内建(A3);观测计数;gazetteer 随写回生长,依赖度递减 |
+| trgm 对 CJK 短串弱 | 阈值 0.6/0.4 + 折叠 + 歧义走 clarify;不指望 trgm 扛 romaji/zh |
+| 折叠阈值 10km 误折/漏折 | B2' 钉双例;阈值为常量可调,测试为准 |
+| 指令重写影响其他意图路由 | A10 + 全量 eval 重跑(B5)兜底;C3/C4/H 族不动作为回归screen |
+| eval 大改基线漂移 | PR-B 重跑基线,gate 按新语义重置(v1.1/v1.2 勘误先例) |
+| 迁移含 DML 无先例 | 深思后接受(deploy 只跑 atlas apply,别无通道);数据 migration-owned、一次性、可重放 |
 
-## 7. Open Questions(带默认值,评审可推翻)
+## 7. Open Questions(带默认值)
 
-- **OQ1** 外部兜底选 Google(默认,key 已备,zh/en 支持最好)vs 国土地理院 API(免费,仅日文)。
-  默认 Google;若成本敏感,PR-B 可加 GSI 为第一兜底、Google 第二。
-- **OQ2** 候选 label 本地化(zh 用户见"西宮北口駅(兵库县)")——默认 PR-A 仅 ja label,
-  PR-B 用 geo_names 数据本地化城市部分。
-- **OQ3** `points` 表自身地名(如"大吉山展望台")是否并入 gazetteer 查询(UNION)——默认 PR-B 不做,
-  记 follow-up(它让"圣地名"本身可作为搜索中心)。
+- **OQ1(已定案)**:外部兜底 = GSI。Google 因 ToS 出局(存储违规);GSI 免费无 key 可存储。
+- **OQ2** 候选 label 本地化(zh 用户见汉字简体标签)——默认 PR-A ja label,PR-B 城市部分用
+  geo_names 本地化。
+- **OQ3** `points` 表地名并入 gazetteer 查询(圣地名作为搜索中心)——默认不做,记 follow-up。
 
-## 8. Follow-ups(不在本 spec 范围)
+## 8. Follow-ups(不在本 spec)
 
-- 路线 origin(`plan_route`/K-path `execute_selected_route`)接入 `catalog.geocode`。
-- `sql_agent.py` 死代码清理(SQLAgent、旧 resolve_location、Python geocoding gateway)。
-- 检索质量量尺体系化(内容级 recall/precision,超出 `nonempty_results` 的完整方案)。
-- CI agent-eval job 解禁策略。
+- 路线 origin(`plan_route`/K-path)接入 `catalog.geocode`。
+- E2/G4 族 eval 收紧(明确 `last_location` 注入 session 指令与否后再定)。
+- `sql_agent.py` 死代码清理(含 Python 版 Google gateway 一并退役)。
+- 检索质量量尺体系化(`nonempty_results` 之上的 recall/precision)。
+- 瞬态 Google 兜底(30 天 TTL、不入 gazetteer)——仅当 GSI+gazetteer 实测 miss 率不可接受时。

--- a/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
+++ b/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
@@ -1,6 +1,6 @@
 # Catalog Geocoding — 真正实现"按地点搜圣地"
 
-- **Status**: v3 — 二轮双评审仲裁定稿候选(v1 needs-rework×2;v2 sonnet approve-with-changes / codex needs-rework;v3 吸收全部 P0/P1)
+- **Status**: **v4 定稿**(v3 终审:sonnet approve-with-changes + codex approve-with-changes,全部修改项已折入;双评审闭环完成)
 - **Date**: 2026-07-13
 - **Related**: SD-29 · `docs/ARCHITECTURE.md:215` · MiMo eval search_nearby 错误分析 · GOAL 同目录 `*-GOAL.md`
 - **PRs**: PR-A (capability), PR-B (data + measurement)
@@ -22,7 +22,7 @@
 MiMo 残余 8 错误全属此类,模型无关。
 
 **新发现(codex 复核实证,v3 起修)**:现有代码把"零行成功"当失败——
-`_run_catalog_nearby` `success=bool(rows)`(`catalog_tools.py:161`)→ 零行不写 tool_state
+`_run_catalog_nearby` `success=bool(rows)`(`catalog_tools.py:167`)→ 零行不写 tool_state
 (`catalog_tools.py:71`)→ validator 拒绝 search_response(`pilgrimage_agent.py:389`)。
 即"诚实空结果"在当前管道**不可能存在**。
 
@@ -152,22 +152,22 @@ GRANT SELECT ON locations, location_aliases TO catalog_svc;   -- 只读即可(�
 4. 全 miss → 返回空候选。
 
 **(b) 候选折叠(单一 tier 的命中行上执行)**
-1. union-find 单链聚簇:任意两行距离 ≤10km 即连通(算法先例 `lib/clustering.ts:72-91`,阈值不同)。
+1. union-find 单链聚簇:任意两行距离 ≤12km 即连通(算法先例 `lib/clustering.ts:72-91`,阈值不同)。
    桥链效应(A-B-C 链式连通)对同名候选集合是**期望行为**(同城多站折一)。
 2. 每簇代表:kind 优先 `station > city > ward > landmark > prefecture`;同 kind 按
    `priority DESC, id ASC`(确定性 tiebreak,v2 缺失)。
 3. 簇按代表的 `(exact 命中优先, priority DESC, id ASC)` 排序,截断至 `limit`。
-4. 测试钉:西宮→1(PR-B 三行折一)、府中→2(跨域)、東京→1(PR-A seed 双行:東京駅-東京 city
-   实测 10.56km —— **正因超 10km 会分簇,seed 中東京 city 与東京駅 合并为一行**(id `seed:tokyo`,
-   kind=city,別名 東京/东京/東京駅/东京站 → 同簇免疫;v2 的 10.5km 陷阱由 seed 数据消解,
-   PR-B 车站导入后 東京駅 为独立 mlit 行,与 city 行 10.56km >10km —— 折叠阈值定为 **12km**
-   以覆盖首都圈这一实测边界;B2' 用真实坐标钉住)。
-   shuffled-input 确定性测试必备。
+4. **有效半径(codex 终审 P1)**:代表按 kind 优先选出,但后续 nearby 的默认半径取
+   **簇内成员 kind 半径的最大值**(mixed city+station 簇 → max(5km,10km)=10km),防止 station
+   代表把城市查询静默缩到 5km。
+5. 测试钉:西宮→1(PR-B 三行折一)、府中→2(跨域)、東京→1(seed 保留 東京 city 与 東京駅
+   **两行真坐标**,实测相距 10.56km——12km 阈值由此实测边界确定,B2' 用真实坐标钉住,
+   有效半径断言 10km)。shuffled-input 确定性测试必备。
 
 ### 3.5 Agent 侧(`apps/agent`)——三态分离(v3 核心重设计)
 
 **管道语义前置修复(PR-A,scope 限 nearby 路径)**:
-- `_run_catalog_nearby`:`success` 改为"查询执行成功"(零行也是 True);payload 恒写
+- `_run_catalog_nearby`:仅改**其调用 `_store_catalog_result` 时传入的 `success=` 实参**为"查询执行成功"(零行也是 True;共享的 `_store_catalog_result` 本体与 resolve/search_bangumi 路径不动——sonnet 终审 NEW-3a);payload 恒写
   `tool_state["search_nearby"]`(含 `row_count: 0`)。零行时 SSE data 照发,`status:"empty"`
   已有字段承载。→ 诚实空结果全链路可达(validator 放行、`NearbyMap` 渲染空态)。
 - 新增内部 step 工具名 `geocode`(仅在歧义/零候选/prefecture 收窄路径记录,`success=True`,
@@ -181,7 +181,7 @@ GRANT SELECT ON locations, location_aliases TO catalog_svc;   -- 只读即可(�
 |---|---|---|
 | location 空 + 有 GPS | origin 坐标 → nearby | 结果(可为诚实空) |
 | location 空 + 无 GPS | `ModelRetry`:请给地点或分享位置 | →clarify |
-| 1 候选,kind≠prefecture | nearby(kind 半径:station/ward/landmark 5km、city 10km) | 结果(可为诚实空) |
+| 1 候选,kind≠prefecture | nearby(**有效半径**:簇内 kind 半径最大值;station/ward/landmark 5km、city 10km) | 结果(可为诚实空) |
 | 1 候选,kind=prefecture | geocode-step + `ModelRetry`("X县太大,问用户哪个市/站") | →clarify(`success=true`) |
 | ≥2 簇 | geocode-step + `ModelRetry` 携簇代表 label(≤5,消毒:仅取自类型化 `GeocodeCandidate.label`,长度截断——SD-19 `_retry_message` 规则的显式豁免) | →clarify,options=地名字符串(anime 富化空结果可容忍,AC A6 断言) |
 | 0 候选 | geocode-step + `ModelRetry`("查无此地,请问用户站名/市名") | →clarify;**显式地名不回退 GPS** |
@@ -213,8 +213,9 @@ GRANT SELECT ON locations, location_aliases TO catalog_svc;   -- 只读即可(�
 
 1. **翻转面**:C1 全 16 + C2 全 17 中"具体真实地名"→ `["search_nearby"]`,`expected_data_keys`
    → `["results"]`;**都道府县 carve-out 按 §3.6 裸名/后缀规则逐 case 审计**(数据集含 8 个
-   都道府县形 case,不是 v2 说的 5 个;岐阜裸名两案统一翻转,后缀案保留收窄)。C3/C4/H1/H2/H4
-   不动(已核无 search_nearby 翻转面);E2/G4 收紧 follow-up。
+   都道府县形 case,不是 v2 说的 5 个;岐阜裸名两案统一翻转,后缀案保留收窄)。C3/H1/H2/H4 不动(已核无 search_nearby 翻转面);**C4 的 `acceptable_stages` 追加
+   `clarify_after_nearby`**(模型合法先试 search_nearby 再 clarify 的轨迹不再被误扣——sonnet 终审
+   NEW-2;disjunction 语义下严格更宽容);E2/G4 收紧 follow-up。
 2. **歧义轨迹**:新 stage **`clarify_after_nearby`**(`_STAGE_TOOL_CHAINS` 按 stage 键控,直改
    `clarify` 链会向全部 75 个 clarify case 开放该链——codex 复核实证):
    链 `(("geocode","clarify"),)`、`_STAGE_MIN_STEPS=2`。新歧义 case(府中 ja/zh/en)用之。
@@ -251,9 +252,9 @@ GRANT SELECT ON locations, location_aliases TO catalog_svc;   -- 只读即可(�
 **PR-B**
 | # | AC | 测试 |
 |---|---|---|
-| B1 | Atlas 数据迁移:≥10k 站+≥1.9k 市区+47 县;clean+upgrade 双路径;再 apply no-op | worker vitest(integration,含 pg_trgm) |
+| B1 | Atlas 数据迁移:≥10k 站+≥1.8k 市区+47 县;clean+upgrade 双路径;再 apply no-op | worker vitest(integration,含 pg_trgm) |
 | B2 | trgm:"西宮北口"→西宮北口駅;阈值下不误吸 | worker vitest |
-| B2' | 折叠:西宮→1;府中→2;東京(city+駅 两行)→1(12km 阈值实测钉) | worker vitest |
+| B2' | 折叠:西宮→1;府中→2;東京(city+駅 两行)→1 且有效半径=10km;**corpus 抽查**:100 个高频地名的簇数分布审计(codex 终审) | worker vitest |
 | B3 | C1/C2 翻转 + 8 都道府县 case 按裸名/后缀规则逐案落定 + 新 case + `clarify_after_nearby` stage + 多语言 fixture | eval dataset + agent unit |
 | B4 | `nonempty_results`:≥15 标注;子采样不崩;gate 配对生效 | eval unit |
 | B5 | MiMo 全量重跑:8 case 归零;完整产物附 PR | eval(证据) |

--- a/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
+++ b/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
@@ -1,79 +1,80 @@
 # Catalog Geocoding — 真正实现"按地点搜圣地"
 
-- **Status**: v2 — dual-review rework(v1 双评审均判 needs-rework;本版吸收全部 P0/P1)
+- **Status**: v3 — 二轮双评审仲裁定稿候选(v1 needs-rework×2;v2 sonnet approve-with-changes / codex needs-rework;v3 吸收全部 P0/P1)
 - **Date**: 2026-07-13
 - **Related**: SD-29 · `docs/ARCHITECTURE.md:215` · MiMo eval search_nearby 错误分析 · GOAL 同目录 `*-GOAL.md`
 - **PRs**: PR-A (capability), PR-B (data + measurement)
-- **v2 变更摘要**: ①外部兜底 Google→**国土地理院(GSI)**(Google ToS 禁止永久存储 lat/lng,30 天上限、仅 place_id 可存——双评审 P0,已一手核实);②候选折叠策略(西宮多站折 1、府中跨域=真歧义);③歧义管道精确化(failed-step + 无 tool_state + 武装 validator);④`_INSTRUCTIONS` 全段重写入 PR-A(原文明令禁止 bare-location 调 search_nearby);⑤27 别名/19 坐标对纠数 + 西宮补种;⑥eval 翻转面如实扩到 C1/C2 全族;⑦PR-B seed 改 Atlas 数据迁移(deploy 只跑 atlas apply);⑧契约 enum 化/类型导出/无错误码(优雅降级);⑨kind 感知半径 + 都道府县 carve-out。
+- **v3 变更摘要**: ①**外部兜底整体移出本 spec**(Google 因 ToS 30 天缓存上限出局;GSI 因混入 CSIS 实验数据、要求**用户可见署名**——已一手核实——出局;两者均降级为带 spike 前置的 follow-up)——geocoding = 纯 gazetteer(PR-A 20 行 seed → PR-B ~12k 行,许可干净);②**三态分离重设计**:零行(honest empty)/歧义/真失败是三个不同状态,不再共用 failed-step(v2 方案会把正常歧义变成 `success=false`+`pipeline_error` 的公开 API 失败,且现有代码把零行结果整个丢弃——均为 codex 复核实证);③都道府县 47 行显式种入 + 裸名→县厅市别名(v2 的 prefecture kind 无生产者);④歧义 eval 用独立 stage `clarify_after_nearby`(`_STAGE_TOOL_CHAINS` 按 stage 键控,直改会污染全部 clarify case);⑤折叠算法精确化(tier 短路 + union-find 单链 + 确定性 tiebreak);⑥DML 迁移 hardening(trigger 只算 NULL、CHECK 约束、300 行规则豁免声明)。
 
-## 1. Problem
+## 1. Problem(与 v2 同,数字为实测)
 
-"按地点搜圣地"由两半组成:**地名→坐标(geocoding)** 与 **坐标→附近点位(geo search)**。
-后者是真的(PostGIS `ST_DWithin` + `<->` KNN + GiST,`workers/catalog/src/lib/geo-query.ts:37-51`);
-前者从未实现:
+"按地点搜圣地" = **地名→坐标(geocoding)** + **坐标→附近点位(geo search)**。后者健康
+(PostGIS `ST_DWithin` + `<->` KNN + GiST,`workers/catalog/src/lib/geo-query.ts:37-51`);前者从未实现:
 
-- `_geocode_for_catalog`(`apps/agent/agent/agents/catalog_tools.py:126-138`;GPS 优先在 134-137)
-  只查 session origin 坐标和一个 **27 键/19 坐标对** 的硬编码 dict(`sql_agent.py:71-100`)。
-- 其 docstring 声称 "The catalog service owns richer geocoding"——catalog 契约里**没有** geocode 方法。
-- Agent 指令**明令**bare-location 查询走 `web_search → clarify`、"Do NOT call search_nearby"
-  (`pilgrimage_agent.py:73-82`,例句 108/112)——整条产品路径被禁用后用 clarify 兜底。
+- `_geocode_for_catalog`(`catalog_tools.py:126-138`;GPS 优先 134-137)只查 session origin 坐标 +
+  **27 键/19 坐标对**硬编码 dict(`sql_agent.py:71-100`)。
+- docstring 声称 "The catalog service owns richer geocoding" —— catalog 契约无此方法。
+- Agent 指令明令 bare-location 走 `web_search → clarify`、"Do NOT call search_nearby"
+  (`pilgrimage_agent.py:73-82`,例句 108/112)。
 
-**实测假阴性(库里有数据,却"找不到"):**
+**实测假阴性**:西宮/西宫(凉宫,`hit_sparse`,dict 无键)→ eval `C1_ja_004`/`C1_zh_005` 竟把
+`clarify` 标为正确答案(假阴性制度化);箱根(EVA)→ MiMo `B1_en_001` 重试耗尽;豊郷(K-On)同。
+MiMo 残余 8 错误全属此类,模型无关。
 
-| 查询 | 库内数据 | `_geocode_for_catalog` | eval 现状 |
-|---|---|---|---|
-| 西宮/西宫(凉宫,seed 动画) | `hit_sparse` | `None`(dict 无此键,已实测) | `C1_ja_004`/`C1_zh_005` 把 `clarify` 标为正确 → **假阴性被制度化** |
-| 箱根(EVA) | miss | `None` | MiMo eval `B1_en_001` 重试耗尽报错 |
-| 豊郷(K-On,seed 动画) | 有 | `None` | 无 case |
-
-MiMo 全量 eval 残余 8 个错误全属此类(模型无关;v4-pro 同样撞墙,只是 eval 给它留了 clarify 逃生门)。
+**新发现(codex 复核实证,v3 起修)**:现有代码把"零行成功"当失败——
+`_run_catalog_nearby` `success=bool(rows)`(`catalog_tools.py:161`)→ 零行不写 tool_state
+(`catalog_tools.py:71`)→ validator 拒绝 search_response(`pilgrimage_agent.py:389`)。
+即"诚实空结果"在当前管道**不可能存在**。
 
 ## 2. Goals / Non-goals
 
 **Goals**
-1. 任意常见日本地名(车站/市区,ja 为主 + zh/en 别名)可解析坐标并返回真实结果。
-2. Geocoding 成为 catalog 数据平面能力:**可合法缓存、可生长**、契约化。
-3. 真歧义(跨地域同名)走 clarify;真未知诚实报告;"查不到坐标"不再伪装成"需要澄清"。
-4. 量尺同步修正:翻正被制度化的假阴性 + 第一个内容级 metric。
+1. 常见日本地名(车站/市区/都道府县,ja 主 + zh/en 别名)可解析坐标并返回真实结果。
+2. Geocoding 成为 catalog 数据平面能力:**许可干净、可审计**、契约化。
+3. 三态各归其位:零行=诚实空结果(`success=true`);跨域同名=歧义→clarify;查无此名=引导 clarify;
+   都不再伪装成失败或"需要澄清"。
+4. 量尺同步修正:翻正制度化假阴性 + 第一个内容级 metric。
 
 **Non-goals**
-- ❌ LLM 参与 geocode 链 / 模型报坐标("Never fabricate coordinates" 红线不动)。
-- ❌ 向量/语义检索(SD-29;DD-11/12/13/22 冻结)。
-- ❌ **Google Geocoding**(ToS:lat/lng 仅可缓存 30 天、禁止预取/永久存储、仅 place_id 例外——
-  与写回式 gazetteer 根本冲突。若未来 GSI miss 率证明需要,再按"瞬态、不落库、带 TTL"模式单独评估)。
-- ❌ 反向 geocoding、路线 origin 接入(follow-up)、前端、`/v1/bangumi/*`、`sql_agent.py` 死代码清理、
-  CI agent-eval 解禁。
+- ❌ LLM 参与 geocode / 模型报坐标(红线不动)。
+- ❌ 向量/语义(SD-29;DD-11/12/13/22 冻结)。
+- ❌ **一切外部 geocoder**(本 spec 范围内):Google 违 ToS(lat/lng 缓存 ≤30 天,仅 place_id 可存);
+  GSI AddressSearch 混入 CSIS シンプルジオコーディング実験数据,其参加规约要求 Web 应用**用户可见界面**
+  显示「CSISシンプルジオコーディング実験を利用」+ 链接(已核实:gsimaps issue #29 + CSIS 参加规约)——
+  前端改动超出本 GOAL 范围,且端点无公开 schema/SLA。外部兜底整体降级 follow-up(§8,含 spike 前置)。
+- ❌ 反向 geocoding、路线 origin(follow-up)、前端、`/v1/bangumi/*`、`sql_agent.py` 清理、CI eval 解禁。
+
+**没有外部兜底的覆盖论证**:PR-B gazetteer(MLIT 全部车站 ~10.6k + GeoNames cities500 全部市区町村
+~1.9k + 47 都道府县)覆盖:全部 8 个 MiMo 失败地名、全部 C1/C2 eval 地名(西宮市/箱根町/豊郷町/
+高円寺=杉並区内车站 均在源内)。gazetteer 外的长尾 → 诚实 clarify,仍严格优于现状(27 别名 → ~12k 行)。
 
 ## 3. Design
 
-### 3.1 架构位置与数据流
+### 3.1 架构与数据流
 
-Agent 保持 upstream-free(`test_agent_upstream_free.py` 不变;`CatalogClient` 是唯一 sanctioned seam,
-加 `geocode()` 不违反——已核)。模式与番名搜索同构:本地表精确查 → miss 调外部 → **写回**(GSI 结果
-无存储限制,出典明记即可)→ 下次本地命中。
+Agent 保持 upstream-free(`test_agent_upstream_free.py` 不变;`CatalogClient` 是 sanctioned seam)。
 
 ```
 search_nearby(location)                     [agent tool, 编排]
-  → catalog.geocode(location)               [新 RPC]
-      locations/location_aliases 精确查      ← PR-A: 19+1 坐标 · 30 别名 seed;PR-B: ~12k 行
-      → (PR-B) pg_trgm 模糊
-      → GSI 地名検索 API 兜底 + 写回          ← 免费、无 key、可存储(出典明记)
+  → catalog.geocode(location)               [新 RPC;纯本地 gazetteer,无出网]
+      exact(locations/location_aliases)     ← PR-A: 20 坐标行 · 30 别名;PR-B: ~12k 行
+      →(exact-miss 时)pg_trgm 模糊(PR-B)
       → 候选折叠(§3.4b)
-  → 1 候选 → catalog.nearby(lat,lng,kind 感知半径)   [契约不动]
-  → ≥2 簇 → failed-step + ModelRetry 携候选 → clarify
-  → 0 候选 → failed-step + 单次 ModelRetry → clarify(显式地名时**不**回退 GPS)
+  → 1 候选(kind≠prefecture)→ catalog.nearby(lat,lng,kind 半径)→ 结果(含零行=诚实空)
+  → 1 候选(kind=prefecture)→ geocode-step + ModelRetry 引导收窄
+  → ≥2 簇 → geocode-step(success=True,data=候选)+ ModelRetry 携候选 → clarify
+  → 0 候选 → geocode-step(success=True,data=空)+ ModelRetry → clarify
 ```
 
-**取舍**:独立 `/catalog/geocode`,`nearby` 契约零改动。延迟事实(纠 v1):agent→catalog 是 HTTP
-(`CatalogClient` 超时 30s,`catalog_client.py:128-137`);worker→DB 当前为直连 `DATABASE_URL`
-(Hyperdrive 在 `wrangler.toml:6-19` 处于注释状态);GSI 兜底最多 +8s(超时 8s),仍远低于 30s。
+延迟:agent→catalog HTTP(client 超时 30s);worker→DB 直连 `DATABASE_URL`(Hyperdrive 注释中);
+无出网调用 → geocode 为纯 DB 毫秒级。
 
-### 3.2 Contract(`packages/contract/src/contract.ts`,纯增量)
+### 3.2 Contract(纯增量)
 
 ```ts
-export const GeocodeKind = z.enum(["station", "city", "ward", "landmark", "prefecture", "external"]);
+export const GeocodeKind = z.enum(["station", "city", "ward", "landmark", "prefecture"]);
 export type GeocodeKind = z.infer<typeof GeocodeKind>;
-export const GeocodeSource = z.enum(["seed", "mlit", "geonames", "gsi", "manual"]);
+export const GeocodeSource = z.enum(["seed", "mlit", "geonames", "manual"]);
 export type GeocodeSource = z.infer<typeof GeocodeSource>;
 
 export const GeocodeInput = z.object({
@@ -84,7 +85,7 @@ export type GeocodeInput = z.infer<typeof GeocodeInput>;
 
 export const GeocodeCandidate = z.object({
   id: z.string(),
-  label: z.string(),          // 消歧展示: "西宮駅(兵庫県・station)"
+  label: z.string(),          // "西宮駅(兵庫県)" — pref 缺失时降级为 name
   name: z.string(),
   lat: Latitude, lng: Longitude,
   kind: GeocodeKind,
@@ -92,220 +93,199 @@ export const GeocodeCandidate = z.object({
 });
 export type GeocodeCandidate = z.infer<typeof GeocodeCandidate>;
 
-export const GeocodeResult = z.object({ candidates: z.array(GeocodeCandidate) }); // 折叠后 0..limit
+export const GeocodeResult = z.object({ candidates: z.array(GeocodeCandidate) });
 export type GeocodeResult = z.infer<typeof GeocodeResult>;
 
 geocode: oc.route({ method: "POST", path: "/catalog/geocode",
-                    summary: "Resolve a place name to coordinate candidates" })
+                    summary: "Resolve a place name to coordinate candidates (local gazetteer)" })
   .input(GeocodeInput)
-  .output(GeocodeResult),   // 无 .errors():GSI 失败=优雅降级返回本地结果;本地 DB 失败=自然 500
+  .output(GeocodeResult),   // 无 .errors():纯 DB 查询,先例= nearby(contract.ts:81-85)
 ```
 
-同步事项:`workers/catalog/src/types.ts` 加类型镜像(该文件 lockstep 注释所要求);`emit:openapi`
-幂等检查随 PR-A;**不**扩 `UPSTREAM_UNAVAILABLE` 枚举(v1 的错误语义自相矛盾,已删)。
+`workers/catalog/src/types.ts` 加镜像;`emit:openapi` 幂等随 PR-A。
 
-### 3.3 Schema(`db/migrations/`,Atlas;新迁移文件 + `atlas migrate hash` 更新)
+### 3.3 Schema(`db/migrations/`,Atlas;新迁移 + `atlas migrate hash`)
 
 ```sql
 CREATE TABLE locations (
-  id         TEXT PRIMARY KEY,          -- 'seed:uji' / 'mlit:st-<code>' / 'gsi:<hash>'
+  id         TEXT PRIMARY KEY,          -- 'seed:uji' / 'mlit:st-<code>' / 'geonames:<id>' / 'pref:13'
   name       TEXT NOT NULL,
-  kind       TEXT NOT NULL,             -- station|city|ward|landmark|prefecture|external
+  kind       TEXT NOT NULL CHECK (kind IN ('station','city','ward','landmark','prefecture')),
   latitude   DOUBLE PRECISION NOT NULL,
   longitude  DOUBLE PRECISION NOT NULL,
   location   GEOGRAPHY(POINT, 4326),
-  source     TEXT NOT NULL,             -- seed|mlit|geonames|gsi|manual
+  source     TEXT NOT NULL CHECK (source IN ('seed','mlit','geonames','manual')),
   pref       TEXT,
   created_at TIMESTAMPTZ DEFAULT now(), updated_at TIMESTAMPTZ DEFAULT now()
 );
--- sync_points_coordinates() 只引用 NEW.latitude/longitude/location(已核可直接复用):
+-- 注意(codex 复核):sync_points_coordinates() 仅在 NEW.location IS NULL 时计算(init.sql:29-45)。
+-- 本 spec 全部写入为 INSERT(location 置 NULL → 触发计算);无 UPDATE 坐标场景(无外部写回)。
 CREATE TRIGGER trg_locations_sync_coordinates
   BEFORE INSERT OR UPDATE ON locations
   FOR EACH ROW EXECUTE FUNCTION sync_points_coordinates();
 
 CREATE TABLE location_aliases (
   alias            TEXT NOT NULL,
-  alias_normalized TEXT NOT NULL,       -- normalizeAlias() 同款(lib/alias.ts:55)
+  alias_normalized TEXT NOT NULL,
   location_id      TEXT NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
-  lang             TEXT,                -- ja|zh|en|NULL
+  lang             TEXT CHECK (lang IN ('ja','zh','en') OR lang IS NULL),
   priority         INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (alias_normalized, location_id)
 );
 CREATE INDEX idx_location_aliases_norm ON location_aliases (alias_normalized);
-GRANT SELECT, INSERT, UPDATE ON locations, location_aliases TO catalog_svc;  -- 对齐 init.sql:383-397
+GRANT SELECT ON locations, location_aliases TO catalog_svc;   -- 只读即可(无运行时写回)
 -- PR-B 独立迁移: CREATE EXTENSION IF NOT EXISTS pg_trgm;
 --   CREATE INDEX idx_location_aliases_trgm ON location_aliases USING GIN (alias_normalized gin_trgm_ops);
 ```
 
-**PR-A seed(同迁移内 DML;deploy 只跑 `atlas migrate apply`,故数据必须随迁移走):**
-- `KNOWN_LOCATIONS` 实为 **27 个别名键 → 19 个唯一坐标对**(已实测纠数;v1 写 26 为误)。
-  迁移按 19 行 `locations` + 27 行 `location_aliases` 落库(zh 变体行 `lang='zh'`:东京/东京站/
-  秋叶原/镰仓/涩谷/横滨;其余 `lang='ja'` 或共用 NULL)。
-- **补种西宮**(dict 原本没有,而它是旗舰回归案例):`locations` +1(西宮駅,station,兵庫)+
-  别名 3 行:西宮(ja)/西宫(zh)/nishinomiya(en)。共 **20 locations / 30 aliases**。
-- Seed 数据为 migration-owned 一次性 bootstrap(现有迁移无 DML 先例,但 deploy 机制决定了这是
-  唯一会被执行的通道;评审已认可)。
+**PR-A seed(迁移内 DML;deploy 只跑 `atlas migrate apply`,数据必须随迁移)**:
+27 别名键 → 19 坐标行,+ 西宮駅(补种)= **20 locations / 30 aliases**(zh 行 `lang='zh'`:东京/
+东京站/秋叶原/镰仓/涩谷/横滨/西宫;en:nishinomiya)。DML 语义:**apply 一次;再次
+`atlas migrate apply` 为 no-op**(非"可重放");clean-DB 与 upgrade-DB 双路径测试。
 
-### 3.4 Worker 解析链(`workers/catalog/src/lib/geocode.ts` + `api/geocode.ts`)
+### 3.4 Worker 解析(`lib/geocode.ts` + `api/geocode.ts`;raw-sql 模板,禁 Drizzle builder)
 
-**(a) 解析顺序**
-1. `norm = normalizeAlias(query)`。
-2. **Exact**:`CatalogDb.execute(sql\`SELECT ... FROM location_aliases a JOIN locations l ...
-   WHERE a.alias_normalized=${norm} ORDER BY a.priority DESC\`)`(读写走 `CatalogDb` raw-sql 模板,
-   与 `api/nearby.ts:45-55` 一致;禁 Drizzle fluent builder——workerd 挂起已文档化)。
-3. **(PR-B) Fuzzy**:`similarity(alias_normalized, ${norm}) > 0.4`,按相似度降序;最高分 ≥0.6 且
-   折叠后唯一 → 单候选;否则并入候选集。
-4. **GSI 兜底**:`GET https://msearch.gsi.go.jp/address-search/AddressSearch?q=<query>`
-   (无 key;8s 超时;经 `CatalogContext.fetchImpl` 注入以便测试 mock——该注入点已存在)。
-   解析 GeoJSON 候选 ≤limit。**失败/超时/零结果 → logger.warning + 返回本地结果**(优雅降级)。
-5. **写回**:GSI 候选 upsert `locations`(`id='gsi:'+sha1(title+coords)[:16]`,`source='gsi'`,
-   `kind='external'`)+ `location_aliases`(原 query→各候选,`ON CONFLICT DO NOTHING`)。
-   合法性:GSI 属政府標準利用規約(CC-BY 4.0 互換),存储/再配布允许,出典明记于
-   `docs/data-sources.md`(PR-A 建档)。
-6. 全链确定性,无 LLM,无 key,无 secret ops。
+**(a) 检索(严格短路,v2 歧义已纠)**
+1. `norm = normalizeAlias(query)`(`lib/alias.ts:55`)。
+2. **Exact**:命中 → 携命中行进入 (b),**不再执行后续级**。
+3. **(PR-B) Fuzzy**:仅 exact-miss 时;`similarity > 0.4` 降序取 ≤10;命中 → 进入 (b)。
+4. 全 miss → 返回空候选。
 
-**(b) 候选折叠(新;v1 缺失,PR-B 规模下必需)**
-Exact/fuzzy/GSI 合并后:按坐标聚簇(簇内任意两点 ≤10km);每簇取最高优先级代表
-(kind 优先 station > city > ward > landmark > prefecture > external;同 kind 取 priority 高者)。
-- 1 簇 → 返回单候选(西宮:JR西宮駅+阪神西宮駅+西宮市 → 折 1)。
-- ≥2 簇 → 每簇一个代表作为歧义候选(府中:東京 vs 広島 → 2)。
-测试钉住:`西宮→1`、`府中→2`(PR-B B2';PR-A 用 seed 内数据钉 `東京→1`)。
+**(b) 候选折叠(单一 tier 的命中行上执行)**
+1. union-find 单链聚簇:任意两行距离 ≤10km 即连通(算法先例 `lib/clustering.ts:72-91`,阈值不同)。
+   桥链效应(A-B-C 链式连通)对同名候选集合是**期望行为**(同城多站折一)。
+2. 每簇代表:kind 优先 `station > city > ward > landmark > prefecture`;同 kind 按
+   `priority DESC, id ASC`(确定性 tiebreak,v2 缺失)。
+3. 簇按代表的 `(exact 命中优先, priority DESC, id ASC)` 排序,截断至 `limit`。
+4. 测试钉:西宮→1(PR-B 三行折一)、府中→2(跨域)、東京→1(PR-A seed 双行:東京駅-東京 city
+   实测 10.56km —— **正因超 10km 会分簇,seed 中東京 city 与東京駅 合并为一行**(id `seed:tokyo`,
+   kind=city,別名 東京/东京/東京駅/东京站 → 同簇免疫;v2 的 10.5km 陷阱由 seed 数据消解,
+   PR-B 车站导入后 東京駅 为独立 mlit 行,与 city 行 10.56km >10km —— 折叠阈值定为 **12km**
+   以覆盖首都圈这一实测边界;B2' 用真实坐标钉住)。
+   shuffled-input 确定性测试必备。
 
-### 3.5 Agent 侧(`apps/agent`)
+### 3.5 Agent 侧(`apps/agent`)——三态分离(v3 核心重设计)
 
-- `CatalogClientProtocol`/`CatalogClient`/`MockCatalogClient` 增 `geocode(query, limit=5)`。
-  Mock fixture(PR-A 起即多语言):西宮/西宫/nishinomiya、宇治、東京/东京、府中×2(跨域)、
-  未知名 → 空;PR-B 扩:镰仓/秋叶原/宫崎 + G4 `last_location` 形态(宇治市/東京都/神奈川県)。
-- `search_nearby(location: str = "", radius: int = 0)` 编排(替换 `_geocode_for_catalog`):
+**管道语义前置修复(PR-A,scope 限 nearby 路径)**:
+- `_run_catalog_nearby`:`success` 改为"查询执行成功"(零行也是 True);payload 恒写
+  `tool_state["search_nearby"]`(含 `row_count: 0`)。零行时 SSE data 照发,`status:"empty"`
+  已有字段承载。→ 诚实空结果全链路可达(validator 放行、`NearbyMap` 渲染空态)。
+- 新增内部 step 工具名 `geocode`(仅在歧义/零候选/prefecture 收窄路径记录,`success=True`,
+  data=候选摘要;**成功直达路径不记**,保持 C1/C2 期望链 `("search_nearby",)` 的精确率不受污染)。
+  该 step 保证 `ctx.deps.steps` 非空 → validator 武装;`AgentResult.success` 不受影响
+  (`agent_result.py:40` 语义 = 全部 step 成功);无 `pipeline_error`(`response_builder.py:82`)。
 
-| 输入情形 | 行为 |
-|---|---|
-| `location` 空 + 有 GPS | origin 坐标(现行"我附近"路径) |
-| `location` 空 + 无 GPS | failed-step + `ModelRetry`:请用户给地点或分享位置(→clarify) |
-| 非空,折叠后 1 候选 | `nearby(lat, lng, radius or kind 默认半径)`;**kind='prefecture' 例外**:不搜,failed-step + `ModelRetry` 引导 clarify 收窄到市/站 |
-| 非空,≥2 簇 | **failed-step(success=False, error="ambiguous_location")+ 不写 tool_state** + `ModelRetry` 消息携候选 label,指示"call clarify with these options" |
-| 非空,0 候选 | **不回退 GPS**(v1 的矛盾已删):failed-step + 单次 `ModelRetry`:"Could not locate '<X>'. Call clarify to ask for a nearby station or city." |
+`search_nearby(location: str = "", radius: int = 0)` 行为表:
 
-- **歧义/失败管道语义(关键,v1 未定义)**:失败路径记 `StepRecord(success=False)` →
-  `ctx.deps.steps` 非空 → `output_validator` 保持武装(`pilgrimage_agent.py:386` 的空步跳过
-  不触发);**不写 `tool_state["search_nearby"]`** → 模型若强行返回 `search_response`,
-  validator 现有规则(`389-395`)直接拒绝——无需新增 validator 逻辑,也不会把歧义 payload
-  渲染成 `NearbyMap`(`response_builder.py` `_UI_MAP` 已核)。SSE 沿用 `_store_catalog_result`
-  失败分支的 "failed" 事件。clarify 的 options 走既有 `list[str]` 通道;anime 富化对地名字符串
-  空结果即可(AC A6 覆盖)。
-- **kind 感知默认半径**:station/ward/landmark 5000m、city 10000m、prefecture 不搜(上表)。
-- **`_INSTRUCTIONS` 全段重写(PR-A 范围;v1 "同步一句"为严重低估)**:
-  Location/nearby 工作流从 "web_search → clarify、Do NOT call search_nearby"(73-82)改为
-  "有地名 → 直接 `search_nearby(location=地名原样)`;'我附近' → `location=''`";例句 108/112
-  同步改写;AC 加 grep 断言旧禁令文案已移除。GPS 优先级修正:显式地名 > GPS(原 134-137 行为)。
-- 删 `catalog_tools.py` 对 `KNOWN_LOCATIONS` 的 import。
-- "单次 ModelRetry"的实现口径:消息设计为一次反馈即引导 clarify;agent `retries=2` 全局设置不动,
-  以消息内容而非重试预算控制行为(v1 表述"恰好一次"不可强制,已纠)。
+| 情形 | 行为 | 响应形态 |
+|---|---|---|
+| location 空 + 有 GPS | origin 坐标 → nearby | 结果(可为诚实空) |
+| location 空 + 无 GPS | `ModelRetry`:请给地点或分享位置 | →clarify |
+| 1 候选,kind≠prefecture | nearby(kind 半径:station/ward/landmark 5km、city 10km) | 结果(可为诚实空) |
+| 1 候选,kind=prefecture | geocode-step + `ModelRetry`("X县太大,问用户哪个市/站") | →clarify(`success=true`) |
+| ≥2 簇 | geocode-step + `ModelRetry` 携簇代表 label(≤5,消毒:仅取自类型化 `GeocodeCandidate.label`,长度截断——SD-19 `_retry_message` 规则的显式豁免) | →clarify,options=地名字符串(anime 富化空结果可容忍,AC A6 断言) |
+| 0 候选 | geocode-step + `ModelRetry`("查无此地,请问用户站名/市名") | →clarify;**显式地名不回退 GPS** |
+
+- 歧义后模型强返 `search_response` → tool_state 无键 → validator 现有规则拒绝(A6')。
+- `_INSTRUCTIONS` **全段重写**(PR-A):Location/nearby 工作流改为"有地名 → `search_nearby(地名原样)`;
+  '我附近' → `location=''`";删除 "Do NOT call search_nearby" 禁令与例句 108/112 旧流;A10 grep 断言。
+- GPS 优先级:显式地名 > GPS;ModelRetry 消息以内容引导 clarify(`retries=2` 全局不动)。
+- 删 `KNOWN_LOCATIONS` import。`MockCatalogClient.geocode` fixture(PR-A 即多语言):西宮/西宫/
+  nishinomiya、宇治、東京/东京、府中×2、山梨県(prefecture)、未知名→空;PR-B 扩 G4 形态
+  (宇治市/東京都/神奈川県)与 镰仓/秋叶原/宫崎。
 
 ### 3.6 数据(PR-B)
 
-- 车站:国土数値情報 N02(v2023,URL/取得日/SHA256 锁定于 `docs/data-sources.md`),~10.6k 站。
-  原始记录含路线/事业者重复——按 **站名+坐标聚簇去重** 后落 `locations`(转换脚本文档化)。
-- 城市/区:GeoNames JP cities500(CC-BY 4.0,同样锁版本),~1.9k 行,kind=city/ward。
-- zh/en 城市别名:`geo_names.py` 数据导出(**655/662 条有非空 zh**——v1 的 662/747 表述已纠);
-  车站 PR-B 仅 ja,长尾靠 GSI 写回生长。
-- **落库方式 = Atlas 数据迁移**(生成的 SQL 迁移文件检入,deploy 的 `atlas migrate apply` 自动执行;
-  v1 的独立 seed 脚本永远不会被 deploy 调用,已废)。生成器脚本 + 校验(行数/checksum)检入
-  `workers/catalog/scripts/`,供再生成审计。
-- pg_trgm:Neon 官方支持;独立迁移 + preview-branch 应用测试;B1 集成测试镜像需含 pg_trgm
-  (postgis/postgis 镜像自带 contrib,测试内 `CREATE EXTENSION`)。
+- 车站:MLIT 国土数値情報 N02(版本/URL/取得日/SHA256 锁 `docs/data-sources.md`),
+  **站名+坐标聚簇去重**(原始按路线/事业者重复)→ ~10.6k 行(kind=station)。
+- 市区町村:GeoNames JP cities500(CC-BY 4.0,锁版本)→ ~1.9k 行(kind=city/ward)。
+- **都道府县 47 行**(kind=prefecture,县厅坐标):**带后缀别名**(岐阜県/神奈川県/宮崎県…+
+  zh 简体 后缀形 + en "X Prefecture");**裸名**(岐阜/神奈川/宮崎/埼玉…)别名指向**县厅所在市**行
+  (岐阜市/横浜市/宮崎市/さいたま市)——裸名查询直接搜市,后缀查询触发收窄引导。
+  (消解 v2 的 prefecture 无生产者 + 岐阜自相矛盾;裸名/后缀行为由 B3 逐 case 审计钉住。)
+- zh/en 城市别名:`geo_names.py` 数据导出(**655/662 条非空 zh**)。
+- 落库 = **Atlas 数据迁移**(生成 SQL 检入;~12k 行大文件为生成物,**豁免 300 行文件规则并在文件头
+  声明 generated-artifact**,分块为多迁移文件亦可);生成器 + 行数/checksum 校验脚本检入
+  `workers/catalog/scripts/`。
+- pg_trgm:独立迁移;B1 测试镜像 `CREATE EXTENSION`(postgis 镜像含 contrib);Neon 官方支持。
 
 ### 3.7 Eval 与量尺(PR-B)
 
-1. **翻转面如实声明(v1 只列 2 个为严重低估)**:C1 全族 16 case + C2 全族 17 case 中,
-   凡"具体真实地名"一律 `["clarify"]` → `["search_nearby"]`(含 hit_complete/hit_sparse/
-   miss-but-geocodable——miss 的正确行为是诚实空结果,同属 search_nearby 轨迹);
-   **carve-out**:C2 中 5 个都道府县级 case(埼玉/山梨/神奈川/岐阜/宮崎)按 §3.5 的 prefecture
-   规则保留 clarify(经由"geocode 成功→引导收窄"的诚实路径)。`expected_data_keys` 同步由
-   clarify 键改为 `["results"]`。C3(动画+地点)/C4(真模糊)/H2/H4(路线意图)不动——
-   已核 H1/H2/H4 的 acceptable_stages 不含 search_nearby 翻转风险;H1(GPS 空地名路径)不变。
-   E2/G4 的可选收紧记 follow-up,不入 PR-B。
-2. **歧义轨迹计分**:`_STAGE_TOOL_CHAINS` 为歧义 case 增 `("search_nearby","clarify")` 链
-   (否则正确的"搜→问"轨迹被 tool_precision/step_efficiency 双重扣分——评审已算出 0.5)。
-   新增歧义 case:府中(ja/zh/en 各 1,期望 search_nearby→clarify)。
-3. **新 case**:箱根(honest-empty)、豊郷(hit)、Nishinomiya(en)、西宫(zh)。
-4. **`nonempty_results`(L1 内容级 metric,第一颗钉子)**:
-   - dataset 字段 `expect_nonempty: true`,**标注 ≥10 个**翻转后的 hit_complete/hit_sparse case
-     (满足 `gate.py:96` `min_paired=10`,否则 gate 静默跳过——评审已核)。
-   - 评估器读 `tool_state["search_nearby"]["row_count"]`(权威来源,非模型文本)。
-   - 未标注 case 返回 `{}`(pydantic-evals 按 key 出现的 case 求均值,已核安全);
-     **`METRIC_NAMES` 条件收录**:`collect_scores` 对缺失 metric 抛 `ValueError`
-     (`eval_report.py:14-19`),故 `EVAL_MAX_CASES` 子采样可能抽不到标注 case——
-     实现为"标注 case 存在才纳入 METRIC_NAMES"或 presence-aware 收集(实现挑其一,测试钉住)。
-   - харness 触点全列:`AgentExpected` 字段(`evaluators.py:53-59`)、`_expected()`
-     (`eval_harness.py:118-121`)、评估器注册与 `METRIC_NAMES`(`eval_harness.py:69-79,146-156`)、
-     gate 配对(`gate.py:201-215`)。
-5. **B5 证据口径**:附**完整 run 产物**(results JSON 或其摘录)+ 修复前 8 个 case id 列表
-   (B1_en_001, C1_ja_004, C1_zh_005, I1_zh_004, I3_en_002, J3_en_001, L3_en_001, A3_en_008)——
-   v1 引用的 checked-in 旧产物不能作证,已纠。
-6. 边界不变:trajectory tier 用 MockCatalog;CI agent-eval 仍禁用,PR-B 不动 CI。
+1. **翻转面**:C1 全 16 + C2 全 17 中"具体真实地名"→ `["search_nearby"]`,`expected_data_keys`
+   → `["results"]`;**都道府县 carve-out 按 §3.6 裸名/后缀规则逐 case 审计**(数据集含 8 个
+   都道府县形 case,不是 v2 说的 5 个;岐阜裸名两案统一翻转,后缀案保留收窄)。C3/C4/H1/H2/H4
+   不动(已核无 search_nearby 翻转面);E2/G4 收紧 follow-up。
+2. **歧义轨迹**:新 stage **`clarify_after_nearby`**(`_STAGE_TOOL_CHAINS` 按 stage 键控,直改
+   `clarify` 链会向全部 75 个 clarify case 开放该链——codex 复核实证):
+   链 `(("geocode","clarify"),)`、`_STAGE_MIN_STEPS=2`。新歧义 case(府中 ja/zh/en)用之。
+3. **新 case**:箱根(honest-empty:geocode 成功+零行,断言 `row_count==0` 且 `success=true`)、
+   豊郷(hit)、Nishinomiya(en)、西宫(zh)、山梨県(prefecture 收窄)。
+4. **`nonempty_results`**:`expect_nonempty: true` 标注 **≥15** 个翻转 hit case(>min_paired=10,
+   容忍 errored 抽损);评估器读 `tool_state["search_nearby"]["row_count"]`;未标注返回 `{}`;
+   `METRIC_NAMES` 条件收录 vs `collect_scores` ValueError(`eval_report.py:14-19`)——实现挑一,
+   测试钉;触点:`evaluators.py:53-59`、`eval_harness.py:69-79,118-121,146-156`、`gate.py:96,201-215`。
+5. **B5 证据**:完整 run 产物 + 8 case id(B1_en_001, C1_ja_004, C1_zh_005, I1_zh_004, I3_en_002,
+   J3_en_001, L3_en_001, A3_en_008)归零对照。
+6. CI agent-eval 仍禁用,不动。
 
-## 4. Acceptance Criteria(Quality Ratchet:每条带测试)
+## 4. Acceptance Criteria(每条带测试)
 
 **PR-A**
 | # | AC | 测试 |
 |---|---|---|
-| A1 | `/catalog/geocode` exact:西宮(seed 补种)与 東京(折叠后 1 候选)返回正确坐标 | worker vitest |
-| A2 | 本地 miss → GSI 调用(fetchImpl mock)→ 候选返回 + `locations`/`location_aliases` 写回;同 query 二次查询不再出网 | worker vitest |
-| A3 | GSI 超时/非 200/零结果 → warning + 返回本地结果,无异常 | worker vitest |
-| A4 | `nearby`/`search` 契约与行为零变化;`emit:openapi` 幂等;`types.ts` 镜像同步 | 既有测试 + drift check |
-| A5 | agent `search_nearby("西宮")` → geocode→nearby→rows(FunctionModel e2e,MockCatalog) | agent unit (e2e) |
-| A6 | 歧义("府中")→ failed-step + 无 tool_state + ModelRetry 携候选;模型转 clarify(options 为地名字符串)成功产出 ClarifyResponse | agent unit (e2e) |
-| A6' | 歧义后模型强行返回 `search_response` → 被 output_validator 拒绝 | agent unit |
-| A7 | 未知地名 → failed-step + ModelRetry(含 clarify 引导);**不**出现重试耗尽 UnexpectedModelBehavior(消息即引导) | agent unit |
-| A8 | 三态优先级:显式地名>GPS;空地名→GPS;空地名无 GPS→ModelRetry | agent unit ×3 |
-| A8' | kind='prefecture' → 不搜、引导收窄 | agent unit |
-| A9 | 迁移 seed 平价:**30 条别名**(TS fixture 镜像迁移 SQL,来源=迁移文件)全部经 `/catalog/geocode` 解析到期望坐标 | worker vitest(测试 PG) |
-| A10 | `_INSTRUCTIONS` 不再含 "Do NOT call search_nearby" 禁令;新 nearby 工作流 + 例句就位 | agent unit(grep 断言) |
-| A11 | 全量门禁:agent pytest ≥933 passed / ≥82% cov;worker vitest;mypy/ruff/tsc;drift | ci |
+| A1 | geocode exact:西宮/西宫/nishinomiya → 兵庫坐标;東京 → 1 候选 | worker vitest |
+| A2 | gazetteer miss → 空候选,**零出网**(fetch 未被调用断言) | worker vitest |
+| A3 | 折叠:seed 内多别名同点折一;shuffled-input 结果确定 | worker vitest |
+| A4 | `nearby`/`search` 契约零变化;`emit:openapi` 幂等;`types.ts` 镜像 | 既有 + drift |
+| A5 | agent `search_nearby("西宮")` e2e → rows(FunctionModel+Mock) | agent unit |
+| A5' | **诚实空**:geocode 成功+nearby 零行 → `search_response` 通过 validator,`success=true`,`row_count=0`,无 `pipeline_error` | agent unit (e2e) |
+| A6 | 歧义(府中)→ geocode-step(success=True)+ ModelRetry 携候选 → clarify 产出;`AgentResult.success==true`,无 `pipeline_error` | agent unit (e2e) |
+| A6' | 歧义后强返 search_response → validator 拒绝 | agent unit |
+| A7 | 0 候选 → ModelRetry 引导 clarify;无重试耗尽;不回退 GPS | agent unit |
+| A8 | 三态优先级:显式地名>GPS / 空→GPS / 空+无GPS→ModelRetry | agent unit ×3 |
+| A8' | prefecture(山梨県 fixture)→ 不搜、收窄引导、`success=true` | agent unit |
+| A9 | 迁移 seed 平价:30 别名(TS fixture 镜像迁移 SQL)全解析正确 | worker vitest(测试 PG) |
+| A10 | `_INSTRUCTIONS` 无旧禁令;新工作流+例句就位 | agent unit(grep) |
+| A11 | 全量门禁:agent ≥933 passed/≥82% cov;worker vitest;mypy/ruff/tsc;drift | ci |
 
 **PR-B**
 | # | AC | 测试 |
 |---|---|---|
-| B1 | Atlas 数据迁移应用后 ≥10k 站 + ≥1.5k 市区;迁移可重放(hash 校验) | worker vitest(integration,测试 PG 含 pg_trgm) |
-| B2 | trgm:"西宮北口"→"西宮北口駅";阈值下不误吸 | worker vitest |
-| B2' | 折叠:西宮→1 候选;府中→2 簇 | worker vitest |
-| B3 | C1/C2 翻转(±carve-out)+ 新 case + 歧义链入 `_STAGE_TOOL_CHAINS` + 多语言 mock fixture | eval dataset + agent unit |
-| B4 | `nonempty_results`:≥10 标注 case 正确计分;子采样无标注时不崩(`collect_scores`);gate 配对生效 | eval evaluator unit |
-| B5 | MiMo trajectory 全量重跑:8 个既知 case id 归零;完整产物附 PR | eval(manual gate,PR 附证据) |
+| B1 | Atlas 数据迁移:≥10k 站+≥1.9k 市区+47 县;clean+upgrade 双路径;再 apply no-op | worker vitest(integration,含 pg_trgm) |
+| B2 | trgm:"西宮北口"→西宮北口駅;阈值下不误吸 | worker vitest |
+| B2' | 折叠:西宮→1;府中→2;東京(city+駅 两行)→1(12km 阈值实测钉) | worker vitest |
+| B3 | C1/C2 翻转 + 8 都道府县 case 按裸名/后缀规则逐案落定 + 新 case + `clarify_after_nearby` stage + 多语言 fixture | eval dataset + agent unit |
+| B4 | `nonempty_results`:≥15 标注;子采样不崩;gate 配对生效 | eval unit |
+| B5 | MiMo 全量重跑:8 case 归零;完整产物附 PR | eval(证据) |
 
 ## 5. Ops / Security
 
-- **零新增 secret**(GSI 无 key)——v1 的 GOOGLE_MAPS_API_KEY worker 注入整段作废;该 secret 维持
-  container 现状不动。
-- `docs/data-sources.md`(PR-A 建,PR-B 扩):GSI 出典(国土地理院・地名検索 API,政府標準利用規約
-  2.0)、MLIT N02(版本/URL/取得日/SHA256)、GeoNames(CC-BY 4.0)。
-- 迁移经 Atlas(`db/migrations/` + `atlas migrate hash`);`supabase/migrations/` 历史树不动。
-- GSI 调用观测:worker 记 `gsi_geocode_called` 计数日志。
+- **零新增 secret、零出网依赖**(外部 geocoder 全部移出)。
+- `docs/data-sources.md`(PR-B):MLIT N02(出典明记)+ GeoNames(CC-BY 4.0)+ 版本/URL/日期/SHA256。
+- 迁移经 Atlas;`supabase/migrations/` 不动。
 
 ## 6. Risks
 
 | 风险 | 缓解 |
 |---|---|
-| GSI 对 zh/en 查询弱 | gazetteer 别名(zh 655 城市 + seed zh 行)承担主力;miss → 诚实 clarify;若真实 miss 率高,再评估"瞬态 Google(30 天 TTL,不入 gazetteer)"为独立决策 |
-| GSI 可用性/限流 | 优雅降级已内建(A3);观测计数;gazetteer 随写回生长,依赖度递减 |
-| trgm 对 CJK 短串弱 | 阈值 0.6/0.4 + 折叠 + 歧义走 clarify;不指望 trgm 扛 romaji/zh |
-| 折叠阈值 10km 误折/漏折 | B2' 钉双例;阈值为常量可调,测试为准 |
-| 指令重写影响其他意图路由 | A10 + 全量 eval 重跑(B5)兜底;C3/C4/H 族不动作为回归screen |
-| eval 大改基线漂移 | PR-B 重跑基线,gate 按新语义重置(v1.1/v1.2 勘误先例) |
-| 迁移含 DML 无先例 | 深思后接受(deploy 只跑 atlas apply,别无通道);数据 migration-owned、一次性、可重放 |
+| 无外部兜底 → gazetteer 外地名 miss | 12k 行覆盖论证(§2);miss=诚实 clarify;真实 miss 率观测(worker 记 `geocode_miss` 计数)作为 follow-up 外部兜底的触发数据 |
+| 12km 折叠阈值边界 | B2' 以真实坐标(東京 city↔駅 10.56km)钉;阈值常量可调,测试为准 |
+| 桥链过度折叠 | 仅同查询候选集内聚簇,同名跨域天然 >12km;shuffled 确定性测试 |
+| nearby 零行语义变更波及 search_bangumi 家族 | scope 限 `_run_catalog_nearby`;`search_bangumi` 路径不动;A11 全量门禁回归 |
+| 指令重写影响意图路由 | A10 + B5 全量重跑;C3/C4/H 族为回归 screen |
+| DML 迁移 + 大生成文件 | apply-once 语义 + 双路径测试;generated-artifact 豁免声明/分块 |
+| eval 大改基线漂移 | PR-B 重跑基线,gate 新语义重置(v1.1/v1.2 先例) |
 
 ## 7. Open Questions(带默认值)
 
-- **OQ1(已定案)**:外部兜底 = GSI。Google 因 ToS 出局(存储违规);GSI 免费无 key 可存储。
-- **OQ2** 候选 label 本地化(zh 用户见汉字简体标签)——默认 PR-A ja label,PR-B 城市部分用
-  geo_names 本地化。
-- **OQ3** `points` 表地名并入 gazetteer 查询(圣地名作为搜索中心)——默认不做,记 follow-up。
+- **OQ1(定案)**:本 spec 无外部 geocoder。follow-up 触发条件:`geocode_miss` 观测显示真实
+  miss 率 >X%(阈值由观测定)→ 届时在「瞬态 Google(30 天 TTL 不落库)」vs「GSI+前端 CSIS 署名」
+  间做带 spike 的独立决策(spike 清单:响应 schema fixtures、限流、多 backend provenance)。
+- **OQ2** 候选 label 本地化 —— 默认 PR-A ja,PR-B 城市部分用 geo_names。
+- **OQ3** `points` 地名并入 gazetteer(圣地名作搜索中心)—— 默认不做,follow-up。
 
-## 8. Follow-ups(不在本 spec)
+## 8. Follow-ups
 
-- 路线 origin(`plan_route`/K-path)接入 `catalog.geocode`。
-- E2/G4 族 eval 收紧(明确 `last_location` 注入 session 指令与否后再定)。
-- `sql_agent.py` 死代码清理(含 Python 版 Google gateway 一并退役)。
-- 检索质量量尺体系化(`nonempty_results` 之上的 recall/precision)。
-- 瞬态 Google 兜底(30 天 TTL、不入 gazetteer)——仅当 GSI+gazetteer 实测 miss 率不可接受时。
+- 外部 geocoder 兜底(见 OQ1,spike 前置 + 许可决议)。
+- 路线 origin 接入 `catalog.geocode`;E2/G4 eval 收紧;`sql_agent.py` 清理(含 Python Google gateway);
+  检索质量量尺体系化;CI agent-eval 解禁。

--- a/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
+++ b/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
@@ -173,7 +173,8 @@ GRANT SELECT ON locations, location_aliases TO catalog_svc;   -- 只读即可(�
 - `_run_catalog_nearby`:仅改**其调用 `_store_catalog_result` 时传入的 `success=` 实参**为"查询执行成功"(零行也是 True;共享的 `_store_catalog_result` 本体与 resolve/search_bangumi 路径不动——sonnet 终审 NEW-3a);payload 恒写
   `tool_state["search_nearby"]`(含 `row_count: 0`)。零行时 SSE data 照发,`status:"empty"`
   已有字段承载。→ 诚实空结果全链路可达(validator 放行、`NearbyMap` 渲染空态)。
-- 新增内部 step 工具名 `geocode`(仅在歧义/零候选/prefecture 收窄路径记录,`success=True`,
+- 新增内部 step 工具名 `geocode`(在歧义/零候选/prefecture 收窄/缺地名无GPS 路径记录 `success=True`;
+  transient 失败路径记录 `success=False`——实现勘误:所有 ModelRetry 出口都先记 step,堵死空步解武,
   data=候选摘要;**成功直达路径不记**,保持 C1/C2 期望链 `("search_nearby",)` 的精确率不受污染)。
   该 step 保证 `ctx.deps.steps` 非空 → validator 武装;`AgentResult.success` 不受影响
   (`agent_result.py:40` 语义 = 全部 step 成功);无 `pipeline_error`(`response_builder.py:82`)。

--- a/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
+++ b/docs/superpowers/specs/2026-07-13-catalog-geocoding.md
@@ -90,6 +90,9 @@ export const GeocodeCandidate = z.object({
   lat: Latitude, lng: Longitude,
   kind: GeocodeKind,
   source: GeocodeSource,
+  effective_radius_m: z.number().int().positive().optional(),
+  // ^ 簇内成员 kind 半径最大值(§3.4b.4);agent 的 nearby 调用优先用它
+  //   (PR 评审 F1 勘误:v4 正文有此规则但契约段漏列字段)
 });
 export type GeocodeCandidate = z.infer<typeof GeocodeCandidate>;
 

--- a/packages/contract/openapi.json
+++ b/packages/contract/openapi.json
@@ -613,6 +613,12 @@
                               "manual"
                             ],
                             "type": "string"
+                          },
+                          "effective_radius_m": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991,
+                            "exclusiveMinimum": 0
                           }
                         },
                         "required": [

--- a/packages/contract/openapi.json
+++ b/packages/contract/openapi.json
@@ -534,6 +534,109 @@
         }
       }
     },
+    "/catalog/geocode": {
+      "post": {
+        "operationId": "geocode",
+        "summary": "Resolve a place name to coordinate candidates (local gazetteer)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "default": 5
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "candidates": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "label": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "lat": {
+                            "type": "number",
+                            "minimum": -90,
+                            "maximum": 90
+                          },
+                          "lng": {
+                            "type": "number",
+                            "minimum": -180,
+                            "maximum": 180
+                          },
+                          "kind": {
+                            "enum": [
+                              "station",
+                              "city",
+                              "ward",
+                              "landmark",
+                              "prefecture"
+                            ],
+                            "type": "string"
+                          },
+                          "source": {
+                            "enum": [
+                              "seed",
+                              "mlit",
+                              "geonames",
+                              "manual"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "label",
+                          "name",
+                          "lat",
+                          "lng",
+                          "kind",
+                          "source"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "candidates"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/catalog/route": {
       "post": {
         "operationId": "route",

--- a/packages/contract/src/contract.ts
+++ b/packages/contract/src/contract.ts
@@ -53,6 +53,33 @@ export const NearbyResult = z.object({
 });
 export type NearbyResult = z.infer<typeof NearbyResult>;
 
+/** geocode(query, limit?) -> { candidates } */
+export const GeocodeKind = z.enum(["station", "city", "ward", "landmark", "prefecture"]);
+export type GeocodeKind = z.infer<typeof GeocodeKind>;
+
+export const GeocodeSource = z.enum(["seed", "mlit", "geonames", "manual"]);
+export type GeocodeSource = z.infer<typeof GeocodeSource>;
+
+export const GeocodeInput = z.object({
+  query: z.string().min(1),
+  limit: z.number().int().min(1).max(10).default(5),
+});
+export type GeocodeInput = z.infer<typeof GeocodeInput>;
+
+export const GeocodeCandidate = z.object({
+  id: z.string(),
+  label: z.string(),
+  name: z.string(),
+  lat: Latitude,
+  lng: Longitude,
+  kind: GeocodeKind,
+  source: GeocodeSource,
+});
+export type GeocodeCandidate = z.infer<typeof GeocodeCandidate>;
+
+export const GeocodeResult = z.object({ candidates: z.array(GeocodeCandidate) });
+export type GeocodeResult = z.infer<typeof GeocodeResult>;
+
 /** route(point_ids, origin?, pacing?) -> Route */
 export const RouteInput = z.object({
   point_ids: z.array(z.string()),
@@ -83,6 +110,14 @@ export const catalogContract = {
     .input(NearbyInput)
     // Pure DB/PostGIS query: no upstream dependency, so no UPSTREAM_UNAVAILABLE.
     .output(NearbyResult),
+  geocode: oc
+    .route({
+      method: "POST",
+      path: "/catalog/geocode",
+      summary: "Resolve a place name to coordinate candidates (local gazetteer)",
+    })
+    .input(GeocodeInput)
+    .output(GeocodeResult),
   route: oc
     .route({ method: "POST", path: "/catalog/route", summary: "Plan an ordered, timed route over selected points" })
     .input(RouteInput)

--- a/packages/contract/src/contract.ts
+++ b/packages/contract/src/contract.ts
@@ -74,6 +74,7 @@ export const GeocodeCandidate = z.object({
   lng: Longitude,
   kind: GeocodeKind,
   source: GeocodeSource,
+  effective_radius_m: z.number().int().positive().optional(),
 });
 export type GeocodeCandidate = z.infer<typeof GeocodeCandidate>;
 

--- a/workers/catalog/src/api/geocode.ts
+++ b/workers/catalog/src/api/geocode.ts
@@ -1,0 +1,23 @@
+import { sql } from "drizzle-orm";
+import type { CatalogDb } from "../db/client";
+import { collapseGeocodeHits, type GeocodeHit } from "../lib/geocode";
+import { normalizeAlias } from "../lib/alias";
+import type { GeocodeInput, GeocodeResult } from "../types";
+
+async function exactHits(db: CatalogDb, normalized: string): Promise<GeocodeHit[]> {
+  const result = await db.execute(sql`
+    SELECT l.id, l.name, l.kind, l.latitude, l.longitude, l.source, l.pref,
+           a.priority, TRUE AS exact
+    FROM location_aliases a
+    JOIN locations l ON l.id = a.location_id
+    WHERE a.alias_normalized = ${normalized}
+  `);
+  return result.rows as unknown as GeocodeHit[];
+}
+
+/** Resolve only against the local gazetteer; an exact miss returns empty in PR-A. */
+export async function geocode(db: CatalogDb, input: GeocodeInput): Promise<GeocodeResult> {
+  const hits = await exactHits(db, normalizeAlias(input.query));
+  const candidates = collapseGeocodeHits(hits, input.limit).map(({ effectiveRadiusM: _, ...candidate }) => candidate);
+  return { candidates };
+}

--- a/workers/catalog/src/api/geocode.ts
+++ b/workers/catalog/src/api/geocode.ts
@@ -18,6 +18,6 @@ async function exactHits(db: CatalogDb, normalized: string): Promise<GeocodeHit[
 /** Resolve only against the local gazetteer; an exact miss returns empty in PR-A. */
 export async function geocode(db: CatalogDb, input: GeocodeInput): Promise<GeocodeResult> {
   const hits = await exactHits(db, normalizeAlias(input.query));
-  const candidates = collapseGeocodeHits(hits, input.limit).map(({ effectiveRadiusM: _, ...candidate }) => candidate);
+  const candidates = collapseGeocodeHits(hits, input.limit);
   return { candidates };
 }

--- a/workers/catalog/src/lib/geocode.ts
+++ b/workers/catalog/src/lib/geocode.ts
@@ -1,0 +1,112 @@
+import { haversine } from "./geo";
+import type { GeocodeCandidate, GeocodeKind, GeocodeSource } from "../types";
+
+const CLUSTER_RADIUS_M = 12_000;
+const KIND_ORDER: Readonly<Record<GeocodeKind, number>> = {
+  station: 5,
+  city: 4,
+  ward: 3,
+  landmark: 2,
+  prefecture: 1,
+};
+const KIND_RADIUS_M: Readonly<Record<GeocodeKind, number>> = {
+  station: 5_000,
+  city: 10_000,
+  ward: 5_000,
+  landmark: 5_000,
+  prefecture: 10_000,
+};
+
+export interface GeocodeHit {
+  id: string;
+  name: string;
+  kind: GeocodeKind;
+  latitude: number;
+  longitude: number;
+  source: GeocodeSource;
+  pref: string | null;
+  priority: number;
+  exact: boolean;
+}
+
+export interface CollapsedGeocodeCandidate extends GeocodeCandidate {
+  effectiveRadiusM: number;
+}
+
+function find(parent: number[], index: number): number {
+  let node = index;
+  while (parent[node] !== node) {
+    parent[node] = parent[parent[node] ?? node] ?? node;
+    node = parent[node] ?? node;
+  }
+  return node;
+}
+
+function union(parent: number[], left: number, right: number): void {
+  const leftRoot = find(parent, left);
+  const rightRoot = find(parent, right);
+  if (leftRoot === rightRoot) return;
+  parent[Math.max(leftRoot, rightRoot)] = Math.min(leftRoot, rightRoot);
+}
+
+function connectNearby(hits: GeocodeHit[], parent: number[]): void {
+  for (let left = 0; left < hits.length; left += 1) {
+    connectFrom(hits, parent, left);
+  }
+}
+
+function connectFrom(hits: GeocodeHit[], parent: number[], left: number): void {
+  const source = hits[left];
+  if (!source) return;
+  for (let right = left + 1; right < hits.length; right += 1) {
+    const target = hits[right];
+    if (target && nearby(source, target)) union(parent, left, right);
+  }
+}
+
+function nearby(left: GeocodeHit, right: GeocodeHit): boolean {
+  return haversine(left.latitude, left.longitude, right.latitude, right.longitude) <= CLUSTER_RADIUS_M;
+}
+
+function representativeOrder(a: GeocodeHit, b: GeocodeHit): number {
+  return KIND_ORDER[b.kind] - KIND_ORDER[a.kind] || b.priority - a.priority || a.id.localeCompare(b.id);
+}
+
+function clusterOrder(a: GeocodeHit, b: GeocodeHit): number {
+  return Number(b.exact) - Number(a.exact) || b.priority - a.priority || a.id.localeCompare(b.id);
+}
+
+function collapseMembers(members: GeocodeHit[]): CollapsedGeocodeCandidate {
+  const representative = clusterRepresentative(members);
+  return {
+    id: representative.id,
+    label: representative.pref ? `${representative.name}(${representative.pref})` : representative.name,
+    name: representative.name,
+    lat: representative.latitude,
+    lng: representative.longitude,
+    kind: representative.kind,
+    source: representative.source,
+    effectiveRadiusM: Math.max(...members.map((member) => KIND_RADIUS_M[member.kind])),
+  };
+}
+
+function clusterRepresentative(members: GeocodeHit[]): GeocodeHit {
+  const representative = [...members].sort(representativeOrder)[0];
+  if (!representative) throw new Error("geocode cluster cannot be empty");
+  return representative;
+}
+
+/** Collapse one lookup tier with 12km single-link union-find clustering. */
+export function collapseGeocodeHits(hits: GeocodeHit[], limit: number): CollapsedGeocodeCandidate[] {
+  const parent = hits.map((_, index) => index);
+  connectNearby(hits, parent);
+  const groups = new Map<number, GeocodeHit[]>();
+  hits.forEach((hit, index) => {
+    const root = find(parent, index);
+    groups.set(root, [...(groups.get(root) ?? []), hit]);
+  });
+  return [...groups.values()]
+    .sort((a, b) => clusterOrder(clusterRepresentative(a), clusterRepresentative(b)))
+    .map(collapseMembers)
+    .slice(0, limit);
+}

--- a/workers/catalog/src/lib/geocode.ts
+++ b/workers/catalog/src/lib/geocode.ts
@@ -30,7 +30,7 @@ export interface GeocodeHit {
 }
 
 export interface CollapsedGeocodeCandidate extends GeocodeCandidate {
-  effectiveRadiusM: number;
+  effective_radius_m: number;
 }
 
 function find(parent: number[], index: number): number {
@@ -86,7 +86,7 @@ function collapseMembers(members: GeocodeHit[]): CollapsedGeocodeCandidate {
     lng: representative.longitude,
     kind: representative.kind,
     source: representative.source,
-    effectiveRadiusM: Math.max(...members.map((member) => KIND_RADIUS_M[member.kind])),
+    effective_radius_m: Math.max(...members.map((member) => KIND_RADIUS_M[member.kind])),
   };
 }
 

--- a/workers/catalog/src/router.ts
+++ b/workers/catalog/src/router.ts
@@ -2,6 +2,7 @@ import { catalogContract } from "@seichijunrei/contract";
 import { implement } from "@orpc/server";
 import { search as searchHandler, searchDb } from "./api/search";
 import { nearby as nearbyHandler } from "./api/nearby";
+import { geocode as geocodeHandler } from "./api/geocode";
 import { route as routeHandler } from "./api/route";
 import { spots as spotsHandler, SpotNotFoundError } from "./api/spots";
 import type { CatalogDb, NeonSql } from "./db/client";
@@ -36,6 +37,10 @@ const spots = os.spots.handler(async ({ input, context }) =>
 
 const nearby = os.nearby.handler(async ({ input, context }) =>
   nearbyHandler(context.db, context.neonSql, input),
+);
+
+const geocode = os.geocode.handler(async ({ input, context }) =>
+  geocodeHandler(context.db, input),
 );
 
 const MAX_ROUTE_POINT_IDS = 500;
@@ -78,5 +83,5 @@ async function callSpots(db: CatalogDb, input: { bangumi_id: string; origin?: Or
   }
 }
 
-export const catalogRouter = { search, spots, nearby, route, ingest };
+export const catalogRouter = { search, spots, nearby, geocode, route, ingest };
 export type CatalogRouter = typeof catalogRouter;

--- a/workers/catalog/src/types.ts
+++ b/workers/catalog/src/types.ts
@@ -35,6 +35,7 @@ export interface GeocodeCandidate {
   lng: number;
   kind: GeocodeKind;
   source: GeocodeSource;
+  effective_radius_m?: number;
 }
 
 export interface GeocodeResult {

--- a/workers/catalog/src/types.ts
+++ b/workers/catalog/src/types.ts
@@ -19,6 +19,28 @@ export type Origin = { lat: number; lng: number } | string;
 /** Pacing for route itineraries — mirrors `Pacing` in the contract. */
 export type Pacing = "chill" | "normal" | "packed";
 
+export type GeocodeKind = "station" | "city" | "ward" | "landmark" | "prefecture";
+export type GeocodeSource = "seed" | "mlit" | "geonames" | "manual";
+
+export interface GeocodeInput {
+  query: string;
+  limit: number;
+}
+
+export interface GeocodeCandidate {
+  id: string;
+  label: string;
+  name: string;
+  lat: number;
+  lng: number;
+  kind: GeocodeKind;
+  source: GeocodeSource;
+}
+
+export interface GeocodeResult {
+  candidates: GeocodeCandidate[];
+}
+
 /** A single pilgrimage point row — mirrors `PilgrimagePoint` in the contract. */
 export interface PilgrimagePoint {
   id: string;

--- a/workers/catalog/test/contract-parity.worker.test.ts
+++ b/workers/catalog/test/contract-parity.worker.test.ts
@@ -126,6 +126,8 @@ const _sr_b: LocalSearchResult = null as unknown as ContractSearchResult;
 // --- Geocode ---
 const _gc_a: ContractGeocodeCandidate = null as unknown as LocalGeocodeCandidate;
 const _gc_b: LocalGeocodeCandidate = null as unknown as ContractGeocodeCandidate;
+const _gc_radius_a: ContractGeocodeCandidate["effective_radius_m"] = null as unknown as LocalGeocodeCandidate["effective_radius_m"];
+const _gc_radius_b: LocalGeocodeCandidate["effective_radius_m"] = null as unknown as ContractGeocodeCandidate["effective_radius_m"];
 const _gi_a: ContractGeocodeInput = null as unknown as LocalGeocodeInput;
 const _gi_b: LocalGeocodeInput = null as unknown as ContractGeocodeInput;
 const _gr_a: ContractGeocodeResult = null as unknown as LocalGeocodeResult;
@@ -154,7 +156,7 @@ const _uu_b: LocalUpstreamUnavailableData = null as unknown as ContractUpstreamU
 void _pp_a; void _pp_b; void _ts_a; void _ts_b; void _tl_a; void _tl_b; void _tl_attr_a; void _tl_attr_b; void _ti_a; void _ti_b;
 void _ir_a; void _ir_b; void _r_a; void _r_b; void _pac_a; void _pac_b; void _orig_a; void _orig_b;
 void _sr_a; void _sr_b;
-void _gc_a; void _gc_b; void _gi_a; void _gi_b; void _gr_a; void _gr_b;
+void _gc_a; void _gc_b; void _gc_radius_a; void _gc_radius_b; void _gi_a; void _gi_b; void _gr_a; void _gr_b;
 void _ecc_a; void _ecc_b; void _ecat_a; void _ecat_b; void _err_spec_a; void _err_spec_b;
 void _ingest_err_a; void _ingest_err_b;
 void _rtmc_a; void _rtmc_b; void _rtmp_a; void _rtmp_b; void _wnf_a; void _wnf_b; void _uu_a; void _uu_b;

--- a/workers/catalog/test/contract-parity.worker.test.ts
+++ b/workers/catalog/test/contract-parity.worker.test.ts
@@ -26,7 +26,12 @@ import type {
   Origin as ContractOrigin,
 } from "../../../packages/contract/src/models";
 
-import type { SearchResult as ContractSearchResult } from "../../../packages/contract/src/contract";
+import type {
+  GeocodeCandidate as ContractGeocodeCandidate,
+  GeocodeInput as ContractGeocodeInput,
+  GeocodeResult as ContractGeocodeResult,
+  SearchResult as ContractSearchResult,
+} from "../../../packages/contract/src/contract";
 import type { CatalogContract } from "../../../packages/contract/src/contract";
 
 import type {
@@ -49,6 +54,9 @@ import type {
   Pacing as LocalPacing,
   Origin as LocalOrigin,
   SearchResult as LocalSearchResult,
+  GeocodeCandidate as LocalGeocodeCandidate,
+  GeocodeInput as LocalGeocodeInput,
+  GeocodeResult as LocalGeocodeResult,
 } from "../src/types";
 
 import type {
@@ -115,6 +123,14 @@ const _orig_b: LocalOrigin = null as unknown as ContractOrigin;
 const _sr_a: ContractSearchResult = null as unknown as ContractSearchResult;
 const _sr_b: LocalSearchResult = null as unknown as ContractSearchResult;
 
+// --- Geocode ---
+const _gc_a: ContractGeocodeCandidate = null as unknown as LocalGeocodeCandidate;
+const _gc_b: LocalGeocodeCandidate = null as unknown as ContractGeocodeCandidate;
+const _gi_a: ContractGeocodeInput = null as unknown as LocalGeocodeInput;
+const _gi_b: LocalGeocodeInput = null as unknown as ContractGeocodeInput;
+const _gr_a: ContractGeocodeResult = null as unknown as LocalGeocodeResult;
+const _gr_b: LocalGeocodeResult = null as unknown as ContractGeocodeResult;
+
 // --- Catalog errors (from errors.ts, type-only; never import zod values) ---
 const _ecc_a: ContractCatalogErrorCode = null as unknown as LocalCatalogErrorCode;
 const _ecc_b: LocalCatalogErrorCode = null as unknown as ContractCatalogErrorCode;
@@ -138,6 +154,7 @@ const _uu_b: LocalUpstreamUnavailableData = null as unknown as ContractUpstreamU
 void _pp_a; void _pp_b; void _ts_a; void _ts_b; void _tl_a; void _tl_b; void _tl_attr_a; void _tl_attr_b; void _ti_a; void _ti_b;
 void _ir_a; void _ir_b; void _r_a; void _r_b; void _pac_a; void _pac_b; void _orig_a; void _orig_b;
 void _sr_a; void _sr_b;
+void _gc_a; void _gc_b; void _gi_a; void _gi_b; void _gr_a; void _gr_b;
 void _ecc_a; void _ecc_b; void _ecat_a; void _ecat_b; void _err_spec_a; void _err_spec_b;
 void _ingest_err_a; void _ingest_err_b;
 void _rtmc_a; void _rtmc_b; void _rtmp_a; void _rtmp_b; void _wnf_a; void _wnf_b; void _uu_a; void _uu_b;

--- a/workers/catalog/test/fixtures/geocode-seed.ts
+++ b/workers/catalog/test/fixtures/geocode-seed.ts
@@ -1,0 +1,40 @@
+import type { GeocodeHit } from "../../src/lib/geocode";
+
+type SeedLocation = Omit<GeocodeHit, "priority" | "exact">;
+
+export const SEED_LOCATIONS: Readonly<Record<string, SeedLocation>> = {
+  "seed:uji": { id: "seed:uji", name: "宇治", kind: "city", latitude: 34.8843, longitude: 135.7997, source: "seed", pref: "京都府" },
+  "seed:kyoto": { id: "seed:kyoto", name: "京都", kind: "city", latitude: 35.0116, longitude: 135.7681, source: "seed", pref: "京都府" },
+  "seed:kyoto-station": { id: "seed:kyoto-station", name: "京都駅", kind: "station", latitude: 34.9858, longitude: 135.7588, source: "seed", pref: "京都府" },
+  "seed:tokyo-station": { id: "seed:tokyo-station", name: "東京駅", kind: "station", latitude: 35.6812, longitude: 139.7671, source: "seed", pref: "東京都" },
+  "seed:tokyo": { id: "seed:tokyo", name: "東京", kind: "city", latitude: 35.6762, longitude: 139.6503, source: "seed", pref: "東京都" },
+  "seed:shinjuku": { id: "seed:shinjuku", name: "新宿", kind: "ward", latitude: 35.6896, longitude: 139.7006, source: "seed", pref: "東京都" },
+  "seed:akihabara": { id: "seed:akihabara", name: "秋葉原", kind: "landmark", latitude: 35.7023, longitude: 139.7745, source: "seed", pref: "東京都" },
+  "seed:takayama": { id: "seed:takayama", name: "飛騨高山", kind: "city", latitude: 36.1461, longitude: 137.2522, source: "seed", pref: "岐阜県" },
+  "seed:kamakura": { id: "seed:kamakura", name: "鎌倉", kind: "city", latitude: 35.3192, longitude: 139.5467, source: "seed", pref: "神奈川県" },
+  "seed:osaka": { id: "seed:osaka", name: "大阪", kind: "city", latitude: 34.6937, longitude: 135.5023, source: "seed", pref: "大阪府" },
+  "seed:shibuya": { id: "seed:shibuya", name: "渋谷", kind: "ward", latitude: 35.6580, longitude: 139.7016, source: "seed", pref: "東京都" },
+  "seed:ikebukuro": { id: "seed:ikebukuro", name: "池袋", kind: "landmark", latitude: 35.7295, longitude: 139.7109, source: "seed", pref: "東京都" },
+  "seed:yokohama": { id: "seed:yokohama", name: "横浜", kind: "city", latitude: 35.4437, longitude: 139.6380, source: "seed", pref: "神奈川県" },
+  "seed:nara": { id: "seed:nara", name: "奈良", kind: "city", latitude: 34.6851, longitude: 135.8048, source: "seed", pref: "奈良県" },
+  "seed:hiroshima": { id: "seed:hiroshima", name: "広島", kind: "city", latitude: 34.3853, longitude: 132.4553, source: "seed", pref: "広島県" },
+  "seed:hiroshima-station": { id: "seed:hiroshima-station", name: "広島駅", kind: "station", latitude: 34.3976, longitude: 132.4753, source: "seed", pref: "広島県" },
+  "seed:nagoya": { id: "seed:nagoya", name: "名古屋", kind: "city", latitude: 35.1815, longitude: 136.9066, source: "seed", pref: "愛知県" },
+  "seed:uji-station": { id: "seed:uji-station", name: "宇治駅", kind: "station", latitude: 34.8891, longitude: 135.8008, source: "seed", pref: "京都府" },
+  "seed:rokujizo": { id: "seed:rokujizo", name: "六地蔵", kind: "station", latitude: 34.9340, longitude: 135.7930, source: "seed", pref: "京都府" },
+  "seed:nishinomiya-station": { id: "seed:nishinomiya-station", name: "西宮駅", kind: "station", latitude: 34.7386, longitude: 135.3485, source: "manual", pref: "兵庫県" },
+};
+
+export const SEED_ALIASES: readonly (readonly [string, string])[] = [
+  ["宇治", "seed:uji"], ["京都", "seed:kyoto"], ["京都站", "seed:kyoto-station"],
+  ["京都駅", "seed:kyoto-station"], ["東京駅", "seed:tokyo-station"], ["东京站", "seed:tokyo-station"],
+  ["東京", "seed:tokyo"], ["东京", "seed:tokyo"], ["新宿", "seed:shinjuku"],
+  ["秋叶原", "seed:akihabara"], ["秋葉原", "seed:akihabara"], ["飛騨高山", "seed:takayama"],
+  ["高山", "seed:takayama"], ["鎌倉", "seed:kamakura"], ["镰仓", "seed:kamakura"],
+  ["大阪", "seed:osaka"], ["渋谷", "seed:shibuya"], ["涩谷", "seed:shibuya"],
+  ["池袋", "seed:ikebukuro"], ["横浜", "seed:yokohama"], ["横滨", "seed:yokohama"],
+  ["奈良", "seed:nara"], ["広島", "seed:hiroshima"], ["広島駅", "seed:hiroshima-station"],
+  ["名古屋", "seed:nagoya"], ["宇治駅", "seed:uji-station"], ["六地蔵", "seed:rokujizo"],
+  ["西宮", "seed:nishinomiya-station"], ["西宫", "seed:nishinomiya-station"],
+  ["nishinomiya", "seed:nishinomiya-station"],
+];

--- a/workers/catalog/test/geocode-migration-parity.spike.test.ts
+++ b/workers/catalog/test/geocode-migration-parity.spike.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { URL } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { GeocodeHit } from "../src/lib/geocode";
+import { SEED_ALIASES, SEED_LOCATIONS } from "./fixtures/geocode-seed";
+
+/**
+ * Pure-filesystem spike proving the geocode seed fixture stays in parity with
+ * the authoritative catalog-geocoding migration. It runs in the Node spike
+ * pool because the workerd pool cannot read outside workers/catalog.
+ */
+
+const MIGRATION_SQL = readFileSync(
+  new URL("../../../db/migrations/20260714000001_catalog_geocoding.sql", import.meta.url),
+  "utf8",
+);
+
+function insertValues(table: string): string {
+  const pattern = new RegExp(`INSERT INTO ${table} \\([^;]+?\\) VALUES([\\s\\S]+?);`);
+  const values = MIGRATION_SQL.match(pattern)?.[1];
+  if (!values) throw new Error(`missing ${table} seed INSERT`);
+  return values;
+}
+
+function migrationLocations(): typeof SEED_LOCATIONS {
+  const rows: Record<string, (typeof SEED_LOCATIONS)[string]> = {};
+  const tuple = /\('([^']+)', '([^']+)', '([^']+)', (-?\d+(?:\.\d+)?), (-?\d+(?:\.\d+)?), '([^']+)', '([^']+)'\)/g;
+  for (const match of insertValues("locations").matchAll(tuple)) {
+    const [, id, name, kind, latitude, longitude, source, pref] = match;
+    if (!id || !name || !kind || !latitude || !longitude || !source || !pref) continue;
+    rows[id] = {
+      id,
+      name,
+      kind: kind as GeocodeHit["kind"],
+      latitude: Number(latitude),
+      longitude: Number(longitude),
+      source: source as GeocodeHit["source"],
+      pref,
+    };
+  }
+  return rows;
+}
+
+function migrationAliases(): readonly (readonly [string, string])[] {
+  const aliases: [string, string][] = [];
+  const tuple = /\('([^']+)', '([^']+)', '([^']+)', (?:'[^']+'|NULL), \d+\)/g;
+  for (const match of insertValues("location_aliases").matchAll(tuple)) {
+    const [, alias, normalized, locationId] = match;
+    if (!alias || !normalized || !locationId) continue;
+    expect(normalized).toBe(alias);
+    aliases.push([alias, locationId]);
+  }
+  return aliases;
+}
+
+describe("catalog geocode migration parity", () => {
+  it("A9 mirrors the audited locations and aliases", () => {
+    expect(migrationLocations()).toEqual(SEED_LOCATIONS);
+    expect(migrationAliases()).toEqual(SEED_ALIASES);
+  });
+});

--- a/workers/catalog/test/geocode.worker.test.ts
+++ b/workers/catalog/test/geocode.worker.test.ts
@@ -26,7 +26,7 @@ function hit(overrides: Partial<GeocodeHit>): GeocodeHit {
   return { ...NISHINOMIYA, ...overrides };
 }
 
-describe("catalog geocode", () => {
+describe("catalog geocode lookup", () => {
   it.each(["西宮", "西宫", "nishinomiya"])("A1 exact lookup resolves %s", async (query) => {
     const result = await geocode(fakeDb([NISHINOMIYA]), { query, limit: 5 });
     expect(result.candidates).toEqual([{
@@ -63,7 +63,9 @@ describe("catalog geocode", () => {
     await expect(geocode(fakeDb([]), { query: "不存在", limit: 5 })).resolves.toEqual({ candidates: [] });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+});
 
+describe("catalog geocode clustering", () => {
   it("A3 single-link clustering collapses a bridge chain", () => {
     const chain = [
       hit({ id: "a", longitude: 135.00 }),
@@ -106,7 +108,9 @@ describe("catalog geocode", () => {
       "second",
     ]);
   });
+});
 
+describe("catalog geocode seed fixture", () => {
   it("A9 seed fixture resolves all 30 aliases to the 20 audited locations", () => {
     expect(Object.keys(SEED_LOCATIONS)).toHaveLength(20);
     expect(SEED_ALIASES).toHaveLength(30);

--- a/workers/catalog/test/geocode.worker.test.ts
+++ b/workers/catalog/test/geocode.worker.test.ts
@@ -37,7 +37,19 @@ describe("catalog geocode", () => {
       lng: 135.3485,
       kind: "station",
       source: "manual",
+      effective_radius_m: 5000,
     }]);
+  });
+
+  it("A1 mixed city and station cluster carries a 10km effective radius over the wire", async () => {
+    const city = hit({ id: "city", name: "西宮市", kind: "city", priority: 100 });
+    const result = await geocode(fakeDb([NISHINOMIYA, city]), { query: "西宮", limit: 5 });
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]).toMatchObject({
+      id: NISHINOMIYA.id,
+      kind: "station",
+      effective_radius_m: 10_000,
+    });
   });
 
   it("A1 東京 exact lookup returns one collapsed candidate", async () => {
@@ -67,10 +79,35 @@ describe("catalog geocode", () => {
     const preferredStation = hit({ id: "station-a", kind: "station", priority: 5 });
     const expected = collapseGeocodeHits([city, station, preferredStation], 5);
     expect(collapseGeocodeHits([preferredStation, city, station], 5)).toEqual(expected);
-    expect(expected[0]).toMatchObject({ id: "station-a", effectiveRadiusM: 10_000 });
+    expect(expected[0]).toMatchObject({ id: "station-a", effective_radius_m: 10_000 });
   });
 
-  it("A9 migration mirror resolves all 30 aliases to the 20 audited locations", () => {
+  it("A3 orders multiple clusters by exactness, priority, and id", () => {
+    const clusters = [
+      hit({ id: "fuzzy", longitude: 135, priority: 999, exact: false }),
+      hit({ id: "exact-low", longitude: 136, priority: 1 }),
+      hit({ id: "exact-high", longitude: 137, priority: 100 }),
+    ];
+    expect(collapseGeocodeHits(clusters, 5).map((candidate) => candidate.id)).toEqual([
+      "exact-high",
+      "exact-low",
+      "fuzzy",
+    ]);
+  });
+
+  it("A3 truncates ordered clusters at the requested limit", () => {
+    const clusters = [
+      hit({ id: "third", longitude: 135, priority: 1 }),
+      hit({ id: "first", longitude: 136, priority: 3 }),
+      hit({ id: "second", longitude: 137, priority: 2 }),
+    ];
+    expect(collapseGeocodeHits(clusters, 2).map((candidate) => candidate.id)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("A9 seed fixture resolves all 30 aliases to the 20 audited locations", () => {
     expect(Object.keys(SEED_LOCATIONS)).toHaveLength(20);
     expect(SEED_ALIASES).toHaveLength(30);
     for (const [alias, locationId] of SEED_ALIASES) {

--- a/workers/catalog/test/geocode.worker.test.ts
+++ b/workers/catalog/test/geocode.worker.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CatalogDb } from "../src/db/client";
+import { geocode } from "../src/api/geocode";
+import { collapseGeocodeHits, type GeocodeHit } from "../src/lib/geocode";
+import { SEED_ALIASES, SEED_LOCATIONS } from "./fixtures/geocode-seed";
+
+const NISHINOMIYA: GeocodeHit = {
+  id: "seed:nishinomiya-station",
+  name: "西宮駅",
+  kind: "station",
+  latitude: 34.7386,
+  longitude: 135.3485,
+  source: "manual",
+  pref: "兵庫県",
+  priority: 100,
+  exact: true,
+};
+
+function fakeDb(rows: GeocodeHit[]): CatalogDb {
+  return {
+    execute: (_query: unknown) => Promise.resolve({ rows }),
+  } as unknown as CatalogDb;
+}
+
+function hit(overrides: Partial<GeocodeHit>): GeocodeHit {
+  return { ...NISHINOMIYA, ...overrides };
+}
+
+describe("catalog geocode", () => {
+  it.each(["西宮", "西宫", "nishinomiya"])("A1 exact lookup resolves %s", async (query) => {
+    const result = await geocode(fakeDb([NISHINOMIYA]), { query, limit: 5 });
+    expect(result.candidates).toEqual([{
+      id: NISHINOMIYA.id,
+      label: "西宮駅(兵庫県)",
+      name: "西宮駅",
+      lat: 34.7386,
+      lng: 135.3485,
+      kind: "station",
+      source: "manual",
+    }]);
+  });
+
+  it("A1 東京 exact lookup returns one collapsed candidate", async () => {
+    const tokyo = hit({ id: "seed:tokyo", name: "東京", kind: "city", latitude: 35.6762, longitude: 139.6503, pref: "東京都" });
+    const result = await geocode(fakeDb([tokyo]), { query: "東京", limit: 5 });
+    expect(result.candidates).toHaveLength(1);
+  });
+
+  it("A2 miss returns empty without calling fetch", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(geocode(fakeDb([]), { query: "不存在", limit: 5 })).resolves.toEqual({ candidates: [] });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("A3 single-link clustering collapses a bridge chain", () => {
+    const chain = [
+      hit({ id: "a", longitude: 135.00 }),
+      hit({ id: "b", longitude: 135.10 }),
+      hit({ id: "c", longitude: 135.20 }),
+    ];
+    expect(collapseGeocodeHits(chain, 5)).toHaveLength(1);
+  });
+
+  it("A3 representative and output are deterministic after shuffling", () => {
+    const city = hit({ id: "city", kind: "city", priority: 100 });
+    const station = hit({ id: "station-z", kind: "station", priority: 5 });
+    const preferredStation = hit({ id: "station-a", kind: "station", priority: 5 });
+    const expected = collapseGeocodeHits([city, station, preferredStation], 5);
+    expect(collapseGeocodeHits([preferredStation, city, station], 5)).toEqual(expected);
+    expect(expected[0]).toMatchObject({ id: "station-a", effectiveRadiusM: 10_000 });
+  });
+
+  it("A9 migration mirror resolves all 30 aliases to the 20 audited locations", () => {
+    expect(Object.keys(SEED_LOCATIONS)).toHaveLength(20);
+    expect(SEED_ALIASES).toHaveLength(30);
+    for (const [alias, locationId] of SEED_ALIASES) {
+      const location = SEED_LOCATIONS[locationId];
+      expect(location, alias).toBeDefined();
+      if (!location) throw new Error(`missing seed location for ${alias}`);
+      expect(collapseGeocodeHits([{ ...location, priority: 100, exact: true }], 5)[0]?.id).toBe(locationId);
+    }
+  });
+});


### PR DESCRIPTION
## What

Implements **PR-A** of [spec v4](docs/superpowers/specs/2026-07-13-catalog-geocoding.md) (dual-reviewed ×3 rounds, both reviewers approve; [GOAL](docs/superpowers/specs/2026-07-13-catalog-geocoding-GOAL.md)): the geocoding half of "search near a place" — which was never actually implemented (a 27-alias hardcoded dict + a docstring IOU). Flagship false negative fixed: 西宮 (Haruhi's home turf, data IN the DB) returned "not found"; the eval had even institutionalized `clarify` as the correct answer for it.

**Pure local gazetteer — zero egress, zero new secrets.** External geocoders were evaluated and rejected on compliance grounds during spec review (Google: lat/lng cacheable ≤30 days; GSI: merges CSIS experiment data requiring user-visible attribution — both first-hand verified). Fallback deferred to a spike-gated follow-up.

## Changes (21 files, +1029/−37)

- **db**: `locations`/`location_aliases` + coordinate-sync trigger + CHECK constraints + seed migration (19 legacy coordinate rows from `KNOWN_LOCATIONS` + deliberate 西宮駅 = 20 locations / 30 aliases incl. zh/en variants)
- **contract**: `/catalog/geocode` (typed `GeocodeKind`/`GeocodeSource` enums, candidates with disambiguation labels); `emit:openapi` idempotent; `types.ts` mirror
- **worker**: exact alias lookup (strict short-circuit) + pure candidate-collapse fn — union-find single-link 12 km, kind-priority representative, deterministic tiebreak, **effective radius = max member kind radius**
- **agent**: three-state `search_nearby` rewrite:
  - honest-empty = **successful** result (`success=true`, `row_count: 0` in tool_state) — fixes a pre-existing bug where zero-row results were unreachable (validator rejected them)
  - ambiguity / unknown / prefecture-narrowing = success `geocode` step + `ModelRetry` → clarify (never `success=false`/`pipeline_error` for normal flows)
  - explicit place name beats GPS; instructions rewritten (the "Do NOT call search_nearby" prohibition removed)

## Verification (independently re-run by lead, not self-reported)

| Gate | Result |
|---|---|
| agent full suite | **934 passed**, coverage 84.42% (floor 82) |
| worker vitest | green, 90.44% stmts (Codex sandbox can't bind 127.0.0.1 — run on host) |
| mypy strict / ruff | clean (51 files) |
| openapi | second emit byte-identical |
| anti-tamper scan | modified tests all additive; 0 suppressions; 0 deleted assertions |

**End-to-end (real MiMo, same repro script that previously failed):**
- Before: `search_nearby` guessed place names ×3 → `Could not resolve coordinates` → `UnexpectedModelBehavior: exceeded max retries` (8 such cases in the full eval)
- After: model calls `search_nearby({"location": "西宫"})` on turn 1 → geocode resolves → returns 2 Haruhi spots (西宮北口駅, 甲陽園駅) → `success=true`, clean single-step trajectory

## AC → test mapping

A1-A4, A9 → `workers/catalog/test/geocode.worker.test.ts` (8 tests incl. 30-alias seed parity fixture) + `contract-parity.worker.test.ts`; A5/A5'/A6/A6'/A7/A8/A8' → `apps/agent/agent/tests/unit/test_catalog_geocoding_agent.py`; A10 → instructions grep assertions in `test_pilgrimage_agent.py`; A11 → full gates above.

## Ops

**None.** No secrets, no egress; the migration auto-applies via the existing `atlas migrate apply` deploy step.

## Notes

- Authored by Codex (gpt-5.6-sol) under spec v4; committed by lead after gate verification (Codex sandbox mounts `.git` read-only — discovered this session).
- PR-B (12k-row MLIT/GeoNames gazetteer + pg_trgm fuzzy + eval flips + `nonempty_results` metric) follows on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)