### PR TITLE
fix(agent): CatalogClient shared AsyncClient with connection pooling (#303)

### DIFF
--- a/apps/agent/agent/clients/catalog_client.py
+++ b/apps/agent/agent/clients/catalog_client.py
@@ -45,6 +45,11 @@ logger = structlog.get_logger(__name__)
 CATALOG_REQUEST_TIMEOUT_SECONDS = 25.0
 CATALOG_TOTAL_TIMEOUT_SECONDS = 80.0
 _TRANSIENT_STATUS_CODES = frozenset({408, 429})
+_CATALOG_HTTP_LIMITS = httpx.Limits(
+    max_connections=20,
+    max_keepalive_connections=10,
+    keepalive_expiry=30.0,
+)
 
 # Re-exported so callers depend on this client, not on agent internals.
 __all__ = [
@@ -208,11 +213,12 @@ class CatalogClient:
         *,
         timeout: float = CATALOG_REQUEST_TIMEOUT_SECONDS,
         max_retries: int = 3,
+        http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
         self._max_retries = max_retries
-        self._client: httpx.AsyncClient | None = None
+        self._client = http_client
 
     async def search(self, query: str) -> list[PilgrimagePoint]:
         """Resolve a free-text query to its pilgrimage points."""
@@ -285,16 +291,18 @@ class CatalogClient:
     def _http(self) -> httpx.AsyncClient:
         """Return the shared httpx client, creating it lazily."""
         if self._client is None or self._client.is_closed:
-            wrapped = httpx.AsyncHTTPTransport(trust_env=True)
-            transport = AsyncTenacityTransport(
-                _retry_config(self._max_retries),
-                wrapped=wrapped,
-            )
-            self._client = httpx.AsyncClient(
-                timeout=self._timeout,
-                transport=transport,
-            )
+            self._client = self._build_http_client()
         return self._client
+
+    def _build_http_client(self) -> httpx.AsyncClient:
+        wrapped = httpx.AsyncHTTPTransport(
+            trust_env=True,
+            limits=_CATALOG_HTTP_LIMITS,
+        )
+        transport = AsyncTenacityTransport(
+            _retry_config(self._max_retries), wrapped=wrapped
+        )
+        return httpx.AsyncClient(timeout=self._timeout, transport=transport)
 
     async def _rpc(self, method: str, body: Mapping[str, object]) -> JSONDict:
         """POST ``body`` to the method endpoint with retry on transient errors."""

--- a/apps/agent/agent/tests/unit/test_catalog_client.py
+++ b/apps/agent/agent/tests/unit/test_catalog_client.py
@@ -5,9 +5,11 @@ Response envelopes mirror packages/contract:
   ingest -> {status, version?, point_count?, reason?}.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
-import pytest
+import httpx
 
 from agent.clients.catalog_client import (
     CatalogClient,
@@ -34,29 +36,29 @@ def test_geocode_types_remain_reexported() -> None:
     assert GeocodeSource.__module__ == "agent.clients.geocode"
 
 
-def _mock_httpx(monkeypatch: pytest.MonkeyPatch, json_payload: object) -> MagicMock:
-    """Patch ``httpx.AsyncClient`` so POST returns ``json_payload``."""
-    response = MagicMock()
-    response.status_code = 200
-    response.json = MagicMock(return_value=json_payload)
+@asynccontextmanager
+async def _mock_catalog(
+    json_payload: object,
+) -> AsyncIterator[tuple[CatalogClient, list[httpx.Request]]]:
+    requests: list[httpx.Request] = []
 
-    client = MagicMock()
-    client.post = AsyncMock(return_value=response)
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=False)
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=json_payload)
 
-    monkeypatch.setattr(
-        "agent.clients.catalog_client.httpx.AsyncClient",
-        MagicMock(return_value=client),
-    )
-    return client
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = CatalogClient("https://catalog.test", http_client=http_client)
+    try:
+        yield client, requests
+    finally:
+        await client.aclose()
 
 
-async def test_search_parses_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_search_parses_rows() -> None:
     """search() reads the {rows, synced_at} envelope into PilgrimagePoint models."""
-    _mock_httpx(monkeypatch, {"rows": [_POINT], "synced_at": "2026-06-21T00:00:00Z"})
-
-    points = await CatalogClient("https://catalog.test").search("響け")
+    payload = {"rows": [_POINT], "synced_at": "2026-06-21T00:00:00Z"}
+    async with _mock_catalog(payload) as (client, _):
+        points = await client.search("響け")
 
     assert points == [
         PilgrimagePoint(
@@ -65,50 +67,40 @@ async def test_search_parses_rows(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
 
-async def test_search_posts_query_to_catalog_path(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_search_posts_query_to_catalog_path() -> None:
     """search() POSTs {query} to /catalog/search."""
-    client = _mock_httpx(monkeypatch, {"rows": [], "synced_at": ""})
+    async with _mock_catalog({"rows": [], "synced_at": ""}) as (client, requests):
+        await client.search("響け")
 
-    await CatalogClient("https://catalog.test").search("響け")
-
-    url, kwargs = client.post.call_args.args[0], client.post.call_args.kwargs
-    assert url == "https://catalog.test/catalog/search"
-    assert kwargs["json"] == {"query": "響け"}
+    assert str(requests[0].url) == "https://catalog.test/catalog/search"
+    assert json.loads(requests[0].content) == {"query": "響け"}
 
 
-async def test_spots_parses_single_point(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_spots_parses_single_point() -> None:
     """spots() reads the {point, distance_m?} envelope into one PilgrimagePoint."""
-    _mock_httpx(monkeypatch, {"point": _POINT, "distance_m": 120.0})
-
-    point = await CatalogClient("https://catalog.test").spots("115908")
+    async with _mock_catalog({"point": _POINT, "distance_m": 120.0}) as (client, _):
+        point = await client.spots("115908")
 
     assert point == PilgrimagePoint(
         id="p1", name="Uji Bridge", latitude=34.89, longitude=135.80, city="Uji"
     )
 
 
-async def test_nearby_parses_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_nearby_parses_rows() -> None:
     """nearby() reads the {rows} envelope and POSTs lat/lng/radius_m."""
-    client = _mock_httpx(monkeypatch, {"rows": [_POINT]})
-
-    points = await CatalogClient("https://catalog.test").nearby(
-        34.89, 135.80, radius_m=500
-    )
+    async with _mock_catalog({"rows": [_POINT]}) as (client, requests):
+        points = await client.nearby(34.89, 135.80, radius_m=500)
 
     assert len(points) == 1
     assert points[0].city == "Uji"
-    assert client.post.call_args.kwargs["json"] == {
+    assert json.loads(requests[0].content) == {
         "lat": 34.89,
         "lng": 135.80,
         "radius_m": 500,
     }
 
 
-async def test_geocode_parses_candidates_and_posts_limit(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_geocode_parses_candidates_and_posts_limit() -> None:
     candidate = {
         "id": "seed:nishinomiya",
         "label": "西宮駅(兵庫県)",
@@ -119,70 +111,62 @@ async def test_geocode_parses_candidates_and_posts_limit(
         "source": "manual",
         "effective_radius_m": 10000,
     }
-    client = _mock_httpx(monkeypatch, {"candidates": [candidate]})
-
-    result = await CatalogClient("https://catalog.test").geocode("西宮", limit=3)
+    async with _mock_catalog({"candidates": [candidate]}) as (client, requests):
+        result = await client.geocode("西宮", limit=3)
 
     assert result == [GeocodeCandidate.model_validate(candidate)]
     assert result[0].kind == GeocodeKind.STATION
     assert result[0].source == GeocodeSource.MANUAL
     assert result[0].effective_radius_m == 10_000
-    assert client.post.call_args.args[0] == "https://catalog.test/catalog/geocode"
-    assert client.post.call_args.kwargs["json"] == {"query": "西宮", "limit": 3}
+    assert str(requests[0].url) == "https://catalog.test/catalog/geocode"
+    assert json.loads(requests[0].content) == {"query": "西宮", "limit": 3}
 
 
-async def test_route_parses_route(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_route_parses_route() -> None:
     """route() validates the Route envelope and POSTs point_ids."""
-    client = _mock_httpx(monkeypatch, {"ordered_points": [_POINT], "point_count": 1})
-
-    route = await CatalogClient("https://catalog.test").route(["p1"])
+    payload = {"ordered_points": [_POINT], "point_count": 1}
+    async with _mock_catalog(payload) as (client, requests):
+        route = await client.route(["p1"])
 
     assert isinstance(route, Route)
     assert route.point_count == 1
-    assert client.post.call_args.kwargs["json"] == {"point_ids": ["p1"]}
+    assert json.loads(requests[0].content) == {"point_ids": ["p1"]}
 
 
-async def test_route_posts_coordinate_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_route_posts_coordinate_origin() -> None:
     """route() sends origin only when coordinates are provided."""
-    client = _mock_httpx(monkeypatch, {"ordered_points": [_POINT], "point_count": 1})
+    payload = {"ordered_points": [_POINT], "point_count": 1}
+    async with _mock_catalog(payload) as (client, requests):
+        await client.route(["p1"], origin=(34.89, 135.8))
 
-    await CatalogClient("https://catalog.test").route(["p1"], origin=(34.89, 135.8))
-
-    assert client.post.call_args.kwargs["json"] == {
+    assert json.loads(requests[0].content) == {
         "point_ids": ["p1"],
         "origin": {"lat": 34.89, "lng": 135.8},
     }
 
 
-async def test_ingest_parses_ingested(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_ingest_parses_ingested() -> None:
     """ingest() reads the {status, version, point_count} envelope when ingested."""
-    _mock_httpx(monkeypatch, {"status": "ingested", "version": 3, "point_count": 7})
-
-    result = await CatalogClient("https://catalog.test").ingest("10380")
+    payload = {"status": "ingested", "version": 3, "point_count": 7}
+    async with _mock_catalog(payload) as (client, _):
+        result = await client.ingest("10380")
 
     assert result == IngestResult(status="ingested", version=3, point_count=7)
 
 
-async def test_ingest_posts_bangumi_id_to_catalog_path(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_ingest_posts_bangumi_id_to_catalog_path() -> None:
     """ingest() POSTs {bangumi_id} to /catalog/ingest."""
-    client = _mock_httpx(monkeypatch, {"status": "in_progress"})
+    async with _mock_catalog({"status": "in_progress"}) as (client, requests):
+        await client.ingest("10380")
 
-    await CatalogClient("https://catalog.test").ingest("10380")
-
-    url, kwargs = client.post.call_args.args[0], client.post.call_args.kwargs
-    assert url == "https://catalog.test/catalog/ingest"
-    assert kwargs["json"] == {"bangumi_id": "10380"}
+    assert str(requests[0].url) == "https://catalog.test/catalog/ingest"
+    assert json.loads(requests[0].content) == {"bangumi_id": "10380"}
 
 
-async def test_ingest_parses_empty_with_reason(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_ingest_parses_empty_with_reason() -> None:
     """ingest() carries the reason for a non-ingested status (empty/failed)."""
-    _mock_httpx(monkeypatch, {"status": "empty", "reason": "no points"})
-
-    result = await CatalogClient("https://catalog.test").ingest("999")
+    async with _mock_catalog({"status": "empty", "reason": "no points"}) as (client, _):
+        result = await client.ingest("999")
 
     assert result.status == "empty"
     assert result.reason == "no points"

--- a/apps/agent/agent/tests/unit/test_catalog_client_http.py
+++ b/apps/agent/agent/tests/unit/test_catalog_client_http.py
@@ -47,21 +47,19 @@ def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     return sleep
 
 
-async def test_reuses_one_http_client_across_requests(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_reuses_one_http_client_across_requests() -> None:
     calls: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         calls.append(request)
         return _response(request, 200, {"rows": [], "synced_at": ""})
 
-    constructor = _install_transport(monkeypatch, handler)
-    client = CatalogClient("https://catalog.test")
+    shared = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = CatalogClient("https://catalog.test", http_client=shared)
     await client.search("響け")
     await client.search("氷菓")
 
-    assert constructor.call_count == 1
+    assert client._http() is shared
     assert len(calls) == 2
     await client.aclose()
 

--- a/apps/agent/agent/tests/unit/test_catalog_wiring.py
+++ b/apps/agent/agent/tests/unit/test_catalog_wiring.py
@@ -9,7 +9,10 @@ so we assert the agent drove its data path through that client.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from fastapi.testclient import TestClient
 
 from agent.clients.catalog_client import CatalogClient
 from agent.config.settings import Settings
@@ -78,3 +81,28 @@ def test_app_factory_builds_catalog_client() -> None:
     client = build_catalog_client(settings)
     assert isinstance(client, CatalogClient)
     assert client._base_url == "https://catalog.test"
+
+
+def test_fastapi_lifespan_closes_catalog_client() -> None:
+    catalog = MagicMock(spec=CatalogClient)
+    catalog.aclose = AsyncMock()
+    model_client = MagicMock(spec=httpx.AsyncClient)
+    model_client.aclose = AsyncMock()
+    session_store = InMemorySessionStore()
+    db = build_stub_db()
+    with (
+        patch(
+            "agent.interfaces.fastapi_service.build_catalog_client",
+            return_value=catalog,
+        ),
+        patch(
+            "agent.interfaces.fastapi_service.build_model_http_client",
+            return_value=model_client,
+        ),
+    ):
+        from agent.interfaces.fastapi_service import create_fastapi_app
+
+        app = create_fastapi_app(db=db, session_store=session_store)
+        with TestClient(app):
+            assert app.state.catalog_client is catalog
+    catalog.aclose.assert_awaited_once()

--- a/apps/agent/agent/tests/unit/test_phase1c_catalog_client.py
+++ b/apps/agent/agent/tests/unit/test_phase1c_catalog_client.py
@@ -1,44 +1,44 @@
 """Phase 1c pins for typed Catalog endpoint and route invariants."""
 
+import json
+
 import pytest
 from pydantic import ValidationError
 
 from agent.clients.catalog_client import (
-    CatalogClient,
     PilgrimagePoint,
     ResolveResolved,
     Route,
     SearchResult,
 )
-from agent.tests.unit.test_catalog_client import _mock_httpx
+from agent.tests.unit.test_catalog_client import _mock_catalog
 
 _POINT = {"id": "p1", "name": "Uji Bridge", "latitude": 34.89, "longitude": 135.8}
 
 
-async def test_resolve_posts_to_typed_phase1a_endpoint(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_resolve_posts_to_typed_phase1a_endpoint() -> None:
     payload = {
         "outcome": "resolved",
         "match": {"bangumi_id": "115908", "title": "響け！ユーフォニアム"},
     }
-    client = _mock_httpx(monkeypatch, payload)
-    result = await CatalogClient("https://catalog.test").resolve("京吹")
+    async with _mock_catalog(payload) as (client, requests):
+        result = await client.resolve("京吹")
     assert isinstance(result, ResolveResolved)
-    assert client.post.call_args.args[0] == "https://catalog.test/catalog/resolve"
-    assert client.post.call_args.kwargs["json"] == {"query": "京吹"}
+    assert str(requests[0].url) == "https://catalog.test/catalog/resolve"
+    assert json.loads(requests[0].content) == {"query": "京吹"}
 
 
-async def test_points_by_work_id_never_repeats_free_text_search(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    client = _mock_httpx(monkeypatch, {"rows": [_POINT], "synced_at": "now"})
-    result = await CatalogClient("https://catalog.test").points_by_work_id("115908")
+async def test_points_by_work_id_never_repeats_free_text_search() -> None:
+    async with _mock_catalog({"rows": [_POINT], "synced_at": "now"}) as (
+        client,
+        requests,
+    ):
+        result = await client.points_by_work_id("115908")
     assert result == SearchResult(
         rows=[PilgrimagePoint.model_validate(_POINT)], synced_at="now"
     )
-    assert client.post.call_args.args[0].endswith("/catalog/points-by-work-id")
-    assert client.post.call_args.kwargs["json"] == {"work_id": "115908"}
+    assert str(requests[0].url).endswith("/catalog/points-by-work-id")
+    assert json.loads(requests[0].content) == {"work_id": "115908"}
 
 
 def test_route_rejects_count_without_matching_ordered_points() -> None:


### PR DESCRIPTION
Closes #303.

## What

`CatalogClient._post_json` opened a fresh `httpx.AsyncClient` per request — every agent→catalog call (resolve / search / route, the hottest path) paid a new TCP+TLS handshake and forfeited httpx's built-in pooling. Per the recorded owner direction: use the library's own supported mechanism, no hand-rolled pooling layer.

- `CatalogClient` now owns ONE reusable `AsyncClient` (constructor-injected or lazily created) with bounded `httpx.Limits`; `aclose()` supported.
- FastAPI lifespan teardown already closed the catalog client — now pinned by a regression test.
- Tests migrated from patching per-call client construction to real `AsyncClient` over `httpx.MockTransport`; added a reuse-identity test (same client instance across calls) and a shutdown-close test.

## Verification (lead, live)

make lint / typecheck / test — 279 files formatted, mypy 106 files clean, **1089 passed, coverage 87.79%** (floor 82%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)