### PR TITLE
feat(agent): E1 progressive AI SDK chat stream (tool + data parts)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,11 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: '__snapshots__/'
+        exclude: '__snapshots__/|\.sse$'
       - id: end-of-file-fixer
+        # Recorded SSE fixtures must keep their wire-accurate trailing blank
+        # line (event terminator); do not let the fixer collapse it.
+        exclude: '\.sse$'
       - id: check-yaml
       - id: check-toml
 

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -3,26 +3,18 @@
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
 from typing import Annotated, Literal, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic_ai.ui.vercel_ai.response_types import (
-    BaseChunk,
-    DataChunk,
-    DoneChunk,
-    FinishChunk,
-    FinishStepChunk,
-    StartChunk,
-    StartStepChunk,
-)
 from starlette.responses import Response, StreamingResponse
 
+from agent.agents.runtime_deps import OnStep
 from agent.interfaces.routes._deps import (
     TrustedAuthContext,
     _get_runtime_api,
     _require_trusted_user,
 )
+from agent.interfaces.routes.chat_stream import stream_chat
 from agent.interfaces.schemas import PublicAPIRequest, PublicAPIResponse
 
 router = APIRouter(prefix="/v1", tags=["chat"])
@@ -122,29 +114,22 @@ def _runtime_request(request: Request, body: dict[str, object]) -> PublicAPIRequ
     )
 
 
-def _event(chunk: BaseChunk) -> str:
-    return f"data: {chunk.encode(6)}\n\n"
-
-
-async def _response_stream(response: PublicAPIResponse) -> AsyncIterator[str]:
-    yield _event(StartChunk())
-    yield _event(StartStepChunk())
-    yield _event(DataChunk(type="data-response", data=response.model_dump(mode="json")))
-    yield _event(FinishStepChunk())
-    yield _event(FinishChunk(finish_reason="stop"))
-    yield _event(DoneChunk())
-
-
 @router.post("/chat", responses={422: {"description": "Invalid chat request"}})
 async def handle_chat(
     request: Request,
     auth: Annotated[TrustedAuthContext, Depends(_require_trusted_user)],
 ) -> Response:
-    """Execute chat through RuntimeAPI; pending state is loaded by session ID."""
+    """Stream chat as an AI SDK UI message stream with tool + data parts."""
     api_request = _runtime_request(request, _decode_body(await request.body()))
-    response = await _get_runtime_api(request).handle(api_request, user_id=auth.user_id)
+    runtime_api = _get_runtime_api(request)
+
+    async def handler(on_step: OnStep) -> PublicAPIResponse:
+        return await runtime_api.handle(
+            api_request, user_id=auth.user_id, on_step=on_step
+        )
+
     return StreamingResponse(
-        _response_stream(response),
+        stream_chat(handler),
         media_type="text/event-stream",
         headers={"x-vercel-ai-ui-message-stream": "v1"},
     )

