### PR TITLE
feat(users): routes delete + claim endpoints (#333)

### DIFF
--- a/packages/contract/src/users-contract.ts
+++ b/packages/contract/src/users-contract.ts
@@ -96,6 +96,26 @@ export const SaveRouteInput = z.object({
 /** Inferred save-route input. */
 export type SaveRouteInput = z.infer<typeof SaveRouteInput>;
 
+/** Input for deleting one user-owned route. */
+export const DeleteRouteInput = z.object({ id: z.uuid() });
+/** Inferred delete-route input. */
+export type DeleteRouteInput = z.infer<typeof DeleteRouteInput>;
+
+/** Result returned after deleting one user-owned route. */
+export const DeleteRouteResult = z.object({ deleted: z.literal(true) });
+/** Inferred delete-route result. */
+export type DeleteRouteResult = z.infer<typeof DeleteRouteResult>;
+
+/** Input for claiming routes created during an anonymous session. */
+export const ClaimRoutesInput = z.object({ session_id: z.string().min(1) });
+/** Inferred claim-routes input. */
+export type ClaimRoutesInput = z.infer<typeof ClaimRoutesInput>;
+
+/** Number of anonymous routes assigned to the authenticated caller. */
+export const ClaimRoutesResult = z.object({ claimed_count: z.number().int().nonnegative() });
+/** Inferred claim-routes result. */
+export type ClaimRoutesResult = z.infer<typeof ClaimRoutesResult>;
+
 /** Result returned when listing the caller's routes. */
 export const ListRoutesResult = z.object({ routes: z.array(UserRoute) });
 /** Inferred list-routes result. */
@@ -111,6 +131,15 @@ export const usersContract = {
     .input(SaveRouteInput)
     .errors(pickUsersErrors(["ROUTE_NOT_FOUND", "ROUTE_NOT_OWNED"]))
     .output(UserRoute),
+  deleteRoute: oc
+    .route({ method: "DELETE", path: "/v1/users/routes/{id}", summary: "Delete a saved route" })
+    .input(DeleteRouteInput)
+    .errors(pickUsersErrors(["ROUTE_NOT_FOUND", "ROUTE_NOT_OWNED"]))
+    .output(DeleteRouteResult),
+  claimRoutes: oc
+    .route({ method: "POST", path: "/v1/users/routes/claim", summary: "Claim anonymous routes" })
+    .input(ClaimRoutesInput)
+    .output(ClaimRoutesResult),
 };
 
 /** Users oRPC contract type. */

--- a/packages/contract/users-openapi.json
+++ b/packages/contract/users-openapi.json
@@ -322,6 +322,232 @@
           }
         }
       }
