### PR TITLE
Wave 1: composition modernization — naming, decoupled tools, hooks, deferred loading, typed state

### DIFF
--- a/apps/agent/agent/agents/agent_result.py
+++ b/apps/agent/agent/agents/agent_result.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from pydantic_ai.messages import ModelMessage
 
 from agent.agents.runtime_models import RuntimeStageOutput
+from agent.agents.tool_state import LegacyPayload
 
 
 @dataclass
@@ -29,7 +30,7 @@ class AgentResult:
 
     output: RuntimeStageOutput
     steps: list[StepRecord] = field(default_factory=list)
-    tool_state: dict[str, object] = field(default_factory=dict)
+    tool_state: LegacyPayload = field(default_factory=dict)
     new_messages: list[ModelMessage] = field(default_factory=list)
 
     @property

--- a/apps/agent/agent/agents/agent_result.py
+++ b/apps/agent/agent/agents/agent_result.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from pydantic_ai.messages import ModelMessage
+from pydantic_ai.usage import RunUsage
 
 from agent.agents.runtime_models import RuntimeStageOutput
 from agent.agents.tool_state import LegacyPayload
@@ -32,6 +33,7 @@ class AgentResult:
     steps: list[StepRecord] = field(default_factory=list)
     tool_state: LegacyPayload = field(default_factory=dict)
     new_messages: list[ModelMessage] = field(default_factory=list)
+    usage: RunUsage | None = None
 
     @property
     def intent(self) -> str:

--- a/apps/agent/agent/agents/animichi_agent.py
+++ b/apps/agent/agent/agents/animichi_agent.py
@@ -1,15 +1,4 @@
-"""PydanticAI agent definition for the anime pilgrimage runtime.
-
-This module defines ONLY the agent object and its instructions. Tools are
-registered in ``animichi_tools`` (imported lazily at run time).
-The runner that executes the agent lives in ``animichi_runner``.
-
-Separation rationale:
-- Agent def must exist before ``@agent.tool`` decorators run.
-- Tools import the agent → tools module depends on this module.
-- Runner imports both → runner depends on tools + agent.
-- Keeping them apart avoids circular imports and keeps each file < 300 lines.
-"""
+"""PydanticAI agent definition for the anime pilgrimage runtime."""
 
 from __future__ import annotations
 
@@ -23,6 +12,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.output import ToolOutput
 
