### PR TITLE
feat(agent): locale current-turn policy + translation retrieval fixes (#304 part B)

### DIFF
--- a/apps/agent/agent/agents/animichi_agent.py
+++ b/apps/agent/agent/agents/animichi_agent.py
@@ -38,6 +38,7 @@ from agent.infrastructure.observability import (
     record_agent_run_error,
     record_managed_prompt_resolution,
 )
+from agent.utils.language import locale_name, resolve_reply_language
 
 MANAGED_PROMPT_NAME = "animichi-instructions"
 MANAGED_PROMPT_LABEL = "production"
@@ -143,9 +144,10 @@ class _AnimichiManagedPrompt(ManagedPrompt[RuntimeDeps]):
             resolved = self.resolved
             if resolved is None:
                 return None
-            return (
+            base = (
                 resolved.value if _prompt_failure(resolved) is None else _INSTRUCTIONS
             )
+            return f"{base.rstrip()}\n\n{_current_turn_language(_ctx)}"
 
         return instructions
 
@@ -355,13 +357,20 @@ def _history_capabilities() -> list[AgentCapability[RuntimeDeps]]:
     return [native_history_compaction(_summarize_tool_content)]
 
 
-_LOCALE_NAMES = {"ja": "Japanese", "zh": "Simplified Chinese", "en": "English"}
+def _current_turn_language(ctx: RunContext[RuntimeDeps]) -> str:
+    locale = resolve_reply_language(ctx.deps.query, ctx.deps.locale)
+    return (
+        f"Current turn reply language: {locale_name(locale)}. "
+        "This current-turn directive overrides conversation history and locale "
+        "fallback. Proper nouns may remain in their original script, but write "
+        "all prose in the current turn reply language."
+    )
 
 
 def trusted_session_context(deps: RuntimeDeps) -> str:
     """Serialize volatile typed state into a trusted user-turn part."""
     session = deps.tool_state.session
-    lang = _LOCALE_NAMES.get(deps.locale, "Japanese")
+    lang = locale_name(deps.locale)
     parts = [f"Locale fallback: {lang}."]
     if session.current_anime is not None:
         anime = session.current_anime
@@ -405,7 +414,7 @@ def build_animichi_agent() -> Agent[RuntimeDeps, RuntimeOutput]:
     managed_prompt = _managed_prompt_capability()
     _record_missing_managed_prompt_token()
     instructions: AgentInstructions[RuntimeDeps] = (
-        _INSTRUCTIONS if managed_prompt is None else None
+        [_INSTRUCTIONS, _current_turn_language] if managed_prompt is None else None
     )
     agent: Agent[RuntimeDeps, RuntimeOutput] = Agent(
         resolve_model(None),

--- a/apps/agent/agent/agents/catalog_tools.py
+++ b/apps/agent/agent/agents/catalog_tools.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from pydantic_ai import RunContext
 
-from agent.agents.agent_result import (
-    ProducedSearch,
-    RejectedSearch,
-)
+from agent.agents.agent_result import ProducedSearch, RejectedSearch
 from agent.agents.catalog_adapter import build_search_state
 from agent.agents.catalog_failures import (
     CATALOG_FAILURES,
@@ -22,6 +19,7 @@ from agent.agents.session_state import (
     ResultRef,
 )
 from agent.agents.step_recording import _record
+from agent.agents.title_matching import looks_like_wrong_variant
 from agent.agents.tool_outcomes import (
     NearbyEmpty,
     NearbyMissingLocation,
@@ -97,14 +95,13 @@ def _clear_pending(deps: RuntimeDeps) -> None:
 async def run_resolve(
     ctx: RunContext[RuntimeDeps], catalog: CatalogClientProtocol, title: str
 ) -> ResolveResolved | ResolveAmbiguous | ResolveNotFound | ResolveUpstreamDown:
-    """Resolve one anime and atomically stage every clarify outcome."""
     result: ResolveResolved | ResolveAmbiguous | ResolveNotFound | ResolveUpstreamDown
     try:
         resolved = await catalog.resolve(title)
     except CATALOG_FAILURES:
         result = ResolveUpstreamDown()
     else:
-        result = _adapt_resolve(ctx.deps, resolved)
+        result = _adapt_resolve(ctx.deps, resolved, title)
     _record(
         ctx.deps, ToolName.RESOLVE_ANIME.value, {"title": title}, result.model_dump()
     )
@@ -112,29 +109,43 @@ async def run_resolve(
 
 
 def _adapt_resolve(
-    deps: RuntimeDeps, resolved: object
+    deps: RuntimeDeps, resolved: object, query: str
 ) -> ResolveResolved | ResolveAmbiguous | ResolveNotFound | ResolveUpstreamDown:
     if isinstance(resolved, CatalogResolveResolved):
-        _clear_pending(deps)
-        match = resolved.match
-        deps.tool_state.session.current_anime = CurrentAnime(
-            bangumi_id=match.bangumi_id, title=match.title or match.title_cn
-        )
-        return ResolveResolved(
-            bangumi_id=match.bangumi_id,
-            anime_title=match.title or match.title_cn,
-        )
+        return _adapt_resolved(deps, resolved, query)
     if isinstance(resolved, CatalogResolveAmbiguous):
-        candidates = [_candidate(candidate) for candidate in resolved.candidates]
-        _set_pending(deps, "anime_ambiguity", candidates)
-        return ResolveAmbiguous(
-            candidate_ids=[candidate.id for candidate in candidates]
-        )
+        return _adapt_ambiguous(deps, resolved)
     if isinstance(resolved, CatalogResolveNotFound):
-        _set_pending(deps, "anime_not_found", [])
-        return ResolveNotFound()
+        return _adapt_not_found(deps)
     _clear_pending(deps)
     return ResolveUpstreamDown()
+
+
+def _adapt_resolved(
+    deps: RuntimeDeps, resolved: CatalogResolveResolved, query: str
+) -> ResolveResolved | ResolveNotFound:
+    match = resolved.match
+    if looks_like_wrong_variant(query, (match.title, match.title_cn)):
+        return _adapt_not_found(deps)
+    _clear_pending(deps)
+    title = match.title or match.title_cn
+    deps.tool_state.session.current_anime = CurrentAnime(
+        bangumi_id=match.bangumi_id, title=title
+    )
+    return ResolveResolved(bangumi_id=match.bangumi_id, anime_title=title)
+
+
+def _adapt_ambiguous(
+    deps: RuntimeDeps, resolved: CatalogResolveAmbiguous
+) -> ResolveAmbiguous:
+    candidates = [_candidate(candidate) for candidate in resolved.candidates]
+    _set_pending(deps, "anime_ambiguity", candidates)
+    return ResolveAmbiguous(candidate_ids=[candidate.id for candidate in candidates])
+
+
+def _adapt_not_found(deps: RuntimeDeps) -> ResolveNotFound:
+    _set_pending(deps, "anime_not_found", [])
+    return ResolveNotFound()
 
 
 async def run_work_search(

--- a/apps/agent/agent/agents/title_matching.py
+++ b/apps/agent/agent/agents/title_matching.py
@@ -1,0 +1,59 @@
+"""Pure title normalization and variant-conflict checks."""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Mapping
+
+
+def normalize_title(value: str) -> str:
+    """NFKC-fold, case-fold, and remove formatting punctuation and spacing."""
+    folded = unicodedata.normalize("NFKC", value).casefold()
+    return "".join(char for char in folded if char.isalnum())
+
+
+def best_alias_match(query: str, aliases: Mapping[str, str]) -> str | None:
+    """Choose an exact normalized alias, then the longest contained alias."""
+    normalized = normalize_title(query)
+    matches = _alias_matches(normalized, aliases)
+    return max(matches, key=lambda item: item[:2])[2] if matches else None
+
+
+def _alias_matches(
+    query: str, aliases: Mapping[str, str]
+) -> list[tuple[bool, int, str]]:
+    normalized = (
+        (normalize_title(alias), work_id) for alias, work_id in aliases.items()
+    )
+    return [
+        (alias == query, len(alias), work_id)
+        for alias, work_id in normalized
+        if alias in query
+    ]
+
+
+def looks_like_wrong_variant(query: str, titles: tuple[str, ...]) -> bool:
+    """Detect a parent/season result that conflicts with a specific title query."""
+    normalized_query = normalize_title(query)
+    candidates = tuple(normalize_title(title) for title in titles if title)
+    if normalized_query in candidates:
+        return False
+    return any(_variant_conflict(normalized_query, title) for title in candidates)
+
+
+def _variant_conflict(query: str, title: str) -> bool:
+    if title in query and len(query) - len(title) >= 2:
+        return True
+    prefix = _common_prefix_length(query, title)
+    return prefix >= 4 and len(query) - prefix >= 2 and len(title) - prefix >= 2
+
+
+def _common_prefix_length(left: str, right: str) -> int:
+    return next(
+        (
+            index
+            for index, pair in enumerate(zip(left, right, strict=False))
+            if pair[0] != pair[1]
+        ),
+        min(len(left), len(right)),
+    )

--- a/apps/agent/agent/agents/translation.py
+++ b/apps/agent/agent/agents/translation.py
@@ -12,6 +12,7 @@ from pydantic_ai.models import Model
 from pydantic_ai.usage import RunUsage
 
 from agent.agents.base import create_agent, resolve_model
+from agent.agents.title_matching import looks_like_wrong_variant
 from agent.clients.catalog_client import (
     CatalogClientProtocol,
     ResolveOutcome,
@@ -97,13 +98,16 @@ async def _catalog_zh_title(
     except (APIError, OSError, RuntimeError, ValueError) as exc:
         logger.warning("translation_catalog_failed", title=title, error=str(exc))
         return None
-    return _resolved_title_cn(outcome)
+    return _resolved_title_cn(outcome, title)
 
 
-def _resolved_title_cn(outcome: ResolveOutcome) -> str | None:
+def _resolved_title_cn(outcome: ResolveOutcome, query: str) -> str | None:
     if not isinstance(outcome, ResolveResolved):
         return None
-    title_cn = outcome.match.title_cn.strip()
+    match = outcome.match
+    if looks_like_wrong_variant(query, (match.title, match.title_cn)):
+        return None
+    title_cn = match.title_cn.strip()
     return title_cn or None
 
 

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -7,7 +7,6 @@ session management in ``session_facade``, and persistence in ``persistence``.
 from __future__ import annotations
 
 import asyncio
-import re
 from dataclasses import dataclass
 from time import perf_counter
 from typing import cast
@@ -72,6 +71,7 @@ from agent.interfaces.session_facade import (
     extract_context_delta,
     normalize_session_state,
 )
+from agent.utils.language import detect_language, resolve_reply_language
 
 __all__ = [
     "PublicAPIError",
@@ -118,22 +118,6 @@ def default_catalog_client() -> CatalogClient:
     client to route through; production injects one explicitly via the lifespan.
     """
     return CatalogClient(base_url=get_settings().catalog_api_url)
-
-
-_CJK_RE = re.compile(r"[\u4e00-\u9fff]")
-_KANA_RE = re.compile(r"[\u3040-\u30ff]")
-
-
-def detect_language(text: str) -> str:
-    """Detect whether *text* is Chinese, Japanese, or English.
-
-    Heuristic: kana → ja, CJK only → zh, else → en.
-    """
-    if _KANA_RE.search(text):
-        return "ja"
-    if _CJK_RE.search(text):
-        return "zh"
-    return "en"
 
 
 class RuntimeAPI:
@@ -373,7 +357,10 @@ class RuntimeAPI:
             )
         if model_path:
             await _apply_translation_gate(
-                result, request.locale, on_step, model=resolved_model
+                result,
+                resolve_reply_language(request.text, request.locale),
+                on_step,
+                model=resolved_model,
             )
         response = agent_result_to_response(
             result,
@@ -593,7 +580,7 @@ async def _apply_translation_gate(
     message = result.message
     if not message:
         return
-    detected = detect_language(message)
+    detected = resolve_reply_language(message, locale)
     if detected == locale:
         return
     if on_step is not None:

--- a/apps/agent/agent/tests/eval/datasets/agent_eval_v3.json
+++ b/apps/agent/agent/tests/eval/datasets/agent_eval_v3.json
@@ -14772,5 +14772,206 @@
       "difficulty": "medium",
       "notes": "Tokyo and Hiroshima clusters"
     }
+  },
+  {
+    "id": "Q304_locale_zh_001",
+    "path": "general_anime_qa",
+    "tier": "happy",
+    "query": "为什么动漫圣地巡礼这么受欢迎",
+    "locale": "ja",
+    "acceptable_stages": [
+      "general_qa"
+    ],
+    "expected_data_keys": [],
+    "context": {
+      "message_history": [
+        {
+          "user": "日本語で案内してください",
+          "assistant": "承知しました。日本語でご案内します。"
+        }
+      ]
+    },
+    "selected_point_ids": null,
+    "metadata": {
+      "db_state": "none",
+      "difficulty": "medium",
+      "notes": "Current Chinese turn must override Japanese history and browser locale.",
+      "tags": [
+        "issue-304",
+        "pending-eval",
+        "locale-current-turn"
+      ]
+    }
+  },
+  {
+    "id": "Q304_locale_en_001",
+    "path": "general_anime_qa",
+    "tier": "happy",
+    "query": "Why are anime pilgrimage sites popular?",
+    "locale": "ja",
+    "acceptable_stages": [
+      "general_qa"
+    ],
+    "expected_data_keys": [],
+    "context": {
+      "message_history": [
+        {
+          "user": "日本語で案内してください",
+          "assistant": "承知しました。日本語でご案内します。"
+        }
+      ]
+    },
+    "selected_point_ids": null,
+    "metadata": {
+      "db_state": "none",
+      "difficulty": "medium",
+      "notes": "Current English turn must override Japanese history and browser locale.",
+      "tags": [
+        "issue-304",
+        "pending-eval",
+        "locale-current-turn"
+      ]
+    }
+  },
+  {
+    "id": "Q304_locale_ja_001",
+    "path": "general_anime_qa",
+    "tier": "happy",
+    "query": "アニメの聖地巡礼はなぜ人気ですか",
+    "locale": "en",
+    "acceptable_stages": [
+      "general_qa"
+    ],
+    "expected_data_keys": [],
+    "context": {
+      "message_history": [
+        {
+          "user": "Please answer in English.",
+          "assistant": "Sure, I will answer in English."
+        }
+      ]
+    },
+    "selected_point_ids": null,
+    "metadata": {
+      "db_state": "none",
+      "difficulty": "medium",
+      "notes": "Current Japanese turn must override English history and browser locale.",
+      "tags": [
+        "issue-304",
+        "pending-eval",
+        "locale-current-turn"
+      ]
+    }
+  },
+  {
+    "id": "Q304_retrieval_sequel_001",
+    "path": "exact_db_api_ok",
+    "tier": "happy",
+    "query": "涼宮ハルヒの消失の聖地を教えて",
+    "locale": "ja",
+    "acceptable_stages": [
+      "search_bangumi"
+    ],
+    "expected_data_keys": [
+      "results"
+    ],
+    "context": null,
+    "selected_point_ids": null,
+    "metadata": {
+      "anime": "涼宮ハルヒの消失",
+      "bangumi_id": "3375",
+      "db_state": "hit_sparse",
+      "difficulty": "medium",
+      "notes": "Specific sequel must not resolve to the parent Haruhi entry.",
+      "tags": [
+        "issue-304",
+        "pending-eval",
+        "translation-retrieval",
+        "sequel"
+      ]
+    }
+  },
+  {
+    "id": "Q304_retrieval_season_001",
+    "path": "exact_db_api_ok",
+    "tier": "happy",
+    "query": "LoveLive! Sunshine!! pilgrimage spots",
+    "locale": "en",
+    "acceptable_stages": [
+      "search_bangumi"
+    ],
+    "expected_data_keys": [
+      "results"
+    ],
+    "context": null,
+    "selected_point_ids": null,
+    "metadata": {
+      "anime": "ラブライブ! サンシャイン!!",
+      "bangumi_id": "165553",
+      "db_state": "hit_sparse",
+      "difficulty": "medium",
+      "notes": "Specific season alias must outrank the shorter parent-series alias.",
+      "tags": [
+        "issue-304",
+        "pending-eval",
+        "translation-retrieval",
+        "season"
+      ]
+    }
+  },
+  {
+    "id": "Q304_retrieval_place_001",
+    "path": "nearby_bare_location",
+    "tier": "happy",
+    "query": "秋叶原附近有什么动漫圣地",
+    "locale": "zh",
+    "acceptable_stages": [
+      "search_nearby"
+    ],
+    "expected_data_keys": [
+      "results"
+    ],
+    "expect_nonempty": true,
+    "context": null,
+    "selected_point_ids": null,
+    "metadata": {
+      "db_state": "hit_sparse",
+      "difficulty": "medium",
+      "notes": "Translated place name must remain on nearby/geocode routing, not anime resolution.",
+      "tags": [
+        "issue-304",
+        "pending-eval",
+        "translation-retrieval",
+        "place-name"
+      ]
+    }
+  },
+  {
+    "id": "Q304_retrieval_alias_001",
+    "path": "exact_db_api_ok",
+    "tier": "happy",
+    "query": "ＳＰＹ　ＦＡＭＩＬＹ pilgrimage locations",
+    "locale": "en",
+    "acceptable_stages": [
+      "search_bangumi"
+    ],
+    "expected_data_keys": [
+      "results"
+    ],
+    "context": null,
+    "selected_point_ids": null,
+    "metadata": {
+      "anime": "SPY×FAMILY",
+      "bangumi_id": "396387",
+      "db_state": "hit_sparse",
+      "difficulty": "medium",
+      "notes": "Full-width community spelling must normalize to the catalog alias.",
+      "tags": [
+        "issue-304",
+        "pending-eval",
+        "translation-retrieval",
+        "community-alias"
+      ]
+    }
   }
 ]

--- a/apps/agent/agent/tests/eval/datasets/translation_v1.json
+++ b/apps/agent/agent/tests/eval/datasets/translation_v1.json
@@ -65,5 +65,9 @@
   {"id":"T087","title":"四月は君の嘘","target":"en","expected":"Your Lie in April","source_hint":"web_search","metadata":{"category":"anime_title","difficulty":"hard","note":"official English localization"}},
   {"id":"T088","title":"四月は君の嘘","target":"zh","expected":"四月是你的谎言","source_hint":"web_search","metadata":{"category":"anime_title","difficulty":"medium","note":"direct Chinese translation"}},
   {"id":"T089","title":"蟲師","target":"en","expected":"Mushishi","source_hint":"web_search","metadata":{"category":"anime_title","difficulty":"hard","note":"romanized title, NOT 'Bug Master'"}},
-  {"id":"T090","title":"らき☆すた","target":"zh","expected":"幸运星","source_hint":"web_search","metadata":{"category":"anime_title","difficulty":"hard","note":"community Chinese title, NOT literal"}}
+  {"id":"T090","title":"らき☆すた","target":"zh","expected":"幸运星","source_hint":"web_search","metadata":{"category":"anime_title","difficulty":"hard","note":"community Chinese title, NOT literal"}},
+
+  {"id":"Q304_T_SEQUEL_001","title":"涼宮ハルヒの消失","target":"zh","expected":"凉宫春日的消失","source_hint":"db","metadata":{"category":"anime_title","difficulty":"medium","note":"specific sequel must not resolve to parent entry","tags":["issue-304","pending-eval","translation-retrieval","sequel"]}},
+  {"id":"Q304_T_PLACE_001","title":"秋葉原駅","target":"zh","expected":"秋叶原站","source_hint":"llm","metadata":{"category":"place_name","difficulty":"easy","note":"place name must bypass anime-title resolution","tags":["issue-304","pending-eval","translation-retrieval","place-name"]}},
+  {"id":"Q304_T_ALIAS_001","title":"ＳＰＹ　ＦＡＭＩＬＹ","target":"zh","expected":"间谍过家家","source_hint":"db","metadata":{"category":"anime_title","difficulty":"medium","note":"full-width community spelling normalizes to catalog alias","tags":["issue-304","pending-eval","translation-retrieval","community-alias"]}}
 ]

--- a/apps/agent/agent/tests/eval/evaluators.py
+++ b/apps/agent/agent/tests/eval/evaluators.py
@@ -17,7 +17,7 @@ from pydantic_evals.evaluators import Evaluator, EvaluatorContext, LLMJudge
 
 from agent.agents.agent_result import AgentResult
 from agent.agents.session_state import RoutePayloadState, SearchPayloadState
-from agent.interfaces.public_api import detect_language
+from agent.utils.language import resolve_reply_language
 
 EVALUATOR_VERSION = "official-v1"
 
@@ -188,13 +188,14 @@ def _nonempty(result: AgentResult) -> bool:
 
 @dataclass
 class LocaleMatch(Evaluator[AgentInput, AgentResult, AgentExpected]):
-    """L1: 1.0 if the reply language matches the requested locale."""
+    """L1: match current-turn language, using the requested locale as fallback."""
 
     def evaluate(self, ctx: _Ctx) -> Mapping[str, float]:
         message = ctx.output.message
         if not message:
             return {"locale_match": 0.0}
-        matched = detect_language(message) == ctx.inputs.locale
+        expected = resolve_reply_language(ctx.inputs.query, ctx.inputs.locale)
+        matched = resolve_reply_language(message, expected) == expected
         return {"locale_match": 1.0 if matched else 0.0}
 
 

--- a/apps/agent/agent/tests/eval/mock_catalog_client.py
+++ b/apps/agent/agent/tests/eval/mock_catalog_client.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from agent.agents.geo_utils import haversine_distance
 from agent.agents.models import TimedItinerary, TimedStop, TransitLeg
+from agent.agents.title_matching import best_alias_match
 from agent.clients.catalog_client import (
     AnimeCandidate,
     IngestResult,
@@ -128,11 +129,7 @@ class MockCatalogClient:
 
     @staticmethod
     def _match_title(query: str) -> str | None:
-        q = query.lower()
-        for alias, bangumi_id in _TITLE_ALIASES.items():
-            if alias in q:
-                return bangumi_id
-        return None
+        return best_alias_match(query, _TITLE_ALIASES)
 
     @staticmethod
     def _match_location(name: str) -> tuple[float, float, str] | None:

--- a/apps/agent/agent/tests/unit/test_agent_quality_304.py
+++ b/apps/agent/agent/tests/unit/test_agent_quality_304.py
@@ -1,0 +1,110 @@
+"""Issue #304 deterministic locale and retrieval regressions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from agent.agents.catalog_tools import run_resolve
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_outcomes import ResolveNotFound
+from agent.agents.translation import TranslationResult, translate_title
+from agent.clients.catalog_client import AnimeCandidate, ResolveResolved
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+_DATASETS = Path(__file__).parents[1] / "eval" / "datasets"
+_PENDING_EVAL_IDS = {
+    "agent_eval_v3.json": {
+        "Q304_locale_zh_001",
+        "Q304_locale_en_001",
+        "Q304_locale_ja_001",
+        "Q304_retrieval_sequel_001",
+        "Q304_retrieval_season_001",
+        "Q304_retrieval_place_001",
+        "Q304_retrieval_alias_001",
+    },
+    "translation_v1.json": {
+        "Q304_T_SEQUEL_001",
+        "Q304_T_PLACE_001",
+        "Q304_T_ALIAS_001",
+    },
+}
+
+
+def _deps(catalog: MockCatalogClient) -> RuntimeDeps:
+    return RuntimeDeps(db=MagicMock(), locale="zh", query="query", catalog=catalog)
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_id"),
+    [
+        pytest.param("涼宮ハルヒの消失", "3375", id="sequel-exact-title"),
+        pytest.param("LoveLive! Sunshine!!", "165553", id="season-alias"),
+        pytest.param("ＳＰＹ　ＦＡＭＩＬＹ", "396387", id="nfkc-community-alias"),
+    ],
+)
+async def test_retrieval_prefers_normalized_specific_alias(
+    query: str, expected_id: str
+) -> None:
+    outcome = await MockCatalogClient().resolve(query)
+
+    assert isinstance(outcome, ResolveResolved)
+    assert outcome.match.bangumi_id == expected_id
+
+
+async def test_resolve_rejects_parent_entry_for_sequel_query() -> None:
+    catalog = MockCatalogClient()
+    catalog.resolve = AsyncMock(
+        return_value=ResolveResolved(
+            outcome="resolved",
+            match=AnimeCandidate(
+                bangumi_id="11291",
+                title="涼宮ハルヒの憂鬱",
+                title_cn="凉宫春日的忧郁",
+            ),
+        )
+    )
+    deps = _deps(catalog)
+
+    outcome = await run_resolve(MagicMock(deps=deps), catalog, "涼宮ハルヒの消失")
+
+    assert isinstance(outcome, ResolveNotFound)
+    pending = deps.tool_state.session.pending_clarification
+    assert pending is not None
+    assert pending.reason == "anime_not_found"
+
+
+async def test_place_name_translation_never_uses_anime_retrieval() -> None:
+    catalog = MockCatalogClient()
+    catalog.resolve = AsyncMock(
+        side_effect=AssertionError("place name reached anime resolver")
+    )
+    translator = Agent(TestModel(custom_output_text="秋叶原"))
+
+    with patch("agent.agents.translation.translation_agent", translator):
+        result = await translate_title(
+            "秋葉原",
+            target_locale="zh",
+            kind="place_name",
+            catalog=catalog,
+        )
+
+    catalog.resolve.assert_not_awaited()
+    assert result == TranslationResult("秋葉原", "秋叶原", "llm", 0.6)
+
+
+def test_issue_304_eval_cases_are_tagged_and_pending() -> None:
+    for filename, ids in _PENDING_EVAL_IDS.items():
+        rows = json.loads((_DATASETS / filename).read_text())
+        tagged = {
+            row["id"]: row["metadata"]["tags"] for row in rows if row["id"] in ids
+        }
+        assert tagged.keys() == ids
+        assert all(
+            {"issue-304", "pending-eval"} <= set(tags) for tags in tagged.values()
+        )

--- a/apps/agent/agent/tests/unit/test_animichi_agent.py
+++ b/apps/agent/agent/tests/unit/test_animichi_agent.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
+import pytest
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ToolCallPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 
 from agent.agents.animichi_agent import _INSTRUCTIONS, trusted_session_context
@@ -123,3 +131,35 @@ def test_empty_trusted_context_has_locale_only() -> None:
     context = trusted_session_context(deps)
 
     assert context == "[Trusted runtime context]\nLocale fallback: English."
+
+
+@pytest.mark.parametrize(
+    ("query", "fallback", "expected"),
+    [
+        ("请介绍圣地巡礼礼仪", "ja", "Simplified Chinese"),
+        ("Explain anime pilgrimage etiquette", "ja", "English"),
+        ("聖地巡礼のマナーを教えて", "en", "Japanese"),
+    ],
+)
+async def test_current_turn_language_is_rendered_in_instructions(
+    query: str, fallback: str, expected: str
+) -> None:
+    rendered = ""
+
+    def respond(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal rendered
+        rendered = info.instructions or ""
+        return ModelResponse(parts=[ToolCallPart("qa_response", {"message": "ok"})])
+
+    history = [ModelRequest(parts=[UserPromptPart("前の日本語の質問")])]
+    await run_animichi_agent(
+        text=query,
+        db=MagicMock(),
+        locale=fallback,
+        model=FunctionModel(respond),
+        message_history=history,
+        catalog=MockCatalogClient(),
+    )
+
+    assert f"Current turn reply language: {expected}." in rendered
+    assert "overrides conversation history and locale fallback" in rendered

--- a/apps/agent/agent/tests/unit/test_eval_dataset_geocoding.py
+++ b/apps/agent/agent/tests/unit/test_eval_dataset_geocoding.py
@@ -22,6 +22,7 @@ NEW_CASES = {
     "C5_ja_001",
     "C5_zh_001",
     "C5_en_001",
+    "Q304_retrieval_place_001",
 }
 CASE_GEOCODE_KEYS: dict[str, str | None] = {
     "C1_ja_001": "宇治",
@@ -73,6 +74,7 @@ CASE_GEOCODE_KEYS: dict[str, str | None] = {
     "C5_ja_001": "府中",
     "C5_zh_001": "府中",
     "C5_en_001": "府中",
+    "Q304_retrieval_place_001": "秋叶原",
     "E2_ja_001": "京都",
     "E2_ja_002": None,
     "E2_ja_003": None,

--- a/apps/agent/agent/tests/unit/test_eval_evaluators_component.py
+++ b/apps/agent/agent/tests/unit/test_eval_evaluators_component.py
@@ -101,6 +101,15 @@ def test_locale_match_scores_message_language(
     assert dict(LocaleMatch().evaluate(evaluator_ctx)) == expected
 
 
+def test_locale_match_prefers_current_query_over_stale_locale() -> None:
+    evaluator_ctx = ctx(
+        AgentInput(query="请介绍圣地巡礼", locale="ja"),
+        result(steps(), QAResponseModel(message="圣地巡礼是一种旅行方式。")),
+        AgentExpected(["general_qa"]),
+    )
+    assert dict(LocaleMatch().evaluate(evaluator_ctx)) == {"locale_match": 1.0}
+
+
 def test_available_data_keys_use_new_registry_vocabulary() -> None:
     search = result(
         steps("search_nearby"),

--- a/apps/agent/agent/tests/unit/test_managed_prompt.py
+++ b/apps/agent/agent/tests/unit/test_managed_prompt.py
@@ -151,6 +151,20 @@ async def test_remote_source_and_version_are_recorded(
     ]
 
 
+async def test_managed_prompt_appends_current_turn_language(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANIMICHI_MANAGED_PROMPT", "1")
+    _patch_resolution(monkeypatch, value=_INSTRUCTIONS)
+
+    rendered = await _run_and_capture_instructions()
+
+    assert "Current turn reply language: English." in rendered
+    assert rendered.index("Current turn reply language") > rendered.index(
+        "Web and language"
+    )
+
+
 async def test_remote_content_drift_falls_back_to_checked_in_prompt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/agent/agent/tests/unit/test_managed_prompt_gates.py
+++ b/apps/agent/agent/tests/unit/test_managed_prompt_gates.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from agent.agents.animichi_agent import _INSTRUCTIONS, build_animichi_agent
+from agent.agents.animichi_agent import (
+    _INSTRUCTIONS,
+    _current_turn_language,
+    build_animichi_agent,
+)
 
 
 def test_default_and_kill_switch_keep_construction_equal(
@@ -15,5 +19,6 @@ def test_default_and_kill_switch_keep_construction_equal(
     monkeypatch.setenv("LOGFIRE_API_KEY", "api-key")
     killed_agent = build_animichi_agent()
 
-    assert default_agent._instructions == killed_agent._instructions == [_INSTRUCTIONS]
+    expected = [_INSTRUCTIONS, _current_turn_language]
+    assert default_agent._instructions == killed_agent._instructions == expected
     assert repr(default_agent._root_capability) == repr(killed_agent._root_capability)

--- a/apps/agent/agent/tests/unit/test_public_api_pipeline.py
+++ b/apps/agent/agent/tests/unit/test_public_api_pipeline.py
@@ -22,6 +22,7 @@ from agent.infrastructure.session.memory import InMemorySessionStore
 from agent.interfaces.public_api import PublicAPIRequest, RuntimeAPI, detect_language
 from agent.tests.db_doubles import build_persistence_supabase_double
 from agent.tests.unit.conftest_public_api import install_mock_pipeline
+from agent.utils.language import resolve_reply_language
 
 
 @pytest.fixture(autouse=True)
@@ -148,8 +149,18 @@ async def test_selected_point_ids_bypass_planner(mock_db: MagicMock) -> None:
         ("3件の聖地が見つかりました。", "ja"),
         ("Found 3 pilgrimage spots.", "en"),
         ("東京の聖地を探しています", "ja"),
+        ("ｱﾆﾒ", "ja"),
+        ("𠀀", "zh"),
         ("", "en"),
     ],
 )
 def test_detect_language(text: str, expected: str) -> None:
     assert detect_language(text) == expected
+
+
+def test_scriptless_current_turn_uses_locale_fallback() -> None:
+    assert resolve_reply_language("123?!", "zh") == "zh"
+
+
+def test_han_only_japanese_title_uses_cjk_locale_fallback() -> None:
+    assert resolve_reply_language("京吹", "ja") == "ja"

--- a/apps/agent/agent/tests/unit/test_public_api_translation.py
+++ b/apps/agent/agent/tests/unit/test_public_api_translation.py
@@ -98,6 +98,27 @@ async def test_translation_gate_skips_when_locale_matches(
     assert emitted == []
 
 
+async def test_current_query_language_overrides_stale_browser_locale(
+    mock_db: MagicMock,
+) -> None:
+    result = _search_result(locale="ja", message="找到了3处圣地。")
+    translate = AsyncMock(side_effect=AssertionError("correct reply was retranslated"))
+
+    with (
+        patch(
+            "agent.interfaces.public_api.run_animichi_agent",
+            new=AsyncMock(return_value=result),
+        ),
+        patch("agent.interfaces.public_api.translate_text", new=translate),
+    ):
+        response = await RuntimeAPI(mock_db, model_http_client=MagicMock()).handle(
+            PublicAPIRequest(text="查找圣地", locale="ja")
+        )
+
+    translate.assert_not_awaited()
+    assert response.message == "找到了3处圣地。"
+
+
 async def test_translation_gate_shares_parent_scope_with_toolless_agent(
     mock_db: MagicMock,
 ) -> None:

--- a/apps/agent/agent/utils/language.py
+++ b/apps/agent/agent/utils/language.py
@@ -1,0 +1,57 @@
+"""Current-turn reply-language policy shared by runtime and evals."""
+
+from __future__ import annotations
+
+_HAN_RANGES = (
+    (0x3400, 0x4DBF),
+    (0x4E00, 0x9FFF),
+    (0xF900, 0xFAFF),
+    (0x20000, 0x2FA1F),
+)
+_KANA_RANGES = ((0x3040, 0x30FF), (0x31F0, 0x31FF), (0xFF66, 0xFF9D))
+_LOCALE_NAMES = {"en": "English", "ja": "Japanese", "zh": "Simplified Chinese"}
+_SIMPLIFIED_HINTS = frozenset("为么这请绍仪动欢凉宫间过发见处门车边还让圣")
+
+
+def _in_ranges(char: str, ranges: tuple[tuple[int, int], ...]) -> bool:
+    point = ord(char)
+    return any(start <= point <= end for start, end in ranges)
+
+
+def _is_latin(char: str) -> bool:
+    point = ord(char)
+    return (char.isascii() and char.isalpha()) or 0x00C0 <= point <= 0x024F
+
+
+def _script_counts(text: str) -> tuple[int, int, int]:
+    kana = sum(_in_ranges(char, _KANA_RANGES) for char in text)
+    han = sum(_in_ranges(char, _HAN_RANGES) for char in text)
+    latin = sum(_is_latin(char) for char in text)
+    return kana, han, latin
+
+
+def detect_language(text: str) -> str:
+    """Detect ja/zh/en from Unicode scripts, defaulting unknown text to English."""
+    kana, han, latin = _script_counts(text)
+    if kana and kana + han >= latin:
+        return "ja"
+    if han and han >= latin:
+        return "zh"
+    return "en"
+
+
+def resolve_reply_language(text: str, fallback: str) -> str:
+    """Prefer meaningful current-turn script evidence over the runtime fallback."""
+    kana, han, latin = _script_counts(text)
+    if han and any(char in _SIMPLIFIED_HINTS for char in text):
+        return "zh"
+    if kana or latin >= 2:
+        return detect_language(text)
+    if han:
+        return fallback if fallback in {"ja", "zh"} else "zh"
+    return fallback if fallback in _LOCALE_NAMES else "ja"
+
+
+def locale_name(locale: str) -> str:
+    """Return the model-facing name for one supported locale."""
+    return _LOCALE_NAMES.get(locale, "Japanese")


### PR DESCRIPTION
Part B of #304 (behavior half; evaluator half shipped in #354). No model-backed evals were run — per the batch-at-the-end directive, evidence is deterministic unit tests + 10 pending eval cases.

## 1. Locale (targets the 71.8% locale_match gap)

Diagnosis: only a generic language instruction + browser-locale fallback existed — no current-turn directive, and the translation gate could translate a CORRECT response back into a stale `request.locale`.

Fix: one shared Unicode-aware policy (`utils/language.py`) now feeds all three consumers — dynamic instructions (current-turn directive rendered after canonical instructions, both managed + local prompts), the translation gate, and the locale evaluator. Handles zh/en/ja, half-width kana, supplementary Han, simplified-Chinese hints, Han-only Japanese titles.

⚠️ **Evaluator-affecting**: `evaluators.py` locale judgment now uses this policy — the next full run's `locale_match` is NOT directly comparable to the #354 baseline number. Flag it when reading the next report.

## 2. Sequel/season retrieval (续作误返)

Root cause: deterministic retrieval was first-substring-wins, so short parent aliases beat specific works (e.g. 涼宮ハルヒの消失, LoveLive! Sunshine!!). Fix: NFKC/case/punctuation normalization → exact-match preference → longest-alias preference (`agents/title_matching.py`); resolve + translation boundaries reject obvious parent/variant mismatches instead of returning a wrong localized title.

## 3. Place names + community aliases

- Place names: the redesigned typed translation path already bypasses anime resolution for `kind="place_name"` — no production fix needed; behavior is now regression-locked.
- Community aliases: orthographic variants (full-width ＳＰＹ　ＦＡＭＩＬＹ etc.) fixed by the same normalization.
- **Out of scope (recorded)**: semantic aliases absent from catalog data (未闻花名, 俺ガイル) cannot be fixed agent-side; needs catalog/worker alias records. The agent now at least rejects obviously wrong parents.

## Tests

New `test_agent_quality_304.py` + FunctionModel instruction assertions (zh/en/ja, managed-prompt ordering), stale-locale translation-gate regressions, Unicode edge regressions, retrieval fixtures (sequel/season/full-width/wrong-parent/place-name). Pending evals: 7 agent + 3 translation cases tagged `issue-304`/`pending-eval`, written but NOT executed.

## Verification (lead, live)

make lint / typecheck / test — 282 files formatted, mypy 107 files clean, **1104 passed, coverage 87.66%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)