+    },
+    "/v1/users/routes/{id}": {
+      "delete": {
+        "operationId": "deleteRoute",
+        "summary": "Delete a saved route",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deleted": {
+                      "const": true
+                    }
+                  },
+                  "required": [
+                    "deleted"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "ROUTE_NOT_OWNED"
+                        },
+                        "status": {
+                          "const": 403
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "Route belongs to another user"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "route_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "route_id"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "ROUTE_NOT_FOUND"
+                        },
+                        "status": {
+                          "const": 404
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "No such saved route"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "route_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "route_id"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users/routes/claim": {
+      "post": {
+        "operationId": "claimRoutes",
+        "summary": "Claim anonymous routes",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "session_id": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "session_id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "claimed_count": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "claimed_count"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/workers/users/src/api/routes.ts
+++ b/workers/users/src/api/routes.ts
@@ -1,4 +1,8 @@
 import type {
+  ClaimRoutesInput,
+  ClaimRoutesResult,
+  DeleteRouteInput,
+  DeleteRouteResult,
   ListRoutesResult,
   RouteStatus,
   SaveRouteInput,
@@ -113,4 +117,31 @@ export async function saveRoute(
   return input.id
     ? updateRoute(db, userId, { ...input, id: input.id })
     : createRoute(db, userId, input);
+}
+
+/** Delete a route after explicit ownership validation. */
+export async function deleteRoute(
+  db: DbExecutor,
+  userId: string,
+  input: DeleteRouteInput,
+): Promise<DeleteRouteResult> {
+  await assertOwner(db, userId, input.id);
+  const result = await db.execute(sql`
+    DELETE FROM routes WHERE id = ${input.id} AND user_id = ${userId} RETURNING id
+  `);
+  if (result.rows.length === 0) throw routeNotOwned(input.id);
+  return { deleted: true };
+}
+
+/** Atomically assign this session's still-anonymous routes to the caller. */
+export async function claimRoutes(
+  db: DbExecutor,
+  userId: string,
+  input: ClaimRoutesInput,
+): Promise<ClaimRoutesResult> {
+  const result = await db.execute(sql`
+    UPDATE routes SET user_id = ${userId}
+    WHERE session_id = ${input.session_id} AND user_id IS NULL RETURNING id
+  `);
+  return { claimed_count: result.rows.length };
 }

--- a/workers/users/src/router.ts
+++ b/workers/users/src/router.ts
@@ -1,6 +1,11 @@
 import { usersContract } from "@seichijunrei/contract";
 import { implement } from "@orpc/server";
-import { listRoutes as listHandler, saveRoute as saveHandler } from "./api/routes";
+import {
+  claimRoutes as claimHandler,
+  deleteRoute as deleteHandler,
+  listRoutes as listHandler,
+  saveRoute as saveHandler,
+} from "./api/routes";
 import type { DbExecutor } from "./db/client";
 
 /** Per-request dependencies established by authentication middleware. */
@@ -14,8 +19,14 @@ const listRoutes = os.listRoutes.handler(async ({ context }) =>
 const saveRoute = os.saveRoute.handler(async ({ input, context }) =>
   saveHandler(context.db, context.userId, input),
 );
+const deleteRoute = os.deleteRoute.handler(async ({ input, context }) =>
+  deleteHandler(context.db, context.userId, input),
+);
+const claimRoutes = os.claimRoutes.handler(async ({ input, context }) =>
+  claimHandler(context.db, context.userId, input),
+);
 
 /** Users service oRPC implementation. */
-export const usersRouter = { listRoutes, saveRoute };
+export const usersRouter = { listRoutes, saveRoute, deleteRoute, claimRoutes };
 /** Users router type. */
 export type UsersRouter = typeof usersRouter;

--- a/workers/users/test/helpers.ts
+++ b/workers/users/test/helpers.ts
@@ -55,6 +55,7 @@ export function authTools(): Promise<AuthTools> {
 /** Mutable row representation owned by the reusable fake executor. */
 export interface FakeRouteRow {
   id: string;
+  session_id: string | null;
   user_id: string | null;
   title: string;
   point_ids: string[];
@@ -80,6 +81,7 @@ function insertRow(values: unknown[]): FakeRouteRow {
   const status = routeStatus(values[3]);
   return {
     id: NEW_ID,
+    session_id: null,
     user_id: typeof values[0] === "string" ? values[0] : null,
     title: typeof values[1] === "string" ? values[1] : "",
     point_ids: Array.isArray(values[2]) ? values[2].filter((v): v is string => typeof v === "string") : [],
@@ -99,7 +101,23 @@ function updateRow(row: FakeRouteRow, values: unknown[]): void {
   row.updated_at = NOW;
 }
 
-/** In-memory raw-SQL executor matching list, owner, insert, and update queries. */
+function deleteRows(rows: FakeRouteRow[], values: unknown[]): unknown[] {
+  const [id, userId] = values;
+  const index = rows.findIndex((row) => row.id === id && row.user_id === userId);
+  if (index < 0) return [];
+  const deleted = rows.splice(index, 1)[0];
+  return deleted ? [{ id: deleted.id }] : [];
+}
+
+function claimRows(rows: FakeRouteRow[], values: unknown[]): unknown[] {
+  const [userId, sessionId] = values;
+  if (typeof userId !== "string" || typeof sessionId !== "string") return [];
+  const claimed = rows.filter((row) => row.session_id === sessionId && row.user_id === null);
+  for (const row of claimed) row.user_id = userId;
+  return claimed.map((row) => ({ id: row.id }));
+}
+
+/** In-memory raw-SQL executor matching every user-route query. */
 export function fakeDb(seed: FakeRouteRow[] = []): { db: DbExecutor; rows: FakeRouteRow[] } {
   const rows = [...seed];
   const execute = (query: SQL): Promise<{ rows: unknown[] }> => {
@@ -112,6 +130,12 @@ export function fakeDb(seed: FakeRouteRow[] = []): { db: DbExecutor; rows: FakeR
       const row = insertRow(values);
       rows.push(row);
       return Promise.resolve({ rows: [row] });
+    }
+    if (text.includes("delete from routes")) {
+      return Promise.resolve({ rows: deleteRows(rows, values) });
+    }
+    if (text.includes("set user_id")) {
+      return Promise.resolve({ rows: claimRows(rows, values) });
     }
     if (text.includes("update routes")) {
       const [id, userId] = values.slice(-2);

--- a/workers/users/test/route-mutations.worker.test.ts
+++ b/workers/users/test/route-mutations.worker.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { createUsersApp } from "../src/index";
+import type { DbExecutor } from "../src/db/client";
+import { authTools, fakeDb, type FakeRouteRow, TEST_ENV } from "./helpers";
+
+const ROUTE_A = "00000000-0000-4000-8000-00000000000a";
+const ROUTE_B = "00000000-0000-4000-8000-00000000000b";
+const UNKNOWN = "00000000-0000-4000-8000-00000000000f";
+const SESSION = "anonymous-session";
+
+function row(overrides: Partial<FakeRouteRow> = {}): FakeRouteRow {
+  return {
+    id: ROUTE_A, session_id: null, user_id: "user-a", title: "Tokyo",
+    point_ids: [], status: "saved", saved_at: null,
+    updated_at: "2026-07-13T04:00:00.000Z", ...overrides,
+  };
+}
+
+async function setup(seed: FakeRouteRow[] = []) {
+  const auth = await authTools();
+  const store = fakeDb(seed);
+  const app = createUsersApp({ getKey: auth.getKey, makeDb: () => store.db });
+  const token = await auth.makeJwt({ sub: "user-a" });
+  const headers = { Authorization: `Bearer ${token}`, "content-type": "application/json" };
+  return { app, headers, rows: store.rows };
+}
+
+function deleteRoute(app: Awaited<ReturnType<typeof setup>>["app"], headers: HeadersInit, id: string) {
+  return app.request(`/v1/users/routes/${id}`, { method: "DELETE", headers }, TEST_ENV);
+}
+
+function claimRoutes(app: Awaited<ReturnType<typeof setup>>["app"], headers: HeadersInit) {
+  return app.request("/v1/users/routes/claim", {
+    method: "POST", headers, body: JSON.stringify({ session_id: SESSION }),
+  }, TEST_ENV);
+}
+
+function requiredMutation(mutation: SQL | undefined): SQL {
+  if (!mutation) throw new Error("expected mutation query");
+  return mutation;
+}
+
+function captureDb(ownerRows: unknown[] = []) {
+  let mutation: SQL | undefined;
+  const execute: DbExecutor["execute"] = (query) => {
+    const rendered = new PgDialect().sqlToQuery(query).sql.toLowerCase();
+    if (rendered.includes("select user_id")) return Promise.resolve({ rows: ownerRows });
+    mutation = query;
+    return Promise.resolve({ rows: [{ id: ROUTE_A }] });
+  };
+  return { db: { execute }, query: () => requiredMutation(mutation) };
+}
+
+async function setupWith(db: DbExecutor) {
+  const auth = await authTools();
+  const token = await auth.makeJwt({ sub: "user-a" });
+  const app = createUsersApp({ getKey: auth.getKey, makeDb: () => db });
+  return { app, headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" } };
+}
+
+describe("route deletion wire", () => {
+  it("deletes a route owned by the JWT subject", async () => {
+    const { app, headers, rows } = await setup([row()]);
+    const response = await deleteRoute(app, headers, ROUTE_A);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ deleted: true });
+    expect(rows).toEqual([]);
+  });
+
+  it("returns ROUTE_NOT_FOUND for an unknown route", async () => {
+    const { app, headers } = await setup();
+    const response = await deleteRoute(app, headers, UNKNOWN);
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      defined: true, code: "ROUTE_NOT_FOUND", data: { route_id: UNKNOWN },
+    });
+  });
+
+  it("cannot delete another user's route", async () => {
+    const seed = row({ user_id: "user-b" });
+    const { app, headers, rows } = await setup([seed]);
+    const response = await deleteRoute(app, headers, ROUTE_A);
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ defined: true, code: "ROUTE_NOT_OWNED" });
+    expect(rows).toEqual([seed]);
+  });
+
+  it("scopes the atomic delete statement to route id and user id", async () => {
+    const capture = captureDb([{ user_id: "user-a" }]);
+    const { app, headers } = await setupWith(capture.db);
+    expect((await deleteRoute(app, headers, ROUTE_A)).status).toBe(200);
+    const rendered = new PgDialect().sqlToQuery(capture.query());
+    expect(rendered.sql.toLowerCase()).toContain("user_id");
+    expect(rendered.params).toEqual([ROUTE_A, "user-a"]);
+  });
+});
+
+describe("anonymous route claim wire", () => {
+  it("claims every anonymous route in the session and returns the count", async () => {
+    const { app, headers, rows } = await setup([
+      row({ session_id: SESSION, user_id: null }),
+      row({ id: ROUTE_B, session_id: SESSION, user_id: null }),
+    ]);
+    const response = await claimRoutes(app, headers);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ claimed_count: 2 });
+    expect(rows.map((item) => item.user_id)).toEqual(["user-a", "user-a"]);
+  });
+
+  it("is idempotent when the same session is claimed twice", async () => {
+    const { app, headers } = await setup([row({ session_id: SESSION, user_id: null })]);
+    expect(await (await claimRoutes(app, headers)).json()).toEqual({ claimed_count: 1 });
+    expect(await (await claimRoutes(app, headers)).json()).toEqual({ claimed_count: 0 });
+  });
+
+  it("returns zero when the session has no routes", async () => {
+    const { app, headers } = await setup();
+    const response = await claimRoutes(app, headers);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ claimed_count: 0 });
+  });
+
+  it("cannot steal a route already owned by another user", async () => {
+    const seed = row({ session_id: SESSION, user_id: "user-b" });
+    const { app, headers, rows } = await setup([seed]);
+    const response = await claimRoutes(app, headers);
+    expect(await response.json()).toEqual({ claimed_count: 0 });
+    expect(rows).toEqual([seed]);
+  });
+
+  it("claims only null owners in one session-scoped update", async () => {
+    const capture = captureDb();
+    const { app, headers } = await setupWith(capture.db);
+    expect((await claimRoutes(app, headers)).status).toBe(200);
+    const rendered = new PgDialect().sqlToQuery(capture.query());
+    expect(rendered.sql.toLowerCase()).toContain("user_id is null");
+    expect(rendered.params).toEqual(["user-a", SESSION]);
+  });
+});

--- a/workers/users/test/routes-api.worker.test.ts
+++ b/workers/users/test/routes-api.worker.test.ts
@@ -15,7 +15,7 @@ const UPDATE_INPUT: SaveRouteInput = {
 
 function row(overrides: Partial<FakeRouteRow> = {}): FakeRouteRow {
   return {
-    id: ID, user_id: "user-a", title: "Tokyo", point_ids: ["p1"],
+    id: ID, session_id: null, user_id: "user-a", title: "Tokyo", point_ids: ["p1"],
     status: "saved", saved_at: RAW, updated_at: RAW, ...overrides,
   };
 }


### PR DESCRIPTION
Closes #333 (S2.8 follow-up; server-side only, apps/web untouched — frontend integration lands with S1.7).

## Endpoints

- **`DELETE /v1/users/routes/{id}`** — `assertOwner` preflight (precise 404 `ROUTE_NOT_FOUND` / 403 `ROUTE_NOT_OWNED`, matching #331 semantics) + atomic `DELETE … WHERE id = ? AND user_id = ? RETURNING id` as the race-safe boundary.
- **`POST /v1/users/routes/claim`** — claims anonymous-session routes: single `UPDATE … SET user_id WHERE session_id = ? AND user_id IS NULL RETURNING id`. Idempotent (re-claim / empty session → `claimed_count: 0`); rows already owned by anyone are ineligible — anti-steal and idempotency are the same invariant.

Contract + generated OpenAPI updated in `packages/contract` (emit is byte-deterministic; drift check clean).

## Tests

9 new endpoint tests in `route-mutations.worker.test.ts`: delete happy/not-found/cross-user/atomic-predicate; claim happy/idempotent/empty/anti-steal/`user_id IS NULL` predicate. Suite: 4 files, 34 passed.

## Verification (lead, live)

- `pnpm install --frozen-lockfile` → oxlint (`--deny-warnings`) clean, `tsc --noEmit` clean, 34/34 tests, coverage 81% stmts
- `emit:openapi` re-run → zero drift vs committed json

## Recorded (not implemented)

JWT verification drift between edge (#328: dual-issuer, feature-gated, explicit `NEON_AUTH_ISSUER`) and users (#331: Neon-only, issuer derived from JWKS URL) — future shared-package candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)