### PR TITLE
fix(catalog): kill all 15 non-null-assertion suppressions + route cluster truncation (#302, #301)

### DIFF
--- a/packages/contract/openapi.json
+++ b/packages/contract/openapi.json
@@ -1161,6 +1161,19 @@
                     "anime_title_cn": {
                       "type": "string"
                     },
+                    "truncated": {
+                      "type": "boolean"
+                    },
+                    "shown_cluster_count": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "total_cluster_count": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
                     "timed_itinerary": {
                       "type": "object",
                       "properties": {

--- a/packages/contract/src/models.ts
+++ b/packages/contract/src/models.ts
@@ -159,6 +159,9 @@ export const Route = z.object({
   cover_url: z.string().optional(),
   anime_title: z.string().optional(),
   anime_title_cn: z.string().optional(),
+  truncated: z.boolean().optional(),
+  shown_cluster_count: z.number().int().optional(),
+  total_cluster_count: z.number().int().optional(),
   timed_itinerary: TimedItinerary,
 });
 export type Route = z.infer<typeof Route>;

--- a/workers/catalog/.oxlintrc.json
+++ b/workers/catalog/.oxlintrc.json
@@ -8,5 +8,8 @@
     "coverage/**",
     "vitest.config.ts",
     "vitest.spike.config.ts"
-  ]
+  ],
+  "options": {
+    "reportUnusedDisableDirectives": "error"
+  }
 }

--- a/workers/catalog/package.json
+++ b/workers/catalog/package.json
@@ -8,7 +8,7 @@
     "build:topology": "tsx scripts/transit/build-topology.ts",
     "dev": "wrangler dev",
     "fetch:n02": "tsx scripts/transit/fetch-n02.ts",
-    "lint:oxlint": "oxlint --type-aware --deny-warnings .",
+    "lint:oxlint": "node scripts/oxlint/check-no-inline-config.mjs && oxlint --type-aware --deny-warnings .",
     "test": "npm run test:worker && npm run test:spike",
     "test:worker": "vitest run --config vitest.config.ts --coverage",
     "test:spike": "vitest run --config vitest.spike.config.ts",

--- a/workers/catalog/scripts/oxlint/check-no-inline-config.mjs
+++ b/workers/catalog/scripts/oxlint/check-no-inline-config.mjs
@@ -1,0 +1,49 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const EXTENSIONS = new Set([".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx"]);
+const EXCLUDED = new Set([".git", ".wrangler", "coverage", "dist", "node_modules"]);
+const PREFIXES = ["eslint", "oxlint"].join("|");
+const DIRECTIVE = new RegExp(`(?:\\/\\/|\\/\\*)\\s*(?:${PREFIXES})-(?:disable|enable)(?:-next-line|-line)?\\b`, "gu");
+const LEGACY_FILE = "test/catalog-api.spike.test.ts";
+const LEGACY_LINE = ["// eslint", "disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist"].join("-");
+
+/** @param {string} directory @returns {string[]} */
+function sourceFiles(directory) {
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (EXCLUDED.has(entry.name)) continue;
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...sourceFiles(path));
+    else if (EXTENSIONS.has(extname(entry.name))) files.push(path);
+  }
+  return files;
+}
+
+/** @param {string} text @param {number} index */
+function lineAt(text, index) {
+  const start = text.lastIndexOf("\n", index - 1) + 1;
+  const end = text.indexOf("\n", index);
+  return text.slice(start, end < 0 ? undefined : end).trim();
+}
+
+/** @param {string} file @returns {string[]} */
+function inlineConfigFailures(file) {
+  const text = readFileSync(file, "utf8");
+  const name = relative(ROOT, file).replaceAll("\\", "/");
+  let legacyAllowed = false;
+  return [...text.matchAll(DIRECTIVE)].flatMap((match) => {
+    if (!legacyAllowed && name === LEGACY_FILE && lineAt(text, match.index) === LEGACY_LINE) {
+      legacyAllowed = true;
+      return [];
+    }
+    const line = text.slice(0, match.index).split("\n").length;
+    return [`${name}:${String(line)}: inline lint configuration is forbidden`];
+  });
+}
+
+const failures = sourceFiles(ROOT).flatMap(inlineConfigFailures);
+for (const failure of failures) process.stderr.write(`${failure}\n`);
+if (failures.length > 0) process.exitCode = 1;

--- a/workers/catalog/scripts/oxlint/tsconfig.json
+++ b/workers/catalog/scripts/oxlint/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["*.mjs"]
+}

--- a/workers/catalog/src/api/route.ts
+++ b/workers/catalog/src/api/route.ts
@@ -6,7 +6,7 @@
  * (`packages/contract/src/models.ts`).
  *
  * Flow: fetch points for `point_ids` (joined to bangumi for the anime title) ->