--- a/apps/agent/agent/interfaces/routes/chat_stream.py
+++ b/apps/agent/agent/interfaces/routes/chat_stream.py
@@ -1,0 +1,156 @@
+"""Progressive AI SDK UI message stream over pydantic-ai Vercel chunk types.
+
+Emits the standard AI SDK UI message stream on `/v1/chat`: tool parts for
+tool-call progress, and custom `data-response` parts overwritten in place by a
+single ID so the discriminated `intent` field is readable ahead of the rest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from contextlib import suppress
+
+import structlog
+from pydantic_ai.ui.vercel_ai.response_types import (
+    BaseChunk,
+    DataChunk,
+    DoneChunk,
+    ErrorChunk,
+    FinishChunk,
+    FinishStepChunk,
+    StartChunk,
+    StartStepChunk,
+    ToolInputAvailableChunk,
+    ToolInputStartChunk,
+    ToolOutputAvailableChunk,
+)
+
+from agent.agents.runtime_deps import OnStep, StepEvent
+from agent.interfaces.schemas import PublicAPIResponse
+
+logger = structlog.get_logger(__name__)
+
+RESPONSE_DATA_ID = "response"
+_SDK_VERSION = 6
+_ERROR_TEXT = "Something went wrong. Please try again."
+
+ChatHandler = Callable[[OnStep], Awaitable[PublicAPIResponse]]
+_Queue = asyncio.Queue["BaseChunk | None"]
+
+
+class _ToolPartTranslator:
+    """Map running/done step events onto AI SDK tool parts with stable IDs."""
+
+    def __init__(self) -> None:
+        self._call_ids: dict[str, str] = {}
+        self._count = 0
+
+    def translate(self, step: StepEvent) -> list[BaseChunk]:
+        if step.status == "running":
+            return self._begin(step)
+        return self._finish(step)
+
+    def _begin(self, step: StepEvent) -> list[BaseChunk]:
+        self._count += 1
+        call_id = f"{step.tool}-{self._count}"
+        self._call_ids[step.tool] = call_id
+        return [
+            ToolInputStartChunk(tool_call_id=call_id, tool_name=step.tool),
+            ToolInputAvailableChunk(
+                tool_call_id=call_id, tool_name=step.tool, input=step.data
+            ),
+        ]
+
+    def _finish(self, step: StepEvent) -> list[BaseChunk]:
+        call_id = self._call_ids.get(step.tool, f"{step.tool}-0")
+        return [ToolOutputAvailableChunk(tool_call_id=call_id, output=step.data)]
+
+
+def _data_parts(response: PublicAPIResponse) -> list[BaseChunk]:
+    return [
+        DataChunk(
+            type="data-response", id=RESPONSE_DATA_ID, data={"intent": response.intent}
+        ),
+        DataChunk(
+            type="data-response",
+            id=RESPONSE_DATA_ID,
+            data=response.model_dump(mode="json"),
+        ),
+    ]
+
+
+def _response_chunks(response: PublicAPIResponse) -> list[BaseChunk]:
+    return [
+        *_data_parts(response),
+        FinishStepChunk(),
+        FinishChunk(finish_reason="stop"),
+        DoneChunk(),
+    ]
+
+
+def _error_chunks() -> list[BaseChunk]:
+    return [
+        ErrorChunk(error_text=_ERROR_TEXT),
+        FinishStepChunk(),
+        FinishChunk(finish_reason="error"),
+        DoneChunk(),
+    ]
+
+
+async def _put_all(queue: _Queue, chunks: Sequence[BaseChunk]) -> None:
+    for chunk in chunks:
+        await queue.put(chunk)
+
+
+def _make_on_step(queue: _Queue) -> OnStep:
+    translator = _ToolPartTranslator()
+
+    async def on_step(step: StepEvent) -> None:
+        await _put_all(queue, translator.translate(step))
+
+    return on_step
+
+
+async def _produce(handler: ChatHandler, queue: _Queue) -> None:
+    await _put_all(queue, [StartChunk(), StartStepChunk()])
+    try:
+        response = await handler(_make_on_step(queue))
+    except Exception as exc:
+        logger.exception("chat_stream_error", error=str(exc))
+        await _put_all(queue, _error_chunks())
+    else:
+        await _put_all(queue, _response_chunks(response))
+    await queue.put(None)
+
+
+async def _drain(queue: _Queue) -> AsyncIterator[BaseChunk]:
+    while True:
+        chunk = await queue.get()
+        if chunk is None:
+            return
+        yield chunk
+
+
+def _frame(chunk: BaseChunk) -> str:
+    return f"data: {chunk.encode(_SDK_VERSION)}\n\n"
+
+
+async def _settle(task: asyncio.Task[None]) -> None:
+    if task.done():
+        await task
+        return
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+
+async def stream_chat(handler: ChatHandler) -> AsyncIterator[str]:
+    """Yield SSE frames for one chat turn: start -> tools -> data -> finish."""
+    queue: _Queue = asyncio.Queue()
+    task = asyncio.create_task(_produce(handler, queue))
+    try:
+        async for chunk in _drain(queue):
+            yield _frame(chunk)
+    finally:
+        await _settle(task)

--- a/apps/agent/agent/tests/unit/test_chat_endpoint.py
+++ b/apps/agent/agent/tests/unit/test_chat_endpoint.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.agents.runtime_deps import OnStep, StepEvent
 from agent.interfaces.public_api import RuntimeAPI
 from agent.interfaces.schemas import PublicAPIResponse
 from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
@@ -159,6 +161,70 @@ async def test_chat_invalid_locale_defaults_to_ja() -> None:
             headers={"X-User-Id": "user-1", "X-Locale": "fr"},
         )
     assert runtime.handle.await_args.args[0].locale == "ja"
+
+
+class _StepRuntime:
+    """Runtime double that replays step events before returning a response."""
+
+    def __init__(
+        self, response: PublicAPIResponse, steps: list[StepEvent] | None = None
+    ) -> None:
+        self._response = response
+        self._steps = steps or []
+        self._db = build_stub_db()
+
+    async def handle(
+        self, request: object, *, user_id: str | None = None, on_step: OnStep = ...
+    ) -> PublicAPIResponse:
+        for step in self._steps:
+            if on_step is not ...:
+                await on_step(step)
+        return self._response
+
+
+def _frame_types(body: str) -> list[str]:
+    types: list[str] = []
+    for line in body.splitlines():
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: ") :]
+        types.append("[DONE]" if payload == "[DONE]" else json.loads(payload)["type"])
+    return types
+
+
+async def test_chat_stream_frame_structure_and_header() -> None:
+    steps = [
+        StepEvent(tool="resolve_anime", status="running", data={}),
+        StepEvent(tool="resolve_anime", status="done", data={"bangumi_id": 1}),
+    ]
+    runtime = _StepRuntime(_runtime().handle.return_value, steps)
+    app, _ = build_app(runtime_api=runtime)  # type: ignore[arg-type]
+    async with async_client(app) as client:
+        response = await client.post(
+            "/v1/chat", json=_body(), headers={"X-User-Id": "user-1"}
+        )
+    assert response.headers["x-vercel-ai-ui-message-stream"] == "v1"
+    types = _frame_types(response.text)
+    assert types[:2] == ["start", "start-step"]
+    assert types[-1] == "[DONE]"
+    assert "tool-input-start" in types
+    assert "tool-output-available" in types
+    assert types.index("tool-output-available") < types.index("data-response")
+
+
+async def test_chat_stream_emits_error_part_when_handle_fails() -> None:
+    runtime = MagicMock(spec=RuntimeAPI)
+    runtime.handle = AsyncMock(side_effect=RuntimeError("db down"))
+    runtime._db = build_stub_db()
+    app, _ = build_app(runtime_api=runtime)
+    async with async_client(app) as client:
+        response = await client.post(
+            "/v1/chat", json=_body(), headers={"X-User-Id": "user-1"}
+        )
+    assert response.status_code == 200
+    assert '"type":"error"' in response.text
+    assert "db down" not in response.text
+    assert '"type":"data-response"' not in response.text
 
 
 async def test_chat_partial_response_completes_as_data_response() -> None:

--- a/apps/agent/agent/tests/unit/test_chat_endpoint.py
+++ b/apps/agent/agent/tests/unit/test_chat_endpoint.py
@@ -163,33 +163,37 @@ async def test_chat_invalid_locale_defaults_to_ja() -> None:
     assert runtime.handle.await_args.args[0].locale == "ja"
 
 
-class _StepRuntime:
-    """Runtime double that replays step events before returning a response."""
-
-    def __init__(
-        self, response: PublicAPIResponse, steps: list[StepEvent] | None = None
-    ) -> None:
-        self._response = response
-        self._steps = steps or []
-        self._db = build_stub_db()
-
-    async def handle(
-        self, request: object, *, user_id: str | None = None, on_step: OnStep = ...
+def _replay_runtime(response: PublicAPIResponse, steps: list[StepEvent]) -> MagicMock:
+    async def _handle(
+        request: object, *, user_id: str | None = None, on_step: OnStep | None = None
     ) -> PublicAPIResponse:
-        for step in self._steps:
-            if on_step is not ...:
+        for step in steps:
+            if on_step is not None:
                 await on_step(step)
-        return self._response
+        return response
+
+    runtime = MagicMock(spec=RuntimeAPI)
+    runtime.handle = AsyncMock(side_effect=_handle)
+    runtime._db = build_stub_db()
+    return runtime
+
+
+def _frame_type(payload: str) -> str:
+    if payload == "[DONE]":
+        return "[DONE]"
+    chunk: object = json.loads(payload)
+    assert isinstance(chunk, dict)
+    kind = chunk["type"]
+    assert isinstance(kind, str)
+    return kind
 
 
 def _frame_types(body: str) -> list[str]:
-    types: list[str] = []
-    for line in body.splitlines():
-        if not line.startswith("data: "):
-            continue
-        payload = line[len("data: ") :]
-        types.append("[DONE]" if payload == "[DONE]" else json.loads(payload)["type"])
-    return types
+    return [
+        _frame_type(line[len("data: ") :])
+        for line in body.splitlines()
+        if line.startswith("data: ")
+    ]
 
 
 async def test_chat_stream_frame_structure_and_header() -> None:
@@ -197,8 +201,11 @@ async def test_chat_stream_frame_structure_and_header() -> None:
         StepEvent(tool="resolve_anime", status="running", data={}),
         StepEvent(tool="resolve_anime", status="done", data={"bangumi_id": 1}),
     ]
-    runtime = _StepRuntime(_runtime().handle.return_value, steps)
-    app, _ = build_app(runtime_api=runtime)  # type: ignore[arg-type]
+    response_body = PublicAPIResponse(
+        success=True, status="ok", intent="search_bangumi", message="Found."
+    )
+    runtime = _replay_runtime(response_body, steps)
+    app, _ = build_app(runtime_api=runtime)
     async with async_client(app) as client:
         response = await client.post(
             "/v1/chat", json=_body(), headers={"X-User-Id": "user-1"}

--- a/apps/agent/agent/tests/unit/test_chat_stream.py
+++ b/apps/agent/agent/tests/unit/test_chat_stream.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import json
 
 from agent.agents.runtime_deps import OnStep, StepEvent
-from agent.interfaces.routes.chat_stream import RESPONSE_DATA_ID, stream_chat
+from agent.interfaces.routes.chat_stream import (
+    RESPONSE_DATA_ID,
+    ChatHandler,
+    stream_chat,
+)
 from agent.interfaces.schemas import PublicAPIResponse
 
 
-async def _collect(handler: object) -> list[str]:
-    return [frame async for frame in stream_chat(handler)]  # type: ignore[arg-type]
+async def _collect(handler: ChatHandler) -> list[str]:
+    return [frame async for frame in stream_chat(handler)]
 
 
 def _parse(frames: list[str]) -> list[object]:
@@ -23,11 +27,17 @@ def _parse(frames: list[str]) -> list[object]:
     return chunks
 
 
+def _type_of(chunk: object) -> str:
+    if chunk == "[DONE]":
+        return "[DONE]"
+    assert isinstance(chunk, dict)
+    kind = chunk["type"]
+    assert isinstance(kind, str)
+    return kind
+
+
 def _types(chunks: list[object]) -> list[str]:
-    out: list[str] = []
-    for chunk in chunks:
-        out.append("[DONE]" if chunk == "[DONE]" else str(chunk["type"]))  # type: ignore[index]
-    return out
+    return [_type_of(chunk) for chunk in chunks]
 
 
 def _of_type(chunks: list[object], type_name: str) -> list[dict[str, object]]:
@@ -48,7 +58,7 @@ async def _plain_handler(_on_step: OnStep) -> PublicAPIResponse:
     return _response()
 
 
-def _tool_handler(response: PublicAPIResponse) -> object:
+def _tool_handler(response: PublicAPIResponse) -> ChatHandler:
     async def handler(on_step: OnStep) -> PublicAPIResponse:
         await on_step(
             StepEvent(tool="resolve_anime", status="running", data={"t": "x"})

--- a/apps/agent/agent/tests/unit/test_chat_stream.py
+++ b/apps/agent/agent/tests/unit/test_chat_stream.py
@@ -1,0 +1,132 @@
+"""Unit tests for the progressive AI SDK UI message stream."""
+
+from __future__ import annotations
+
+import json
+
+from agent.agents.runtime_deps import OnStep, StepEvent
+from agent.interfaces.routes.chat_stream import RESPONSE_DATA_ID, stream_chat
+from agent.interfaces.schemas import PublicAPIResponse
+
+
+async def _collect(handler: object) -> list[str]:
+    return [frame async for frame in stream_chat(handler)]  # type: ignore[arg-type]
+
+
+def _parse(frames: list[str]) -> list[object]:
+    chunks: list[object] = []
+    for frame in frames:
+        assert frame.startswith("data: ")
+        assert frame.endswith("\n\n")
+        body = frame[len("data: ") : -2]
+        chunks.append(body if body == "[DONE]" else json.loads(body))
+    return chunks
+
+
+def _types(chunks: list[object]) -> list[str]:
+    out: list[str] = []
+    for chunk in chunks:
+        out.append("[DONE]" if chunk == "[DONE]" else str(chunk["type"]))  # type: ignore[index]
+    return out
+
+
+def _of_type(chunks: list[object], type_name: str) -> list[dict[str, object]]:
+    return [
+        chunk
+        for chunk in chunks
+        if isinstance(chunk, dict) and chunk.get("type") == type_name
+    ]
+
+
+def _response(intent: str = "greet_user") -> PublicAPIResponse:
+    return PublicAPIResponse(
+        success=True, status="ok", intent=intent, message="hi", data={"k": "v"}
+    )
+
+
+async def _plain_handler(_on_step: OnStep) -> PublicAPIResponse:
+    return _response()
+
+
+def _tool_handler(response: PublicAPIResponse) -> object:
+    async def handler(on_step: OnStep) -> PublicAPIResponse:
+        await on_step(
+            StepEvent(tool="resolve_anime", status="running", data={"t": "x"})
+        )
+        await on_step(StepEvent(tool="resolve_anime", status="done", data={"id": 1}))
+        return response
+
+    return handler
+
+
+async def _failing_handler(_on_step: OnStep) -> PublicAPIResponse:
+    raise RuntimeError("boom")
+
+
+async def test_stream_emits_ordered_envelope_for_plain_response() -> None:
+    chunks = _parse(await _collect(_plain_handler))
+    assert _types(chunks) == [
+        "start",
+        "start-step",
+        "data-response",
+        "data-response",
+        "finish-step",
+        "finish",
+        "[DONE]",
+    ]
+
+
+async def test_finish_reason_is_stop_on_success() -> None:
+    chunks = _parse(await _collect(_plain_handler))
+    assert _of_type(chunks, "finish")[0]["finishReason"] == "stop"
+
+
+async def test_intent_arrives_before_full_data_part() -> None:
+    parts = _of_type(_parse(await _collect(_plain_handler)), "data-response")
+    assert parts[0]["data"] == {"intent": "greet_user"}
+    full = parts[1]["data"]
+    assert isinstance(full, dict)
+    assert full["intent"] == "greet_user"
+    assert set(full) > {"intent"}
+
+
+async def test_progressive_data_parts_share_one_id() -> None:
+    parts = _of_type(_parse(await _collect(_plain_handler)), "data-response")
+    assert [part["id"] for part in parts] == [RESPONSE_DATA_ID, RESPONSE_DATA_ID]
+
+
+async def test_tool_steps_become_tool_parts_with_stable_call_id() -> None:
+    chunks = _parse(await _collect(_tool_handler(_response("search_bangumi"))))
+    start = _of_type(chunks, "tool-input-start")[0]
+    available = _of_type(chunks, "tool-input-available")[0]
+    output = _of_type(chunks, "tool-output-available")[0]
+    call_id = start["toolCallId"]
+    assert available["toolCallId"] == call_id
+    assert output["toolCallId"] == call_id
+    assert start["toolName"] == "resolve_anime"
+    assert available["input"] == {"t": "x"}
+    assert output["output"] == {"id": 1}
+
+
+async def test_tool_parts_precede_data_parts() -> None:
+    order = _types(_parse(await _collect(_tool_handler(_response()))))
+    assert order.index("tool-output-available") < order.index("data-response")
+
+
+async def test_handler_failure_emits_error_part_not_data() -> None:
+    chunks = _parse(await _collect(_failing_handler))
+    assert _types(chunks) == [
+        "start",
+        "start-step",
+        "error",
+        "finish-step",
+        "finish",
+        "[DONE]",
+    ]
+    assert _of_type(chunks, "finish")[0]["finishReason"] == "error"
+    assert _of_type(chunks, "data-response") == []
+
+
+async def test_error_text_does_not_leak_exception_detail() -> None:
+    error = _of_type(_parse(await _collect(_failing_handler)), "error")[0]
+    assert "boom" not in str(error["errorText"])

--- a/apps/agent/agent/tests/unit/test_chat_stream_fixtures.py
+++ b/apps/agent/agent/tests/unit/test_chat_stream_fixtures.py
@@ -26,11 +26,17 @@ def _chunks(raw: str) -> list[object]:
     return out
 
 
+def _type_of(chunk: object) -> str:
+    if chunk == "[DONE]":
+        return "[DONE]"
+    assert isinstance(chunk, dict)
+    kind = chunk["type"]
+    assert isinstance(kind, str)
+    return kind
+
+
 def _types(chunks: list[object]) -> list[str]:
-    return [
-        "[DONE]" if chunk == "[DONE]" else str(chunk["type"])  # type: ignore[index]
-        for chunk in chunks
-    ]
+    return [_type_of(chunk) for chunk in chunks]
 
 
 def _data_parts(chunks: list[object]) -> list[dict[str, object]]:
@@ -39,6 +45,12 @@ def _data_parts(chunks: list[object]) -> list[dict[str, object]]:
         for chunk in chunks
         if isinstance(chunk, dict) and chunk.get("type") == "data-response"
     ]
+
+
+def _data_of(part: dict[str, object]) -> dict[str, object]:
+    value = part["data"]
+    assert isinstance(value, dict)
+    return value
 
 
 @pytest.mark.parametrize("name", _STREAM_FIXTURES)
@@ -59,13 +71,13 @@ def test_search_fixture_carries_tool_and_progressive_parts() -> None:
     parts = _data_parts(chunks)
     assert parts[0]["data"] == {"intent": "plan_route"}
     assert {part["id"] for part in parts} == {"response"}
-    assert set(parts[1]["data"]) > {"intent"}  # type: ignore[arg-type]
+    assert set(_data_of(parts[1])) > {"intent"}
 
 
 def test_clarify_fixture_is_intent_first() -> None:
     parts = _data_parts(_chunks(_load("clarify")))
     assert parts[0]["data"] == {"intent": "clarify"}
-    assert parts[1]["data"]["status"] == "needs_clarification"  # type: ignore[index]
+    assert _data_of(parts[1])["status"] == "needs_clarification"
 
 
 def test_error_fixture_has_error_part_and_no_data() -> None:

--- a/apps/agent/agent/tests/unit/test_chat_stream_fixtures.py
+++ b/apps/agent/agent/tests/unit/test_chat_stream_fixtures.py
@@ -1,0 +1,77 @@
+"""Validate the recorded chat-stream SSE fixtures consumed by C0.2."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[3] / "tests/fixtures/chat_stream"
+_STREAM_FIXTURES = ("search", "clarify", "error")
+
+
+def _load(name: str) -> str:
+    return (_FIXTURE_DIR / f"{name}.sse").read_text(encoding="utf-8")
+
+
+def _chunks(raw: str) -> list[object]:
+    out: list[object] = []
+    for block in raw.split("\n\n"):
+        if not block:
+            continue
+        assert block.startswith("data: ")
+        payload = block[len("data: ") :]
+        out.append(payload if payload == "[DONE]" else json.loads(payload))
+    return out
+
+
+def _types(chunks: list[object]) -> list[str]:
+    return [
+        "[DONE]" if chunk == "[DONE]" else str(chunk["type"])  # type: ignore[index]
+        for chunk in chunks
+    ]
+
+
+def _data_parts(chunks: list[object]) -> list[dict[str, object]]:
+    return [
+        chunk
+        for chunk in chunks
+        if isinstance(chunk, dict) and chunk.get("type") == "data-response"
+    ]
+
+
+@pytest.mark.parametrize("name", _STREAM_FIXTURES)
+def test_fixture_is_well_framed_and_terminated(name: str) -> None:
+    raw = _load(name)
+    assert raw.endswith("\n\n")
+    types = _types(_chunks(raw))
+    assert types[0] == "start"
+    assert types[1] == "start-step"
+    assert types[-1] == "[DONE]"
+    assert types[-2] == "finish"
+
+
+def test_search_fixture_carries_tool_and_progressive_parts() -> None:
+    chunks = _chunks(_load("search"))
+    types = _types(chunks)
+    assert types.count("tool-output-available") == 3
+    parts = _data_parts(chunks)
+    assert parts[0]["data"] == {"intent": "plan_route"}
+    assert {part["id"] for part in parts} == {"response"}
+    assert set(parts[1]["data"]) > {"intent"}  # type: ignore[arg-type]
+
+
+def test_clarify_fixture_is_intent_first() -> None:
+    parts = _data_parts(_chunks(_load("clarify")))
+    assert parts[0]["data"] == {"intent": "clarify"}
+    assert parts[1]["data"]["status"] == "needs_clarification"  # type: ignore[index]
+
+
+def test_error_fixture_has_error_part_and_no_data() -> None:
+    chunks = _chunks(_load("error"))
+    types = _types(chunks)
+    assert "error" in types
+    assert "data-response" not in types
+    finish = [c for c in chunks if isinstance(c, dict) and c["type"] == "finish"][0]
+    assert finish["finishReason"] == "error"