+from agent.agents.animichi_tools import TOOLS as ANIMICHI_TOOLS
 from agent.agents.base import resolve_model
 from agent.agents.runtime_deps import RuntimeDeps
 from agent.agents.runtime_models import (
@@ -32,6 +22,7 @@ from agent.agents.runtime_models import (
     RouteResponseModel,
     SearchResponseModel,
 )
+from agent.agents.web_tools import TOOLS as WEB_TOOLS
 
 COMPACT_THRESHOLD = 40  # ~5 turns × 8 messages/turn
 _KEEP_RECENT = 8  # Keep latest turn fully uncompressed
@@ -298,6 +289,7 @@ animichi_agent = Agent(
         ToolOutput(GreetingResponseModel, name="greeting_response"),
     ],
     instructions=_INSTRUCTIONS,
+    tools=[*ANIMICHI_TOOLS, *WEB_TOOLS],
     retries=2,
     capabilities=[
         ProcessHistory(_compact_tool_results),

--- a/apps/agent/agent/agents/animichi_agent.py
+++ b/apps/agent/agent/agents/animichi_agent.py
@@ -33,6 +33,7 @@ from agent.agents.runtime_models import (
     RouteResponseModel,
     SearchResponseModel,
 )
+from agent.agents.tool_state import ToolState
 from agent.agents.web_tools import DEFERRED_TOOLS
 from agent.agents.web_tools import TOOLS as WEB_TOOLS
 from agent.infrastructure.observability import record_agent_run_error
@@ -409,37 +410,36 @@ def build_animichi_agent(
     return agent
 
 
-def _add_resolve_context(state: dict[str, object], parts: list[str]) -> None:
-    resolve_data = state.get("resolve_anime")
-    if not isinstance(resolve_data, dict):
+def _add_resolve_context(state: ToolState, parts: list[str]) -> None:
+    resolve_data = state.resolve_anime
+    if resolve_data is None:
         return
-    title = resolve_data.get("title", "")
-    bid = resolve_data.get("bangumi_id", "")
+    title = resolve_data.title or ""
+    bid = resolve_data.bangumi_id or ""
     if title:
         parts.append(f"Current anime: {title} (bangumi_id={bid})")
 
 
-def _add_search_context(state: dict[str, object], parts: list[str]) -> None:
-    search_data = state.get("search_bangumi")
-    if not isinstance(search_data, dict):
+def _add_search_context(state: ToolState, parts: list[str]) -> None:
+    search_data = state.search_bangumi
+    if search_data is None:
         return
-    row_count = search_data.get("row_count", 0)
-    metadata = search_data.get("metadata", {})
-    title = metadata.get("anime_title", "") if isinstance(metadata, dict) else ""
+    row_count = search_data.row_count
+    title = search_data.metadata.anime_title if search_data.metadata else ""
     suffix = f" for {title}" if title else ""
     parts.append(f"Search results available: {row_count} spots{suffix}")
 
 
-def _add_nearby_context(state: dict[str, object], parts: list[str]) -> None:
-    search_nearby = state.get("search_nearby")
-    if not isinstance(search_nearby, dict):
+def _add_nearby_context(state: ToolState, parts: list[str]) -> None:
+    search_nearby = state.search_nearby
+    if search_nearby is None:
         return
-    row_count = search_nearby.get("row_count", 0)
+    row_count = search_nearby.row_count
     parts.append(f"Nearby search results available: {row_count} spots")
 
 
-def _add_clarify_context(state: dict[str, object], parts: list[str]) -> None:
-    if state.get("pending_clarify"):
+def _add_clarify_context(state: ToolState, parts: list[str]) -> None:
+    if state.pending_clarify:
         parts.append(
             "Previous turn ended with clarification "
             "— user's response is the current message"
@@ -472,13 +472,13 @@ async def validate_output(
     tool_state = ctx.deps.tool_state
     if isinstance(output, SearchResponseModel):
         tool_key = str(output.intent)
-        if tool_key not in tool_state:
+        if not tool_state.has_payload(tool_key):
             raise ModelRetry(
                 f"You returned a search response but never called {tool_key}. "
                 "Call the search tool first, then return the response."
             )
     if isinstance(output, RouteResponseModel):
-        if "plan_route" not in tool_state and "plan_selected" not in tool_state:
+        if not tool_state.plan_route and not tool_state.plan_selected:
             raise ModelRetry(
                 "You returned a route response but never called plan_route. "
                 "Call plan_route first, then return the response."

--- a/apps/agent/agent/agents/animichi_agent.py
+++ b/apps/agent/agent/agents/animichi_agent.py
@@ -2,14 +2,25 @@
 
 from __future__ import annotations
 
+import os
+from typing import NoReturn
+
 from pydantic_ai import Agent, ModelRetry, RunContext
-from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.agent import AgentInstructions
+from pydantic_ai.capabilities import (
+    AgentCapability,
+    Hooks,
+    ProcessHistory,
+    ToolSearch,
+)
 from pydantic_ai.messages import (
+    InstructionPart,
     ModelMessage,
     ModelRequest,
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai.models import ModelRequestContext
 from pydantic_ai.output import ToolOutput
 
 from agent.agents.animichi_tools import TOOLS as ANIMICHI_TOOLS
@@ -22,10 +33,20 @@ from agent.agents.runtime_models import (
     RouteResponseModel,
     SearchResponseModel,
 )
+from agent.agents.web_tools import DEFERRED_TOOLS
 from agent.agents.web_tools import TOOLS as WEB_TOOLS
+from agent.infrastructure.observability import record_agent_run_error
 
 COMPACT_THRESHOLD = 40  # ~5 turns × 8 messages/turn
 _KEEP_RECENT = 8  # Keep latest turn fully uncompressed
+
+RuntimeOutput = (
+    ClarifyResponseModel
+    | SearchResponseModel
+    | RouteResponseModel
+    | QAResponseModel
+    | GreetingResponseModel
+)
 
 _INSTRUCTIONS = """\
 You are the runtime agent for Animichi, an anime pilgrimage (聖地巡礼) search \
@@ -277,31 +298,31 @@ def _pick_keep_from(turn_starts: list[int], total: int) -> int:
     return keep_from
 
 
-animichi_agent = Agent(
-    resolve_model(None),
-    name="animichi",
-    deps_type=RuntimeDeps,
-    output_type=[
+def _modern_composition_enabled() -> bool:
+    """Resolve the construction-time rollback switch (default: modern)."""
+    return os.environ.get("ANIMICHI_MODERN_COMPOSITION", "1") != "0"
+
+
+def _output_types() -> list[ToolOutput[RuntimeOutput]]:
+    return [
         ToolOutput(ClarifyResponseModel, name="clarify_response"),
         ToolOutput(SearchResponseModel, name="search_response"),
         ToolOutput(RouteResponseModel, name="route_response"),
         ToolOutput(QAResponseModel, name="qa_response"),
         ToolOutput(GreetingResponseModel, name="greeting_response"),
-    ],
-    instructions=_INSTRUCTIONS,
-    tools=[*ANIMICHI_TOOLS, *WEB_TOOLS],
-    retries=2,
-    capabilities=[
+    ]
+
+
+def _history_capabilities() -> list[ProcessHistory[RuntimeDeps]]:
+    return [
         ProcessHistory(_compact_tool_results),
         ProcessHistory(_sliding_window),
-    ],
-)
+    ]
 
 
 _LOCALE_NAMES = {"ja": "Japanese", "zh": "Simplified Chinese", "en": "English"}
 
 
-@animichi_agent.instructions
 def _inject_session_context(ctx: RunContext[RuntimeDeps]) -> str:
     """Inject locale enforcement and current session state for multi-turn."""
     parts: list[str] = []
@@ -319,6 +340,73 @@ def _inject_session_context(ctx: RunContext[RuntimeDeps]) -> str:
     _add_nearby_context(state, parts)
     _add_clarify_context(state, parts)
     return "\n## Current session state\n" + "\n".join(f"- {p}" for p in parts)
+
+
+def _modern_hooks() -> Hooks[RuntimeDeps]:
+    hooks = Hooks[RuntimeDeps]()
+
+    @hooks.on.before_model_request
+    def inject_session(
+        ctx: RunContext[RuntimeDeps], request_context: ModelRequestContext
+    ) -> ModelRequestContext:
+        dynamic = _inject_session_context(ctx)
+        params = request_context.model_request_parameters
+        instruction_parts = params.instruction_parts or []
+        if not any(part.content == dynamic for part in instruction_parts):
+            params.instruction_parts = [
+                *instruction_parts,
+                InstructionPart(content=dynamic, dynamic=True),
+            ]
+        request = request_context.messages[-1]
+        if not isinstance(request, ModelRequest) or dynamic in (
+            request.instructions or ""
+        ):
+            return request_context
+        request.instructions = "\n\n".join(
+            filter(None, [request.instructions, dynamic])
+        )
+        return request_context
+
+    @hooks.on.run_error
+    def record_error(
+        _ctx: RunContext[RuntimeDeps], *, error: BaseException
+    ) -> NoReturn:
+        record_agent_run_error(error)
+        raise error
+
+    return hooks
+
+
+def build_animichi_agent(
+    *, modern_composition: bool | None = None
+) -> Agent[RuntimeDeps, RuntimeOutput]:
+    """Construct the runtime agent in modern or one-switch rollback mode."""
+    modern = (
+        _modern_composition_enabled()
+        if modern_composition is None
+        else modern_composition
+    )
+    instructions: AgentInstructions[RuntimeDeps] = (
+        _INSTRUCTIONS if modern else [_INSTRUCTIONS, _inject_session_context]
+    )
+    tools = [*ANIMICHI_TOOLS, *(DEFERRED_TOOLS if modern else WEB_TOOLS)]
+    capabilities: list[AgentCapability[RuntimeDeps]] = [*_history_capabilities()]
+    if modern:
+        capabilities.extend(
+            [_modern_hooks(), ToolSearch[RuntimeDeps](strategy="keywords")]
+        )
+    agent: Agent[RuntimeDeps, RuntimeOutput] = Agent(
+        resolve_model(None),
+        name="animichi",
+        deps_type=RuntimeDeps,
+        output_type=_output_types(),
+        instructions=instructions,
+        tools=tools,
+        retries=2,
+        capabilities=capabilities,
+    )
+    agent.output_validator(validate_output)
+    return agent
 
 
 def _add_resolve_context(state: dict[str, object], parts: list[str]) -> None:
@@ -358,7 +446,6 @@ def _add_clarify_context(state: dict[str, object], parts: list[str]) -> None:
         )
 
 
-@animichi_agent.output_validator  # type: ignore[arg-type]
 async def validate_output(
     ctx: RunContext[RuntimeDeps],
     output: (
@@ -397,3 +484,6 @@ async def validate_output(
                 "Call plan_route first, then return the response."
             )
     return output
+
+
+animichi_agent = build_animichi_agent()

--- a/apps/agent/agent/agents/animichi_runner.py
+++ b/apps/agent/agent/agents/animichi_runner.py
@@ -1,8 +1,4 @@
-"""Runner: execute the pilgrimage agent and return AgentResult.
-
-Separated from the agent definition so that the agent module stays small
-and the tool module can import the agent object without circular deps.
-"""
+"""Runner: execute the pilgrimage agent and return AgentResult."""
 
 from __future__ import annotations
 
@@ -11,12 +7,8 @@ from pydantic_ai.messages import ModelMessage
 from pydantic_ai.models import Model
 from pydantic_ai.settings import ModelSettings
 
-import agent.agents.animichi_tools as _tools  # noqa: F401
-import agent.agents.web_tools as _web_tools  # noqa: F401
 from agent.agents.agent_result import AgentResult
-
-# Importing animichi_tools triggers @tool registrations on the agent.
-from agent.agents.animichi_agent import animichi_agent  # noqa: F401
+from agent.agents.animichi_agent import animichi_agent
 from agent.agents.runtime_deps import (
     OnStep,
     RuntimeDeps,

--- a/apps/agent/agent/agents/animichi_runner.py
+++ b/apps/agent/agent/agents/animichi_runner.py
@@ -111,6 +111,7 @@ async def run_animichi_agent(
         steps=list(deps.steps),
         tool_state=deps.tool_state.to_legacy_dict(),
         new_messages=list(run_result.new_messages()),
+        usage=run_result.usage,
     )
     logger.info(
         "animichi_agent_complete",

--- a/apps/agent/agent/agents/animichi_runner.py
+++ b/apps/agent/agent/agents/animichi_runner.py
@@ -15,49 +15,50 @@ from agent.agents.runtime_deps import (
     TitleTranslator,
     WebSearcher,
 )
+from agent.agents.tool_state import SearchState, ToolState
 from agent.clients.catalog_client import CatalogClientProtocol
 from agent.domain.ports import DatabasePort
 
 logger = structlog.get_logger(__name__)
 
 
-def _seed_geo_coords(tool_state: dict[str, object], context: dict[str, object]) -> None:
+def _seed_geo_coords(tool_state: ToolState, context: dict[str, object]) -> None:
     origin_lat = context.get("origin_lat")
     origin_lng = context.get("origin_lng")
     if isinstance(origin_lat, int | float):
-        tool_state["origin_lat"] = float(origin_lat)
+        tool_state.origin_lat = float(origin_lat)
     if isinstance(origin_lng, int | float):
-        tool_state["origin_lng"] = float(origin_lng)
+        tool_state.origin_lng = float(origin_lng)
 
 
-def _seed_search_data(
-    tool_state: dict[str, object], context: dict[str, object]
-) -> None:
+def _seed_search_data(tool_state: ToolState, context: dict[str, object]) -> None:
     raw = context.get("last_search_data")
     if not isinstance(raw, dict):
         return
-    for key in ("search_bangumi", "search_nearby"):
-        value = raw.get(key)
-        if isinstance(value, dict):
-            tool_state[key] = value
-    if "rows" in raw and "search_bangumi" not in tool_state:
-        tool_state["search_bangumi"] = raw
+    bangumi = raw.get("search_bangumi")
+    nearby = raw.get("search_nearby")
+    if isinstance(bangumi, dict):
+        tool_state.search_bangumi = SearchState.model_validate(bangumi)
+    if isinstance(nearby, dict):
+        tool_state.search_nearby = SearchState.model_validate(nearby)
+    if "rows" in raw and tool_state.search_bangumi is None:
+        tool_state.search_bangumi = SearchState.model_validate(raw)
 
 
 def _seed_tool_state(deps: RuntimeDeps, context: dict[str, object] | None) -> None:
-    deps.tool_state["locale"] = deps.locale
+    deps.tool_state.locale = deps.locale
     if context is None:
         return
     last_location = context.get("last_location")
     if isinstance(last_location, str) and last_location:
-        deps.tool_state["last_location"] = last_location
+        deps.tool_state.last_location = last_location
     _seed_geo_coords(deps.tool_state, context)
 
     raw_candidates = context.get("resolve_candidates")
     if isinstance(raw_candidates, list) and raw_candidates:
-        deps.tool_state["resolve_candidates"] = raw_candidates
+        deps.tool_state.resolve_candidates = raw_candidates
     if context.get("pending_clarify") is True:
-        deps.tool_state["pending_clarify"] = True
+        deps.tool_state.pending_clarify = True
 
     _seed_search_data(deps.tool_state, context)
 
@@ -108,7 +109,7 @@ async def run_animichi_agent(
     result = AgentResult(
         output=raw_output,
         steps=list(deps.steps),
-        tool_state=dict(deps.tool_state),
+        tool_state=deps.tool_state.to_legacy_dict(),
         new_messages=list(run_result.new_messages()),
     )
     logger.info(

--- a/apps/agent/agent/agents/animichi_tools.py
+++ b/apps/agent/agent/agents/animichi_tools.py
@@ -102,9 +102,9 @@ async def search_bangumi(
     """
     resolved_id = bangumi_id or None
     if not resolved_id:
-        resolve_data = ctx.deps.tool_state.get("resolve_anime")
-        if isinstance(resolve_data, dict):
-            resolved_id = resolve_data.get("bangumi_id")
+        resolve_data = ctx.deps.tool_state.resolve_anime
+        if resolve_data is not None:
+            resolved_id = resolve_data.bangumi_id
     if not resolved_id:
         raise ModelRetry(
             "Call resolve_anime(title) first to get a bangumi_id, "
@@ -148,7 +148,7 @@ async def search_nearby(
         radius: Search radius in meters. Default is 5000 (5km). Use 0 for default.
                 Use smaller radius for specific stations, larger for cities.
     """
-    ctx.deps.tool_state.pop(ToolName.SEARCH_NEARBY.value, None)
+    ctx.deps.tool_state.remove_payload(ToolName.SEARCH_NEARBY)
     params: dict[str, object] = {"location": location}
     if radius > 0:
         params["radius"] = radius
@@ -184,10 +184,10 @@ async def plan_route(
                 Leave empty for default "normal" pace.
         start_time: Departure time as "HH:MM". Leave empty for default "09:00".
     """
-    search_data = ctx.deps.tool_state.get("search_bangumi") or ctx.deps.tool_state.get(
-        "search_nearby"
+    search_data = (
+        ctx.deps.tool_state.search_bangumi or ctx.deps.tool_state.search_nearby
     )
-    if not isinstance(search_data, dict) or not search_data.get("rows"):
+    if search_data is None or not search_data.rows:
         raise ModelRetry(
             "Call search_bangumi or search_nearby first to get pilgrimage points, "
             "then call plan_route to create the walking route."

--- a/apps/agent/agent/agents/animichi_tools.py
+++ b/apps/agent/agent/agents/animichi_tools.py
@@ -7,8 +7,7 @@ no Anitabi/Bangumi gateways). The ephemeral tools (greet_user / general_qa /
 clarify) echo LLM-supplied payloads without any read path.
 
 Step/plumbing helpers live in ``tool_runtime``; the catalog read path lives in
-``catalog_tools``. Import this module after ``animichi_agent`` is created so
-the decorators can attach to it.
+``catalog_tools``.
 """
 
 from __future__ import annotations
@@ -18,8 +17,8 @@ import json
 import structlog
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic_ai import ModelRetry, RunContext
+from pydantic_ai.tools import ToolFuncEither
 
-from agent.agents.animichi_agent import animichi_agent
 from agent.agents.catalog_tools import (
     _bangumi_search_query,
     _run_catalog_nearby,
@@ -46,7 +45,6 @@ def _require_catalog(deps: RuntimeDeps) -> CatalogClientProtocol:
     return deps.catalog
 
 
-@animichi_agent.tool
 async def resolve_anime(ctx: RunContext[RuntimeDeps], title: str) -> dict[str, object]:
     """Look up an anime by title and return its unique database identifier.
 
@@ -78,7 +76,6 @@ async def resolve_anime(ctx: RunContext[RuntimeDeps], title: str) -> dict[str, o
     )
 
 
-@animichi_agent.tool
 async def search_bangumi(
     ctx: RunContext[RuntimeDeps],
     bangumi_id: str = "",
@@ -131,7 +128,6 @@ async def search_bangumi(
     )
 
 
-@animichi_agent.tool
 async def search_nearby(
     ctx: RunContext[RuntimeDeps],
     *,
@@ -165,7 +161,6 @@ async def search_nearby(
     )
 
 
-@animichi_agent.tool
 async def plan_route(
     ctx: RunContext[RuntimeDeps],
     *,
@@ -207,7 +202,6 @@ async def plan_route(
     return await _run_catalog_route(ctx, _require_catalog(ctx.deps), params=params)
 
 
-@animichi_agent.tool
 async def greet_user(ctx: RunContext[RuntimeDeps], message: str) -> dict[str, object]:
     """Respond to greetings and "what can you do?" questions.
 
@@ -229,7 +223,6 @@ async def greet_user(ctx: RunContext[RuntimeDeps], message: str) -> dict[str, ob
     )
 
 
-@animichi_agent.tool
 async def general_qa(ctx: RunContext[RuntimeDeps], answer: str) -> dict[str, object]:
     """Answer general questions about anime pilgrimage (etiquette, tips, costs, planning).
 
@@ -312,7 +305,6 @@ class ClarifyArgs(BaseModel):
         return decoded
 
 
-@animichi_agent.tool
 async def clarify(
     ctx: RunContext[RuntimeDeps],
     args: ClarifyArgs,
@@ -332,3 +324,14 @@ async def clarify(
               ``ClarifyArgs`` for field-level docs (``question``, ``options``).
     """
     return await run_clarify(ctx.deps, question=args.question, options=args.options)
+
+
+TOOLS: list[ToolFuncEither[RuntimeDeps]] = [
+    resolve_anime,
+    search_bangumi,
+    search_nearby,
+    plan_route,
+    greet_user,
+    general_qa,
+    clarify,
+]

--- a/apps/agent/agent/agents/base.py
+++ b/apps/agent/agent/agents/base.py
@@ -161,6 +161,7 @@ def describe_model(model: object) -> str:
 def create_agent(
     model: Model | str | None = None,
     *,
+    name: str,
     system_prompt: str = "",
     output_type: type[T],
     tool_retries: int = 2,
@@ -171,6 +172,7 @@ def create_agent(
 def create_agent(
     model: Model | str | None = None,
     *,
+    name: str,
     system_prompt: str = "",
     output_type: None = None,
     tool_retries: int = 2,
@@ -180,6 +182,7 @@ def create_agent(
 def create_agent(
     model: Model | str | None = None,
     *,
+    name: str,
     system_prompt: str = "",
     output_type: type[T] | None = None,
     tool_retries: int = 2,
@@ -187,9 +190,12 @@ def create_agent(
     """Create a Pydantic AI agent with the given configuration."""
     selected = resolve_model(model)
     if output_type is None:
-        return Agent(selected, system_prompt=system_prompt, retries=tool_retries)
+        return Agent(
+            selected, name=name, system_prompt=system_prompt, retries=tool_retries
+        )
     return Agent(
         selected,
+        name=name,
         system_prompt=system_prompt,
         output_type=output_type,
         retries=tool_retries,

--- a/apps/agent/agent/agents/catalog_tools.py
+++ b/apps/agent/agent/agents/catalog_tools.py
@@ -21,6 +21,7 @@ from agent.agents.tool_runtime import (
     _record_step,
     _summarize_for_llm,
 )
+from agent.agents.tool_state import ToolState
 from agent.clients.catalog_client import (
     CatalogClientProtocol,
     PilgrimagePoint,
@@ -63,7 +64,7 @@ async def _store_catalog_result(
     )
     if success:
         _localize_city_names(payload, deps.locale)
-        deps.tool_state[tool.value] = payload
+        deps.tool_state.set_payload(tool, payload)
         await _emit_step(deps, tool.value, "done", payload)
         return _summarize_for_llm(tool, payload)
     await _emit_step(deps, tool.value, "failed", {"error": _NO_DATA_ERROR})
@@ -90,17 +91,15 @@ async def _run_catalog_search(
     )
 
 
-def _bangumi_search_query(state: dict[str, object], bangumi_id: str) -> str:
+def _bangumi_search_query(state: ToolState, bangumi_id: str) -> str:
     """Pick the catalog query for search_bangumi: resolved title, else id.
 
     The catalog search path is title/query based, so prefer the title captured
     by resolve_anime; fall back to the bangumi_id when no title is known.
     """
-    resolve_data = state.get("resolve_anime")
-    if isinstance(resolve_data, dict):
-        title = resolve_data.get("title")
-        if isinstance(title, str) and title:
-            return title
+    resolve_data = state.resolve_anime
+    if resolve_data is not None and resolve_data.title:
+        return resolve_data.title
     return bangumi_id
 
 
@@ -116,12 +115,12 @@ def _shape_search_or_resolve(
     return build_search_payload(points, tool=search_tool)
 
 
-def _origin_coordinates(state: dict[str, object]) -> tuple[float, float] | None:
+def _origin_coordinates(state: ToolState) -> tuple[float, float] | None:
     """Return typed session GPS coordinates when both values are present."""
-    lat = state.get("origin_lat")
-    lng = state.get("origin_lng")
-    if isinstance(lat, int | float) and isinstance(lng, int | float):
-        return float(lat), float(lng)
+    lat = state.origin_lat
+    lng = state.origin_lng
+    if lat is not None and lng is not None:
+        return lat, lng
     return None
 
 
@@ -259,17 +258,12 @@ async def _run_catalog_nearby(
     )
 
 
-def _point_ids_from_state(state: dict[str, object]) -> list[str]:
+def _point_ids_from_state(state: ToolState) -> list[str]:
     """Collect point ids from the most recent search results in tool_state."""
-    search = state.get("search_bangumi") or state.get("search_nearby")
-    rows = search.get("rows") if isinstance(search, dict) else None
-    if not isinstance(rows, list):
+    search = state.search_bangumi or state.search_nearby
+    if search is None:
         return []
-    return [
-        str(row["id"])
-        for row in rows
-        if isinstance(row, dict) and isinstance(row.get("id"), str)
-    ]
+    return [row.id for row in search.rows if row.id is not None]
 
 
 async def _run_catalog_route(

--- a/apps/agent/agent/agents/handlers/answer_question.py
+++ b/apps/agent/agent/agents/handlers/answer_question.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from agent.agents.handlers.result import HandlerResult
 from agent.agents.models import PlanStep
 
@@ -21,7 +23,7 @@ def _build_candidates(options: list[str]) -> list[dict[str, object]]:
 
 async def execute(
     step: PlanStep,
-    context: dict[str, object],
+    context: Mapping[str, object],
     db: object,
     retriever: object,
 ) -> HandlerResult:
@@ -38,7 +40,7 @@ async def execute(
 
 async def execute_clarify(
     step: PlanStep,
-    context: dict[str, object],
+    context: Mapping[str, object],
     db: object,
     retriever: object,
 ) -> HandlerResult:

--- a/apps/agent/agent/agents/handlers/greet_user.py
+++ b/apps/agent/agent/agents/handlers/greet_user.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from agent.agents.handlers.result import HandlerResult
 from agent.agents.models import PlanStep
 
 
 async def execute(
     step: PlanStep,
-    context: dict[str, object],
+    context: Mapping[str, object],
     db: object,
     retriever: object,
 ) -> HandlerResult:

--- a/apps/agent/agent/agents/route_area_splitter.py
+++ b/apps/agent/agent/agents/route_area_splitter.py
@@ -56,6 +56,7 @@ class AreaSplitResult(BaseModel):
 
 route_planner_agent: Agent[None, AreaSplitResult] = Agent(
     resolve_model(None),
+    name="route_planner",
     output_type=AreaSplitResult,
     instructions=_SPLIT_INSTRUCTIONS,
     retries=1,

--- a/apps/agent/agent/agents/runtime_deps.py
+++ b/apps/agent/agent/agents/runtime_deps.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 
 from agent.agents.agent_result import StepRecord
 from agent.agents.guardrails import WebResult
+from agent.agents.tool_state import ToolState
 from agent.agents.translation import TranslationResult
 from agent.clients.catalog_client import CatalogClientProtocol
 from agent.domain.ports import DatabasePort
@@ -34,12 +35,5 @@ class RuntimeDeps:
     web_searcher: WebSearcher | None = None
     title_translator: TitleTranslator | None = None
 
-    # Mutable per-run state accumulated during the agent run.
-    # ponytail: mixes two concerns — fixed session fields (origin_lat/lng, locale,
-    # last_location, resolve_candidates, pending_clarify) that should be typed
-    # dataclass fields, plus ToolName-keyed tool results (genuinely dynamic, legit).
-    # Reads are all literal-key. Cleanup (split into typed session state + a
-    # dict[ToolName, ...] results map, ~8 files) deferred to the Wave 3 agent→Worker
-    # runtime rewrite — see memory project_tool_state_followup.
-    tool_state: dict[str, object] = field(default_factory=dict)
+    tool_state: ToolState = field(default_factory=ToolState)
     steps: list[StepRecord] = field(default_factory=list)

--- a/apps/agent/agent/agents/selected_route.py
+++ b/apps/agent/agent/agents/selected_route.py
@@ -9,8 +9,10 @@ from agent.agents.agent_result import AgentResult, StepRecord
 from agent.agents.catalog_adapter import build_route_payload
 from agent.agents.error_messages import build_error_message
 from agent.agents.messages import build_message
+from agent.agents.models import ToolName
 from agent.agents.runtime_deps import OnStep
 from agent.agents.runtime_models import RouteDataModel, RouteModel, RouteResponseModel
+from agent.agents.tool_state import ToolState
 from agent.clients.catalog_client import CatalogClientProtocol, Route
 from agent.clients.errors import APIError
 
@@ -96,10 +98,12 @@ def _build_success_result(
         message=message,
         data=RouteDataModel(route=route_model),
     )
+    tool_state = ToolState()
+    tool_state.set_payload(ToolName.PLAN_SELECTED, payload)
     return AgentResult(
         output=output,
         steps=[step],
-        tool_state={"plan_selected": payload},
+        tool_state=tool_state.to_legacy_dict(),
     )
 
 

--- a/apps/agent/agent/agents/sql_agent.py
+++ b/apps/agent/agent/agents/sql_agent.py
@@ -138,6 +138,7 @@ async def resolve_location(
     try:
         agent = create_agent(
             get_default_model(),
+            name="location_resolver",
             system_prompt=_RESOLVE_LOCATION_PROMPT.format(
                 known_locations=_KNOWN_KEYS_STR,
             ),

--- a/apps/agent/agent/agents/tool_runtime.py
+++ b/apps/agent/agent/agents/tool_runtime.py
@@ -8,7 +8,7 @@ greet/qa handlers; the catalog read path lives in ``catalog_tools``.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 
 from pydantic_ai import RunContext
 
@@ -100,7 +100,7 @@ async def _run_ephemeral(
     tool: ToolName,
     params: dict[str, object],
     handler: Callable[
-        [PlanStep, dict[str, object], object, object], Awaitable[HandlerResult]
+        [PlanStep, Mapping[str, object], object, object], Awaitable[HandlerResult]
     ],
 ) -> dict[str, object]:
     """Run an upstream-free handler (greet/qa) and record/emit its result.
@@ -113,7 +113,7 @@ async def _run_ephemeral(
 
     result = await handler(
         PlanStep(tool=tool, params=params),
-        deps.tool_state,
+        deps.tool_state.to_legacy_dict(),
         None,
         None,
     )
@@ -129,7 +129,7 @@ async def _run_ephemeral(
 
     if result.success and result.data:
         _localize_city_names(result.data, deps.locale)
-        deps.tool_state[tool.value] = result.data
+        deps.tool_state.set_payload(tool, result.data)
         await _emit_step(deps, tool.value, "done", result.data)
     else:
         error_data: dict[str, object] = {"error": result.error or "Unknown error"}
@@ -159,8 +159,8 @@ async def run_clarify(
         "candidates": candidates,
         "status": "needs_clarification",
     }
-    deps.tool_state[ToolName.CLARIFY.value] = payload
-    deps.tool_state["pending_clarify"] = True
+    deps.tool_state.set_payload(ToolName.CLARIFY, payload)
+    deps.tool_state.pending_clarify = True
     _record_step(
         deps,
         tool=ToolName.CLARIFY.value,
@@ -174,4 +174,7 @@ async def run_clarify(
     # Without this, some models (e.g. DeepSeek V4 Flash) continue calling
     # search_bangumi instead of waiting for user input.
     payload["action_required"] = "return clarify_response"
+    clarify_state = deps.tool_state.clarify
+    if clarify_state is not None:
+        clarify_state.action_required = "return clarify_response"
     return payload

--- a/apps/agent/agent/agents/tool_state.py
+++ b/apps/agent/agent/agents/tool_state.py
@@ -12,9 +12,15 @@ LegacyPayload: TypeAlias = dict[str, JsonValue]
 
 
 class _LegacyCompatibleModel(BaseModel):
-    """Type known fields while retaining fields from older persisted sessions."""
+    """Retain unknown fields hydrated by the persisted search-session seed."""
 
     model_config = ConfigDict(extra="allow")
+
+
+class _RuntimePayloadModel(BaseModel):
+    """Reject unknown fields in payloads written only by typed runtime code."""
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class PointState(_LegacyCompatibleModel):
@@ -37,7 +43,7 @@ class PointState(_LegacyCompatibleModel):
     city: str | None = None
 
 
-class CandidateState(_LegacyCompatibleModel):
+class CandidateState(_RuntimePayloadModel):
     """Resolve/clarify candidate shared by live tools and session backfill."""
 
     title: str
@@ -48,7 +54,7 @@ class CandidateState(_LegacyCompatibleModel):
     spot_count: int | None = None
 
 
-class ResolveAnimeState(_LegacyCompatibleModel):
+class ResolveAnimeState(_RuntimePayloadModel):
     """State emitted by ``resolve_anime``."""
 
     bangumi_id: str | None = None
@@ -101,7 +107,7 @@ class SearchState(_LegacyCompatibleModel):
     summary: SearchSummaryState | None = None
 
 
-class RouteSummaryState(_LegacyCompatibleModel):
+class RouteSummaryState(_RuntimePayloadModel):
     """Counts and distance totals attached to a planned route."""
 
     point_count: int
@@ -112,7 +118,7 @@ class RouteSummaryState(_LegacyCompatibleModel):
     without_coordinates: int
 
 
-class RouteState(_LegacyCompatibleModel):
+class RouteState(_RuntimePayloadModel):
     """State emitted by route planning and selected-point routing."""
 
     ordered_points: list[PointState] = Field(default_factory=list)
@@ -123,14 +129,14 @@ class RouteState(_LegacyCompatibleModel):
     summary: RouteSummaryState | None = None
 
 
-class InfoState(_LegacyCompatibleModel):
+class InfoState(_RuntimePayloadModel):
     """State emitted by greeting and general-QA tools."""
 
     message: str
     status: str
 
 
-class ClarifyState(_LegacyCompatibleModel):
+class ClarifyState(_RuntimePayloadModel):
     """State emitted by the clarification tool."""
 
     question: str

--- a/apps/agent/agent/agents/tool_state.py
+++ b/apps/agent/agent/agents/tool_state.py
@@ -1,0 +1,211 @@
+"""Typed, session-scoped state accumulated by agent tools."""
+
+from __future__ import annotations
+
+from typing import Literal, TypeAlias, cast
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+
+from agent.agents.models import TimedItinerary, ToolName
+
+LegacyPayload: TypeAlias = dict[str, JsonValue]
+
+
+class _LegacyCompatibleModel(BaseModel):
+    """Type known fields while retaining fields from older persisted sessions."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class PointState(_LegacyCompatibleModel):
+    """A search or route point; fields are optional for legacy session rows."""
+
+    id: str | None = None
+    name: str | None = None
+    name_cn: str | None = None
+    episode: int | None = None
+    time_seconds: int | None = None
+    screenshot_url: str | None = None
+    bangumi_id: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    title: str | None = None
+    title_cn: str | None = None
+    distance_m: float | None = None
+    origin: str | None = None
+    cover_url: str | None = None
+    city: str | None = None
+
+
+class CandidateState(_LegacyCompatibleModel):
+    """Resolve/clarify candidate shared by live tools and session backfill."""
+
+    title: str
+    bangumi_id: str | None = None
+    cover_url: str | None = None
+    city: str | None = None
+    points_count: int | None = None
+    spot_count: int | None = None
+
+
+class ResolveAnimeState(_LegacyCompatibleModel):
+    """State emitted by ``resolve_anime``."""
+
+    bangumi_id: str | None = None
+    title: str | None = None
+    ambiguous: bool | None = None
+    candidates: list[CandidateState] = Field(default_factory=list)
+
+
+class SearchMetadataState(_LegacyCompatibleModel):
+    """Anime metadata attached to a search payload."""
+
+    anime_title: str | None = None
+    anime_title_cn: str | None = None
+    cover_url: str | None = None
+    data_origin: str | None = None
+    source: str | None = None
+    radius_m: int | None = None
+    cache: str | None = None
+
+
+class NearbyGroupState(_LegacyCompatibleModel):
+    """One anime grouping in nearby-search results."""
+
+    bangumi_id: str
+    title: str
+    cover_url: str | None = None
+    points_count: int | None = None
+    closest_distance_m: float | None = None
+
+
+class SearchSummaryState(_LegacyCompatibleModel):
+    """Compact search result counts and provenance."""
+
+    count: int
+    source: str
+    cache: str
+
+
+class SearchState(_LegacyCompatibleModel):
+    """Shared state shape for bangumi and nearby searches."""
+
+    rows: list[PointState] = Field(default_factory=list)
+    items: list[PointState] | None = None
+    row_count: int = 0
+    strategy: Literal["geo", "bangumi"] | None = None
+    metadata: SearchMetadataState | None = None
+    nearby_groups: list[NearbyGroupState] | None = None
+    status: str | None = None
+    empty: bool | None = None
+    summary: SearchSummaryState | None = None
+
+
+class RouteSummaryState(_LegacyCompatibleModel):
+    """Counts and distance totals attached to a planned route."""
+
+    point_count: int
+    total_minutes: int
+    total_distance_m: float
+    clusters: int
+    with_coordinates: int
+    without_coordinates: int
+
+
+class RouteState(_LegacyCompatibleModel):
+    """State emitted by route planning and selected-point routing."""
+
+    ordered_points: list[PointState] = Field(default_factory=list)
+    timed_itinerary: TimedItinerary | None = None
+    point_count: int = 0
+    cover_url: str | None = None
+    status: str | None = None
+    summary: RouteSummaryState | None = None
+
+
+class InfoState(_LegacyCompatibleModel):
+    """State emitted by greeting and general-QA tools."""
+
+    message: str
+    status: str
+
+
+class ClarifyState(_LegacyCompatibleModel):
+    """State emitted by the clarification tool."""
+
+    question: str
+    options: list[str] = Field(default_factory=list)
+    candidates: list[CandidateState] = Field(default_factory=list)
+    status: Literal["needs_clarification"]
+    action_required: str | None = None
+
+
+ToolPayload: TypeAlias = (
+    ResolveAnimeState | SearchState | RouteState | InfoState | ClarifyState
+)
+
+
+class ToolState(BaseModel):
+    """Typed runtime state with an explicit legacy-dict serialization boundary."""
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    locale: str | None = None
+    last_location: str | None = None
+    origin_lat: float | None = None
+    origin_lng: float | None = None
+    resolve_candidates: list[CandidateState | str] | None = None
+    pending_clarify: bool | None = None
+    resolve_anime: ResolveAnimeState | None = None
+    search_bangumi: SearchState | None = None
+    search_nearby: SearchState | None = None
+    plan_route: RouteState | None = None
+    plan_selected: RouteState | None = None
+    answer_question: InfoState | None = None
+    greet_user: InfoState | None = None
+    clarify: ClarifyState | None = None
+
+    def set_payload(self, tool: ToolName, payload: object) -> None:
+        """Validate a tool payload into its corresponding typed sub-state."""
+        model_type = _PAYLOAD_MODELS[tool]
+        setattr(self, tool.value, model_type.model_validate(payload))
+
+    def remove_payload(self, tool: ToolName) -> None:
+        """Clear a tool result before a new attempt."""
+        setattr(self, tool.value, None)
+        self.__pydantic_fields_set__.discard(tool.value)
+
+    def payload_for(self, tool: str) -> LegacyPayload | None:
+        """Serialize one tool payload for an existing wire/UI boundary."""
+        payload = getattr(self, tool, None)
+        if not isinstance(payload, BaseModel):
+            return None
+        return cast(LegacyPayload, _dump_model(payload))
+
+    def has_payload(self, tool: str) -> bool:
+        """Return whether a tool has populated state."""
+        return isinstance(getattr(self, tool, None), BaseModel)
+
+    def legacy_keys(self) -> set[str]:
+        """Return keys present at the historical dictionary boundary."""
+        return set(self.to_legacy_dict())
+
+    def to_legacy_dict(self) -> LegacyPayload:
+        """Serialize to the exact heterogeneous dict shape used historically."""
+        return cast(LegacyPayload, _dump_model(self))
+
+
+def _dump_model(model: BaseModel) -> object:
+    return model.model_dump(mode="json", exclude_unset=True)
+
+
+_PAYLOAD_MODELS: dict[ToolName, type[ToolPayload]] = {
+    ToolName.RESOLVE_ANIME: ResolveAnimeState,
+    ToolName.SEARCH_BANGUMI: SearchState,
+    ToolName.SEARCH_NEARBY: SearchState,
+    ToolName.PLAN_ROUTE: RouteState,
+    ToolName.PLAN_SELECTED: RouteState,
+    ToolName.ANSWER_QUESTION: InfoState,
+    ToolName.GREET_USER: InfoState,
+    ToolName.CLARIFY: ClarifyState,
+}

--- a/apps/agent/agent/agents/translation.py
+++ b/apps/agent/agent/agents/translation.py
@@ -112,6 +112,7 @@ IMPORTANT RULES:
 
 translation_agent: Agent[TranslationDeps, str] = Agent(
     resolve_model(None),
+    name="translation",
     deps_type=TranslationDeps,
     output_type=str,
     instructions=_TRANSLATION_INSTRUCTIONS,

--- a/apps/agent/agent/agents/web_tools.py
+++ b/apps/agent/agent/agents/web_tools.py
@@ -1,8 +1,6 @@
-"""Web-facing tool registrations (web_search, translate_anime_title).
+"""Web-facing tool definitions (web_search, translate_anime_title).
 
 Extracted from animichi_tools.py to keep that file under 300 lines.
-Import this module after ``animichi_agent`` is created so the decorators
-can attach to it.
 """
 
 from __future__ import annotations
@@ -17,8 +15,8 @@ from pydantic_ai.common_tools.duckduckgo import (
     DuckDuckGoResult,
     duckduckgo_search_tool,
 )
+from pydantic_ai.tools import ToolFuncEither
 
-from agent.agents.animichi_agent import animichi_agent
 from agent.agents.guardrails import (
     WebResult,
     detect_prompt_injection,
@@ -70,7 +68,6 @@ def _log_result_injections(results: list[WebResult]) -> None:
         )
 
 
-@animichi_agent.tool
 async def web_search(
     ctx: RunContext[RuntimeDeps],
     *,
@@ -106,7 +103,6 @@ async def web_search(
     return wrap_untrusted_web_results(results)
 
 
-@animichi_agent.tool
 async def translate_anime_title(
     ctx: RunContext[RuntimeDeps],
     *,
@@ -143,3 +139,6 @@ async def _translate_title(
     if deps.title_translator is not None:
         return await deps.title_translator(title, target_language)
     return await translate_title(title, target_locale=target_language, db=deps.db)
+
+
+TOOLS: list[ToolFuncEither[RuntimeDeps]] = [web_search, translate_anime_title]

--- a/apps/agent/agent/agents/web_tools.py
+++ b/apps/agent/agent/agents/web_tools.py
@@ -15,7 +15,7 @@ from pydantic_ai.common_tools.duckduckgo import (
     DuckDuckGoResult,
     duckduckgo_search_tool,
 )
-from pydantic_ai.tools import ToolFuncEither
+from pydantic_ai.tools import Tool, ToolFuncEither
 
 from agent.agents.guardrails import (
     WebResult,
@@ -142,3 +142,8 @@ async def _translate_title(
 
 
 TOOLS: list[ToolFuncEither[RuntimeDeps]] = [web_search, translate_anime_title]
+
+DEFERRED_TOOLS: list[Tool[RuntimeDeps]] = [
+    Tool(web_search, defer_loading=True),
+    Tool(translate_anime_title, defer_loading=True),
+]

--- a/apps/agent/agent/infrastructure/observability/__init__.py
+++ b/apps/agent/agent/infrastructure/observability/__init__.py
@@ -13,6 +13,7 @@ Usage:
 
 from agent.infrastructure.observability.runtime import (
     http_span,
+    record_agent_run_error,
     record_http_request,
     record_runtime_request,
     runtime_span,
@@ -20,6 +21,7 @@ from agent.infrastructure.observability.runtime import (
 
 __all__ = [
     "http_span",
+    "record_agent_run_error",
     "record_http_request",
     "record_runtime_request",
     "runtime_span",

--- a/apps/agent/agent/infrastructure/observability/runtime.py
+++ b/apps/agent/agent/infrastructure/observability/runtime.py
@@ -68,3 +68,13 @@ def record_http_request(
     }
     _http_requests.add(1, attributes)
     _http_duration.record(duration_ms, attributes)
+
+
+def record_agent_run_error(error: BaseException) -> None:
+    """Record a failed PydanticAI run without changing propagation semantics."""
+    logfire.error(
+        "animichi_agent_run_error",
+        error_type=type(error).__name__,
+        error_message=str(error)[:500],
+        _exc_info=error,
+    )

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -21,6 +21,7 @@ from starlette.responses import Response
 
 from agent.agents.animichi_runner import animichi_agent
 from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_state import ToolState
 from agent.domain.ports import DatabasePort
 from agent.interfaces.public_api import default_catalog_client
 from agent.interfaces.routes._deps import (
@@ -113,8 +114,8 @@ def _make_on_complete(
         # Merge full tool_state data into the output's empty data section.
         # Wrap under "results" or "route" to match response_builder.py convention.
         intent = data.get("intent", "")
-        tool_data = deps.tool_state.get(intent)
-        if isinstance(tool_data, dict) and isinstance(data.get("data"), dict):
+        tool_data = deps.tool_state.payload_for(str(intent))
+        if tool_data is not None and isinstance(data.get("data"), dict):
             if intent in ("plan_route", "plan_selected"):
                 data["data"] = {"route": tool_data}
             else:
@@ -158,7 +159,7 @@ async def handle_chat(
 
     # Pre-populate tool_state with clarify context if detected
     if clarify_ctx:
-        deps.tool_state.update(clarify_ctx)
+        deps.tool_state = ToolState.model_validate(clarify_ctx)
         logger.info("chat_clarify_context_detected", clarify_ctx=clarify_ctx)
 
     return await VercelAIAdapter.dispatch_request(

--- a/apps/agent/agent/interfaces/session_facade.py
+++ b/apps/agent/agent/interfaces/session_facade.py
@@ -446,6 +446,7 @@ async def compact_session_interactions(
 
     agent = create_agent(
         get_default_model(),
+        name="session_compactor",
         system_prompt=(
             "Summarize the session in 1-2 sentences. Capture what the user was "
             "researching and keep the same language as the interaction text."
@@ -495,6 +496,7 @@ async def generate_and_save_title(
     try:
         agent = create_agent(
             get_default_model(),
+            name="conversation_title",
             system_prompt=(
                 "Generate a very short conversation title (<=15 characters) in the "
                 "same language as the query. Output only the title."

--- a/apps/agent/agent/tests/eval/exec_tiers.py
+++ b/apps/agent/agent/tests/eval/exec_tiers.py
@@ -21,6 +21,16 @@ OutputT = TypeVar("OutputT")
 MetadataT = TypeVar("MetadataT")
 
 
+class UsageRow(BaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+    requests: int = 0
+
+
+class UsageSummary(UsageRow):
+    cases_with_usage: int = 0
+
+
 class CaseRow(BaseModel):
     id: str | None = None
     scores: dict[str, float] | None = None
@@ -34,6 +44,7 @@ class CaseRow(BaseModel):
     query: str | None = None
     locale: str | None = None
     expected_stages: list[str] | None = None
+    usage: UsageRow | None = None
 
 
 class ResultsPayload(BaseModel):
@@ -49,6 +60,7 @@ class ResultsPayload(BaseModel):
     errored_count: int
     scores: dict[str, float]
     cases: list[CaseRow]
+    usage: UsageSummary = UsageSummary()
 
 
 @dataclass(frozen=True)
@@ -130,6 +142,7 @@ def build_results_payload(
         errored_count=len(report.failures),
         scores=scores,
         cases=_case_rows(report),
+        usage=_aggregate_usage(report),
     )
 
 
@@ -235,6 +248,30 @@ def _case_row(
         query=_input_query(inputs),
         locale=_input_locale(inputs),
         expected_stages=_expected_stages(metadata),
+        usage=_output_usage(output),
+    )
+
+
+def _output_usage(output: object | None) -> UsageRow | None:
+    if not isinstance(output, AgentResult) or output.usage is None:
+        return None
+    return UsageRow(
+        input_tokens=output.usage.input_tokens,
+        output_tokens=output.usage.output_tokens,
+        requests=output.usage.requests,
+    )
+
+
+def _aggregate_usage(
+    report: EvaluationReport[InputsT, OutputT, MetadataT],
+) -> UsageSummary:
+    usages = [_output_usage(case.output) for case in report.cases]
+    present = [usage for usage in usages if usage is not None]
+    return UsageSummary(
+        input_tokens=sum(usage.input_tokens for usage in present),
+        output_tokens=sum(usage.output_tokens for usage in present),
+        requests=sum(usage.requests for usage in present),
+        cases_with_usage=len(present),
     )
 
 

--- a/apps/agent/agent/tests/fixtures/tool_state_legacy_shape.json
+++ b/apps/agent/agent/tests/fixtures/tool_state_legacy_shape.json
@@ -11,15 +11,16 @@
     "candidates": [{"title": "響け！ユーフォニアム", "bangumi_id": "485", "cover_url": "/cover.jpg", "city": "", "points_count": 0}]
   },
   "search_bangumi": {
-    "rows": [{"id": "p1", "name": "宇治橋", "name_cn": "宇治桥", "episode": 1, "time_seconds": 42, "screenshot_url": "/shot.jpg", "bangumi_id": "485", "latitude": 34.89, "longitude": 135.81, "title": "響け！ユーフォニアム", "title_cn": "吹响吧！上低音号", "distance_m": 120.0, "origin": "catalog", "cover_url": "/cover.jpg"}],
+    "rows": [{"id": "p1", "name": "宇治橋", "name_cn": "宇治桥", "episode": 1, "time_seconds": 42, "screenshot_url": "/shot.jpg", "bangumi_id": "485", "latitude": 34.89, "longitude": 135.81, "title": "響け！ユーフォニアム", "title_cn": "吹响吧！上低音号", "distance_m": 120.0, "origin": "catalog", "cover_url": "/cover.jpg", "legacy_point_alien": "preserved"}],
     "items": [{"id": "p1", "name": "宇治橋", "name_cn": "宇治桥", "episode": 1, "time_seconds": 42, "screenshot_url": "/shot.jpg", "bangumi_id": "485", "latitude": 34.89, "longitude": 135.81, "title": "響け！ユーフォニアム", "title_cn": "吹响吧！上低音号", "distance_m": 120.0, "origin": "catalog", "cover_url": "/cover.jpg"}],
     "row_count": 1,
     "strategy": "bangumi",
-    "metadata": {"anime_title": "響け！ユーフォニアム", "anime_title_cn": "吹响吧！上低音号", "cover_url": "/cover.jpg", "data_origin": "catalog", "source": "catalog"},
-    "nearby_groups": [{"bangumi_id": "485", "title": "響け！ユーフォニアム", "cover_url": "/cover.jpg", "points_count": 1, "closest_distance_m": 120.0}],
+    "metadata": {"anime_title": "響け！ユーフォニアム", "anime_title_cn": "吹响吧！上低音号", "cover_url": "/cover.jpg", "data_origin": "catalog", "source": "catalog", "legacy_metadata_alien": "preserved"},
+    "nearby_groups": [{"bangumi_id": "485", "title": "響け！ユーフォニアム", "cover_url": "/cover.jpg", "points_count": 1, "closest_distance_m": 120.0, "legacy_group_alien": "preserved"}],
     "status": "ok",
     "empty": false,
-    "summary": {"count": 1, "source": "catalog", "cache": "miss"}
+    "summary": {"count": 1, "source": "catalog", "cache": "miss", "legacy_summary_alien": "preserved"},
+    "legacy_search_alien": "preserved"
   },
   "search_nearby": {"rows": [], "items": [], "row_count": 0, "strategy": "geo", "metadata": {}, "nearby_groups": [], "status": "empty", "empty": true, "summary": {"count": 0, "source": "catalog", "cache": "miss"}},
   "plan_route": {

--- a/apps/agent/agent/tests/fixtures/tool_state_legacy_shape.json
+++ b/apps/agent/agent/tests/fixtures/tool_state_legacy_shape.json
@@ -1,0 +1,37 @@
+{
+  "locale": "ja",
+  "last_location": "宇治",
+  "origin_lat": 34.886,
+  "origin_lng": 135.805,
+  "resolve_candidates": [{"title": "響け！ユーフォニアム", "bangumi_id": "485"}],
+  "pending_clarify": true,
+  "resolve_anime": {
+    "bangumi_id": "485",
+    "title": "響け！ユーフォニアム",
+    "candidates": [{"title": "響け！ユーフォニアム", "bangumi_id": "485", "cover_url": "/cover.jpg", "city": "", "points_count": 0}]
+  },
+  "search_bangumi": {
+    "rows": [{"id": "p1", "name": "宇治橋", "name_cn": "宇治桥", "episode": 1, "time_seconds": 42, "screenshot_url": "/shot.jpg", "bangumi_id": "485", "latitude": 34.89, "longitude": 135.81, "title": "響け！ユーフォニアム", "title_cn": "吹响吧！上低音号", "distance_m": 120.0, "origin": "catalog", "cover_url": "/cover.jpg"}],
+    "items": [{"id": "p1", "name": "宇治橋", "name_cn": "宇治桥", "episode": 1, "time_seconds": 42, "screenshot_url": "/shot.jpg", "bangumi_id": "485", "latitude": 34.89, "longitude": 135.81, "title": "響け！ユーフォニアム", "title_cn": "吹响吧！上低音号", "distance_m": 120.0, "origin": "catalog", "cover_url": "/cover.jpg"}],
+    "row_count": 1,
+    "strategy": "bangumi",
+    "metadata": {"anime_title": "響け！ユーフォニアム", "anime_title_cn": "吹响吧！上低音号", "cover_url": "/cover.jpg", "data_origin": "catalog", "source": "catalog"},
+    "nearby_groups": [{"bangumi_id": "485", "title": "響け！ユーフォニアム", "cover_url": "/cover.jpg", "points_count": 1, "closest_distance_m": 120.0}],
+    "status": "ok",
+    "empty": false,
+    "summary": {"count": 1, "source": "catalog", "cache": "miss"}
+  },
+  "search_nearby": {"rows": [], "items": [], "row_count": 0, "strategy": "geo", "metadata": {}, "nearby_groups": [], "status": "empty", "empty": true, "summary": {"count": 0, "source": "catalog", "cache": "miss"}},
+  "plan_route": {
+    "ordered_points": [],
+    "timed_itinerary": {"stops": [], "legs": [], "total_minutes": 0, "total_distance_m": 0.0, "spot_count": 0, "pacing": "normal", "start_time": "09:00", "export_google_maps_url": [], "export_ics": ""},
+    "point_count": 0,
+    "cover_url": "",
+    "status": "ok",
+    "summary": {"point_count": 0, "total_minutes": 0, "total_distance_m": 0.0, "clusters": 0, "with_coordinates": 0, "without_coordinates": 0}
+  },
+  "plan_selected": {"ordered_points": [], "timed_itinerary": {"stops": [], "legs": [], "total_minutes": 0, "total_distance_m": 0.0, "spot_count": 0, "pacing": "normal", "start_time": "09:00", "export_google_maps_url": [], "export_ics": ""}, "point_count": 0, "cover_url": "", "status": "ok", "summary": {"point_count": 0, "total_minutes": 0, "total_distance_m": 0.0, "clusters": 0, "with_coordinates": 0, "without_coordinates": 0}},
+  "answer_question": {"message": "マナーを守りましょう。", "status": "info"},
+  "greet_user": {"message": "こんにちは。", "status": "info"},
+  "clarify": {"question": "どちらですか？", "options": ["TV", "映画"], "candidates": [{"title": "TV", "cover_url": null, "spot_count": 0, "city": ""}], "status": "needs_clarification", "action_required": "return clarify_response"}
+}

--- a/apps/agent/agent/tests/unit/test_agent_base.py
+++ b/apps/agent/agent/tests/unit/test_agent_base.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import ast
+import inspect
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.openai import OpenAIChatModel
 
-from agent.agents.base import describe_model, parse_model_spec, resolve_model
+from agent.agents.base import (
+    create_agent,
+    describe_model,
+    parse_model_spec,
+    resolve_model,
+)
 from agent.config.settings import Settings
 
 
@@ -29,6 +37,46 @@ def _test_settings() -> Settings:
 
 def _deepseek_extra_body() -> object:
     return {"thinking": {"type": "disabled"}}
+
+
+def _agent_calls(path: Path) -> list[ast.Call]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Agent"
+    ]
+
+
+def _has_non_none_name(call: ast.Call) -> bool:
+    names = {keyword.arg: keyword.value for keyword in call.keywords}
+    value = names.get("name")
+    return value is not None and not (
+        isinstance(value, ast.Constant) and value.value is None
+    )
+
+
+def _unnamed_agent_calls() -> list[str]:
+    source_root = Path(__file__).parents[2]
+    files = (path for path in source_root.rglob("*.py") if "tests" not in path.parts)
+    return [
+        f"{path.relative_to(source_root)}:{call.lineno}"
+        for path in files
+        for call in _agent_calls(path)
+        if not _has_non_none_name(call)
+    ]
+
+
+def test_every_agent_construction_has_explicit_name() -> None:
+    assert _unnamed_agent_calls() == []
+
+
+def test_create_agent_requires_name() -> None:
+    parameter = inspect.signature(create_agent).parameters["name"]
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameter.default is inspect.Parameter.empty
 
 
 class TestResolveModel:

--- a/apps/agent/agent/tests/unit/test_agent_upstream_free.py
+++ b/apps/agent/agent/tests/unit/test_agent_upstream_free.py
@@ -4,11 +4,8 @@ GOAL §7 ("旧 agent 上游调用已删净") requires every agent path — the f
 tools AND clarify candidate enrichment — to route only through the injected
 :class:`CatalogClientProtocol`. This locks that invariant three ways:
 
-  1. Static: ``animichi_tools`` / ``catalog_tools`` / ``tool_runtime`` /
-     ``tools`` import no upstream client (Anitabi/Bangumi gateways), no DB
-     Retriever, and no legacy data handlers. With clarify rewired onto the
-     catalog, ``tools`` joins the seam — the agent has no remaining gateway
-     touch.
+  1. Static: tool definitions and their catalog seam import no upstream client
+     (Anitabi/Bangumi gateways), no DB Retriever, and no legacy data handlers.
   2. Static: no seam module references a ``deps.gateway`` attribute (the field
      no longer exists on ``RuntimeDeps``; this also catches a reintroduced
      gateway hop before it can compile).
@@ -32,6 +29,7 @@ from agent.domain.ports import DatabasePort
 # Modules that form the catalog-only agent seam. These must stay free of any
 # upstream/DB read path. ``tools`` (clarify enrichment) is included now that it
 # resolves via the catalog instead of the Bangumi gateway.
+_TOOL_MODULES = ("animichi_tools", "web_tools")
 _SEAM_MODULES = ("animichi_tools", "catalog_tools", "tool_runtime", "tools")
 
 # Substrings that, if imported by a seam module, mean an upstream/DB read path
@@ -39,6 +37,8 @@ _SEAM_MODULES = ("animichi_tools", "catalog_tools", "tool_runtime", "tools")
 _FORBIDDEN_IMPORT_FRAGMENTS = (
     "gateways",  # anitabi / bangumi upstream gateways
     "retriever",  # DB Retriever read path
+    "infrastructure.supabase",  # direct legacy DB client
+    "domain.ports",  # direct database ports
     "execute_resolve_anime",
     "execute_search_bangumi",
     "execute_search_nearby",
@@ -90,6 +90,19 @@ def test_seam_module_never_touches_deps_gateway(module_name: str) -> None:
     """No seam module reads ``deps.gateway`` — clarify routes via the catalog."""
     accesses = _gateway_attribute_accesses(module_name)
     assert not accesses, f"{module_name} accessed a .gateway attribute: {accesses}"
+
+
+@pytest.mark.parametrize("module_name", _TOOL_MODULES)
+def test_tool_module_does_not_import_animichi_agent(module_name: str) -> None:
+    """Tool definitions must not depend on the composed global agent."""
+    imported = _imported_names(module_name)
+    assert "agent.agents.animichi_agent" not in imported
+
+
+def test_runner_has_no_tool_registration_side_effect_imports() -> None:
+    imported = _imported_names("animichi_runner")
+    forbidden = {"agent.agents.animichi_tools", "agent.agents.web_tools"}
+    assert forbidden.isdisjoint(imported)
 
 
 class _ExplodingDB:

--- a/apps/agent/agent/tests/unit/test_animichi_agent.py
+++ b/apps/agent/agent/tests/unit/test_animichi_agent.py
@@ -234,12 +234,16 @@ class TestSessionContextInjection:
         from agent.agents.animichi_agent import _inject_session_context
 
         ctx = MagicMock()
-        ctx.deps.tool_state = {
-            "search_bangumi": {
-                "row_count": 76,
-                "metadata": {"anime_title": "涼宮ハルヒの憂鬱"},
+        from agent.agents.tool_state import ToolState
+
+        ctx.deps.tool_state = ToolState.model_validate(
+            {
+                "search_bangumi": {
+                    "row_count": 76,
+                    "metadata": {"anime_title": "涼宮ハルヒの憂鬱"},
+                }
             }
-        }
+        )
         result = _inject_session_context(ctx)
         assert "76 spots" in result
         assert "涼宮ハルヒの憂鬱" in result
@@ -248,7 +252,9 @@ class TestSessionContextInjection:
         from agent.agents.animichi_agent import _inject_session_context
 
         ctx = MagicMock()
-        ctx.deps.tool_state = {}
+        from agent.agents.tool_state import ToolState
+
+        ctx.deps.tool_state = ToolState()
         ctx.deps.locale = "ja"
         result = _inject_session_context(ctx)
         assert "default to Japanese" in result
@@ -258,8 +264,10 @@ class TestSessionContextInjection:
         from agent.agents.animichi_agent import _inject_session_context
 
         ctx = MagicMock()
-        ctx.deps.tool_state = {
-            "resolve_anime": {"title": "君の名は。", "bangumi_id": "160209"}
-        }
+        from agent.agents.tool_state import ToolState
+
+        ctx.deps.tool_state = ToolState.model_validate(
+            {"resolve_anime": {"title": "君の名は。", "bangumi_id": "160209"}}
+        )
         result = _inject_session_context(ctx)
         assert "君の名は。" in result

--- a/apps/agent/agent/tests/unit/test_animichi_runner.py
+++ b/apps/agent/agent/tests/unit/test_animichi_runner.py
@@ -15,7 +15,7 @@ def test_seed_tool_state_sets_locale() -> None:
         db=MagicMock(), locale="zh", query="test", catalog=MockCatalogClient()
     )
     _seed_tool_state(deps, None)
-    assert deps.tool_state["locale"] == "zh"
+    assert deps.tool_state.locale == "zh"
 
 
 def test_seed_tool_state_with_context() -> None:
@@ -33,12 +33,12 @@ def test_seed_tool_state_with_context() -> None:
         },
     }
     _seed_tool_state(deps, context)
-    assert deps.tool_state["last_location"] == "宇治"
+    assert deps.tool_state.last_location == "宇治"
     import pytest
 
-    assert deps.tool_state["origin_lat"] == pytest.approx(34.886)
-    assert deps.tool_state["origin_lng"] == pytest.approx(135.805)
-    assert "search_bangumi" in deps.tool_state
+    assert deps.tool_state.origin_lat == pytest.approx(34.886)
+    assert deps.tool_state.origin_lng == pytest.approx(135.805)
+    assert deps.tool_state.search_bangumi is not None
 
 
 def test_seed_tool_state_ignores_non_string_location() -> None:
@@ -48,7 +48,7 @@ def test_seed_tool_state_ignores_non_string_location() -> None:
         db=MagicMock(), locale="en", query="test", catalog=MockCatalogClient()
     )
     _seed_tool_state(deps, {"last_location": 123})
-    assert "last_location" not in deps.tool_state
+    assert deps.tool_state.last_location is None
 
 
 def test_seed_tool_state_ignores_non_dict_search_data() -> None:
@@ -58,7 +58,7 @@ def test_seed_tool_state_ignores_non_dict_search_data() -> None:
         db=MagicMock(), locale="en", query="test", catalog=MockCatalogClient()
     )
     _seed_tool_state(deps, {"last_search_data": "not_a_dict"})
-    assert "search_bangumi" not in deps.tool_state
+    assert deps.tool_state.search_bangumi is None
 
 
 def test_seed_tool_state_restores_clarify_context() -> None:
@@ -79,9 +79,9 @@ def test_seed_tool_state_restores_clarify_context() -> None:
     }
     _seed_tool_state(deps, context)
 
-    assert deps.tool_state.get("pending_clarify") is True
-    candidates = deps.tool_state.get("resolve_candidates")
-    assert isinstance(candidates, list)
+    assert deps.tool_state.pending_clarify is True
+    candidates = deps.tool_state.resolve_candidates
+    assert candidates is not None
     assert len(candidates) == 2
 
 
@@ -92,8 +92,8 @@ def test_seed_tool_state_omits_clarify_when_absent() -> None:
         db=MagicMock(), locale="en", query="test", catalog=MockCatalogClient()
     )
     _seed_tool_state(deps, {"last_location": "Uji"})
-    assert "pending_clarify" not in deps.tool_state
-    assert "resolve_candidates" not in deps.tool_state
+    assert deps.tool_state.pending_clarify is None
+    assert deps.tool_state.resolve_candidates is None
 
 
 def test_seed_tool_state_restores_flat_search_data() -> None:
@@ -111,8 +111,8 @@ def test_seed_tool_state_restores_flat_search_data() -> None:
         },
     }
     _seed_tool_state(deps, context)
-    assert "search_bangumi" in deps.tool_state
-    assert deps.tool_state["search_bangumi"]["row_count"] == 1
+    assert deps.tool_state.search_bangumi is not None
+    assert deps.tool_state.search_bangumi.row_count == 1
 
 
 def test_status_from_payload_extracts_status() -> None:

--- a/apps/agent/agent/tests/unit/test_chat_endpoint.py
+++ b/apps/agent/agent/tests/unit/test_chat_endpoint.py
@@ -247,15 +247,18 @@ class TestDetectClarifyContext:
 
 class TestOnComplete:
     async def test_yields_data_chunk_with_merged_tool_state(self) -> None:
+        from agent.agents.tool_state import ToolState
         from agent.interfaces.routes.chat import _make_on_complete
 
         mock_deps = MagicMock()
-        mock_deps.tool_state = {
-            "search_bangumi": {
-                "rows": [{"id": "p1", "name": "宇治橋", "city": "宇治"}],
-                "row_count": 1,
+        mock_deps.tool_state = ToolState.model_validate(
+            {
+                "search_bangumi": {
+                    "rows": [{"id": "p1", "name": "宇治橋", "city": "宇治"}],
+                    "row_count": 1,
+                }
             }
-        }
+        )
 
         mock_output = MagicMock()
         mock_output.model_dump.return_value = {
@@ -276,10 +279,11 @@ class TestOnComplete:
         assert chunks[0].data["data"]["results"]["rows"][0]["city"] == "宇治"
 
     async def test_no_chunk_for_plain_output(self) -> None:
+        from agent.agents.tool_state import ToolState
         from agent.interfaces.routes.chat import _make_on_complete
 
         mock_deps = MagicMock()
-        mock_deps.tool_state = {}
+        mock_deps.tool_state = ToolState()
         mock_result = MagicMock()
         mock_result.output = "just a string"
 

--- a/apps/agent/agent/tests/unit/test_eval_exec_tiers_results.py
+++ b/apps/agent/agent/tests/unit/test_eval_exec_tiers_results.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TypeAlias
 
+from pydantic_ai.usage import RunUsage
 from pydantic_evals.evaluators import EvaluationResult, EvaluatorSpec
 from pydantic_evals.reporting import (
     EvaluationReport,
@@ -29,7 +30,9 @@ def _score(
 def _result() -> AgentResult:
     output = QAResponseModel(intent="general_qa", message="Hello there")
     return AgentResult(
-        output=output, steps=[StepRecord(tool="answer_question", success=True)]
+        output=output,
+        steps=[StepRecord(tool="answer_question", success=True)],
+        usage=RunUsage(input_tokens=12, output_tokens=4, requests=2),
     )
 
 
@@ -93,3 +96,11 @@ def test_build_results_payload_persists_failures_and_reasons() -> None:
     assert payload.cases[0].expected_stages == ["general_qa"]
     assert payload.cases[1].error == "boom"
     assert payload.cases[1].expected_stages == ["general_qa"]
+    assert payload.usage.model_dump() == {
+        "input_tokens": 12,
+        "output_tokens": 4,
+        "requests": 2,
+        "cases_with_usage": 1,
+    }
+    assert payload.cases[0].usage is not None
+    assert payload.cases[0].usage.requests == 2

--- a/apps/agent/agent/tests/unit/test_eval_usage.py
+++ b/apps/agent/agent/tests/unit/test_eval_usage.py
@@ -1,0 +1,53 @@
+"""Token-usage reporting through the offline trajectory runtime."""
+
+from __future__ import annotations
+
+from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_evals import Case, Dataset
+
+from agent.tests.eval.eval_harness import make_agent_task
+from agent.tests.eval.evaluators import AgentInput
+from agent.tests.eval.exec_tiers import build_results_payload
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+from agent.tests.eval.null_database import NullDatabase
+
+
+def _qa_driver() -> FunctionModel:
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    "qa_response",
+                    {
+                        "intent": "general_qa",
+                        "message": "こんにちは。",
+                        "data": {"status": "info"},
+                        "ui": {},
+                    },
+                )
+            ]
+        )
+
+    return FunctionModel(respond)
+
+
+async def test_mock_trajectory_report_carries_usage() -> None:
+    task = make_agent_task(NullDatabase(), MockCatalogClient, _qa_driver())
+    dataset = Dataset(
+        name="usage",
+        cases=[Case(name="usage-1", inputs=AgentInput("こんにちは", "ja"))],
+    )
+    report = await dataset.evaluate(task, name="usage", max_concurrency=1)
+    payload = build_results_payload(
+        report,
+        model_id="function",
+        dataset="usage",
+        tier="trajectory",
+        case_count=1,
+        scores={},
+    )
+
+    assert payload.usage.requests > 0
+    assert payload.usage.cases_with_usage == 1
+    assert payload.cases[0].usage is not None

--- a/apps/agent/agent/tests/unit/test_handlers.py
+++ b/apps/agent/agent/tests/unit/test_handlers.py
@@ -8,6 +8,7 @@ from agent.agents.handlers.answer_question import execute, execute_clarify
 from agent.agents.handlers.greet_user import execute as execute_greet
 from agent.agents.handlers.result import HandlerResult
 from agent.agents.models import PlanStep, ToolName
+from agent.agents.tool_state import ToolState
 
 _Emitted = list[tuple[str, str, dict[str, object], str, str]]
 
@@ -28,7 +29,7 @@ def _ctx_with_emitter(emitted: _Emitted) -> MagicMock:
 
     deps = MagicMock()
     deps.on_step = fake_on_step
-    deps.tool_state = {}
+    deps.tool_state = ToolState()
     deps.steps = []
     deps.db = MagicMock()
     ctx = MagicMock()

--- a/apps/agent/agent/tests/unit/test_modern_composition.py
+++ b/apps/agent/agent/tests/unit/test_modern_composition.py
@@ -18,9 +18,10 @@ from agent.agents.animichi_agent import (
     _modern_composition_enabled,
     build_animichi_agent,
 )
-from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.runtime_deps import RuntimeDeps, TitleTranslator, WebSearcher
 from agent.agents.translation import TranslationResult
 from agent.tests.eval.mock_catalog_client import MockCatalogClient
+from agent.tests.eval.mock_web import MockWebSearcher
 
 _EAGER = {
     "clarify",
@@ -40,7 +41,7 @@ _QA_OUTPUT = {
 }
 
 
-def test_environment_switch_defaults_on_and_accepts_zero(
+async def test_environment_switch_defaults_on_and_builds_legacy_from_zero(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("ANIMICHI_MODERN_COMPOSITION", raising=False)
@@ -48,14 +49,29 @@ def test_environment_switch_defaults_on_and_accepts_zero(
     monkeypatch.setenv("ANIMICHI_MODERN_COMPOSITION", "0")
     assert _modern_composition_enabled() is False
 
+    observed: set[str] = set()
 
-def _deps(*, title_translator: object | None = None) -> RuntimeDeps:
+    def respond(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        observed.update(tool.name for tool in info.function_tools)
+        return ModelResponse(parts=[ToolCallPart("qa_response", _QA_OUTPUT)])
+
+    # Construction reads the env once, so the singleton changes only after restart.
+    await build_animichi_agent().run("hello", deps=_deps(), model=_local_model(respond))
+    assert observed == _EAGER | _DEFERRED
+
+
+def _deps(
+    *,
+    title_translator: TitleTranslator | None = None,
+    web_searcher: WebSearcher | None = None,
+) -> RuntimeDeps:
     return RuntimeDeps(
         db=MagicMock(),
         locale="zh",
         query="translate",
         catalog=MockCatalogClient(),
         title_translator=title_translator,
+        web_searcher=web_searcher,
     )
 
 
@@ -68,22 +84,19 @@ def _returned(messages: list[ModelMessage], tool_name: str) -> bool:
 
 
 def _local_model(respond: FunctionDef) -> FunctionModel:
-    """FunctionModel configured like a gateway without native tool search."""
-    return FunctionModel(
-        respond,
-        profile=ModelProfile(supported_native_tools=frozenset()),
-    )
+    profile = ModelProfile(supported_native_tools=frozenset())
+    return FunctionModel(respond, profile=profile)
 
 
 @pytest.mark.parametrize(
-    ("modern", "present", "absent"),
+    ("modern", "expected"),
     [
-        (True, _EAGER | {"search_tools"}, _DEFERRED),
-        (False, _EAGER | _DEFERRED, {"search_tools"}),
+        (True, _EAGER | {"search_tools"}),
+        (False, _EAGER | _DEFERRED),
     ],
 )
 async def test_composition_switch_controls_first_request_tools(
-    modern: bool, present: set[str], absent: set[str]
+    modern: bool, expected: set[str]
 ) -> None:
     observed: set[str] = set()
 
@@ -95,12 +108,14 @@ async def test_composition_switch_controls_first_request_tools(
         "hello", deps=_deps(), model=_local_model(respond)
     )
 
-    assert present <= observed
-    assert observed.isdisjoint(absent)
+    # Modern ToolSearch exposes its documented search_tools mechanism alongside
+    # the seven eager domain tools; legacy exposes both web tools directly.
+    assert observed == expected
 
 
-async def test_deferred_tool_is_discovered_and_invoked_end_to_end() -> None:
+async def test_deferred_tools_are_discovered_and_invoked_end_to_end() -> None:
     calls: list[tuple[str, str]] = []
+    search = MockWebSearcher()
 
     async def translate(title: str, locale: str) -> TranslationResult:
         calls.append((title, locale))
@@ -108,23 +123,27 @@ async def test_deferred_tool_is_discovered_and_invoked_end_to_end() -> None:
 
     def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         names = {tool.name for tool in info.function_tools}
-        if "translate_anime_title" not in names:
-            return ModelResponse(
-                parts=[
-                    ToolCallPart("search_tools", {"queries": ["translate anime title"]})
-                ]
-            )
+        if not _DEFERRED <= names:
+            queries = {"queries": ["translate anime title", "web search"]}
+            return ModelResponse(parts=[ToolCallPart("search_tools", queries)])
         if not _returned(messages, "translate_anime_title"):
             args = {"title": "君の名は。", "target_language": "zh"}
             return ModelResponse(parts=[ToolCallPart("translate_anime_title", args)])
+        if not _returned(messages, "web_search"):
+            return ModelResponse(
+                parts=[ToolCallPart("web_search", {"query": "Uji anime location"})]
+            )
         return ModelResponse(parts=[ToolCallPart("qa_response", _QA_OUTPUT)])
 
     result = await build_animichi_agent(modern_composition=True).run(
-        "translate", deps=_deps(title_translator=translate), model=_local_model(respond)
+        "translate",
+        deps=_deps(title_translator=translate, web_searcher=search),
+        model=_local_model(respond),
     )
 
     assert result.output.intent == "general_qa"
     assert calls == [("君の名は。", "zh")]
+    assert search.calls == [("search", ("Uji anime location",))]
 
 
 async def test_session_hook_is_idempotent_across_output_retry() -> None:

--- a/apps/agent/agent/tests/unit/test_modern_composition.py
+++ b/apps/agent/agent/tests/unit/test_modern_composition.py
@@ -1,0 +1,182 @@
+"""Wave 1 Batch B acceptance tests for hooks and progressive disclosure."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionDef, FunctionModel
+from pydantic_ai.profiles import ModelProfile
+
+from agent.agents.animichi_agent import (
+    _modern_composition_enabled,
+    build_animichi_agent,
+)
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.translation import TranslationResult
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+_EAGER = {
+    "clarify",
+    "resolve_anime",
+    "search_bangumi",
+    "search_nearby",
+    "plan_route",
+    "greet_user",
+    "general_qa",
+}
+_DEFERRED = {"web_search", "translate_anime_title"}
+_QA_OUTPUT = {
+    "intent": "general_qa",
+    "message": "ok",
+    "data": {"status": "info", "message": "ok"},
+    "ui": {},
+}
+
+
+def test_environment_switch_defaults_on_and_accepts_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ANIMICHI_MODERN_COMPOSITION", raising=False)
+    assert _modern_composition_enabled() is True
+    monkeypatch.setenv("ANIMICHI_MODERN_COMPOSITION", "0")
+    assert _modern_composition_enabled() is False
+
+
+def _deps(*, title_translator: object | None = None) -> RuntimeDeps:
+    return RuntimeDeps(
+        db=MagicMock(),
+        locale="zh",
+        query="translate",
+        catalog=MockCatalogClient(),
+        title_translator=title_translator,
+    )
+
+
+def _returned(messages: list[ModelMessage], tool_name: str) -> bool:
+    return any(
+        isinstance(part, ToolReturnPart) and part.tool_name == tool_name
+        for message in messages
+        for part in getattr(message, "parts", [])
+    )
+
+
+def _local_model(respond: FunctionDef) -> FunctionModel:
+    """FunctionModel configured like a gateway without native tool search."""
+    return FunctionModel(
+        respond,
+        profile=ModelProfile(supported_native_tools=frozenset()),
+    )
+
+
+@pytest.mark.parametrize(
+    ("modern", "present", "absent"),
+    [
+        (True, _EAGER | {"search_tools"}, _DEFERRED),
+        (False, _EAGER | _DEFERRED, {"search_tools"}),
+    ],
+)
+async def test_composition_switch_controls_first_request_tools(
+    modern: bool, present: set[str], absent: set[str]
+) -> None:
+    observed: set[str] = set()
+
+    def respond(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        observed.update(tool.name for tool in info.function_tools)
+        return ModelResponse(parts=[ToolCallPart("qa_response", _QA_OUTPUT)])
+
+    await build_animichi_agent(modern_composition=modern).run(
+        "hello", deps=_deps(), model=_local_model(respond)
+    )
+
+    assert present <= observed
+    assert observed.isdisjoint(absent)
+
+
+async def test_deferred_tool_is_discovered_and_invoked_end_to_end() -> None:
+    calls: list[tuple[str, str]] = []
+
+    async def translate(title: str, locale: str) -> TranslationResult:
+        calls.append((title, locale))
+        return TranslationResult(title, "你的名字", "test", 1.0)
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        names = {tool.name for tool in info.function_tools}
+        if "translate_anime_title" not in names:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart("search_tools", {"queries": ["translate anime title"]})
+                ]
+            )
+        if not _returned(messages, "translate_anime_title"):
+            args = {"title": "君の名は。", "target_language": "zh"}
+            return ModelResponse(parts=[ToolCallPart("translate_anime_title", args)])
+        return ModelResponse(parts=[ToolCallPart("qa_response", _QA_OUTPUT)])
+
+    result = await build_animichi_agent(modern_composition=True).run(
+        "translate", deps=_deps(title_translator=translate), model=_local_model(respond)
+    )
+
+    assert result.output.intent == "general_qa"
+    assert calls == [("君の名は。", "zh")]
+
+
+async def test_session_hook_is_idempotent_across_output_retry() -> None:
+    instructions: list[str] = []
+
+    def respond(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        instructions.append(info.instructions or "")
+        args = {} if len(instructions) == 1 else _QA_OUTPUT
+        return ModelResponse(parts=[ToolCallPart("qa_response", args)])
+
+    await build_animichi_agent(modern_composition=True).run(
+        "retry", deps=_deps(), model=_local_model(respond)
+    )
+
+    assert len(instructions) == 2
+    counts = [text.count("## Current session state") for text in instructions]
+    assert counts == [1, 1], instructions
+
+
+async def test_modern_switch_records_run_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: list[BaseException] = []
+    monkeypatch.setattr(
+        "agent.agents.animichi_agent.record_agent_run_error", recorded.append
+    )
+
+    def fail(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        raise RuntimeError("model failed")
+
+    with pytest.raises(RuntimeError, match="model failed"):
+        await build_animichi_agent(modern_composition=True).run(
+            "fail", deps=_deps(), model=FunctionModel(fail)
+        )
+
+    assert len(recorded) == 1
+
+
+async def test_legacy_switch_keeps_error_path_outside_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: list[BaseException] = []
+    monkeypatch.setattr(
+        "agent.agents.animichi_agent.record_agent_run_error", recorded.append
+    )
+
+    def fail(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        raise RuntimeError("legacy failed")
+
+    with pytest.raises(RuntimeError, match="legacy failed"):
+        await build_animichi_agent(modern_composition=False).run(
+            "fail", deps=_deps(), model=FunctionModel(fail)
+        )
+
+    assert recorded == []

--- a/apps/agent/agent/tests/unit/test_tool_state.py
+++ b/apps/agent/agent/tests/unit/test_tool_state.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+from pydantic import ValidationError
+
+from agent.agents.models import ToolName
 from agent.agents.tool_state import SearchState, ToolState
 
 
@@ -18,3 +22,13 @@ def test_typed_state_serializes_to_recorded_legacy_shape() -> None:
     assert state.search_bangumi is not None
     assert state.search_bangumi.row_count == 1
     assert state.to_legacy_dict() == legacy_shape
+
+
+def test_runtime_payload_rejects_unknown_typo_key() -> None:
+    state = ToolState()
+
+    with pytest.raises(ValidationError, match="row_cout"):
+        state.set_payload(
+            ToolName.RESOLVE_ANIME,
+            {"title": "響け！ユーフォニアム", "row_cout": 1},
+        )

--- a/apps/agent/agent/tests/unit/test_tool_state.py
+++ b/apps/agent/agent/tests/unit/test_tool_state.py
@@ -1,0 +1,20 @@
+"""Shape and typing tests for the runtime tool state."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent.agents.tool_state import SearchState, ToolState
+
+
+def test_typed_state_serializes_to_recorded_legacy_shape() -> None:
+    fixture_path = Path(__file__).parents[1] / "fixtures/tool_state_legacy_shape.json"
+    legacy_shape = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    state = ToolState.model_validate(legacy_shape)
+
+    assert isinstance(state.search_nearby, SearchState)
+    assert state.search_bangumi is not None
+    assert state.search_bangumi.row_count == 1
+    assert state.to_legacy_dict() == legacy_shape

--- a/apps/agent/agent/tests/unit/test_tools_catalog_wiring.py
+++ b/apps/agent/agent/tests/unit/test_tools_catalog_wiring.py
@@ -8,10 +8,16 @@ method with the expected args — and never touched the DB / upstream APIs.
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+
 from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 
+from agent.agents.animichi_agent import animichi_agent
 from agent.agents.animichi_runner import run_animichi_agent
+from agent.agents.animichi_tools import TOOLS as ANIMICHI_TOOLS
+from agent.agents.web_tools import TOOLS as WEB_TOOLS
 from agent.domain.ports import BangumiRepo, DatabasePort, PointsRepo
 from agent.tests.eval.mock_catalog_client import MockCatalogClient
 
@@ -42,6 +48,37 @@ _GREETING_OUTPUT = {
     "data": {"status": "info", "message": "done"},
     "ui": {},
 }
+
+_EXPECTED_TOOL_NAMES = {
+    "resolve_anime",
+    "search_bangumi",
+    "search_nearby",
+    "plan_route",
+    "greet_user",
+    "general_qa",
+    "clarify",
+    "web_search",
+    "translate_anime_title",
+}
+
+
+def test_agent_constructed_with_exact_tool_catalog() -> None:
+    """All nine stable eval-facing names are injected at construction time."""
+    definitions = [*ANIMICHI_TOOLS, *WEB_TOOLS]
+    assert {tool.__name__ for tool in definitions} == _EXPECTED_TOOL_NAMES
+    assert set(animichi_agent._function_toolset.tools) == _EXPECTED_TOOL_NAMES
+
+
+def test_agent_registers_tools_during_construction() -> None:
+    path = Path(__file__).parents[2] / "agents" / "animichi_agent.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+    construction = next(
+        call
+        for call in calls
+        if isinstance(call.func, ast.Name) and call.func.id == "Agent"
+    )
+    assert "tools" in {keyword.arg for keyword in construction.keywords}
 
 
 def _tool_then_output(tool_name: str, args: dict[str, object]) -> FunctionModel:

--- a/apps/agent/agent/tools/eval_feedback_miner.py
+++ b/apps/agent/agent/tools/eval_feedback_miner.py
@@ -80,7 +80,11 @@ async def mine(
         _model = model
 
     agent: Agent[None, _MinerOutput] = Agent(
-        _model, system_prompt=_MINER_PROMPT, output_type=_MinerOutput, retries=2
+        _model,
+        name="eval_feedback_miner",
+        system_prompt=_MINER_PROMPT,
+        output_type=_MinerOutput,
+        retries=2,
     )
 
     query_list = "\n".join(

--- a/apps/agent/agent/tools/eval_scorer.py
+++ b/apps/agent/agent/tools/eval_scorer.py
@@ -56,6 +56,7 @@ async def score_row(row: dict, model: object) -> float:
 
     agent: Agent[None, _ScoreOutput] = Agent(
         _model,
+        name="eval_scorer",
         system_prompt=_SCORER_PROMPT,
         output_type=_ScoreOutput,
         retries=1,

--- a/docs/superpowers/specs/2026-07-14-agent-modernization.md
+++ b/docs/superpowers/specs/2026-07-14-agent-modernization.md
@@ -45,7 +45,7 @@
 ## 2. Wave 1 — 组合面现代化
 
 1. **`name=`**:**全部构造路径**显式命名——模块级 5 个 + `base.py` 工厂路径(工厂签名加 name 参数);AC 含"无未命名 Agent 构造"的守卫测试
-2. **工具注册解耦(v2 设计定形)**:工具定义模块**去 agent 依赖**(纯函数 + Tool 描述);agent 构造时显式 `tools=[]`/toolset 注入;runner 可加 per-run toolsets(translation_agent 已示范构造注入)。禁止构造后全局变异。**AST 不变量测试随迁**:`test_agent_upstream_free.py`(`_SEAM_MODULES`/import 形状)与 `test_tools_catalog_wiring` 必须迁移而非弱化(评审重点盯)
+2. **工具注册解耦(v2 设计定形)**:工具定义模块**去 agent 依赖**(纯函数 + Tool 描述);agent 构造时显式 `tools=[]`/toolset 注入;per-run toolsets 由 pydantic-ai 2.9.1 `Agent.run(toolsets=)` 原生支持,**有真实消费者时再接线,不预置未消费参数**(translation_agent 已示范构造注入)。禁止构造后全局变异。**AST 不变量测试随迁**:`test_agent_upstream_free.py`(`_SEAM_MODULES`/import 形状)与 `test_tools_catalog_wiring` 必须迁移而非弱化(评审重点盯)
 3. **Progressive disclosure(v2 收窄)**:**eager 集合固定 = 全部 7 个意图工具(clarify、resolve_anime、search_bangumi、search_nearby、plan_route、greet_user、general_qa)**——clarify 是 ModelRetry 文案 mid-run 指名的恢复出口 + 结构化输出逃生门,greet/general_qa 是首轮路由器(schema 小,defer 无肉);**初始 defer 候选仅 web_search + translate_anime_title**;进一步 defer 需分层 eval 证据(按意图族分层看,聚合 F1 会掩盖)。defer 机制前置:确认 2.9.1 的 tool-search/discovery capability 配置 + 可达性测试(deferred 工具必须可被发现并调用,轨迹测试钉);"收窄引导语"是运行时 ModelRetry 文本,不是 defer 对象
 4. **Hooks 横切面**:动态会话状态注入 → `before_model_request`(**幂等性要求:跨 retry/工具环重入不重复注入**);错误遥测 → `on.run_error`;删等价手搓散点
 5. **tool_state typed**:dict 混型 → typed deps/state;**保持异构工具结果的序列化边界**。已知触点:evaluators 读 `tool_state["search_nearby"]["row_count"]`、response_builder/_UI_MAP 按 key 路由、`_seed_search_data` 会话回填、SSE payload 镜像


### PR DESCRIPTION
# Wave 1: composition-surface modernization (capabilities / Hooks / typed state)

Second wave of the agent-modernization sequence (spec §2, dual-reviewed). Five commits, all product code by Codex (gpt-5.6-sol medium) per Policy B, lead-verified.

## What changed

| Batch | Content |
|---|---|
| A (d214b68) | **Universal agent naming** — module-level five + `base.py` factory (required kwarg; consumers session_compactor/conversation_title/location_resolver found & named). **Tool registration decoupled**: tool modules agent-independent (`TOOLS: list[ToolFuncEither[RuntimeDeps]]`), constructor injection, import-order coupling + runner side-effect imports eliminated. AST invariants migrated **stronger** (tool-modules-cannot-import-agent, no side-effect imports, exact nine-name catalog pinned at definition+runtime, construction-time `tools=` AST check) |
| B (ba58c7a) | **Official Hooks**: session-state injection → idempotent `before_model_request` (retry-loop single-injection test); run failures → `hooks.on.run_error` → existing Logfire wrapper. **Progressive disclosure**: `web_search` + `translate_anime_title` deferred behind `ToolSearch(strategy="keywords")` — official LOCAL discovery, zero gateway dependency; **all 7 intent tools eager** per spec red line (clarify is a ModelRetry-named recovery exit). **Rollback**: `ANIMICHI_MODERN_COMPOSITION=0` restores legacy composition (both positions tested) |
| C (f3e6589) | **Typed ToolState** (per-tool sub-states, `extra="allow"`, `dict[str, JsonValue]` export) with the wire/eval boundary serializing to the exact recorded legacy shape (fixture-pinned dict equality). All spec touchpoints migrated; StepRecord persistence deliberately untouched |
| usage (20c8f3d) | AC-1 instrumentation: `RunResult.usage` → per-case + top-level aggregated usage in eval results (schema-additive) |

## AC-1 evidence

- **Gates**: 983 unit tests (hermetic, no `.env`) / lint / mypy strict — green
- **Full 655-case MiMo eval: gate PASS** (43:23; tool_f1 0.759 vs baseline 0.763 = noise band; locale 0.555 best-of-recent; errors 14, all the documented MiMo retry-exhaustion churn family)
- **Token A/B on the identical deterministic `EVAL_MAX_CASES=50` even-spread case selection** (same 50 ids both sides): input **1,995,697 → 1,737,512 (−12.9%)**, output −6.4%, requests 260 → 230 — measured with the modern composition vs `ANIMICHI_MODERN_COMPOSITION=0`
- **Stratified no-regression on protected families**: C1/C2/C3/C4 (clarify/geocoding intents) tool_recall **1.000** in the modern run; weak strata (B1–B3, A3, A5) are the pre-existing MiMo anime-title-routing weakness, untouched by this wave

## Notes for reviewers

- pydantic-ai 2.9.1 mechanism findings recorded in commit ba58c7a: `Tool(defer_loading=True)` + `ToolSearch` local strategy; ProcessHistory capabilities kept as-is (already official)
- `animichi_agent._function_toolset` private-attr access in one test pins the runtime registry (accepted fragility, breaks loudly on upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
