### PR TITLE
chore(eval): calibrate thrash gate p95 limit 6→8 (#28)

### DIFF
--- a/apps/agent/agent/tests/eval/direct_gates.py
+++ b/apps/agent/agent/tests/eval/direct_gates.py
@@ -14,7 +14,11 @@ from agent.agents.agent_result import AgentResult
 
 REQUEST_LIMIT = 12
 TOOL_CALL_LIMIT = 6
-REQUEST_P95_LIMIT = 6
+# Calibrated 2026-07-18 (#28): two stable full-655 official-v1 runs measured
+# request_p95 = 7 (baseline run observed 7-8). The original 6 would fail every
+# healthy run; 8 = observed steady state + 1 headroom. Enforcement stays behind
+# DIRECT_GATE_ENFORCE=1 at eval time.
+REQUEST_P95_LIMIT = 8
 
 
 @dataclass(frozen=True)

--- a/apps/agent/agent/tests/unit/test_eval_direct_gates.py
+++ b/apps/agent/agent/tests/unit/test_eval_direct_gates.py
@@ -52,20 +52,20 @@ def test_direct_gates_reject_over_limit_and_repeated_trajectory() -> None:
     assert any("repeated identical" in failure for failure in failures)
 
 
-def test_direct_gates_reject_request_p95_above_six() -> None:
+def test_direct_gates_reject_request_p95_above_limit() -> None:
     failures = direct_thrash_gate(
-        [TrajectoryCase(f"case-{index}", requests=7) for index in range(20)]
+        [TrajectoryCase(f"case-{index}", requests=9) for index in range(20)]
     )
-    assert failures == ["request_p95=7 exceeds limit=6"]
+    assert failures == ["request_p95=9 exceeds limit=8"]
 
 
 def test_zero_request_cases_do_not_dilute_model_request_p95() -> None:
-    model_cases = [TrajectoryCase(f"model-{index}", requests=7) for index in range(2)]
+    model_cases = [TrajectoryCase(f"model-{index}", requests=9) for index in range(2)]
     deterministic_cases = [
         TrajectoryCase(f"selection-{index}", requests=0) for index in range(39)
     ]
     failures = direct_thrash_gate([*model_cases, *deterministic_cases])
-    assert failures == ["request_p95=7 exceeds limit=6"]
+    assert failures == ["request_p95=9 exceeds limit=8"]
 
 
 def test_trajectory_accounting_excludes_runner_synthesized_steps() -> None:


### PR DESCRIPTION
Task #28 calibration micro-PR.

Evidence: two stable full-655 runs on the official-v1 evaluator measured `request_p95 = 7` (2026-07-17 baseline observed 7–8; 2026-07-18 run 2 = 7, all gates passed, 13/655 API-errored). The pre-calibration limit of 6 would fail every healthy run. New limit **8** = observed steady state + 1 request of headroom.

Enforcement is unchanged: the gate stays report-only unless `DIRECT_GATE_ENFORCE=1` is set at eval time — flip it on at the next batched eval run now that the threshold is honest.

Tests updated to pin the new boundary (9 exceeds 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)