- * `clusterByLocation` (50m) -> typed too-many-clusters guard ->
+ * `clusterByLocation` (50m) -> deterministic 50-cluster cap ->
  * `buildTimedItinerary` -> expand the ordered clusters back to their member
  * points (= `ordered_points`) -> `Route`.
  *
@@ -19,7 +19,6 @@
 import { sql } from "drizzle-orm";
 import type { ClusterablePoint, LocationCluster } from "../lib/clustering";
 import { clusterByLocation } from "../lib/clustering";
-import { routeTooManyClusters } from "../lib/errors";
 import { optional } from "../lib/optional";
 import type { Origin as KernelOrigin, Pacing, TimedItinerary } from "../lib/route";
 import { buildTimedItinerary, MAX_ITINERARY_CLUSTERS } from "../lib/route";
@@ -73,10 +72,10 @@ type PointCluster = LocationCluster<ClusterablePilgrimagePoint>;
 /** Plan an ordered, timed route over `point_ids`. Empty/unknown ids -> count 0. */
 export async function route(db: RouteDb, input: RouteInput): Promise<Route> {
   const points = await fetchPoints(db, input.point_ids);
-  const clusters = clusterByLocation(points, 50);
-  if (clusters.length > MAX_ITINERARY_CLUSTERS) throw routeTooManyClusters(clusters.length, MAX_ITINERARY_CLUSTERS);
+  const allClusters = clusterByLocation(points, 50);
+  const clusters = allClusters.slice(0, MAX_ITINERARY_CLUSTERS);
   const itinerary = buildTimedItinerary(clusters, kernelOpts(input));
-  return assembleRoute(clusters, itinerary);
+  return assembleRoute(clusters, itinerary, allClusters.length);
 }
 
 /** SELECT the points for `ids` joined to their bangumi, preserving `ids` order. */
@@ -143,9 +142,15 @@ function kernelOpts(input: RouteInput): { pacing?: Pacing; origin?: KernelOrigin
 }
 
 /** Assemble the contract `Route` from the ordered clusters and the itinerary. */
-function assembleRoute(clusters: PointCluster[], itinerary: TimedItinerary): Route {
+function assembleRoute(clusters: PointCluster[], itinerary: TimedItinerary, totalClusters: number): Route {
   const ordered = orderPoints(clusters, itinerary);
-  return { ...animeMeta(ordered[0]), ordered_points: ordered, point_count: ordered.length, timed_itinerary: itinerary };
+  return { ...animeMeta(ordered[0]), ...truncationMeta(clusters.length, totalClusters), ordered_points: ordered, point_count: ordered.length, timed_itinerary: itinerary };
+}
+
+/** Add disclosure fields only when the deterministic cluster cap was applied. */
+function truncationMeta(shown: number, total: number): Partial<Pick<Route, "truncated" | "shown_cluster_count" | "total_cluster_count">> {
+  if (shown === total) return {};
+  return { truncated: true, shown_cluster_count: shown, total_cluster_count: total };
 }
 
 /** Expand the itinerary's ordered stops back to their member points, in order. */

--- a/workers/catalog/src/lib/clustering.ts
+++ b/workers/catalog/src/lib/clustering.ts
@@ -29,33 +29,43 @@ export interface LocationCluster<P extends ClusterablePoint = ClusterablePoint> 
   clusterId: string;
 }
 
+type NonEmpty<T> = [T, ...T[]];
+
+/** Mutable union-find node; parent links replace unchecked numeric indexing. */
+class UnionNode {
+  parent: UnionNode = this;
+  rank = 0;
+}
+
+interface PointNode<P extends ClusterablePoint> {
+  point: P;
+  node: UnionNode;
+}
+
 /** Path-compressing find — mirrors Python `_find`. */