--- a/apps/agent/tests/fixtures/chat_stream/clarify.sse
+++ b/apps/agent/tests/fixtures/chat_stream/clarify.sse
@@ -1,0 +1,20 @@
+data: {"type":"start"}
+
+data: {"type":"start-step"}
+
+data: {"type":"tool-input-start","toolCallId":"resolve_anime-1","toolName":"resolve_anime"}
+
+data: {"type":"tool-input-available","toolCallId":"resolve_anime-1","toolName":"resolve_anime","input":{"title":"ハルヒ"}}
+
+data: {"type":"tool-output-available","toolCallId":"resolve_anime-1","output":{"ambiguous":true}}
+
+data: {"type":"data-response","id":"response","data":{"intent":"clarify"}}
+
+data: {"type":"data-response","id":"response","data":{"success":true,"status":"needs_clarification","intent":"clarify","session_id":null,"message":"どの作品でしょうか？","data":{"reason":"title_ambiguous","clarification_id":1,"candidates":[{"id":"115908","title":"涼宮ハルヒの憂鬱","cover_url":null},{"id":"117696","title":"涼宮ハルヒの消失","cover_url":null}]},"session":{},"route_history":[],"errors":[],"ui":{"component":"Clarification"},"generated_title":null,"debug":null}}
+
+data: {"type":"finish-step"}
+
+data: {"type":"finish","finishReason":"stop"}
+
+data: [DONE]
+

