### PR TITLE
fix(catalog): batch transactions on neon-http — ingest flows no longer crash (#362)

### DIFF
--- a/workers/catalog/src/enrich/enrich.ts
+++ b/workers/catalog/src/enrich/enrich.ts
@@ -12,7 +12,8 @@
  *      is a deliberate later-wave decision, not an oversight;
  *   4. build aliases from the bangumi title(s) -> rankAliases -> UPSERT. Only the
  *      Bangumi source is wired here; AniDB/Moegirl/Manual arrive via later ingest;
- *   5. publishVersion() to atomically bump cluster_version (blue/green switch).
+ *   5. append the ordered publish statements to the same atomic batch, bumping
+ *      cluster_version as a blue/green pointer switch.
  *
  * Writes go through raw `sql` (the Drizzle read schema is query-only), parameterized
  * to keep the JSON trust boundary safe. Each function stays <=10 lines.
@@ -22,11 +23,11 @@
  * LATER / optional (noted, NOT built): city_backfill, series-edge graph, and
  * quality-isolation of low-confidence points.
  */
-import { sql } from "drizzle-orm";
+import { sql, type SQL } from "drizzle-orm";
 import type { CatalogDb, DbExecutor } from "../db/client";
 import { clusterByLocation } from "../lib/clustering";
 import { rankAliases, Source, type RankedAlias, type RawAlias } from "../lib/alias";
-import { publishVersion } from "../publish/versioning";
+import { publishVersionStatements, readPublishedVersion } from "../publish/versioning";
 import {
   parseAnitabiPoints,
   parseBangumi,
@@ -45,12 +46,31 @@ export async function enrichWork(db: CatalogDb, workId: string): Promise<EnrichR
   const bangumi = parseBangumi(workId, await readRaw(db, "raw_bangumi", workId));
   const points = parseAnitabiPoints(workId, await readRaw(db, "raw_anitabi", workId));
   logClusters(workId, points);
-  return db.transaction(async (tx) => {
-    await upsertBangumi(tx, bangumi);
-    await upsertPoints(tx, points);
-    await upsertAliases(tx, workId, bangumi);
-    return { version: await publishVersion(tx as unknown as CatalogDb, workId), pointCount: points.length };
-  });
+  const results = await db.batch(prepareBatch(db, enrichStatements(workId, bangumi, points)));
+  return { version: readPublishedVersion(lastResult(results)), pointCount: points.length };
+}
+
+/** Build every work mutation in its mandatory execution order. */
+function enrichStatements(
+  workId: string, bangumi: BangumiRow, points: PointRow[],
+): readonly [SQL, ...SQL[]] {
+  return [
+    upsertBangumi(bangumi), ...upsertPoints(points),
+    upsertAliases(workId, bangumi), ...publishVersionStatements(workId),
+  ];
+}
+
+/** Convert ordered SQL into lazy Drizzle batch items without executing them. */
+function prepareBatch(db: CatalogDb, statements: readonly [SQL, ...SQL[]]) {
+  const [first, ...rest] = statements;
+  return [db.execute(first), ...rest.map((statement) => db.execute(statement))] as const;
+}
+
+/** The publish INSERT is always the final batch item. */
+function lastResult(results: readonly { rows: unknown[] }[]): { rows: unknown[] } {
+  const result = results.at(-1);
+  if (!result) throw new Error("enrich batch returned no results");
+  return result;
 }
 
 /** Read a raw-zone payload for the work; throw if the row is absent. */
@@ -69,8 +89,8 @@ async function readRaw(
 }
 
 /** UPSERT the `bangumi` row keyed by id (re-enrich overwrites in place). */
-async function upsertBangumi(db: DbExecutor, row: BangumiRow): Promise<void> {
-  await db.execute(sql`
+function upsertBangumi(row: BangumiRow): SQL {
+  return sql`
     INSERT INTO bangumi (id, title, title_cn, cover_url, summary, rating, eps_count, air_date)
     VALUES (${row.id}, ${row.title}, ${row.title_cn}, ${row.cover_url},
             ${row.summary}, ${row.rating}, ${row.eps_count}, ${row.air_date})
@@ -78,28 +98,29 @@ async function upsertBangumi(db: DbExecutor, row: BangumiRow): Promise<void> {
       title = EXCLUDED.title, title_cn = EXCLUDED.title_cn, cover_url = EXCLUDED.cover_url,
       summary = EXCLUDED.summary, rating = EXCLUDED.rating,
       eps_count = EXCLUDED.eps_count, air_date = EXCLUDED.air_date
-  `);
+  `;
 }
 
-/** UPSERT every point row keyed by id (idempotent re-enrich, no duplicates). */
-async function upsertPoints(db: DbExecutor, rows: PointRow[]): Promise<void> {
-  for (const row of rows) await upsertPoint(db, row);
-}
-
-/** UPSERT one `points` row; the sync_points_coordinates trigger fills location. */
-async function upsertPoint(db: DbExecutor, row: PointRow): Promise<void> {
-  await db.execute(sql`
+/** UPSERT all point rows in one statement; an empty point set remains a no-op. */
+function upsertPoints(rows: PointRow[]): SQL[] {
+  if (rows.length === 0) return [];
+  return [sql`
     INSERT INTO points (id, bangumi_id, name, name_cn, latitude, longitude,
                         image, episode, time_seconds, origin, origin_url)
-    VALUES (${row.id}, ${row.bangumi_id}, ${row.name}, ${row.name_cn},
-            ${row.latitude}, ${row.longitude}, ${row.image}, ${row.episode},
-            ${row.time_seconds}, ${row.origin}, ${row.origin_url})
+    VALUES ${sql.join(rows.map(pointValues), sql`, `)}
     ON CONFLICT (id) DO UPDATE SET
       bangumi_id = EXCLUDED.bangumi_id, name = EXCLUDED.name, name_cn = EXCLUDED.name_cn,
       latitude = EXCLUDED.latitude, longitude = EXCLUDED.longitude, image = EXCLUDED.image,
       episode = EXCLUDED.episode, time_seconds = EXCLUDED.time_seconds,
       origin = EXCLUDED.origin, origin_url = EXCLUDED.origin_url
-  `);
+  `];
+}
+
+/** Parameterized VALUES tuple for the bulk point UPSERT. */
+function pointValues(row: PointRow): SQL {
+  return sql`(${row.id}, ${row.bangumi_id}, ${row.name}, ${row.name_cn},
+              ${row.latitude}, ${row.longitude}, ${row.image}, ${row.episode},
+              ${row.time_seconds}, ${row.origin}, ${row.origin_url})`;
 }
 
 /** Compute 50m clusters (no cluster_id column to persist) and log the count. */
@@ -109,10 +130,15 @@ function logClusters(workId: string, points: PointRow[]): number {
   return clusters.length;
 }
 
-/** Rank the work's title aliases and UPSERT them into the `aliases` table. */
-async function upsertAliases(db: DbExecutor, workId: string, b: BangumiRow): Promise<void> {
-  const ranked = rankAliases(titleAliases(b));
-  for (const a of ranked) await upsertAlias(db, workId, a);
+/** Rank the work's title aliases and UPSERT them in one statement. */
+function upsertAliases(workId: string, b: BangumiRow): SQL {
+  const aliases = rankAliases(titleAliases(b));
+  return sql`
+    INSERT INTO aliases (work_id, alias, alias_normalized, source, priority)
+    VALUES ${sql.join(aliases.map((alias) => aliasValues(workId, alias)), sql`, `)}
+    ON CONFLICT (work_id, alias, source)
+    DO UPDATE SET alias_normalized = EXCLUDED.alias_normalized, priority = EXCLUDED.priority
+  `;
 }
 
 /** Collect candidate aliases from the bangumi title fields (Bangumi source). */
@@ -122,12 +148,7 @@ function titleAliases(b: BangumiRow): RawAlias[] {
   return raw;
 }
 
-/** UPSERT one alias row keyed by (work_id, alias, source). */
-async function upsertAlias(db: DbExecutor, workId: string, a: RankedAlias): Promise<void> {
-  await db.execute(sql`
-    INSERT INTO aliases (work_id, alias, alias_normalized, source, priority)
-    VALUES (${workId}, ${a.alias}, ${a.alias_normalized}, ${a.source}, ${a.priority})
-    ON CONFLICT (work_id, alias, source)
-    DO UPDATE SET alias_normalized = EXCLUDED.alias_normalized, priority = EXCLUDED.priority
-  `);
+/** Parameterized VALUES tuple for the bulk alias UPSERT. */
+function aliasValues(workId: string, a: RankedAlias): SQL {
+  return sql`(${workId}, ${a.alias}, ${a.alias_normalized}, ${a.source}, ${a.priority})`;
 }

--- a/workers/catalog/src/publish/versioning.ts
+++ b/workers/catalog/src/publish/versioning.ts
@@ -4,48 +4,61 @@
  *   id, work_id, version, is_current, created_at, with the partial unique index
  *   `uq_cluster_version_one_current` (work_id) WHERE is_current.
  *
- * A publish is a blue/green pointer switch done in ONE transaction: flip any
- * current row to is_current=false, THEN insert the new row with is_current=true.
- * The flip-then-insert order is mandatory — insert-then-flip would momentarily
- * leave two current rows and violate the partial unique index. The transaction
- * makes the swap all-or-nothing, so a reader never sees zero or two current rows.
+ * A publish is a blue/green pointer switch done in ONE server-side batch
+ * transaction: flip any current row to is_current=false, THEN insert the new row
+ * with is_current=true. The flip-then-insert order is mandatory — reversing it
+ * would momentarily leave two current rows and violate the partial unique index.
+ * The batch makes the swap all-or-nothing, so a reader never sees zero or two
+ * current rows.
  *
  * Writes go through raw `sql` execute (the Drizzle read schema is query-only),
  * consistent with the ingest/raw-store cards owning all mutations.
  */
-import { sql } from "drizzle-orm";
-import type { CatalogDb, DbExecutor } from "../db/client";
+import { sql, type SQL } from "drizzle-orm";
+import type { CatalogDb } from "../db/client";
+
+interface PublishedVersionRow extends Record<string, unknown> {
+  version: number;
+}
 
 /** Publish a new version for a work; returns the new version number. */
 export async function publishVersion(db: CatalogDb, workId: string): Promise<number> {
-  return db.transaction(async (tx) => {
-    const next = await nextVersion(tx, workId);
-    await flipCurrentOff(tx, workId);
-    await insertCurrent(tx, workId, next);
-    return next;
-  });
+  const [flip, insert] = publishVersionStatements(workId);
+  const [, inserted] = await db.batch([
+    db.execute(flip),
+    db.execute<PublishedVersionRow>(insert),
+  ]);
+  return readPublishedVersion(inserted);
 }
 
-/** Compute max(version)+1 for the work (1 when none exist yet). */
-async function nextVersion(tx: DbExecutor, workId: string): Promise<number> {
-  const rows = (
-    await tx.execute(
-      sql`SELECT COALESCE(MAX(version), 0) + 1 AS next FROM cluster_version WHERE work_id = ${workId}`,
-    )
-  ).rows as { next: number }[];
-  return rows[0]?.next ?? 1;
+/** Ordered flip + insert-select statements shared by standalone and enrich batches. */
+export function publishVersionStatements(
+  workId: string,
+): readonly [SQL, SQL<PublishedVersionRow>] {
+  return [flipCurrentOff(workId), insertCurrent(workId)];
 }
 
 /** Flip the work's current row (if any) to is_current=false. */
-async function flipCurrentOff(tx: DbExecutor, workId: string): Promise<void> {
-  await tx.execute(
-    sql`UPDATE cluster_version SET is_current = FALSE WHERE work_id = ${workId} AND is_current`,
-  );
+function flipCurrentOff(workId: string): SQL {
+  return sql`UPDATE cluster_version SET is_current = FALSE WHERE work_id = ${workId} AND is_current`;
 }
 
-/** Insert the new version as the single current row for the work. */
-async function insertCurrent(tx: DbExecutor, workId: string, version: number): Promise<void> {
-  await tx.execute(
-    sql`INSERT INTO cluster_version (work_id, version, is_current) VALUES (${workId}, ${version}, TRUE)`,
-  );
+/** Atomically derive and insert max(version)+1 (1 when no row exists). */
+function insertCurrent(workId: string): SQL<PublishedVersionRow> {
+  return sql<PublishedVersionRow>`
+    INSERT INTO cluster_version (work_id, version, is_current)
+    SELECT ${workId}, COALESCE(MAX(version), 0) + 1, TRUE
+    FROM cluster_version WHERE work_id = ${workId}
+    RETURNING version
+  `;
+}
+
+/** Read and validate the INSERT ... RETURNING version batch result. */
+export function readPublishedVersion(result: { rows: unknown[] }): number {
+  const row = result.rows[0];
+  if (typeof row !== "object" || row === null || !("version" in row)) {
+    throw new Error("publish batch returned no version");
+  }
+  if (typeof row.version !== "number") throw new Error("publish batch returned an invalid version");
+  return row.version;
 }

--- a/workers/catalog/test/catalog-api.spike.test.ts
+++ b/workers/catalog/test/catalog-api.spike.test.ts
@@ -166,8 +166,12 @@ const NEW_TITLE = "けいおん！";
 
 /** Stub upstream JSON for the NEW work: a Bangumi subject + two Anitabi points. */
 function stubUpstream(): void {
-  const stub = vi.fn((input: string | URL | Request) => {
+  // The neon serverless driver rides global fetch too (Phase B: the DB channel
+  // is HTTP) — pass its /sql traffic through to the real fetch, init included.
+  const realFetch = globalThis.fetch;
+  const stub = vi.fn((input: string | URL | Request, init?: RequestInit) => {
     const url = input instanceof Request ? input.url : input.toString();
+    if (url.includes("/sql")) return realFetch(input, init);
     if (url.includes("/v0/subjects/")) return Promise.resolve(jsonResponse({ name: NEW_TITLE, name_cn: "轻音少女" }));
     if (url.includes("/points/detail")) return Promise.resolve(jsonResponse(ANITABI_POINTS));
     throw new Error(`unexpected upstream url: ${url}`);
@@ -189,8 +193,10 @@ const MISS_TITLE = "響け！ユーフォニアム";
  */
 function stubSearchMiss(): { urls: string[] } {
   const urls: string[] = [];
-  const stub = vi.fn((input: string | URL | Request) => {
+  const realFetch = globalThis.fetch;
+  const stub = vi.fn((input: string | URL | Request, init?: RequestInit) => {
     const url = input instanceof Request ? input.url : input.toString();
+    if (url.includes("/sql")) return realFetch(input, init);
     urls.push(url);
     return Promise.resolve(searchMissResponse(url));
   });

--- a/workers/catalog/test/catalog-api.spike.test.ts
+++ b/workers/catalog/test/catalog-api.spike.test.ts
@@ -4,7 +4,6 @@ import type { CatalogDb } from "../src/db/client";
 import app, { closeDbPools } from "../src/index";
 import {
   databaseDescribe,
-  databaseDescribeKnownFailing,
   localDatabaseUrl,
   openServerlessDb,
   restoreNeonConfig,
@@ -229,7 +228,7 @@ const ANITABI_POINTS = [
   { id: "toyosato-hall", name: "豊郷小学校 講堂", lat: 35.205, lng: 136.2401, ep: 2, s: 90 },
 ];
 
-databaseDescribeKnownFailing("#362", "Catalog ingest end-to-end (fetch stub -> raw -> enrich -> publish -> search)", () => {
+databaseDescribe("Catalog ingest end-to-end (fetch stub -> raw -> enrich -> publish -> search)", () => {
   it("POST /ingest publishes the work, then /search returns the fresh points", async () => {
     stubUpstream();
 
@@ -247,7 +246,7 @@ databaseDescribeKnownFailing("#362", "Catalog ingest end-to-end (fetch stub -> r
   });
 });
 
-databaseDescribeKnownFailing("#362", "Catalog search miss -> Bangumi resolve -> on-demand ingest -> points", () => {
+databaseDescribe("Catalog search miss -> Bangumi resolve -> on-demand ingest -> points", () => {
   it("an UNCOVERED title resolves+ingests on first search, then is an alias hit on the second", async () => {
     const { urls } = stubSearchMiss();
 

--- a/workers/catalog/test/enrich.spike.test.ts
+++ b/workers/catalog/test/enrich.spike.test.ts
@@ -5,7 +5,6 @@ import { saveRawAnitabi, saveRawBangumi } from "../src/ingest/raw-store";
 import { enrichWork } from "../src/enrich/enrich";
 import {
   databaseDescribe,
-  databaseDescribeKnownFailing,
   openServerlessDb,
   restoreNeonConfig,
   truncateCatalog,
@@ -110,7 +109,7 @@ async function assertEnrichAliases(): Promise<void> {
   expect(rows.every((r) => r.source === "bangumi")).toBe(true);
 }
 
-databaseDescribeKnownFailing("#362", "enrichWork composes raw zone -> enriched catalog -> publish", () => {
+databaseDescribe("enrichWork composes raw zone -> enriched catalog -> publish", () => {
   it("returns the published version and point count", async () => {
     const result = await enrichWork(db, "lucky-star");
     expect(result.version).toBe(1);
@@ -139,7 +138,7 @@ databaseDescribeKnownFailing("#362", "enrichWork composes raw zone -> enriched c
   });
 });
 
-databaseDescribeKnownFailing("#362", "re-enrich from raw is idempotent and publishes a new version", () => {
+databaseDescribe("re-enrich from raw is idempotent and publishes a new version", () => {
   it("does not duplicate points and bumps to a new current version", async () => {
     const result = await enrichWork(db, "lucky-star");
     expect(result.version).toBe(2);

--- a/workers/catalog/test/ingest-orchestrator.spike.test.ts
+++ b/workers/catalog/test/ingest-orchestrator.spike.test.ts
@@ -131,12 +131,12 @@ afterAll(() => { restoreNeonConfig(); });
 
 databaseDescribe("ingestWork end-to-end: acquire -> fetch -> raw -> enrich -> publish", () => {
   it("ingests a new work and lands it in the catalog with a current version", async () => {
-    const result = await ingestWork(db, "new-work", { fetchImpl: makeFetch(ANITABI_POINTS) });
+    const result = await ingestWork(db, "460100", { fetchImpl: makeFetch(ANITABI_POINTS) });
     expect(result).toEqual({ status: "ingested", version: 1, pointCount: 2 });
-    expect(await bangumiExists("new-work")).toBe(true);
-    expect(await pointCount("new-work")).toBe(2);
-    expect(await currentVersion("new-work")).toBe(1);
-    expect(await jobStatus("new-work")).toBe("done");
+    expect(await bangumiExists("460100")).toBe(true);
+    expect(await pointCount("460100")).toBe(2);
+    expect(await currentVersion("460100")).toBe(1);
+    expect(await jobStatus("460100")).toBe("done");
   });
 });
 
@@ -145,51 +145,51 @@ databaseDescribe("ingestWork singleflight: concurrent double ingest", () => {
     let release: () => void = () => { /* placeholder replaced by Promise constructor */ };
     const gate = new Promise<void>((r) => (release = r));
     // Winner parks in fetch (job 'running'); loser's acquire then loses the race.
-    const winner = ingestWork(db, "race-work", { fetchImpl: makeGatedFetch(gate) });
-    await awaitRunning("race-work");
-    const loser = await ingestWork(db, "race-work", { fetchImpl: makeFetch(ANITABI_POINTS) });
+    const winner = ingestWork(db, "460101", { fetchImpl: makeGatedFetch(gate) });
+    await awaitRunning("460101");
+    const loser = await ingestWork(db, "460101", { fetchImpl: makeFetch(ANITABI_POINTS) });
     release();
     const a = await winner;
     const statuses = [a.status, loser.status].sort();
     expect(statuses).toEqual(["in_progress", "ingested"]);
-    expect(await currentVersion("race-work")).toBe(1);
+    expect(await currentVersion("460101")).toBe(1);
   });
 });
 
 databaseDescribe("ingestWork empty upstream: no points", () => {
   it("returns 'empty', negative-caches, and blocks re-ingest within TTL", async () => {
     const fetchImpl = makeFetch([]);
-    const result = await ingestWork(db, "empty-work", { fetchImpl });
+    const result = await ingestWork(db, "460102", { fetchImpl });
     expect(result.status).toBe("empty");
-    expect(await jobStatus("empty-work")).toBe("failed");
-    expect(await bangumiExists("empty-work")).toBe(false);
-    const retry = await ingestWork(db, "empty-work", { fetchImpl });
+    expect(await jobStatus("460102")).toBe("failed");
+    expect(await bangumiExists("460102")).toBe(false);
+    const retry = await ingestWork(db, "460102", { fetchImpl });
     expect(retry.status).toBe("empty");
   });
 
   it("parks an upstream 404 for seven days and exposes a genuine-empty guard", async () => {
-    const result = await ingestWork(db, "404-work", { fetchImpl: notFoundFetch });
-    const ttl = await negativeCacheSeconds("404-work");
+    const result = await ingestWork(db, "460104", { fetchImpl: notFoundFetch });
+    const ttl = await negativeCacheSeconds("460104");
 
     expect(result.status).toBe("empty");
     expect(ttl).toBeGreaterThan(6 * 24 * 60 * 60);
     expect(ttl).toBeLessThanOrEqual(7 * 24 * 60 * 60);
-    await expect(ingestGuard(db, "404-work")).resolves.toBe("empty");
+    await expect(ingestGuard(db, "460104")).resolves.toBe("empty");
   });
 });
 
 databaseDescribe("ingestWork failed upstream: fetch throws", () => {
   it("throws typed upstream-unavailable and leaves a re-acquirable job", async () => {
-    await expect(ingestWork(db, "boom-work", { fetchImpl: throwingFetch })).rejects.toMatchObject({
+    await expect(ingestWork(db, "460103", { fetchImpl: throwingFetch })).rejects.toMatchObject({
       code: "UPSTREAM_UNAVAILABLE",
       defined: true,
       status: 502,
     });
-    expect(await jobStatus("boom-work")).toBe("failed");
+    expect(await jobStatus("460103")).toBe("failed");
     // After the negative-cache TTL elapses the work re-acquires and succeeds.
-    await backdateNegativeCache("boom-work");
-    const retry = await ingestWork(db, "boom-work", { fetchImpl: makeFetch(ANITABI_POINTS) });
+    await backdateNegativeCache("460103");
+    const retry = await ingestWork(db, "460103", { fetchImpl: makeFetch(ANITABI_POINTS) });
     expect(retry.status).toBe("ingested");
-    expect(await jobStatus("boom-work")).toBe("done");
+    expect(await jobStatus("460103")).toBe("done");
   });
 });

--- a/workers/catalog/test/ingest-orchestrator.spike.test.ts
+++ b/workers/catalog/test/ingest-orchestrator.spike.test.ts
@@ -4,7 +4,7 @@ import type { CatalogDb } from "../src/db/client";
 import { ingestGuard, ingestWork } from "../src/ingest/orchestrator";
 import type { FetchLike } from "../src/ingest/sources";
 import {
-  databaseDescribeKnownFailing,
+  databaseDescribe,
   openServerlessDb,
   restoreNeonConfig,
   truncateCatalog,
@@ -129,7 +129,7 @@ beforeAll(async () => {
 
 afterAll(() => { restoreNeonConfig(); });
 
-databaseDescribeKnownFailing("#362", "ingestWork end-to-end: acquire -> fetch -> raw -> enrich -> publish", () => {
+databaseDescribe("ingestWork end-to-end: acquire -> fetch -> raw -> enrich -> publish", () => {
   it("ingests a new work and lands it in the catalog with a current version", async () => {
     const result = await ingestWork(db, "new-work", { fetchImpl: makeFetch(ANITABI_POINTS) });
     expect(result).toEqual({ status: "ingested", version: 1, pointCount: 2 });
@@ -140,7 +140,7 @@ databaseDescribeKnownFailing("#362", "ingestWork end-to-end: acquire -> fetch ->
   });
 });
 
-databaseDescribeKnownFailing("#362", "ingestWork singleflight: concurrent double ingest", () => {
+databaseDescribe("ingestWork singleflight: concurrent double ingest", () => {
   it("yields exactly one 'ingested' and one 'in_progress'", async () => {
     let release: () => void = () => { /* placeholder replaced by Promise constructor */ };
     const gate = new Promise<void>((r) => (release = r));
@@ -156,7 +156,7 @@ databaseDescribeKnownFailing("#362", "ingestWork singleflight: concurrent double
   });
 });
 
-databaseDescribeKnownFailing("#362", "ingestWork empty upstream: no points", () => {
+databaseDescribe("ingestWork empty upstream: no points", () => {
   it("returns 'empty', negative-caches, and blocks re-ingest within TTL", async () => {
     const fetchImpl = makeFetch([]);
     const result = await ingestWork(db, "empty-work", { fetchImpl });
@@ -178,7 +178,7 @@ databaseDescribeKnownFailing("#362", "ingestWork empty upstream: no points", () 
   });
 });
 
-databaseDescribeKnownFailing("#362", "ingestWork failed upstream: fetch throws", () => {
+databaseDescribe("ingestWork failed upstream: fetch throws", () => {
   it("throws typed upstream-unavailable and leaves a re-acquirable job", async () => {
     await expect(ingestWork(db, "boom-work", { fetchImpl: throwingFetch })).rejects.toMatchObject({
       code: "UPSTREAM_UNAVAILABLE",

--- a/workers/catalog/test/neon-batch.spike.test.ts
+++ b/workers/catalog/test/neon-batch.spike.test.ts
@@ -1,0 +1,90 @@
+import { expect, it, vi } from "vitest";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm";
+import type { CatalogDb } from "../src/db/client";
+import { enrichWork } from "../src/enrich/enrich";
+import { publishVersion } from "../src/publish/versioning";
+
+interface CapturedQuery extends Promise<{ rows: unknown[] }> {
+  statement: SQL;
+}
+
+const RAW_BANGUMI = { name: "Batch Anime", name_cn: "批次动画" };
+const RAW_ANITABI = [
+  { id: "point-1", name: "Batch Place", geo: [35, 139] },
+  { id: "point-2", name: "Second Place", geo: [36, 140] },
+];
+const dialect = new PgDialect();
+
+function queryText(statement: SQL): string {
+  return dialect.sqlToQuery(statement).sql.replaceAll(/\s+/g, " ").trim();
+}
+
+function queryParams(statement: SQL): unknown[] {
+  return dialect.sqlToQuery(statement).params;
+}
+
+function queryResult(statement: SQL): { rows: unknown[] } {
+  const text = queryText(statement);
+  if (text.includes("FROM raw_bangumi")) return { rows: [{ payload: RAW_BANGUMI }] };
+  if (text.includes("FROM raw_anitabi")) return { rows: [{ payload: RAW_ANITABI }] };
+  return { rows: [] };
+}
+
+function capturedQuery(statement: SQL): CapturedQuery {
+  return Object.assign(Promise.resolve(queryResult(statement)), { statement });
+}
+
+function fakeDb(version: number): {
+  db: CatalogDb;
+  batch: ReturnType<typeof vi.fn<(queries: readonly CapturedQuery[]) => Promise<{ rows: unknown[] }[]>>>;
+} {
+  const execute = vi.fn(capturedQuery);
+  const batch = vi.fn((queries: readonly CapturedQuery[]) =>
+    Promise.resolve(queries.map((_query, index) =>
+      index === queries.length - 1 ? { rows: [{ version }] } : { rows: [] })),
+  );
+  return { db: { execute, batch } as unknown as CatalogDb, batch };
+}
+
+function submittedTexts(
+  batch: ReturnType<typeof vi.fn<(queries: readonly CapturedQuery[]) => Promise<{ rows: unknown[] }[]>>>,
+): string[] {
+  return (batch.mock.calls[0]?.[0] ?? []).map((query) => queryText(query.statement));
+}
+
+function statementAt(queries: readonly CapturedQuery[], index: number): SQL {
+  const query = queries[index];
+  if (!query) throw new Error(`batch query ${String(index)} was not submitted`);
+  return query.statement;
+}
+
+it("publishes with one ordered neon-http batch", async () => {
+  const { db, batch } = fakeDb(7);
+  await expect(publishVersion(db, "batch-work")).resolves.toBe(7);
+  expect(batch).toHaveBeenCalledTimes(1);
+  const texts = submittedTexts(batch);
+  expect(texts).toHaveLength(2);
+  expect(texts[0]).toMatch(/^UPDATE cluster_version SET is_current = FALSE/);
+  expect(texts[1]).toMatch(/^INSERT INTO cluster_version .* SELECT .*MAX\(version\).* RETURNING version$/);
+});
+
+it("submits all enrich writes in one ordered neon-http batch", async () => {
+  const { db, batch } = fakeDb(11);
+  await expect(enrichWork(db, "batch-work")).resolves.toEqual({ version: 11, pointCount: 2 });
+  expect(batch).toHaveBeenCalledTimes(1);
+  const texts = submittedTexts(batch);
+  expect(texts).toHaveLength(5);
+  expect(texts.map((text) => text.split(" ").slice(0, 3).join(" "))).toEqual([
+    "INSERT INTO bangumi", "INSERT INTO points", "INSERT INTO aliases",
+    "UPDATE cluster_version SET", "INSERT INTO cluster_version",
+  ]);
+  const submitted = batch.mock.calls[0]?.[0] ?? [];
+  expect(queryParams(statementAt(submitted, 1))).toEqual(
+    expect.arrayContaining(["point-1", "point-2"]),
+  );
+  expect(queryParams(statementAt(submitted, 2))).toEqual(
+    expect.arrayContaining(["Batch Anime", "批次动画"]),
+  );
+  expect(texts[4]).toMatch(/SELECT .*MAX\(version\).* RETURNING version$/);
+});

--- a/workers/catalog/test/publish.spike.test.ts
+++ b/workers/catalog/test/publish.spike.test.ts
@@ -5,7 +5,7 @@ import { publishVersion } from "../src/publish/versioning";
 import { getRouteSnapshot, saveRouteSnapshot } from "../src/publish/snapshots";
 import { gcOldVersions } from "../src/publish/gc";
 import {
-  databaseDescribeKnownFailing,
+  databaseDescribe,
   openServerlessDb,
   restoreNeonConfig,
   truncateCatalog,
@@ -47,7 +47,7 @@ beforeAll(async () => {
 
 afterAll(() => { restoreNeonConfig(); });
 
-databaseDescribeKnownFailing("#362", "publishVersion atomic version switch over cluster_version", () => {
+databaseDescribe("publishVersion atomic version switch over cluster_version", () => {
   it("publishes v1 as the single current version", async () => {
     const v = await publishVersion(db, "switch");
     expect(v).toBe(1);
@@ -70,7 +70,7 @@ databaseDescribeKnownFailing("#362", "publishVersion atomic version switch over 
   });
 });
 
-databaseDescribeKnownFailing("#362", "saveRouteSnapshot binds a route to a version so it never drifts", () => {
+databaseDescribe("saveRouteSnapshot binds a route to a version so it never drifts", () => {
   it("reads back a v1 snapshot unchanged after v2 publishes (no drift)", async () => {
     await publishVersion(db, "drift");
     await saveRouteSnapshot(db, "drift", 1, { order: ["a", "b"] });
@@ -80,7 +80,7 @@ databaseDescribeKnownFailing("#362", "saveRouteSnapshot binds a route to a versi
   });
 });
 
-databaseDescribeKnownFailing("#362", "gcOldVersions keeps the newest N and never the current", () => {
+databaseDescribe("gcOldVersions keeps the newest N and never the current", () => {
   it("removes v1 but never the current version with keep=1", async () => {
     await publishVersion(db, "gc");
     await publishVersion(db, "gc");


### PR DESCRIPTION
Closes #362. Owner-approved Plan 1 (batch-ify).

## Production fix

`db.transaction()` on the drizzle **neon-http** driver throws unconditionally (`No transactions support in neon-http driver`) — every in-worker ingest flow (enrich → publish) 500'd. Replaced with **`db.batch(...)`** (drizzle 0.45.2 prepares the queries and submits ONE `client.transaction([...])` — a single atomic server-side transaction; the exact path Phase-0 proved live).

- `publish/versioning.ts`: the only in-transaction read (`SELECT MAX`) is inlined as `INSERT … SELECT COALESCE(MAX(version),0)+1 … RETURNING version`; flip-then-insert order preserved (blue/green pointer-switch doc kept). New shared `publishVersionStatements()` for composition.
- `enrich/enrich.ts`: nested transaction + `tx as unknown as CatalogDb` cast removed; bangumi/points/aliases upserts + the two publish statements compose into ONE five-statement batch; version read from the batch's RETURNING result.
- `grep -r '\.transaction(' src/` → zero matches.

## Tests

- New `neon-batch.spike.test.ts`: asserts exactly one batch call, flip-before-insert order, five-statement enrich shape, parameter preservation.
- **All 19 `#362` known-failing spikes unlocked**; acceptance peeled two more fixture-era issues on the way:
  - fossil work ids ("empty-work" etc.) predating the `BANGUMI_ID_RE = /^\d+$/` validation → numeric ids;
  - `vi.stubGlobal("fetch")` hijacked the DB channel (since Phase B the neon driver rides global fetch) → stubs now pass `/sql` through with `init` forwarded.

## Verification (lead, live)

- oxlint / tsc clean; worker suite **232 passed**
- Full spike suite with Neon Local + ephemeral cloud branch: **69 passed / 4 skipped (#363) / 0 failed** — including singleflight concurrency, negative-cache TTL, 404 parking, and concurrent double-publish (exactly one current row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)