-function find(parent: number[], i: number): number {
-  let node = i;
-  while (parent[node] !== node) {
+function find(node: UnionNode): UnionNode {
+  let root = node;
+  while (root.parent !== root) {
     // path compression: point at grandparent
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- union-find indices bounded by n
-    parent[node] = parent[parent[node]!]!;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- union-find indices bounded by n
-    node = parent[node]!;
+    root.parent = root.parent.parent;
+    root = root.parent;
   }
-  return node;
+  return root;
 }
 
 /** Union-by-rank — mirrors Python `_union`. */
-function union(parent: number[], rank: number[], a: number, b: number): void {
-  let ra = find(parent, a);
-  let rb = find(parent, b);
+function union(a: UnionNode, b: UnionNode): void {
+  let ra = find(a);
+  let rb = find(b);
   if (ra === rb) {
     return;
   }
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- ra/rb are valid indices from find()
-  if (rank[ra]! < rank[rb]!) {
+  if (ra.rank < rb.rank) {
     [ra, rb] = [rb, ra];
   }
-  parent[rb] = ra;
-  if (rank[ra] === rank[rb]) {
-    rank[ra] = (rank[ra] ?? 0) + 1;
+  rb.parent = ra;
+  if (ra.rank === rb.rank) {
+    ra.rank += 1;
   }
 }
 
@@ -73,79 +83,57 @@ export function clusterByLocation<P extends ClusterablePoint>(
   points: P[],
   radiusM = 50,
 ): LocationCluster<P>[] {
-  const n = points.length;
-  if (n === 0) {
-    return [];
-  }
-
-  const parent = Array.from({ length: n }, (_, i) => i);
-  const rank = new Array<number>(n).fill(0);
-
-  // O(n^2) pairwise comparison, same iteration order as Python (i, then j>i).
-  for (let i = 0; i < n; i += 1) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index bounded by loop [0, n)
-    pairUnion(parent, rank, points, n, points[i]!, i, radiusM);
-  }
-
-  return buildClusters(points, parent);
+  const entries = points.map((point) => ({ point, node: new UnionNode() }));
+  pairUnion(entries, radiusM);
+  return buildClusters(entries);
 }
 
 function pairUnion<P extends ClusterablePoint>(
-  parent: number[],
-  rank: number[],
-  points: P[],
-  n: number,
-  pi: P,
-  i: number,
+  entries: PointNode<P>[],
   radiusM: number,
 ): void {
-  for (let j = i + 1; j < n; j += 1) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index bounded by loop [0, n)
-    const pj = points[j]!;
-    if (haversine(pi.latitude, pi.longitude, pj.latitude, pj.longitude) < radiusM) {
-      union(parent, rank, i, j);
+  // O(n^2) pairwise comparison, same iteration order as Python (i, then j>i).
+  for (const [index, left] of entries.entries()) {
+    for (const right of entries.slice(index + 1)) {
+      unionIfClose(left, right, radiusM);
     }
   }
 }
 
+function unionIfClose<P extends ClusterablePoint>(left: PointNode<P>, right: PointNode<P>, radiusM: number): void {
+  const distance = haversine(left.point.latitude, left.point.longitude, right.point.latitude, right.point.longitude);
+  if (distance < radiusM) union(left.node, right.node);
+}
+
 function buildClusters<P extends ClusterablePoint>(
-  points: P[],
-  parent: number[],
+  entries: PointNode<P>[],
 ): LocationCluster<P>[] {
-  const groups = new Map<number, number[]>();
-  for (let i = 0; i < points.length; i += 1) {
-    const root = find(parent, i);
+  const groups = new Map<UnionNode, NonEmpty<P>>();
+  for (const { point, node } of entries) {
+    const root = find(node);
     const bucket = groups.get(root);
     if (bucket) {
-      bucket.push(i);
+      bucket.push(point);
     } else {
-      groups.set(root, [i]);
+      groups.set(root, [point]);
     }
   }
-
-  const clusters: LocationCluster<P>[] = [];
-  for (const indices of groups.values()) {
-    clusters.push(makeCluster(points, indices));
-  }
+  const clusters = [...groups.values()].map(makeCluster);
   clusters.sort((a, b) => a.clusterId.localeCompare(b.clusterId));
   return clusters;
 }
 
 function makeCluster<P extends ClusterablePoint>(
-  points: P[],
-  indices: number[],
+  members: NonEmpty<P>,
 ): LocationCluster<P> {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- indices are valid array positions
-  const members = indices.map((i) => points[i]!);
   const sumLat = members.reduce((acc, p) => acc + p.latitude, 0);
   const sumLng = members.reduce((acc, p) => acc + p.longitude, 0);
-  const ids = members.map((p) => p.id).sort((a, b) => a.localeCompare(b));
+  const clusterId = members.reduce((id, point) => point.id.localeCompare(id) < 0 ? point.id : id, members[0].id);
   return {
     centerLat: sumLat / members.length,
     centerLng: sumLng / members.length,
     points: members,
     photoCount: members.length,
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- ids is non-empty (at least one member)
-    clusterId: ids[0]!,
+    clusterId,
   };
 }

--- a/workers/catalog/src/lib/route.ts
+++ b/workers/catalog/src/lib/route.ts
@@ -36,6 +36,8 @@ export interface Origin {
   lng: number;
 }
 
+type NonEmpty<T> = [T, ...T[]];
+
 const DWELL_MULTIPLIERS: Record<Pacing, number> = {
   chill: 1.5,
   normal: 1,
@@ -80,8 +82,9 @@ function byDistThenId(lat: number, lng: number, digits: number) {
 }
 
 /** Seed the NN walk: nearest-to-origin, else alphabetically-first clusterId. */
-function seedOrder(clusters: LocationCluster[], origin?: Origin): LocationCluster[] {
-  const remaining = [...clusters];
+function seedOrder(clusters: NonEmpty<LocationCluster>, origin?: Origin): NonEmpty<LocationCluster> {
+  const [first, ...rest] = clusters;
+  const remaining: NonEmpty<LocationCluster> = [first, ...rest];
   if (origin) {
     remaining.sort(byDistThenId(origin.lat, origin.lng, 15));
   } else {
@@ -91,18 +94,30 @@ function seedOrder(clusters: LocationCluster[], origin?: Origin): LocationCluste
 }
 
 /** Pick the next cluster: nearest to `current`, ties broken by clusterId. */
-function pickNext(remaining: LocationCluster[], current: LocationCluster): LocationCluster {
+function pickNext(remaining: NonEmpty<LocationCluster>, current: LocationCluster): LocationCluster {
   remaining.sort(byDistThenId(current.centerLat, current.centerLng, 2));
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- remaining is non-empty (caller guarantees)
-  const best = remaining[0]!;
+  const best = remaining[0];
   const bestDist = distTo(best, current.centerLat, current.centerLng);
-  const tied = remaining.filter(
-    (c) => Math.abs(distTo(c, current.centerLat, current.centerLng) - bestDist) < 0.01,
-  );
-  if (tied.length <= 1) return best;
-  tied.sort((a, b) => a.clusterId.localeCompare(b.clusterId));
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- tied is non-empty (contains at least best)
-  return tied[0]!;
+  return remaining.reduce((winner, candidate) => {
+    const tied = Math.abs(distTo(candidate, current.centerLat, current.centerLng) - bestDist) < 0.01;
+    return tied && candidate.clusterId.localeCompare(winner.clusterId) < 0 ? candidate : winner;
+  }, best);
+}
+
+/** Order a cluster tuple while preserving its non-empty type. */
+function orderNonEmpty(clusters: NonEmpty<LocationCluster>, origin?: Origin): NonEmpty<LocationCluster> {
+  const [first, ...remaining] = seedOrder(clusters, origin);
+  const result: NonEmpty<LocationCluster> = [first];
+  let current = first;
+  while (remaining.length > 0) {
+    const [candidate, ...rest] = remaining;
+    if (!candidate) break;
+    const next = pickNext([candidate, ...rest], current);
+    remaining.splice(remaining.indexOf(next), 1);
+    result.push(next);
+    current = next;
+  }
+  return result;
 }
 
 /**
@@ -114,17 +129,8 @@ export function orderNearestNeighbor(
   clusters: LocationCluster[],
   origin?: Origin,
 ): LocationCluster[] {
-  if (clusters.length <= 1) return [...clusters];
-  const remaining = seedOrder(clusters, origin);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- remaining is non-empty (length > 1 checked above)
-  const result: LocationCluster[] = [remaining.shift()!];
-  while (remaining.length > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- result starts with one element and only grows
-    const next = pickNext(remaining, result.at(-1)!);
-    remaining.splice(remaining.indexOf(next), 1);
-    result.push(next);
-  }
-  return result;
+  const [first, ...rest] = clusters;
+  return first ? orderNonEmpty([first, ...rest], origin) : [];
 }
 
 /**
@@ -226,54 +232,61 @@ export function buildTimedItinerary(
   }
   const startTime = opts.startTime ?? "09:00";
   const pacing = safePacing(opts.pacing ?? "normal");
-  if (clusters.length === 0) {
+  const [first, ...rest] = clusters;
+  if (!first) {
     return { stops: [], legs: [], total_minutes: 0, total_distance_m: 0, pacing, start_time: startTime };
   }
-  return assembleItinerary(orderNearestNeighbor(clusters, opts.origin), startTime, pacing, opts.transit);
+  return assembleItinerary(orderNonEmpty([first, ...rest], opts.origin), startTime, pacing, opts.transit);
+}
+
+interface ItineraryAccumulator {
+  stops: NonEmpty<TimedStop>;
+  legs: TransitLeg[];
+  totalDistance: number;
+  current: LocationCluster;
+  currentStop: TimedStop;
 }
 
 /** Walk the ordered clusters, accumulating stops, legs, and totals. */
 function assembleItinerary(
-  ordered: LocationCluster[],
+  ordered: NonEmpty<LocationCluster>,
   startTime: string,
   pacing: Pacing,
   transit?: TransitIndex,
 ): TimedItinerary {
   const buffer = TRANSIT_BUFFERS[pacing];
-  const stops: TimedStop[] = [];
-  const legs: TransitLeg[] = [];
-  let totalDistance = 0;
-  let currentTime = startTime;
-  for (let i = 0; i < ordered.length; i += 1) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index bounded by loop [0, ordered.length)
-    const cluster = ordered[i]!;
-    const stop = makeStop(cluster, currentTime, computeDwellMinutes(cluster.photoCount, pacing));
-    stops.push(stop);
-    if (i < ordered.length - 1) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- i+1 < ordered.length is guaranteed by the if condition
-      const next = ordered[i + 1]!;
-      const leg = makeLeg(cluster, next, buffer, transit);
-      legs.push(leg);
-      totalDistance += leg.mode === "transit" ? leg.distance_m : haversine(cluster.centerLat, cluster.centerLng, next.centerLat, next.centerLng);
-      currentTime = addMinutes(stop.depart, leg.duration_minutes);
-    }
-  }
-  return finalizeItinerary(stops, legs, totalDistance, startTime, pacing);
+  const [first, ...rest] = ordered;
+  const firstStop = makeStop(first, startTime, computeDwellMinutes(first.photoCount, pacing));
+  const acc: ItineraryAccumulator = { stops: [firstStop], legs: [], totalDistance: 0, current: first, currentStop: firstStop };
+  for (const next of rest) appendCluster(acc, next, pacing, buffer, transit);
+  return finalizeItinerary(acc.stops, acc.legs, acc.totalDistance, startTime, pacing);
+}
+
+/** Append one cluster, including the inbound leg and its timed stop. */
+function appendCluster(acc: ItineraryAccumulator, next: LocationCluster, pacing: Pacing, buffer: number, transit?: TransitIndex): void {
+  const leg = makeLeg(acc.current, next, buffer, transit);
+  const arrive = addMinutes(acc.currentStop.depart, leg.duration_minutes);
+  const stop = makeStop(next, arrive, computeDwellMinutes(next.photoCount, pacing));
+  acc.totalDistance += leg.mode === "transit" ? leg.distance_m : distTo(next, acc.current.centerLat, acc.current.centerLng);
+  acc.legs.push(leg);
+  acc.stops.push(stop);
+  acc.current = next;
+  acc.currentStop = stop;
 }
 
 /** Compute totals and assemble the final `TimedItinerary`. */
 function finalizeItinerary(
-  stops: TimedStop[],
+  stops: NonEmpty<TimedStop>,
   legs: TransitLeg[],
   totalDistance: number,
   startTime: string,
   pacing: Pacing,
 ): TimedItinerary {
+  const lastStop = stops.reduce((_, stop) => stop);
   return {
     stops,
     legs,
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- stops is non-empty (assembleItinerary adds at least one stop)
-    total_minutes: minutesBetween(stops[0]!.arrive, stops.at(-1)!.depart),
+    total_minutes: minutesBetween(stops[0].arrive, lastStop.depart),
     total_distance_m: pyRound(totalDistance, 1),
     spot_count: stops.length,
     pacing,

--- a/workers/catalog/src/lib/series.ts
+++ b/workers/catalog/src/lib/series.ts
@@ -76,11 +76,11 @@ function link(adj: Map<string, Set<string>>, from: string, to: string): void {
 export function walkSeries(edges: SeriesEdge[], startWorkId: string): Set<string> {
   const adj = buildAdjacency(edges);
   const visited = new Set<string>([startWorkId]);
-  const queue: string[] = [startWorkId];
-  while (queue.length > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- queue is non-empty (while condition)
-    const current = queue.shift()!;
-    visit(adj.get(current), visited, queue);
+  let frontier = [startWorkId];
+  while (frontier.length > 0) {
+    const nextFrontier: string[] = [];
+    for (const current of frontier) visit(adj.get(current), visited, nextFrontier);
+    frontier = nextFrontier;
   }
   return visited;
 }

--- a/workers/catalog/src/types.ts
+++ b/workers/catalog/src/types.ts
@@ -159,5 +159,8 @@ export interface Route {
   cover_url?: string;
   anime_title?: string;
   anime_title_cn?: string;
+  truncated?: boolean;
+  shown_cluster_count?: number;
+  total_cluster_count?: number;
   timed_itinerary: TimedItinerary;
 }

--- a/workers/catalog/test/alias.worker.test.ts
+++ b/workers/catalog/test/alias.worker.test.ts
@@ -59,10 +59,8 @@ describe("rankAliases (dedup by normalized form, highest source wins)", () => {
       { alias: "響け！ユーフォニアム", source: Source.Bangumi },
     ]);
     expect(ranked).toHaveLength(1);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-    expect(ranked[0]!.source).toBe(Source.Bangumi);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-    expect(ranked[0]!.priority).toBe(SOURCE_PRIORITY[Source.Bangumi]);
+    expect(ranked.at(0)?.source).toBe(Source.Bangumi);
+    expect(ranked.at(0)?.priority).toBe(SOURCE_PRIORITY[Source.Bangumi]);
   });
 
   it("dedups across full-width vs half-width variants of the same alias", () => {
@@ -71,11 +69,9 @@ describe("rankAliases (dedup by normalized form, highest source wins)", () => {
       { alias: "fate", source: Source.AniDB },
     ]);
     expect(ranked).toHaveLength(1);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-    expect(ranked[0]!.alias_normalized).toBe("fate");
+    expect(ranked.at(0)?.alias_normalized).toBe("fate");
     // AniDB (30) outranks Moegirl (20).
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-    expect(ranked[0]!.source).toBe(Source.AniDB);
+    expect(ranked.at(0)?.source).toBe(Source.AniDB);
   });
 
   it("preserves the original (un-normalized) alias string of the winner", () => {
@@ -83,10 +79,8 @@ describe("rankAliases (dedup by normalized form, highest source wins)", () => {
       { alias: "  Re:Zero  ", source: Source.Bangumi },
       { alias: "re:zero", source: Source.Moegirl },
     ]);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-    expect(ranked[0]!.alias).toBe("  Re:Zero  ");
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-    expect(ranked[0]!.alias_normalized).toBe("re:zero");
+    expect(ranked.at(0)?.alias).toBe("  Re:Zero  ");
+    expect(ranked.at(0)?.alias_normalized).toBe("re:zero");
   });
 
   it("keeps distinct normalized forms as separate rows", () => {

--- a/workers/catalog/test/clustering.worker.test.ts
+++ b/workers/catalog/test/clustering.worker.test.ts
@@ -48,20 +48,13 @@ function assertMergesCloseKeepsFar(): void {
   ];
   const clusters = clusterByLocation(pts);
   expect(clusters.map((c) => c.clusterId)).toEqual(["a", "c"]);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.photoCount).toBe(2);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.centerLat).toBeCloseTo(35.000150000000005, 12);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.centerLng).toBe(135.0);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.points.map((p) => p.id)).toEqual(["a", "b"]);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[1]!.photoCount).toBe(1);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[1]!.centerLat).toBe(35.01);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[1]!.points.map((p) => p.id)).toEqual(["c"]);
+  expect(clusters.at(0)?.photoCount).toBe(2);
+  expect(clusters.at(0)?.centerLat).toBeCloseTo(35.000150000000005, 12);
+  expect(clusters.at(0)?.centerLng).toBe(135.0);
+  expect(clusters.at(0)?.points.map((p) => p.id)).toEqual(["a", "b"]);
+  expect(clusters.at(1)?.photoCount).toBe(1);
+  expect(clusters.at(1)?.centerLat).toBe(35.01);
+  expect(clusters.at(1)?.points.map((p) => p.id)).toEqual(["c"]);
 }
 
 function assertTransitiveChain(): void {
@@ -72,14 +65,10 @@ function assertTransitiveChain(): void {
   ];
   const clusters = clusterByLocation(pts);
   expect(clusters).toHaveLength(1);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.clusterId).toBe("a");
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.photoCount).toBe(3);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.centerLat).toBeCloseTo(35.0003, 12);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.points.map((p) => p.id)).toEqual(["a", "b", "c"]);
+  expect(clusters.at(0)?.clusterId).toBe("a");
+  expect(clusters.at(0)?.photoCount).toBe(3);
+  expect(clusters.at(0)?.centerLat).toBeCloseTo(35.0003, 12);
+  expect(clusters.at(0)?.points.map((p) => p.id)).toEqual(["a", "b", "c"]);
 }
 
 function assertAllDistantSortedById(): void {
@@ -91,10 +80,8 @@ function assertAllDistantSortedById(): void {
   const clusters = clusterByLocation(pts);
   expect(clusters.map((c) => c.clusterId)).toEqual(["x", "y", "z"]);
   expect(clusters.every((c) => c.photoCount === 1)).toBe(true);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.centerLat).toBe(37.0);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[2]!.centerLat).toBe(35.0);