--- a/apps/agent/tests/fixtures/chat_stream/error.sse
+++ b/apps/agent/tests/fixtures/chat_stream/error.sse
@@ -1,0 +1,12 @@
+data: {"type":"start"}
+
+data: {"type":"start-step"}
+
+data: {"type":"error","errorText":"Something went wrong. Please try again."}
+
+data: {"type":"finish-step"}
+
+data: {"type":"finish","finishReason":"error"}
+
+data: [DONE]
+

--- a/apps/agent/tests/fixtures/chat_stream/record_fixtures.py
+++ b/apps/agent/tests/fixtures/chat_stream/record_fixtures.py
@@ -1,0 +1,151 @@
+"""Record real `/v1/chat` SSE fixtures for the chat contract card (C0.2).
+
+Runs the production `stream_chat` generator against representative, deterministic
+turn handlers and writes the raw SSE text to `*.sse` files next to this script.
+The framing, chunk encoding, tool parts, and progressive `data-response` parts
+are produced by the real runtime code path — only the model verdict is stubbed
+so the output is reproducible without a live model or network.
+
+Run (from the repo root):
+
+    cd apps/agent && uv run python tests/fixtures/chat_stream/record_fixtures.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+# Settings validation demands these at import time; the recorder never uses a
+# real DB or model, so stub values keep the script runnable and reproducible.
+os.environ.setdefault("MIMO_API_KEY", "recording-stub")
+os.environ.setdefault("SUPABASE_DB_URL", "postgresql://test:test@localhost:5432/test")
+
+if TYPE_CHECKING:
+    from agent.agents.runtime_deps import OnStep, StepEvent
+    from agent.interfaces.routes.chat_stream import ChatHandler
+    from agent.interfaces.schemas import PublicAPIResponse
+
+_FIXTURE_DIR = Path(__file__).parent
+
+
+def _search_response() -> PublicAPIResponse:
+    from agent.interfaces.schemas import PublicAPIResponse
+
+    results = {
+        "kind": "bangumi",
+        "bangumi_id": 12345,
+        "title": "響け！ユーフォニアム",
+        "row_count": 2,
+        "status": "ok",
+        "strategy": "bangumi",
+        "summary": {"count": 2, "source": "catalog", "cache": "miss"},
+        "rows": [
+            {"id": "p1", "name": "宇治橋", "lat": 34.891, "lng": 135.807, "ep": 1},
+            {"id": "p2", "name": "京阪宇治駅", "lat": 34.911, "lng": 135.806, "ep": 3},
+        ],
+    }
+    route = {
+        "ordered_points": ["p1", "p2"],
+        "point_count": 2,
+        "status": "ok",
+        "total_walk_minutes": 12,
+    }
+    return PublicAPIResponse(
+        success=True,
+        status="ok",
+        intent="plan_route",
+        message="宇治の聖地を2件、徒歩ルートにまとめました。",
+        data={"results": results, "route": route},
+        ui={"component": "RoutePlannerWizard"},
+    )
+
+
+def _clarify_response() -> PublicAPIResponse:
+    from agent.interfaces.schemas import PublicAPIResponse
+
+    return PublicAPIResponse(
+        success=True,
+        status="needs_clarification",
+        intent="clarify",
+        message="どの作品でしょうか？",
+        data={
+            "reason": "title_ambiguous",
+            "clarification_id": 1,
+            "candidates": [
+                {"id": "115908", "title": "涼宮ハルヒの憂鬱", "cover_url": None},
+                {"id": "117696", "title": "涼宮ハルヒの消失", "cover_url": None},
+            ],
+        },
+        ui={"component": "Clarification"},
+    )
+
+
+def _step(tool: str, status: str, data: dict[str, object]) -> StepEvent:
+    from agent.agents.runtime_deps import StepEvent
+
+    return StepEvent(tool=tool, status=status, data=data)
+
+
+def _replaying_handler(
+    steps: Sequence[StepEvent], response: PublicAPIResponse
+) -> ChatHandler:
+    async def handler(on_step: OnStep) -> PublicAPIResponse:
+        for step in steps:
+            await on_step(step)
+        return response
+
+    return handler
+
+
+def _search_handler() -> ChatHandler:
+    steps = [
+        _step("resolve_anime", "running", {"title": "ユーフォ"}),
+        _step("resolve_anime", "done", {"bangumi_id": 12345}),
+        _step("search_bangumi", "running", {"bangumi_id": 12345}),
+        _step("search_bangumi", "done", {"row_count": 2}),
+        _step("plan_route", "running", {}),
+        _step("plan_route", "done", {"point_count": 2}),
+    ]
+    return _replaying_handler(steps, _search_response())
+
+
+def _clarify_handler() -> ChatHandler:
+    steps = [
+        _step("resolve_anime", "running", {"title": "ハルヒ"}),
+        _step("resolve_anime", "done", {"ambiguous": True}),
+    ]
+    return _replaying_handler(steps, _clarify_response())
+
+
+def _error_handler() -> ChatHandler:
+    async def handler(_on_step: OnStep) -> PublicAPIResponse:
+        raise RuntimeError("catalog upstream unavailable")
+
+    return handler
+
+
+async def _record(name: str, handler: ChatHandler) -> Path:
+    from agent.interfaces.routes.chat_stream import stream_chat
+
+    frames = [frame async for frame in stream_chat(handler)]
+    path = _FIXTURE_DIR / f"{name}.sse"
+    path.write_text("".join(frames), encoding="utf-8")
+    return path
+
+
+async def _record_all() -> None:
+    for name, handler in (
+        ("search", _search_handler()),
+        ("clarify", _clarify_handler()),
+        ("error", _error_handler()),
+    ):
+        path = await _record(name, handler)
+        print(f"wrote {path.relative_to(_FIXTURE_DIR.parents[2])}")
+
+
+if __name__ == "__main__":
+    asyncio.run(_record_all())

--- a/apps/agent/tests/fixtures/chat_stream/search.sse
+++ b/apps/agent/tests/fixtures/chat_stream/search.sse
@@ -1,0 +1,32 @@
+data: {"type":"start"}
+
+data: {"type":"start-step"}
+
+data: {"type":"tool-input-start","toolCallId":"resolve_anime-1","toolName":"resolve_anime"}
+
+data: {"type":"tool-input-available","toolCallId":"resolve_anime-1","toolName":"resolve_anime","input":{"title":"ユーフォ"}}
+
+data: {"type":"tool-output-available","toolCallId":"resolve_anime-1","output":{"bangumi_id":12345}}
+
+data: {"type":"tool-input-start","toolCallId":"search_bangumi-2","toolName":"search_bangumi"}
+
+data: {"type":"tool-input-available","toolCallId":"search_bangumi-2","toolName":"search_bangumi","input":{"bangumi_id":12345}}
+
+data: {"type":"tool-output-available","toolCallId":"search_bangumi-2","output":{"row_count":2}}
+
+data: {"type":"tool-input-start","toolCallId":"plan_route-3","toolName":"plan_route"}
+
+data: {"type":"tool-input-available","toolCallId":"plan_route-3","toolName":"plan_route","input":{}}
+
+data: {"type":"tool-output-available","toolCallId":"plan_route-3","output":{"point_count":2}}
+
+data: {"type":"data-response","id":"response","data":{"intent":"plan_route"}}
+
+data: {"type":"data-response","id":"response","data":{"success":true,"status":"ok","intent":"plan_route","session_id":null,"message":"宇治の聖地を2件、徒歩ルートにまとめました。","data":{"results":{"kind":"bangumi","bangumi_id":12345,"title":"響け！ユーフォニアム","row_count":2,"status":"ok","strategy":"bangumi","summary":{"count":2,"source":"catalog","cache":"miss"},"rows":[{"id":"p1","name":"宇治橋","lat":34.891,"lng":135.807,"ep":1},{"id":"p2","name":"京阪宇治駅","lat":34.911,"lng":135.806,"ep":3}]},"route":{"ordered_points":["p1","p2"],"point_count":2,"status":"ok","total_walk_minutes":12}},"session":{},"route_history":[],"errors":[],"ui":{"component":"RoutePlannerWizard"},"generated_title":null,"debug":null}}
+
+data: {"type":"finish-step"}
+
+data: {"type":"finish","finishReason":"stop"}
+
+data: [DONE]
+


### PR DESCRIPTION
## E1 — chat 渐进流 enabler (Wave 0)

Base: `feat/frontend-rebuild`. Scope: `apps/agent` only (Python agent). No `packages/contract` changes.

### What changed
`/v1/chat` previously emitted `start → start-step → single data-response → finish-step → finish → done` with no tool parts and no same-ID progressive overwrite. It now speaks the full **AI SDK UI message stream**:

1. **Tool parts** — each `on_step` running/done event becomes `tool-input-start` → `tool-input-available` → `tool-output-available`, sharing a stable `toolCallId` per call, streamed live as the runtime executes tools.
2. **Progressive data parts (intent-first)** — the typed response is pushed as two `data-response` parts overwritten in place by one ID (`response`): first `{ "intent": … }`, then the full payload. The discriminated `intent` field is readable ahead of the rest, matching the S1.1 contract requirement.
3. **Error framing** — handler failures stream a sanitized AI SDK `error` part + `finish(error)` + `[DONE]` instead of a bubbled 500 (no exception-text leak).

All streaming stays on the single `/v1/chat` endpoint using pydantic-ai 2.11's `VercelAIAdapter` chunk types — no custom SSE event types, no second endpoint (per the S1.1 unified-protocol discipline).

### Fixtures for C0.2
Re-runnable recorder + three raw SSE snapshots under `apps/agent/tests/fixtures/chat_stream/` (`search` / `clarify` / `error`), produced by the real `stream_chat` code path:
```
cd apps/agent && uv run python tests/fixtures/chat_stream/record_fixtures.py
```
`.sse` fixtures are excluded from the end-of-file/whitespace fixers so their wire-accurate trailing `\n\n` event terminator is preserved.

### Tests (AC → test type)
- Stream order, finish reason, tool-part translation, intent-first progressive overwrite, error framing — **unit** (`test_chat_stream.py`)
- Header `x-vercel-ai-ui-message-stream: v1` + frame structure + tool-part ordering + error part at the HTTP boundary — **api** (`test_chat_endpoint.py`)
- Fixture protocol validation (framing, `[DONE]`, intent-first, error semantics) — **unit** (`test_chat_stream_fixtures.py`)

### Gate (in worktree `apps/agent`)
- `make lint` — All checks passed
- `make typecheck` — Success: no issues found in 108 source files
- `make test` — 1182 passed, coverage 88.02% (floor 82%); new `chat_stream.py` at 95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)