### PR TITLE
chore(agent): P3 review-cleanup batch (5 items)

### DIFF
--- a/apps/agent/agent/agents/agent_result.py
+++ b/apps/agent/agent/agents/agent_result.py
@@ -28,7 +28,12 @@ class ProducedSearch:
 class RejectedSearch:
     """A current search outcome that did not produce a registry entry."""
 
-    outcome: Literal["place_ambiguity", "place_unresolved", "missing_location"]
+    outcome: Literal[
+        "place_ambiguity",
+        "place_unresolved",
+        "missing_location",
+        "upstream_unavailable",
+    ]
 
 
 @dataclass(frozen=True)
@@ -43,7 +48,7 @@ class ProducedRoute:
 class RejectedRoute:
     """A current route outcome that did not produce a registry entry."""
 
-    status: Literal["empty", "stale_ref", "pending_sync"]
+    status: Literal["empty", "stale_ref", "pending_sync", "upstream_unavailable"]
 
 
 StepProvenance: TypeAlias = (

--- a/apps/agent/agent/agents/animichi_agent.py
+++ b/apps/agent/agent/agents/animichi_agent.py
@@ -42,7 +42,7 @@ from agent.infrastructure.observability import (
 MANAGED_PROMPT_NAME = "animichi-instructions"
 MANAGED_PROMPT_LABEL = "production"
 _LOCAL_PROMPT_VERSION = (
-    "sha256:22dd743f0cbd213a0414b0708df87219fc2c71741ede70e07b8b03786d72e091"
+    "sha256:0447f548a999f472626f53839fc273cea9c74338b7a125e1ec171f0c8689e825"
 )
 _PROMPT_RESOLUTION_DEADLINE_SECONDS = 2.0
 _PROMPT_RESOLUTION_EXECUTOR = ThreadPoolExecutor(
@@ -80,6 +80,7 @@ Never fabricate locations, coordinates, routes, candidate identity, or catalog d
 - search_nearby place_ambiguity: emit clarify_response using place_candidate_ids.
 - search_nearby place_unresolved: emit clarify_response using its reason and [].
 - search_nearby missing_location: emit clarify_response with missing_location and [].
+- search_nearby or plan_route upstream_unavailable: emit qa_response asking the user to retry.
 - plan_route ok: emit route_response; stale_ref means re-run the relevant search.
 - plan_route pending_sync: emit search_response explaining that catalog data is still syncing and route planning can be retried shortly.
 Never infer ambiguity from query length. Branch only on typed tool outcomes.

--- a/apps/agent/agent/agents/animichi_tools.py
+++ b/apps/agent/agent/agents/animichi_tools.py
@@ -59,7 +59,7 @@ async def search_nearby(
     location: str | None = None,
     radius_m: Annotated[int | None, Field(gt=0)] = None,
 ) -> NearbyToolResult:
-    """Search near a named place, or shared GPS when location is omitted."""
+    """Search near a place or GPS; upstream_unavailable means retry later."""
     await _emit(ctx, "search_nearby", "running", {})
     result = await run_nearby_search(
         ctx, ctx.deps.catalog, location=location, radius_m=radius_m
@@ -73,7 +73,7 @@ async def plan_route(
     search_result_ref: Annotated[str, Field(min_length=1)],
     pacing: Literal["chill", "normal", "packed"] | None = None,
 ) -> RouteToolResult:
-    """Plan one stored result; pending_sync means wait for catalog publication."""
+    """Plan one stored result; upstream_unavailable means retry later."""
     await _emit(ctx, "plan_route", "running", {})
     result = await run_route(ctx, ctx.deps.catalog, search_result_ref, pacing)
     await _emit(ctx, "plan_route", "done", result.model_dump())

--- a/apps/agent/agent/agents/base.py
+++ b/apps/agent/agent/agents/base.py
@@ -24,13 +24,14 @@ from agent.config.model_aliases import (
     credential_value,
     model_alias_from_spec,
 )
-from agent.config.settings import Settings
+from agent.config.settings import Settings, _is_local_base_url
 
 T = TypeVar("T", bound=BaseModel)
 
 _DEFAULT_MODEL_SPEC = "openai:mimo-v2.5@https://api.xiaomimimo.com/v1"
 _MODEL_ALIAS_PATTERN = re.compile(r"[a-z0-9_-]+")
 _APP_CLIENT_HEADER = "X-App-Client"
+_LOCAL_DEV_API_KEY = "local-dev-placeholder"
 
 
 def build_model_http_client(settings: Settings | None = None) -> httpx.AsyncClient:
@@ -63,12 +64,19 @@ def _app_client_name() -> str:
     return f"animichi {environment}"
 
 
+def _model_api_key(alias: ModelAlias) -> str | None:
+    api_key = credential_value(alias.credential_ref)
+    if api_key is None and _is_local_base_url(alias.fixed_base_url):
+        return _LOCAL_DEV_API_KEY
+    return api_key
+
+
 def _sdk_client(
     alias: ModelAlias, client: httpx.AsyncClient, *, max_retries: int
 ) -> AsyncOpenAI:
     return AsyncOpenAI(
         base_url=alias.fixed_base_url,
-        api_key=credential_value(alias.credential_ref),
+        api_key=_model_api_key(alias),
         http_client=client,
         max_retries=max_retries,
         default_headers={_APP_CLIENT_HEADER: _app_client_name()},

--- a/apps/agent/agent/agents/catalog_failures.py
+++ b/apps/agent/agent/agents/catalog_failures.py
@@ -1,0 +1,33 @@
+"""Typed degradation shared by catalog-backed model tools."""
+
+from __future__ import annotations
+
+from agent.agents.agent_result import RejectedSearch
+from agent.agents.models import ToolName
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.step_recording import _record
+from agent.agents.tool_outcomes import NearbyUpstreamDown
+from agent.clients.errors import APIError
+
+CATALOG_FAILURES = (APIError, OSError, RuntimeError)
+
+
+def nearby_params(location: str | None, radius_m: int | None) -> dict[str, object]:
+    params: dict[str, object] = {"location": location}
+    if radius_m is not None:
+        params["radius_m"] = radius_m
+    return params
+
+
+def nearby_upstream_down(
+    deps: RuntimeDeps, location: str | None, radius_m: int | None
+) -> NearbyUpstreamDown:
+    outcome = NearbyUpstreamDown()
+    _record(
+        deps,
+        ToolName.SEARCH_NEARBY.value,
+        nearby_params(location, radius_m),
+        outcome.model_dump(),
+        provenance=RejectedSearch(outcome=outcome.outcome),
+    )
+    return outcome

--- a/apps/agent/agent/agents/catalog_route_tools.py
+++ b/apps/agent/agent/agents/catalog_route_tools.py
@@ -8,6 +8,7 @@ from pydantic_ai import RunContext
 
 from agent.agents.agent_result import ProducedRoute, RejectedRoute, StepProvenance
 from agent.agents.catalog_adapter import build_route_state
+from agent.agents.catalog_failures import CATALOG_FAILURES
 from agent.agents.catalog_tools import _clear_pending
 from agent.agents.models import ToolName
 from agent.agents.runtime_deps import RuntimeDeps
@@ -18,6 +19,7 @@ from agent.agents.tool_outcomes import (
     RouteOk,
     RoutePendingSync,
     RouteStaleRef,
+    RouteUpstreamDown,
 )
 from agent.clients.catalog_client import CatalogClientProtocol, Route
 
@@ -29,11 +31,15 @@ async def run_route(
     catalog: CatalogClientProtocol,
     search_result_ref: str,
     pacing: Pacing | None,
-) -> RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync:
+) -> RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync | RouteUpstreamDown:
     """Route exactly the registry payload named by the model-supplied ref."""
     ref = ResultRef(search_result_ref)
     payload = ctx.deps.tool_state.session.search_results.get(ref)
-    outcome = await _route_outcome(ctx, catalog, ref, payload, pacing)
+    outcome: RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync | RouteUpstreamDown
+    try:
+        outcome = await _route_outcome(ctx, catalog, ref, payload, pacing)
+    except CATALOG_FAILURES:
+        outcome = RouteUpstreamDown()
     _record_route(ctx.deps, search_result_ref, pacing, outcome)
     return outcome
 
@@ -42,7 +48,11 @@ def _record_route(
     deps: RuntimeDeps,
     search_result_ref: str,
     pacing: Pacing | None,
-    outcome: RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync,
+    outcome: RouteOk
+    | RouteEmpty
+    | RouteStaleRef
+    | RoutePendingSync
+    | RouteUpstreamDown,
 ) -> None:
     params: dict[str, object] = {"search_result_ref": search_result_ref}
     if pacing is not None:
@@ -93,7 +103,11 @@ def _store_route(ctx: RunContext[RuntimeDeps], route: Route, ref: ResultRef) -> 
 
 
 def _route_provenance(
-    outcome: RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync,
+    outcome: RouteOk
+    | RouteEmpty
+    | RouteStaleRef
+    | RoutePendingSync
+    | RouteUpstreamDown,
 ) -> StepProvenance:
     if isinstance(outcome, RouteOk):
         return ProducedRoute(status="ok", route_ref=RouteRef(outcome.route_ref))

--- a/apps/agent/agent/agents/catalog_route_tools.py
+++ b/apps/agent/agent/agents/catalog_route_tools.py
@@ -39,6 +39,7 @@ async def run_route(
     try:
         outcome = await _route_outcome(ctx, catalog, ref, payload, pacing)
     except CATALOG_FAILURES:
+        _clear_pending(ctx.deps)
         outcome = RouteUpstreamDown()
     _record_route(ctx.deps, search_result_ref, pacing, outcome)
     return outcome

--- a/apps/agent/agent/agents/catalog_tools.py
+++ b/apps/agent/agent/agents/catalog_tools.py
@@ -7,6 +7,11 @@ from agent.agents.agent_result import (
     RejectedSearch,
 )
 from agent.agents.catalog_adapter import build_search_state
+from agent.agents.catalog_failures import (
+    CATALOG_FAILURES,
+    nearby_params,
+    nearby_upstream_down,
+)
 from agent.agents.models import ToolName
 from agent.agents.runtime_deps import RuntimeDeps
 from agent.agents.session_state import (
@@ -23,6 +28,7 @@ from agent.agents.tool_outcomes import (
     NearbyOk,
     NearbyPlaceAmbiguous,
     NearbyPlaceUnresolved,
+    NearbyUpstreamDown,
     ResolveAmbiguous,
     ResolveNotFound,
     ResolveResolved,
@@ -46,9 +52,6 @@ from agent.clients.catalog_client import (
 from agent.clients.catalog_client import (
     ResolveResolved as CatalogResolveResolved,
 )
-from agent.clients.errors import APIError
-
-_CATALOG_ERRORS = (APIError, OSError, RuntimeError)
 
 
 def _candidate(candidate: AnimeCandidate) -> OrderedCandidate:
@@ -98,7 +101,7 @@ async def run_resolve(
     result: ResolveResolved | ResolveAmbiguous | ResolveNotFound | ResolveUpstreamDown
     try:
         resolved = await catalog.resolve(title)
-    except _CATALOG_ERRORS:
+    except CATALOG_FAILURES:
         result = ResolveUpstreamDown()
     else:
         result = _adapt_resolve(ctx.deps, resolved)
@@ -140,7 +143,7 @@ async def run_work_search(
     """Fetch an already-resolved work without repeating free-text resolution."""
     try:
         result = await catalog.points_by_work_id(bangumi_id)
-    except _CATALOG_ERRORS:
+    except CATALOG_FAILURES:
         failure = SearchUpstreamDown()
         _record(
             ctx.deps,
@@ -242,9 +245,13 @@ async def run_nearby_search(
     | NearbyPlaceAmbiguous
     | NearbyPlaceUnresolved
     | NearbyMissingLocation
+    | NearbyUpstreamDown
 ):
     """Resolve a place into a typed outcome and a registry-backed geo result."""
-    resolved = await _coordinates(ctx.deps, catalog, location)
+    try:
+        resolved = await _coordinates(ctx.deps, catalog, location)
+    except CATALOG_FAILURES:
+        return nearby_upstream_down(ctx.deps, location, radius_m)
     if not isinstance(resolved, tuple):
         _record(
             ctx.deps,
@@ -255,9 +262,12 @@ async def run_nearby_search(
         )
         return resolved
     coords, default_radius = resolved
-    points = await catalog.nearby(
-        coords[0], coords[1], radius_m=radius_m or default_radius
-    )
+    try:
+        points = await catalog.nearby(
+            coords[0], coords[1], radius_m=radius_m or default_radius
+        )
+    except CATALOG_FAILURES:
+        return nearby_upstream_down(ctx.deps, location, radius_m)
     payload = build_search_state(points, kind="nearby", locale=ctx.deps.locale)
     ref = ResultRef(ctx.deps.ref_factory("search", payload.row_count))
     ctx.deps.tool_state.session.store_search_result(ref, payload)
@@ -267,13 +277,10 @@ async def run_nearby_search(
         if payload.row_count
         else NearbyEmpty()
     )
-    params: dict[str, object] = {"location": location}
-    if radius_m is not None:
-        params["radius_m"] = radius_m
     _record(
         ctx.deps,
         ToolName.SEARCH_NEARBY.value,
-        params,
+        nearby_params(location, radius_m),
         outcome.model_dump(),
         provenance=ProducedSearch(outcome=outcome.outcome, result_ref=ref),
     )

--- a/apps/agent/agent/agents/catalog_tools.py
+++ b/apps/agent/agent/agents/catalog_tools.py
@@ -251,6 +251,7 @@ async def run_nearby_search(
     try:
         resolved = await _coordinates(ctx.deps, catalog, location)
     except CATALOG_FAILURES:
+        _clear_pending(ctx.deps)
         return nearby_upstream_down(ctx.deps, location, radius_m)
     if not isinstance(resolved, tuple):
         _record(
@@ -267,6 +268,7 @@ async def run_nearby_search(
             coords[0], coords[1], radius_m=radius_m or default_radius
         )
     except CATALOG_FAILURES:
+        _clear_pending(ctx.deps)
         return nearby_upstream_down(ctx.deps, location, radius_m)
     payload = build_search_state(points, kind="nearby", locale=ctx.deps.locale)
     ref = ResultRef(ctx.deps.ref_factory("search", payload.row_count))

--- a/apps/agent/agent/agents/tool_outcomes.py
+++ b/apps/agent/agent/agents/tool_outcomes.py
@@ -87,12 +87,17 @@ class NearbyMissingLocation(_Outcome):
     clarification_reason: Literal["missing_location"] = "missing_location"
 
 
+class NearbyUpstreamDown(_Outcome):
+    outcome: Literal["upstream_unavailable"] = "upstream_unavailable"
+
+
 NearbyToolResult: TypeAlias = Annotated[
     NearbyOk
     | NearbyEmpty
     | NearbyPlaceAmbiguous
     | NearbyPlaceUnresolved
-    | NearbyMissingLocation,
+    | NearbyMissingLocation
+    | NearbyUpstreamDown,
     Field(discriminator="outcome"),
 ]
 
@@ -116,7 +121,11 @@ class RoutePendingSync(_Outcome):
     status: Literal["pending_sync"] = "pending_sync"
 
 
+class RouteUpstreamDown(_Outcome):
+    status: Literal["upstream_unavailable"] = "upstream_unavailable"
+
+
 RouteToolResult: TypeAlias = Annotated[
-    RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync,
+    RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync | RouteUpstreamDown,
     Field(discriminator="status"),
 ]

--- a/apps/agent/agent/config/settings.py
+++ b/apps/agent/agent/config/settings.py
@@ -62,6 +62,15 @@ def _is_local_base_url(base_url: str | None) -> bool:
     return parsed.hostname in {"localhost", "127.0.0.1"}
 
 
+def _required_model_credential(model_name: str | None, default: str) -> str | None:
+    """Return the credential needed to boot one configured model."""
+    base_url = _openai_model_base_url(model_name, default)
+    credential = _credential_env_for_model(model_name, default)
+    if credential == "OPENAI_COMPAT_API_KEY" and _is_local_base_url(base_url):
+        return None
+    return credential
+
+
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
@@ -234,7 +243,7 @@ class Settings(BaseSettings):
     def _required_model_credentials(self) -> list[str]:
         required: list[str] = []
         for model_name in (self.default_agent_model, self.fallback_agent_model):
-            credential = _credential_env_for_model(
+            credential = _required_model_credential(
                 model_name, self.openai_compat_base_url
             )
             if credential is not None and credential not in required:

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -135,7 +135,7 @@ async def _response_stream(response: PublicAPIResponse) -> AsyncIterator[str]:
     yield _event(DoneChunk())
 
 
-@router.post("/chat")
+@router.post("/chat", responses={422: {"description": "Invalid chat request"}})
 async def handle_chat(
     request: Request,
     auth: Annotated[TrustedAuthContext, Depends(_require_trusted_user)],

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -82,6 +82,22 @@ def _clarification_id(body: dict[str, object]) -> int | None:
     raise HTTPException(status_code=422, detail="clarification_id must be an integer")
 
 
+def _optional_string(body: dict[str, object], field: str) -> str | None:
+    value = body.get(field)
+    if value is None or isinstance(value, str):
+        return value
+    raise HTTPException(status_code=422, detail=f"{field} must be a string")
+
+
+def _optional_float(body: dict[str, object], field: str) -> float | None:
+    value = body.get(field)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise HTTPException(status_code=422, detail=f"{field} must be a number")
+    return float(value)
+
+
 def _decode_body(raw: bytes) -> dict[str, object]:
     try:
         value: object = json.loads(raw)
@@ -100,6 +116,9 @@ def _runtime_request(request: Request, body: dict[str, object]) -> PublicAPIRequ
         selected_point_ids=_optional_ids(body, "selected_point_ids"),
         selected_candidate_ids=_optional_ids(body, "selected_candidate_ids"),
         clarification_id=_clarification_id(body),
+        origin=_optional_string(body, "origin"),
+        origin_lat=_optional_float(body, "origin_lat"),
+        origin_lng=_optional_float(body, "origin_lng"),
     )
 
 

--- a/apps/agent/agent/tests/unit/test_catalog_tool_upstream_degradation.py
+++ b/apps/agent/agent/tests/unit/test_catalog_tool_upstream_degradation.py
@@ -95,10 +95,10 @@ async def test_geocode_api_error_becomes_nearby_upstream_down() -> None:
     assert isinstance(outcome, NearbyUpstreamDown)
     assert deps.steps[-1].data == {"outcome": "upstream_unavailable"}
     assert isinstance(deps.steps[-1].provenance, RejectedSearch)
+    context = MagicMock(deps=deps)
+    stale_response = SearchResponseModel(message="stale")
     with pytest.raises(ModelRetry):
-        await validate_output(
-            MagicMock(deps=deps), SearchResponseModel(message="stale")
-        )
+        await validate_output(context, stale_response)
     assert runtime_stage(QAResponseModel(message="retry"), deps.steps) == "general_qa"
 
 
@@ -115,8 +115,9 @@ async def test_nearby_api_error_becomes_nearby_upstream_down() -> None:
     assert deps.steps[-1].data == {"outcome": "upstream_unavailable"}
     assert isinstance(deps.steps[-1].provenance, RejectedSearch)
     assert deps.tool_state.session.pending_clarification is None
+    context = MagicMock(deps=deps)
     with pytest.raises(ModelRetry):
-        await validate_output(MagicMock(deps=deps), stale_clarification)
+        await validate_output(context, stale_clarification)
 
 
 async def test_route_api_error_becomes_route_upstream_down() -> None:
@@ -136,7 +137,9 @@ async def test_route_api_error_becomes_route_upstream_down() -> None:
     assert deps.steps[-1].data == {"status": "upstream_unavailable"}
     assert isinstance(deps.steps[-1].provenance, RejectedRoute)
     assert deps.tool_state.session.pending_clarification is None
+    context = MagicMock(deps=deps)
+    stale_route = RouteResponseModel(message="stale")
     with pytest.raises(ModelRetry):
-        await validate_output(MagicMock(deps=deps), RouteResponseModel(message="stale"))
+        await validate_output(context, stale_route)
     with pytest.raises(ModelRetry):
-        await validate_output(MagicMock(deps=deps), stale_clarification)
+        await validate_output(context, stale_clarification)

--- a/apps/agent/agent/tests/unit/test_catalog_tool_upstream_degradation.py
+++ b/apps/agent/agent/tests/unit/test_catalog_tool_upstream_degradation.py
@@ -1,0 +1,112 @@
+"""Catalog tool failures degrade to typed, current-turn outcomes."""
+
+from __future__ import annotations
+
+from typing import Literal
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_ai import ModelRetry
+
+from agent.agents.agent_result import RejectedRoute, RejectedSearch
+from agent.agents.animichi_agent import validate_output
+from agent.agents.animichi_runner import runtime_stage
+from agent.agents.catalog_route_tools import run_route
+from agent.agents.catalog_tools import run_nearby_search
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.runtime_models import (
+    QAResponseModel,
+    RouteResponseModel,
+    SearchResponseModel,
+)
+from agent.agents.session_state import (
+    PointState,
+    ResultRef,
+    RoutePayloadState,
+    RouteRef,
+    SearchPayloadState,
+)
+from agent.agents.tool_outcomes import NearbyUpstreamDown, RouteUpstreamDown
+from agent.clients.catalog_client import GeocodeCandidate, PilgrimagePoint, Route
+from agent.clients.errors import APIError
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+
+def _deps(catalog: MockCatalogClient) -> RuntimeDeps:
+    return RuntimeDeps(MagicMock(), "en", "test", catalog)
+
+
+class _GeocodeDownCatalog(MockCatalogClient):
+    async def geocode(self, query: str, *, limit: int = 5) -> list[GeocodeCandidate]:
+        raise APIError("catalog down")
+
+
+class _NearbyDownCatalog(MockCatalogClient):
+    async def nearby(
+        self, lat: float, lng: float, *, radius_m: int = 2000
+    ) -> list[PilgrimagePoint]:
+        raise APIError("catalog down")
+
+
+class _RouteDownCatalog(MockCatalogClient):
+    async def route(
+        self,
+        point_ids: list[str],
+        *,
+        origin: tuple[float, float] | None = None,
+        pacing: Literal["chill", "normal", "packed"] | None = None,
+    ) -> Route:
+        raise APIError("catalog down")
+
+
+async def test_geocode_api_error_becomes_nearby_upstream_down() -> None:
+    catalog = _GeocodeDownCatalog()
+    deps = _deps(catalog)
+    prior_ref = ResultRef("search:prior")
+    deps.tool_state.session.store_search_result(
+        prior_ref,
+        SearchPayloadState(kind="nearby", rows=[PointState(id="old")], row_count=1),
+    )
+
+    outcome = await run_nearby_search(MagicMock(deps=deps), catalog, "Uji", None)
+
+    assert isinstance(outcome, NearbyUpstreamDown)
+    assert deps.steps[-1].data == {"outcome": "upstream_unavailable"}
+    assert isinstance(deps.steps[-1].provenance, RejectedSearch)
+    with pytest.raises(ModelRetry):
+        await validate_output(
+            MagicMock(deps=deps), SearchResponseModel(message="stale")
+        )
+    assert runtime_stage(QAResponseModel(message="retry"), deps.steps) == "general_qa"
+
+
+async def test_nearby_api_error_becomes_nearby_upstream_down() -> None:
+    catalog = _NearbyDownCatalog()
+    deps = _deps(catalog)
+    deps.tool_state.origin_lat = 34.9
+    deps.tool_state.origin_lng = 135.8
+
+    outcome = await run_nearby_search(MagicMock(deps=deps), catalog, None, None)
+
+    assert isinstance(outcome, NearbyUpstreamDown)
+    assert deps.steps[-1].data == {"outcome": "upstream_unavailable"}
+    assert isinstance(deps.steps[-1].provenance, RejectedSearch)
+
+
+async def test_route_api_error_becomes_route_upstream_down() -> None:
+    catalog = _RouteDownCatalog()
+    deps = _deps(catalog)
+    ref = ResultRef("search:test")
+    deps.tool_state.session.store_search_result(
+        ref,
+        SearchPayloadState(kind="nearby", rows=[PointState(id="p1")], row_count=1),
+    )
+    deps.tool_state.session.store_route(RouteRef("route:prior"), RoutePayloadState())
+
+    outcome = await run_route(MagicMock(deps=deps), catalog, str(ref), None)
+
+    assert isinstance(outcome, RouteUpstreamDown)
+    assert deps.steps[-1].data == {"status": "upstream_unavailable"}
+    assert isinstance(deps.steps[-1].provenance, RejectedRoute)
+    with pytest.raises(ModelRetry):
+        await validate_output(MagicMock(deps=deps), RouteResponseModel(message="stale"))

--- a/apps/agent/agent/tests/unit/test_catalog_tool_upstream_degradation.py
+++ b/apps/agent/agent/tests/unit/test_catalog_tool_upstream_degradation.py
@@ -15,11 +15,14 @@ from agent.agents.catalog_route_tools import run_route
 from agent.agents.catalog_tools import run_nearby_search
 from agent.agents.runtime_deps import RuntimeDeps
 from agent.agents.runtime_models import (
+    ClarifyResponseModel,
     QAResponseModel,
     RouteResponseModel,
     SearchResponseModel,
 )
 from agent.agents.session_state import (
+    OrderedCandidate,
+    PendingClarification,
     PointState,
     ResultRef,
     RoutePayloadState,
@@ -34,6 +37,25 @@ from agent.tests.eval.mock_catalog_client import MockCatalogClient
 
 def _deps(catalog: MockCatalogClient) -> RuntimeDeps:
     return RuntimeDeps(MagicMock(), "en", "test", catalog)
+
+
+def _seed_stale_clarification(deps: RuntimeDeps) -> ClarifyResponseModel:
+    candidate_ids = ["old-1", "old-2"]
+    deps.tool_state.session.pending_clarification = PendingClarification(
+        reason="anime_ambiguity",
+        candidate_ids=candidate_ids,
+        ordered_candidates=[
+            OrderedCandidate(id="old-1", title="Old 1"),
+            OrderedCandidate(id="old-2", title="Old 2"),
+        ],
+        revision=1,
+    )
+    deps.tool_state.session.clarification_revision = 1
+    return ClarifyResponseModel(
+        reason="anime_ambiguity",
+        message="Which old result?",
+        candidate_ids=candidate_ids,
+    )
 
 
 class _GeocodeDownCatalog(MockCatalogClient):
@@ -83,6 +105,7 @@ async def test_geocode_api_error_becomes_nearby_upstream_down() -> None:
 async def test_nearby_api_error_becomes_nearby_upstream_down() -> None:
     catalog = _NearbyDownCatalog()
     deps = _deps(catalog)
+    stale_clarification = _seed_stale_clarification(deps)
     deps.tool_state.origin_lat = 34.9
     deps.tool_state.origin_lng = 135.8
 
@@ -91,11 +114,15 @@ async def test_nearby_api_error_becomes_nearby_upstream_down() -> None:
     assert isinstance(outcome, NearbyUpstreamDown)
     assert deps.steps[-1].data == {"outcome": "upstream_unavailable"}
     assert isinstance(deps.steps[-1].provenance, RejectedSearch)
+    assert deps.tool_state.session.pending_clarification is None
+    with pytest.raises(ModelRetry):
+        await validate_output(MagicMock(deps=deps), stale_clarification)
 
 
 async def test_route_api_error_becomes_route_upstream_down() -> None:
     catalog = _RouteDownCatalog()
     deps = _deps(catalog)
+    stale_clarification = _seed_stale_clarification(deps)
     ref = ResultRef("search:test")
     deps.tool_state.session.store_search_result(
         ref,
@@ -108,5 +135,8 @@ async def test_route_api_error_becomes_route_upstream_down() -> None:
     assert isinstance(outcome, RouteUpstreamDown)
     assert deps.steps[-1].data == {"status": "upstream_unavailable"}
     assert isinstance(deps.steps[-1].provenance, RejectedRoute)
+    assert deps.tool_state.session.pending_clarification is None
     with pytest.raises(ModelRetry):
         await validate_output(MagicMock(deps=deps), RouteResponseModel(message="stale"))
+    with pytest.raises(ModelRetry):
+        await validate_output(MagicMock(deps=deps), stale_clarification)

--- a/apps/agent/agent/tests/unit/test_chat_endpoint.py
+++ b/apps/agent/agent/tests/unit/test_chat_endpoint.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from agent.interfaces.public_api import RuntimeAPI
 from agent.interfaces.schemas import PublicAPIResponse
 from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
@@ -101,8 +103,8 @@ async def test_chat_forwards_named_and_coordinate_origin() -> None:
     assert response.status_code == 200
     request = runtime.handle.await_args.args[0]
     assert request.origin == "Kyoto Station"
-    assert request.origin_lat == 34.9858
-    assert request.origin_lng == 135.7588
+    assert request.origin_lat == pytest.approx(34.9858)
+    assert request.origin_lng == pytest.approx(135.7588)
 
 
 async def test_chat_rejects_boolean_clarification_revision() -> None:

--- a/apps/agent/agent/tests/unit/test_chat_endpoint.py
+++ b/apps/agent/agent/tests/unit/test_chat_endpoint.py
@@ -85,6 +85,26 @@ async def test_chat_selection_uses_explicit_ids_and_server_session() -> None:
     assert request.session_id == "session-4"
 
 
+async def test_chat_forwards_named_and_coordinate_origin() -> None:
+    runtime = _runtime()
+    app, _ = build_app(runtime_api=runtime)
+    body = {
+        **_body("near me"),
+        "origin": "Kyoto Station",
+        "origin_lat": 34.9858,
+        "origin_lng": 135.7588,
+    }
+    async with async_client(app) as client:
+        response = await client.post(
+            "/v1/chat", json=body, headers={"X-User-Id": "user-1"}
+        )
+    assert response.status_code == 200
+    request = runtime.handle.await_args.args[0]
+    assert request.origin == "Kyoto Station"
+    assert request.origin_lat == 34.9858
+    assert request.origin_lng == 135.7588
+
+
 async def test_chat_rejects_boolean_clarification_revision() -> None:
     runtime = _runtime()
     app, _ = build_app(runtime_api=runtime)

--- a/apps/agent/agent/tests/unit/test_local_model_credentials.py
+++ b/apps/agent/agent/tests/unit/test_local_model_credentials.py
@@ -1,0 +1,38 @@
+"""Credential behavior at the OpenAI-compatible model construction seam."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from openai import OpenAIError
+from pydantic_ai.models.openai import OpenAIChatModel
+
+from agent.agents.base import get_default_model
+from agent.config.settings import Settings
+
+
+async def test_keyless_localhost_model_builds_but_remote_model_fails() -> None:
+    settings = Settings(
+        _env_file=None,
+        default_agent_model="openai:local@http://localhost:1234/v1",
+        fallback_agent_model=None,
+        openai_compat_api_key="",
+        supabase_db_url="postgresql://local/test",
+    )
+    client = httpx.AsyncClient()
+    try:
+        with patch("agent.config.get_settings", return_value=settings):
+            model = get_default_model(http_client=client)
+        assert isinstance(model, OpenAIChatModel)
+        assert model.client.api_key == "local-dev-placeholder"
+
+        remote = settings.model_copy(
+            update={"default_agent_model": "openai:remote@https://models.example/v1"}
+        )
+        with (
+            patch("agent.config.get_settings", return_value=remote),
+            pytest.raises(OpenAIError, match="Missing credentials"),
+        ):
+            get_default_model(http_client=client)
+    finally:
+        await client.aclose()

--- a/apps/agent/agent/tests/unit/test_phase1c_tool_outcomes.py
+++ b/apps/agent/agent/tests/unit/test_phase1c_tool_outcomes.py
@@ -76,6 +76,7 @@ def test_search_result_partition(payload: dict[str, object]) -> None:
             "outcome": "missing_location",
             "clarification_reason": "missing_location",
         },
+        {"outcome": "upstream_unavailable"},
     ],
 )
 def test_nearby_result_partition(payload: dict[str, object]) -> None:
@@ -96,6 +97,7 @@ def test_nearby_result_partition(payload: dict[str, object]) -> None:
         },
         {"status": "empty"},
         {"status": "stale_ref"},
+        {"status": "upstream_unavailable"},
     ],
 )
 def test_route_result_partition(payload: dict[str, object]) -> None:

--- a/apps/agent/agent/tests/unit/test_settings.py
+++ b/apps/agent/agent/tests/unit/test_settings.py
@@ -110,6 +110,27 @@ class TestAPIKeyValidation:
 
         assert settings.deepseek_api_key == ""
 
+    def test_localhost_compat_model_does_not_require_api_key(self) -> None:
+        settings = Settings(
+            _env_file=None,
+            default_agent_model="openai:local@http://localhost:1234/v1",
+            fallback_agent_model=None,
+            openai_compat_api_key="",
+            supabase_db_url="postgresql://local/test",
+        )
+
+        assert settings.validate_api_keys() == []
+
+    def test_remote_compat_model_hard_requires_api_key(self) -> None:
+        with pytest.raises(ValueError, match="OPENAI_COMPAT_API_KEY"):
+            Settings(
+                _env_file=None,
+                default_agent_model="openai:remote@https://models.example/v1",
+                fallback_agent_model=None,
+                openai_compat_api_key="",
+                supabase_db_url="postgresql://local/test",
+            )
+
     def test_prod_default_requires_mimo_not_deepseek(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/docs/design/2026-07-06-design-sync/docs/spec-chat-page-design.md
+++ b/docs/design/2026-07-06-design-sync/docs/spec-chat-page-design.md
@@ -117,7 +117,7 @@ LocationPrompt、FeedbackButtons。铁则:按压影只给按钮/输入,卡片浮
 
 ## 8. 未决事项(不阻塞 Phase 1)
 
-- 登录墙问题(critique P2,docs/todo.md)——chat 入口是否允许未登录试用
+- 登录墙问题(critique P2,docs/superpowers/plans/archive/2026-04-28-frontend-ssr-migration-todo.md)——chat 入口是否允许未登录试用
 - 流式协议:Vercel AI SDK 迁移曾 revert(79f34a8),Phase 1 实现前需重新定案
 - しおり导出的具体排版(另开设计任务)
 - 现场行走态完整设计(Phase 3+)

--- a/docs/design/2026-07-06-design-sync/docs/spec-chat-page-states.md
+++ b/docs/design/2026-07-06-design-sync/docs/spec-chat-page-states.md
@@ -34,7 +34,7 @@ composing ──send──▶ sending ──▶ running(B2a→B2b→B2c 按时�
 | A2 | 带 query 进入 | 首页搜索框提交跳转 | 进页即渲染 user bubble + 直接进 B2(不重复打字);URL 带 `?q=` | →B2 |
 | A2b | 引用路线进入 | 公开路线页/路线详情页的「アレンジ」 | chat 顶部渲染「📎 引用中:〈路线名〉」上下文卡,agent 以该路线为基底重组;一句话即可改装("出发改大阪、只有上午")。**journey 走查发现的高频入口**——拿别人(或自己)的路线来改,比空输入框更常见 | →B2 |
 | A3 | 恢复历史会话 | 再访/会话列表进入 | 历史消息全量渲染:旧管线一律折叠为足迹行;滚动锚定到底部;最后一张路线卡保持 settled 态 | 任意交互 |
-| A4 | 未登录访问 | 无 session | **未决**(critique P2 登录墙,docs/todo.md)。占位方案:重定向 /login。倾向方案:允许 1 次试用回合后弹登录,本期不实现 | — |
+| A4 | 未登录访问 | 无 session | **未决**(critique P2 登录墙,docs/superpowers/plans/archive/2026-04-28-frontend-ssr-migration-todo.md)。占位方案:重定向 /login。倾向方案:允许 1 次试用回合后弹登录,本期不实现 | — |
 | A5 | 后端不可达 | /healthz 失败或首请求网络错误 | 页面可见但顶部 banner(`--color-error` bg / `--color-error-fg` 字):「サーバーに接続できません · 再試行」;input 禁用 | 重试成功→A1 |
 
 ## B. 回合级 — 分级等待(核心体验)
@@ -138,5 +138,5 @@ Mockup: `spot-picker.html`。
 - E2 旁路不演管线戏:没经过 agent 的操作不显示 agent 过程,只给再計算用时
 
 **未决**:
-- A4 登录墙(critique P2,产品决策,docs/todo.md 已记)
+- A4 登录墙(critique P2,产品决策,docs/superpowers/plans/archive/2026-04-28-frontend-ssr-migration-todo.md 已记)
 - B 各时长阈值(1s/4s/60s)上线后按真实 agent 延迟分布调参

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -183,6 +183,10 @@ Routing defined by `wrangler.toml`:
 
 There are two workflow-backed deploy paths. Neither path is tag-triggered.
 
+### Schema change policy
+
+Migrations can finish before the new container replaces the old one, so a destructive change can briefly break old code that still reads or writes the removed schema; the `route_anime` release, for example, dropped `routes.bangumi_id` in the same release that changed the writer. For schema changes where that overlap matters, use expand/contract: add the replacement first, deploy compatible readers and writers, then remove the old column in a later release. Today’s infrequent, approval-gated cadence keeps this window low-risk, but it does not make destructive same-release changes safe by construction.
+
 ### Main promotion path (`.github/workflows/ci.yml`)
 
 `ci.yml` runs on pushes to `main` and `develop`, plus pull requests. Deploy jobs are narrower: they

--- a/docs/superpowers/plans/archive/2026-04-28-frontend-ssr-migration-todo.md
+++ b/docs/superpowers/plans/archive/2026-04-28-frontend-ssr-migration-todo.md
@@ -1,3 +1,5 @@
+> Archived 2026-07-18: superseded by `docs/superpowers/specs/2026-07-06-frontend-rebuild-spec.md`.
+
 # Frontend Architecture Migration: Static Export → SSR on Cloudflare
 
 ## Status: Planning (2026-04-28)


### PR DESCRIPTION
Bundled review leftovers (task #31). Localhost dev-key exemption, /v1/chat origin fields, nearby/route catalog-error degradation (NearbyUpstreamDown/RouteUpstreamDown — a real gap, not just the flagged search path), stale todo.md archived, expand/contract policy note. logfire[asyncpg] extra DEFERRED (its transitive otel-asyncpg 0.63b1 beta has no installable artifact on macOS arm64 — breaks the venv; instrument_asyncpg already works ad-hoc). Gate green (1087).

🤖 Generated with [Claude Code](https://claude.com/claude-code)