### PR TITLE
ci: root container in the promotion flow + catalog Neon URL fix

### DIFF
--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -29,6 +29,28 @@ on:
         required: false
       NEON_AUTH_JWKS_URL:
         required: false
+      SUPABASE_URL:
+        required: false
+      SUPABASE_ANON_KEY:
+        required: false
+      SUPABASE_SERVICE_ROLE_KEY:
+        required: false
+      SUPABASE_DB_URL:
+        required: false
+      MIMO_API_KEY:
+        required: false
+      DEEPSEEK_API_KEY:
+        required: false
+      GEMINI_API_KEY:
+        required: false
+      GOOGLE_MAPS_API_KEY:
+        required: false
+      LOGFIRE_TOKEN:
+        required: false
+      CORS_ALLOWED_ORIGIN:
+        required: false
+      NEXT_PUBLIC_MAPBOX_TOKEN:
+        required: false
 jobs:
   deploy:
     name: Deploy
@@ -43,6 +65,9 @@ jobs:
         if: ${{ inputs.build_filter != '' }}
         env:
           BUILD_FILTER: ${{ inputs.build_filter }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
         run: pnpm --filter "$BUILD_FILTER" build
       - name: Atlas migrate
         # NOTE: secrets context is NOT allowed in step `if:` (GitHub compile-time
@@ -69,6 +94,9 @@ jobs:
           PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      - name: Verify root container Dockerfile
+        if: ${{ inputs.component == 'root' }}
+        run: test -f Dockerfile
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
@@ -82,6 +110,16 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
           NEON_AUTH_JWKS_URL: ${{ secrets.NEON_AUTH_JWKS_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+          CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
       - name: Smoke
         env:
           COMPONENT: ${{ inputs.component }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,9 +268,48 @@ jobs:
       NEON_AUTH_JWKS_URL: ${{ secrets.NEON_AUTH_JWKS_URL }}
     concurrency: deploy-users-staging
 
+  deploy-root-staging:
+    name: Deploy root staging
+    needs: [deploy-staging, deploy-users-staging]
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/_deploy-component.yml
+    with:
+      component: root
+      environment: staging
+      pulumi_stack: staging
+      working_directory: "."
+      build_filter: frontend
+      run_pulumi: false
+      worker_secrets: |
+        SUPABASE_URL
+        SUPABASE_ANON_KEY
+        SUPABASE_SERVICE_ROLE_KEY
+        SUPABASE_DB_URL
+        MIMO_API_KEY
+        DEEPSEEK_API_KEY
+        GEMINI_API_KEY
+        GOOGLE_MAPS_API_KEY
+        LOGFIRE_TOKEN
+        CORS_ALLOWED_ORIGIN
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+      MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+      LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+      CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
+      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
+    concurrency: deploy-root-staging
+
   post-staging:
     name: Post-deploy (staging)
-    needs: [deploy-staging, deploy-web-staging, deploy-users-staging]
+    needs: [deploy-staging, deploy-web-staging, deploy-users-staging, deploy-root-staging]
     uses: ./.github/workflows/_post-deploy-test.yml
     with:
       environment: staging
@@ -334,9 +373,47 @@ jobs:
       NEON_AUTH_JWKS_URL: ${{ secrets.NEON_AUTH_JWKS_URL }}
     concurrency: deploy-users-prod
 
+  deploy-root-prod:
+    name: Deploy root production
+    needs: [post-staging, deploy-users-prod]
+    uses: ./.github/workflows/_deploy-component.yml
+    with:
+      component: root
+      environment: production
+      pulumi_stack: prod
+      working_directory: "."
+      build_filter: frontend
+      run_pulumi: false
+      worker_secrets: |
+        SUPABASE_URL
+        SUPABASE_ANON_KEY
+        SUPABASE_SERVICE_ROLE_KEY
+        SUPABASE_DB_URL
+        MIMO_API_KEY
+        DEEPSEEK_API_KEY
+        GEMINI_API_KEY
+        GOOGLE_MAPS_API_KEY
+        LOGFIRE_TOKEN
+        CORS_ALLOWED_ORIGIN
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+      MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+      LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+      CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
+      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
+    concurrency: deploy-root-prod
+
   post-prod:
     name: Post-deploy (production)
-    needs: [deploy-prod, deploy-web-prod, deploy-users-prod]
+    needs: [deploy-prod, deploy-web-prod, deploy-users-prod, deploy-root-prod]
     uses: ./.github/workflows/_post-deploy-test.yml
     with:
       environment: production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,11 +62,11 @@ jobs:
           environment: production
           # Catalog reaches Postgres via env.DATABASE_URL until a [[hyperdrive]]
           # binding is provisioned (src/index.ts falls back to DATABASE_URL).
-          # Sourced from the existing SUPABASE_DB_URL secret.
+          # The catalog uses the Neon HTTP client, matching the CI promotion path.
           secrets: |
             DATABASE_URL
         env:
-          DATABASE_URL: ${{ secrets.SUPABASE_DB_URL }}
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
 
       # ── Deploy users Worker (before root — root's USERS [[services]] binding depends on it) ──
       - name: Deploy users Worker

--- a/apps/agent/agent/tests/unit/test_deploy_model_env_consistency.py
+++ b/apps/agent/agent/tests/unit/test_deploy_model_env_consistency.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[5]
 _ENTRYPOINT = _REPO_ROOT / "worker" / "entry.ts"
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _DEPLOY_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "deploy.yml"
+_REUSABLE_DEPLOY_WORKFLOW = (
+    _REPO_ROOT / ".github" / "workflows" / "_deploy-component.yml"
+)
 
 
 def _typescript_string_list(source: str, const_name: str) -> set[str]:
@@ -30,14 +34,31 @@ def _named_workflow_step(source: str, name: str) -> str:
     return step["body"]
 
 
+def _named_workflow_job(source: str, job_id: str) -> str:
+    job = re.search(
+        rf"(?ms)^  {re.escape(job_id)}:\s*$\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\s*$|\Z)",
+        source,
+    )
+    assert job is not None, f"missing workflow job: {job_id}"
+    return job["body"]
+
+
 def _wrangler_secret_names(step: str) -> set[str]:
     secrets = re.search(
-        r"(?m)^[ \t]+secrets:\s*\|\s*$\n"
+        r"(?m)^[ \t]+(?:worker_)?secrets:\s*\|\s*$\n"
         r"(?P<body>(?:^[ \t]+[A-Z][A-Z0-9_]*[ \t]*$\n?)+)",
         step,
     )
     assert secrets is not None, "missing Wrangler secrets block"
     return set(re.findall(r"(?m)^[ \t]+([A-Z][A-Z0-9_]*)[ \t]*$", secrets["body"]))
+
+
+def _mapped_secret_names(source: str) -> set[str]:
+    mappings = re.findall(
+        r"(?m)^\s+([A-Z][A-Z0-9_]*):\s+\$\{\{\s*secrets\.([A-Z][A-Z0-9_]*)\s*}}\s*$",
+        source,
+    )
+    return {name for name, secret in mappings if name == secret}
 
 
 def test_container_required_keys_are_forwarded_and_deployed() -> None:
@@ -51,3 +72,19 @@ def test_container_required_keys_are_forwarded_and_deployed() -> None:
     assert required
     assert required <= forwarded
     assert required <= provisioned
+
+
+def test_ci_root_deploys_match_manual_root_secrets() -> None:
+    deploy = _DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+    root_step = _named_workflow_step(deploy, "Deploy via Wrangler")
+    manual_secrets = _wrangler_secret_names(root_step)
+    ci = _CI_WORKFLOW.read_text(encoding="utf-8")
+    staging = _named_workflow_job(ci, "deploy-root-staging")
+    production = _named_workflow_job(ci, "deploy-root-prod")
+    reusable = _REUSABLE_DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+
+    assert _wrangler_secret_names(staging) == manual_secrets
+    assert _wrangler_secret_names(production) == manual_secrets
+    assert manual_secrets <= _mapped_secret_names(staging)
+    assert manual_secrets <= _mapped_secret_names(production)
+    assert manual_secrets <= _mapped_secret_names(reusable)


### PR DESCRIPTION
Task #30, both umbrella-review deploy findings. Root worker/container now promotes through staging→production like catalog/users (staging pre-validates agent changes at last); catalog manual deploy stops pointing neon-http at a raw PG URL. Consistency test extended to pin exact manual↔CI secret parity. NOTE: this PR's own CI run is the GHA compile validation actionlint cannot provide — check the workflow-parse status here before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)