+  expect(clusters.at(0)?.centerLat).toBe(37.0);
+  expect(clusters.at(2)?.centerLat).toBe(35.0);
 }
 
 function assertAlphabeticalClusterId(): void {
@@ -105,10 +92,8 @@ function assertAlphabeticalClusterId(): void {
   ];
   const clusters = clusterByLocation(pts);
   expect(clusters).toHaveLength(1);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.clusterId).toBe("a");
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  expect(clusters[0]!.points.map((p) => p.id)).toEqual(["m", "a", "z"]);
+  expect(clusters.at(0)?.clusterId).toBe("a");
+  expect(clusters.at(0)?.points.map((p) => p.id)).toEqual(["m", "a", "z"]);
 }
 
 describe("clusterByLocation (clustering.ts)", () => {

--- a/workers/catalog/test/contract-parity.worker.test.ts
+++ b/workers/catalog/test/contract-parity.worker.test.ts
@@ -112,7 +112,7 @@ const _ir_a: ContractIngestResult = null as unknown as ContractIngestResult;
 const _ir_b: LocalIngestResult = null as unknown as ContractIngestResult;
 
 // --- Route ---
-const _r_a: ContractRoute = null as unknown as ContractRoute;
+const _r_a: ContractRoute = null as unknown as LocalRoute;
 const _r_b: LocalRoute = null as unknown as ContractRoute;
 
 // --- Pacing ---

--- a/workers/catalog/test/errors-wire.worker.test.ts
+++ b/workers/catalog/test/errors-wire.worker.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from "vitest";
 import { catalogRouter, type CatalogContext } from "../src/router";
 import type { CatalogDb, NeonSql } from "../src/db/client";
 import type {
-  RouteTooManyClustersData,
   RouteTooManyPointsData,
   UpstreamUnavailableData,
   WorkNotFoundData,
 } from "../src/lib/errors";
+import type { Route } from "../src/types";
 
 interface ErrorEnvelope<TData> {
   defined: true;
@@ -120,7 +120,7 @@ describe("catalog input validation on the OpenAPI wire", () => {
 
 });
 
-describe("catalog typed errors on the OpenAPI wire", () => {
+describe("catalog route limits and typed errors on the OpenAPI wire", () => {
   it("serializes ROUTE_TOO_MANY_POINTS for route input over the router cap", async () => {
     const point_ids = Array.from({ length: 501 }, (_, i) => `p${String(i)}`);
     const res = await call("route", { point_ids }, unreachableContext());
@@ -132,16 +132,15 @@ describe("catalog typed errors on the OpenAPI wire", () => {
     });
   });
 
-  it("serializes ROUTE_TOO_MANY_CLUSTERS after clustering selected points", async () => {
+  it("serializes a successful truncation signal after clustering 51 selected points", async () => {
     const rows = routeRows(51);
     const point_ids = rows.map((r) => r.id);
     const res = await call("route", { point_ids }, context(rows));
-    expect(res.status).toBe(422);
-    expect(await json<RouteTooManyClustersData>(res)).toEqual({
-      defined: true, code: "ROUTE_TOO_MANY_CLUSTERS", status: 422,
-      message: "Route exceeds the maximum number of areas",
-      data: { cluster_count: 51, max_clusters: 50 },
-    });
+    const body = await res.json() as Route;
+    expect(res.status).toBe(200);
+    expect(body.ordered_points).toHaveLength(50);
+    expect(body.timed_itinerary.stops).toHaveLength(50);
+    expect(body).toMatchObject({ truncated: true, shown_cluster_count: 50, total_cluster_count: 51 });
   });
 
   it("serializes WORK_NOT_FOUND for a spots miss", async () => {

--- a/workers/catalog/test/route-api.worker.test.ts
+++ b/workers/catalog/test/route-api.worker.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { ORPCError } from "@orpc/server";
 import { route, type PilgrimagePoint, type RouteDb } from "../src/api/route";
 
 /**
@@ -73,16 +72,6 @@ function fakeDb(rows: FakeRow[]): RouteDb {
 
 const ids = (ps: PilgrimagePoint[]): string[] => ps.map((p) => p.id);
 
-async function routeError(rows: FakeRow[]): Promise<ORPCError<string, unknown>> {
-  try {
-    await route(fakeDb(rows), { point_ids: rows.map((r) => r.id) });
-  } catch (err) {
-    expect(err).toBeInstanceOf(ORPCError);
-    return err as ORPCError<string, unknown>;
-  }
-  throw new Error("expected route to reject");
-}
-
 async function assertTimedRoute(): Promise<void> {
   const r = await route(fakeDb(ROWS), { point_ids: ["a", "b", "c"], pacing: "normal" });
   expect(r.point_count).toBe(3);
@@ -94,12 +83,11 @@ async function assertTimedRoute(): Promise<void> {
 
 async function assertPointFields(): Promise<void> {
   const r = await route(fakeDb(ROWS), { point_ids: ["a"] });
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-  const a = r.ordered_points[0]!;
-  expect(a.screenshot_url).toBe("a.jpg");
-  expect(a.bangumi_id).toBe("k");
-  expect(a.latitude).toBe(35.0);
-  expect(a.city).toBe("Tokyo");
+  const [a] = r.ordered_points;
+  expect(a?.screenshot_url).toBe("a.jpg");
+  expect(a?.bangumi_id).toBe("k");
+  expect(a?.latitude).toBe(35.0);
+  expect(a?.city).toBe("Tokyo");
   expect(r.timed_itinerary.legs).toEqual([]);
 }
 
@@ -141,11 +129,20 @@ describe("route API handler — fetch -> cluster -> itinerary -> Route", () => {
     expect(r.ordered_points).toEqual([]);
   });
 
-  it("rejects with a defined typed error when the selected points make 51 clusters", async () => {
-    const err = await routeError(MANY_ROWS);
-    expect(err.code).toBe("ROUTE_TOO_MANY_CLUSTERS");
-    expect(err.status).toBe(422);
-    expect(err.defined).toBe(true);
-    expect(err.data).toEqual({ cluster_count: 51, max_clusters: 50 });
+  it("caps 51 clusters and discloses the successful truncation", async () => {
+    const r = await route(fakeDb(MANY_ROWS), { point_ids: MANY_ROWS.map((entry) => entry.id) });
+    expect(r.point_count).toBe(50);
+    expect(r.timed_itinerary.stops).toHaveLength(50);
+    expect(ids(r.ordered_points)).not.toContain("p050");
+    expect(r).toMatchObject({ truncated: true, shown_cluster_count: 50, total_cluster_count: 51 });
+  });
+
+  it("keeps the response shape unchanged at the 50-cluster cap", async () => {
+    const rows = MANY_ROWS.slice(0, 50);
+    const r = await route(fakeDb(rows), { point_ids: rows.map((entry) => entry.id) });
+    expect(r.point_count).toBe(50);
+    expect(r).not.toHaveProperty("truncated");
+    expect(r).not.toHaveProperty("shown_cluster_count");
+    expect(r).not.toHaveProperty("total_cluster_count");
   });
 });

--- a/workers/catalog/test/route.worker.test.ts
+++ b/workers/catalog/test/route.worker.test.ts
@@ -172,8 +172,7 @@ describe("buildTimedItinerary — edge cases (Python parity)", () => {
     const r = buildTimedItinerary([mk("a", 35.0, 2, "Solo")], { pacing: "normal" });
     expect(r.legs).toEqual([]);
     expect(r.total_minutes).toBe(8);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test data known to exist
-    expect(r.stops[0]!.depart).toBe("09:08");
+    expect(r.stops.at(0)?.depart).toBe("09:08");
     expect(r.total_distance_m).toBe(0);
   });
 


### PR DESCRIPTION
Closes #302, closes #301.

## #302 — zero-suppression at the type level (15 → 0)

Owner-rejected approach (throwing guard helper) avoided; each suppression died by restructuring so TypeScript narrows naturally:

- `lib/route.ts` 7→0: non-empty tuples for seed/candidate/stops, reduce accumulator for tie selection, destructuring with explicit empty branch, first/rest iteration instead of indexed current/next access.
- `lib/clustering.ts` 7→0: reference-based `UnionNode` (no unchecked parent/rank indices), paired point/node records + `for...of`, non-empty cluster buckets, reduce-derived min ID.
- `lib/series.ts` 1→0: BFS frontier arrays + `for...of`, eliminating `shift()!`.

**Enforcement so none come back**: `.oxlintrc.json` errors on unused disable directives + a non-bypassable preflight (`scripts/oxlint/check-no-inline-config.mjs`, oxlint has no native `noInlineConfig`) rejects any inline rule-disabling before lint runs — validated by a deliberate self-disable probe (exit 1). The single pre-existing directive in the protected spike file is exactly grandfathered.

## #301 — selected-route >50 clusters: truncate instead of generic failure

`api/route.ts` deterministically takes the first 50 cluster-ID-sorted clusters before `buildTimedItinerary` (which throws >50). Oversized selections now succeed with optional top-level fields:

```json
{ "truncated": true, "shown_cluster_count": 50, "total_cluster_count": 51 }
```

At or below 50 the fields are omitted — previous response shape byte-identical. Shared contract schema, catalog mirror, OpenAPI, compile-time parity and wire tests updated.

## Verification (lead, live)

`pnpm install --frozen-lockfile` → preflight + `oxlint --type-aware --deny-warnings` clean, `tsc --noEmit` clean, **worker suite 32 files / 232 passed**, `emit:openapi` re-run → zero drift. Behavior unchanged except the new truncation path (covered by direct API + wire tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)