### PR TITLE
feat(catalog): E2 #275 — S5.4 public animeOverview route (first public exposure)

### DIFF
--- a/packages/contract/openapi.json
+++ b/packages/contract/openapi.json
@@ -1635,6 +1635,148 @@
           }
         }
       }
+    },
+    "/catalog/public/anime-overview/{bangumi_id}": {
+      "get": {
+        "operationId": "animeOverview",
+        "summary": "Public anime overview: bubble aggregation, 名場面 ranking, and sample routes",
+        "parameters": [
+          {
+            "name": "bangumi_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d+$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bangumi_id": {
+                      "type": "string"
+                    },
+                    "points_length": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "circles": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "region": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "lat": {
+                            "type": "number",
+                            "minimum": -90,
+                            "maximum": 90
+                          },
+                          "lng": {
+                            "type": "number",
+                            "minimum": -180,
+                            "maximum": 180
+                          }
+                        },
+                        "required": [
+                          "region",
+                          "count",
+                          "lat",
+                          "lng"
+                        ]
+                      }
+                    },
+                    "scenes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "screenshot_url": {
+                            "type": "string"
+                          },
+                          "shot_count": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "lat": {
+                            "type": "number",
+                            "minimum": -90,
+                            "maximum": 90
+                          },
+                          "lng": {
+                            "type": "number",
+                            "minimum": -180,
+                            "maximum": 180
+                          },
+                          "city": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "screenshot_url",
+                          "shot_count",
+                          "lat",
+                          "lng"
+                        ]
+                      }
+                    },
+                    "sample_routes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "region": {
+                            "type": "string"
+                          },
+                          "point_ids": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "region",
+                          "point_ids"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "bangumi_id",
+                    "points_length",
+                    "circles",
+                    "scenes",
+                    "sample_routes"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/packages/contract/src/contract.ts
+++ b/packages/contract/src/contract.ts
@@ -9,6 +9,7 @@ import { oc } from "@orpc/contract";
 import { z } from "zod";
 import { pickCatalogErrors } from "./errors.js";
 import {
+  AnimeOverview,
   IngestResult,
   Latitude,
   Longitude,
@@ -112,6 +113,12 @@ export const IngestInput = z.object({
 });
 export type IngestInput = z.infer<typeof IngestInput>;
 
+/** animeOverview(bangumi_id) -> AnimeOverview (public, anonymous, read-only GET) */
+export const AnimeOverviewInput = z.object({
+  bangumi_id: z.string().regex(/^\d+$/),
+});
+export type AnimeOverviewInput = z.infer<typeof AnimeOverviewInput>;
+
 export const catalogContract = {
   search: oc
     .route({ method: "POST", path: "/catalog/search", summary: "Search pilgrimage points by anime title" })
@@ -159,6 +166,14 @@ export const catalogContract = {
     .input(IngestInput)
     .errors(pickCatalogErrors(["UPSTREAM_UNAVAILABLE"]))
     .output(IngestResult),
+  animeOverview: oc
+    .route({
+      method: "GET",
+      path: "/catalog/public/anime-overview/{bangumi_id}",
+      summary: "Public anime overview: bubble aggregation, 名場面 ranking, and sample routes",
+    })
+    .input(AnimeOverviewInput)
+    .output(AnimeOverview),
 };
 
 export type CatalogContract = typeof catalogContract;

--- a/packages/contract/src/models.ts
+++ b/packages/contract/src/models.ts
@@ -51,6 +51,55 @@ export const PilgrimagePoint = z.object({
 });
 export type PilgrimagePoint = z.infer<typeof PilgrimagePoint>;
 
+/**
+ * One region bubble for the public anime overview: a place name, its spot count,
+ * and the centroid coordinate the bubble map renders at. Public catalog data
+ * only — no user or internal pipeline fields.
+ */
+export const AnimeOverviewCircle = z.object({
+  region: z.string(),
+  count: z.number().int().nonnegative(),
+  lat: Latitude,
+  lng: Longitude,
+});
+export type AnimeOverviewCircle = z.infer<typeof AnimeOverviewCircle>;
+
+/**
+ * One 名場面 (famous scene) in the public shot-count ranking: the representative
+ * point of a co-located cluster, its thumbnail, and how many shots it aggregates.
+ */
+export const AnimeScene = z.object({
+  id: z.string(),
+  name: z.string(),
+  screenshot_url: z.string(),
+  shot_count: z.number().int().nonnegative(),
+  lat: Latitude,
+  lng: Longitude,
+  city: z.string().optional(),
+});
+export type AnimeScene = z.infer<typeof AnimeScene>;
+
+/** A suggested per-region sample route: the region name plus its member point ids. */
+export const AnimeSampleRoute = z.object({
+  region: z.string(),
+  point_ids: z.array(z.string()),
+});
+export type AnimeSampleRoute = z.infer<typeof AnimeSampleRoute>;
+
+/**
+ * The public anime overview payload: bubble aggregation, 名場面 ranking, and
+ * sample routes for one work. Exposed anonymously (catalog's first public
+ * surface) — every field is derived from already-public catalog data.
+ */
+export const AnimeOverview = z.object({
+  bangumi_id: z.string(),
+  points_length: z.number().int().nonnegative(),
+  circles: z.array(AnimeOverviewCircle),
+  scenes: z.array(AnimeScene),
+  sample_routes: z.array(AnimeSampleRoute),
+});
+export type AnimeOverview = z.infer<typeof AnimeOverview>;
+
 /** Stable catalog identity and trusted display metadata for one anime work. */
 export const AnimeCandidate = z.object({
   bangumi_id: z.string(),

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -21,6 +21,22 @@ function isPublicV1(pathname: string): boolean {
   return PUBLIC_V1.includes(pathname) || /^\/v1\/bangumi\/[^/]+\/guide$/.test(pathname);
 }
 
+/** Catalog's ONLY public prefix: anonymous, read-only overview reads. Every
+ * other /catalog/* path stays private (falls through to OpenNext). */
+function isPublicCatalog(pathname: string): boolean {
+  return pathname.startsWith("/catalog/public/");
+}
+
+/** Forward an anonymous public-catalog read to the private CATALOG binding
+ * (in-datacenter hop). Strips client-supplied X-User-* (anti-forgery); no auth,
+ * no body mutation — read-only. */
+function forwardPublicCatalog(env: Env, request: Request): Promise<Response> {
+  const headers = new Headers(request.headers);
+  headers.delete("X-User-Id");
+  headers.delete("X-User-Type");
+  return env.CATALOG.fetch(new Request(request, { headers }));
+}
+
 /** Forward a /v1 request to the container's default instance. Always strips
  * client-supplied X-User-* (anti-forgery); on authed paths also strips
  * Authorization and injects the worker-verified identity. */
@@ -81,6 +97,14 @@ export function createWorkerApp(deps: {
     c.env.CONTAINER.get(c.env.CONTAINER.idFromName("default")).fetch(c.req.raw),
   );
   app.all("/img/*", (c) => handleImageProxy(c.req.raw, c.executionCtx));
+  // Catalog's first public exposure: /catalog/public/* is anonymous + read-only,
+  // forwarded to the private CATALOG binding. Anything else under /catalog/*
+  // stays private and falls through to OpenNext (never reaches env.CATALOG).
+  app.all("/catalog/public/*", (c) =>
+    isPublicCatalog(new URL(c.req.url).pathname)
+      ? forwardPublicCatalog(c.env, c.req.raw)
+      : c.notFound(),
+  );
   // Hono runs the first matching handler in registration order.
   // /v1/users/* bypasses the container entirely: the users service verifies the
   // Neon Auth JWT itself (jose JWKS), so the edge passes Authorization through

--- a/worker/entry.test.ts
+++ b/worker/entry.test.ts
@@ -24,8 +24,33 @@ test("GET /healthz reaches the container, not OpenNext", async () => {
 
 test("/catalog/* is NOT publicly routed (falls through to OpenNext)", async () => {
   const app = createWorkerApp({ nextHandler: stubNext });
-  const res = await app.request("/catalog/search", { method: "POST" }, {}, stubCtx);
+  let catalogHit = false;
+  const env = { CATALOG: { fetch: async () => { catalogHit = true; return new Response("cat"); } } } as never;
+  const res = await app.request("/catalog/search", { method: "POST" }, env, stubCtx);
   assert.equal(await res.text(), "next"); // hits OpenNext (404-able), never env.CATALOG
+  assert.equal(catalogHit, false); // security: non-allowlisted catalog path stays private
+});
+
+function envWithCatalog(captured: { req?: Request }) {
+  return {
+    CATALOG: { fetch: async (r: Request) => { captured.req = r; return new Response("cat"); } },
+  } as never;
+}
+
+test("/catalog/public/* forwards anonymously to CATALOG, no auth called", async () => {
+  let authCalled = false;
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => { authCalled = true; return { ok: false }; } });
+  const cap: { req?: Request } = {};
+  const res = await app.request("/catalog/public/anime-overview/3302", {}, envWithCatalog(cap), stubCtx);
+  assert.equal(await res.text(), "cat");
+  assert.equal(authCalled, false);
+});
+
+test("/catalog/public/* strips client-forged X-User-Id before forwarding", async () => {
+  const app = createWorkerApp({ nextHandler: stubNext });
+  const cap: { req?: Request } = {};
+  await app.request("/catalog/public/anime-overview/3302", { headers: { "X-User-Id": "forged" } }, envWithCatalog(cap), stubCtx);
+  assert.equal(cap.req?.headers.get("X-User-Id"), null);
 });
 
 test("unknown path falls through to OpenNext", async () => {

--- a/workers/catalog/src/api/anime-overview.ts
+++ b/workers/catalog/src/api/anime-overview.ts
@@ -1,0 +1,149 @@
+/**
+ * Public `animeOverview` read handler — catalog's first anonymous surface.
+ *
+ * Shape source of truth: packages/contract/src/contract.ts ->
+ *   animeOverview(bangumi_id) -> AnimeOverview
+ * Derives three views over a work's published points, all from already-public
+ * catalog data (no user or internal pipeline fields):
+ *   - `circles`: bubble aggregation grouped by region (city), with centroid.
+ *   - `scenes`: 名場面 ranking — co-located points (`clusterByLocation`, 50m)
+ *     collapse into one scene ranked by shot count.
+ *   - `sample_routes`: the top regions with their member point ids.
+ *
+ * Read-only: a single typed `db.execute(sql`...`)` following the geo-query.ts
+ * pattern. Wire shapes come from `../types` (import type erases at compile time,
+ * keeping the contract's zod runtime out of the Worker bundle).
+ */
+
+import { sql } from "drizzle-orm";
+import { clusterByLocation, type LocationCluster } from "../lib/clustering";
+import type { AnimeOverview, AnimeOverviewCircle, AnimeSampleRoute, AnimeScene } from "../types";
+
+export type { AnimeOverview };
+
+const SCENE_LIMIT = 20;
+const SAMPLE_ROUTE_REGION_LIMIT = 3;
+const SAMPLE_ROUTE_POINT_CAP = 12;
+const CLUSTER_RADIUS_M = 50;
+
+/** The one DB capability this handler needs: run a query, get back `{ rows }`. */
+export interface OverviewDb {
+  execute(query: ReturnType<typeof sql>): Promise<{ rows: unknown[] }>;
+}
+
+/** Raw column shape returned by the overview read query. */
+interface OverviewRow {
+  id: string;
+  name: string;
+  image: string | null;
+  latitude: number;
+  longitude: number;
+  city: string | null;
+}
+
+/** Assemble the public overview for one work; empty-but-valid when it has none. */
+export async function animeOverview(
+  db: OverviewDb,
+  input: { bangumi_id: string },
+): Promise<AnimeOverview> {
+  const rows = await fetchRows(db, input.bangumi_id);
+  return {
+    bangumi_id: input.bangumi_id,
+    points_length: rows.length,
+    circles: buildCircles(rows),
+    scenes: buildScenes(rows),
+    sample_routes: buildSampleRoutes(rows),
+  };
+}
+
+/** SELECT the work's points, id-ordered for deterministic downstream ordering. */
+async function fetchRows(db: OverviewDb, bangumiId: string): Promise<OverviewRow[]> {
+  const result = await db.execute(overviewQuery(bangumiId));
+  return result.rows as OverviewRow[];
+}
+
+function overviewQuery(bangumiId: string) {
+  return sql`
+    SELECT id, name, image, latitude, longitude, city
+    FROM points
+    WHERE bangumi_id = ${bangumiId}
+    ORDER BY id ASC
+  `;
+}
+
+/** Group rows by non-empty region (city), preserving id order within a region. */
+function groupByRegion(rows: OverviewRow[]): Map<string, OverviewRow[]> {
+  const groups = new Map<string, OverviewRow[]>();
+  for (const r of rows) {
+    if (!r.city) continue;
+    const bucket = groups.get(r.city) ?? [];
+    bucket.push(r);
+    groups.set(r.city, bucket);
+  }
+  return groups;
+}
+
+/** Region bubbles sorted by spot count desc, then region name asc. */
+function buildCircles(rows: OverviewRow[]): AnimeOverviewCircle[] {
+  const circles = [...groupByRegion(rows)].map(([region, members]) => toCircle(region, members));
+  return circles.sort((a, b) => b.count - a.count || a.region.localeCompare(b.region));
+}
+
+function toCircle(region: string, members: OverviewRow[]): AnimeOverviewCircle {
+  return { region, count: members.length, ...centroid(members) };
+}
+
+function centroid(members: OverviewRow[]): { lat: number; lng: number } {
+  const lat = members.reduce((acc, m) => acc + m.latitude, 0) / members.length;
+  const lng = members.reduce((acc, m) => acc + m.longitude, 0) / members.length;
+  return { lat, lng };
+}
+
+/** 名場面 ranking: co-located clusters ranked by shot count, capped. */
+function buildScenes(rows: OverviewRow[]): AnimeScene[] {
+  const scenes = clusterByLocation(rows, CLUSTER_RADIUS_M).map(toScene);
+  scenes.sort((a, b) => b.shot_count - a.shot_count || a.id.localeCompare(b.id));
+  return scenes.slice(0, SCENE_LIMIT);
+}
+
+function toScene(cluster: LocationCluster<OverviewRow>): AnimeScene {
+  const rep = representative(cluster);
+  const base = sceneBase(rep, cluster.photoCount);
+  return rep.city ? { ...base, city: rep.city } : base;
+}
+
+function sceneBase(rep: OverviewRow, shotCount: number): AnimeScene {
+  return {
+    id: rep.id,
+    name: rep.name,
+    screenshot_url: rep.image ?? "",
+    shot_count: shotCount,
+    lat: rep.latitude,
+    lng: rep.longitude,
+  };
+}
+
+/** The cluster's representative row (its `clusterId` member, always present). */
+function representative(cluster: LocationCluster<OverviewRow>): OverviewRow {
+  const rep = cluster.points.find((p) => p.id === cluster.clusterId);
+  if (!rep) throw new Error(`cluster ${cluster.clusterId} has no representative row`);
+  return rep;
+}
+
+/** One sample route per top region, listing its member point ids (capped). */
+function buildSampleRoutes(rows: OverviewRow[]): AnimeSampleRoute[] {
+  const groups = groupByRegion(rows);
+  return rankRegions(groups)
+    .slice(0, SAMPLE_ROUTE_REGION_LIMIT)
+    .map((region) => toSampleRoute(region, groups.get(region) ?? []));
+}
+
+function rankRegions(groups: Map<string, OverviewRow[]>): string[] {
+  return [...groups.entries()]
+    .sort(([ar, a], [br, b]) => b.length - a.length || ar.localeCompare(br))
+    .map(([region]) => region);
+}
+
+function toSampleRoute(region: string, members: OverviewRow[]): AnimeSampleRoute {
+  return { region, point_ids: members.slice(0, SAMPLE_ROUTE_POINT_CAP).map((m) => m.id) };
+}

--- a/workers/catalog/src/index.ts
+++ b/workers/catalog/src/index.ts
@@ -20,6 +20,15 @@ app.get("/healthz", (c) =>
   c.json({ status: "ok", service: "catalog", env: c.env.ENVIRONMENT ?? "unknown" }),
 );
 
+// Public catalog reads are anonymous and change only on republish — let the edge
+// cache them (5 min browser, 1 h edge). Runs before the /catalog/* oRPC handler,
+// tagging its response on the way back out.
+const PUBLIC_CACHE_CONTROL = "public, max-age=300, s-maxage=3600";
+app.use("/catalog/public/*", async (c, next) => {
+  await next();
+  if (c.res.ok) c.res.headers.set("Cache-Control", PUBLIC_CACHE_CONTROL);
+});
+
 const apiHandler = new OpenAPIHandler(catalogRouter);
 
 /** The Postgres connection string for this request: Hyperdrive in prod, else DATABASE_URL. */

--- a/workers/catalog/src/router.ts
+++ b/workers/catalog/src/router.ts
@@ -7,6 +7,7 @@ import { nearby as nearbyHandler } from "./api/nearby";
 import { geocode as geocodeHandler } from "./api/geocode";
 import { route as routeHandler } from "./api/route";
 import { spots as spotsHandler, SpotNotFoundError } from "./api/spots";
+import { animeOverview as animeOverviewHandler } from "./api/anime-overview";
 import type { CatalogDb, NeonSql } from "./db/client";
 import { ingestWork, type IngestResult as OrchestratorResult } from "./ingest/orchestrator";
 import { routeTooManyPoints, workNotFound } from "./lib/errors";
@@ -77,6 +78,10 @@ const ingest = os.ingest.handler(async ({ input, context }) =>
   ),
 );
 
+const animeOverview = os.animeOverview.handler(async ({ input, context }) =>
+  animeOverviewHandler(context.db, input),
+);
+
 /** Map the orchestrator union (camelCase) onto the snake_case wire shape. */
 function toIngestResult(result: OrchestratorResult): IngestResult {
   if (result.status === "ingested") {
@@ -105,5 +110,6 @@ export const catalogRouter = {
   geocode,
   route,
   ingest,
+  animeOverview,
 };
 export type CatalogRouter = typeof catalogRouter;

--- a/workers/catalog/src/types.ts
+++ b/workers/catalog/src/types.ts
@@ -61,6 +61,40 @@ export interface PilgrimagePoint {
   city?: string;
 }
 
+/** One region bubble — mirrors `AnimeOverviewCircle`. */
+export interface AnimeOverviewCircle {
+  region: string;
+  count: number;
+  lat: number;
+  lng: number;
+}
+
+/** One 名場面 in the shot-count ranking — mirrors `AnimeScene`. */
+export interface AnimeScene {
+  id: string;
+  name: string;
+  screenshot_url: string;
+  shot_count: number;
+  lat: number;
+  lng: number;
+  city?: string;
+}
+
+/** A per-region sample route — mirrors `AnimeSampleRoute`. */
+export interface AnimeSampleRoute {
+  region: string;
+  point_ids: string[];
+}
+
+/** The public anime overview payload — mirrors `AnimeOverview`. */
+export interface AnimeOverview {
+  bangumi_id: string;
+  points_length: number;
+  circles: AnimeOverviewCircle[];
+  scenes: AnimeScene[];
+  sample_routes: AnimeSampleRoute[];
+}
+
 /** Stable anime identity and trusted display metadata — mirrors `AnimeCandidate`. */
 export interface AnimeCandidate {
   bangumi_id: string;

--- a/workers/catalog/test/anime-overview.worker.test.ts
+++ b/workers/catalog/test/anime-overview.worker.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { animeOverview, type OverviewDb } from "../src/api/anime-overview";
+
+/**
+ * Unit tests for the public `animeOverview` read handler
+ * (catalog/src/api/anime-overview.ts). No Docker / no live Postgres: the handler
+ * only touches `db.execute(sql`...`)` returning `{ rows }`, so a typed fake is
+ * injected. Asserts the contract AnimeOverview shape: bubble aggregation
+ * (region + count), 名場面 ranking (by shot count), and per-region sample routes.
+ * Named *.worker.test.ts so vitest-pool-workers picks it up.
+ */
+
+interface FixtureRow {
+  id: string;
+  name: string;
+  image: string | null;
+  latitude: number;
+  longitude: number;
+  city: string | null;
+}
+
+function row(id: string, lat: number, lng: number, city: string | null, image: string | null = null): FixtureRow {
+  return { id, name: id.toUpperCase(), image, latitude: lat, longitude: lng, city };
+}
+
+/** Fake db whose execute() returns the fixture rows once. */
+function fakeDb(rows: FixtureRow[]): OverviewDb {
+  return { execute: () => Promise.resolve({ rows }) };
+}
+
+// Two Kamakura points co-located (< 50m → one cluster of 2 shots) + one lone Hakone point.
+const KAMAKURA_A = row("k1", 35.30660, 139.48890, "Kamakura", "https://img/k1.jpg");
+const KAMAKURA_B = row("k2", 35.30661, 139.48891, "Kamakura");
+const HAKONE = row("h1", 35.23230, 139.10690, "Hakone", "https://img/h1.jpg");
+const SPREAD: FixtureRow[] = [KAMAKURA_A, KAMAKURA_B, HAKONE];
+
+describe("animeOverview (api/anime-overview.ts)", () => {
+  it("aggregates region bubbles with counts and centroids", async () => {
+    const result = await animeOverview(fakeDb(SPREAD), { bangumi_id: "100" });
+    expect(result.bangumi_id).toBe("100");
+    expect(result.points_length).toBe(3);
+    expect(result.circles.map((c) => [c.region, c.count])).toEqual([
+      ["Kamakura", 2],
+      ["Hakone", 1],
+    ]);
+    const [kamakura] = result.circles;
+    expect(kamakura?.lat).toBeCloseTo(35.306605, 6);
+    expect(kamakura?.lng).toBeCloseTo(139.488905, 6);
+  });
+
+  it("ranks 名場面 by shot count (co-located points merge into one scene)", async () => {
+    const result = await animeOverview(fakeDb(SPREAD), { bangumi_id: "100" });
+    expect(result.scenes.map((s) => [s.id, s.shot_count])).toEqual([
+      ["k1", 2],
+      ["h1", 1],
+    ]);
+    const [top] = result.scenes;
+    expect(top).toMatchObject({ name: "K1", screenshot_url: "https://img/k1.jpg", city: "Kamakura" });
+  });
+
+  it("suggests per-region sample routes ordered by spot count", async () => {
+    const result = await animeOverview(fakeDb(SPREAD), { bangumi_id: "100" });
+    expect(result.sample_routes).toEqual([
+      { region: "Kamakura", point_ids: ["k1", "k2"] },
+      { region: "Hakone", point_ids: ["h1"] },
+    ]);
+  });
+
+});
+
+describe("animeOverview edge cases", () => {
+  it("returns an empty-but-valid overview when the work has no points", async () => {
+    const result = await animeOverview(fakeDb([]), { bangumi_id: "999" });
+    expect(result).toEqual({
+      bangumi_id: "999",
+      points_length: 0,
+      circles: [],
+      scenes: [],
+      sample_routes: [],
+    });
+  });
+
+  it("returns empty circles (no region clustering) for spots lacking a city, without erroring", async () => {
+    const noCity: FixtureRow[] = [row("n1", 35.0, 139.0, null), row("n2", 36.0, 140.0, "")];
+    const result = await animeOverview(fakeDb(noCity), { bangumi_id: "200" });
+    expect(result.circles).toEqual([]);
+    expect(result.sample_routes).toEqual([]);
+    expect(result.scenes).toHaveLength(2);
+    expect(result.points_length).toBe(2);
+  });
+
+  it("omits city on a scene whose representative point has no city", async () => {
+    const result = await animeOverview(fakeDb([row("x1", 34.0, 138.0, null)]), { bangumi_id: "300" });
+    expect(result.scenes[0]?.city).toBeUndefined();
+    expect(result.scenes[0]?.screenshot_url).toBe("");
+  });
+
+  it("caps scenes at 20, sample routes at 3 regions, and point ids at 12 per route", async () => {
+    const result = await animeOverview(fakeDb(cappedFixture()), { bangumi_id: "400" });
+    expect(result.scenes).toHaveLength(20);
+    expect(result.sample_routes.map((r) => r.region)).toEqual(["A", "B", "C"]);
+    expect(result.sample_routes[0]?.point_ids).toHaveLength(12);
+  });
+});
+
+/** 21 far-apart points across 4 regions (A:15, B:3, C:2, D:1) — exercises the
+ * scene (20), region (3), and per-route point (12) caps in one fixture. */
+function cappedFixture(): FixtureRow[] {
+  const plan: [string, number][] = [["A", 15], ["B", 3], ["C", 2], ["D", 1]];
+  let seq = 0;
+  return plan.flatMap(([region, n]) =>
+    Array.from({ length: n }, () => {
+      const id = `${region}-${String(seq).padStart(2, "0")}`;
+      return row(id, 30 + seq++ * 0.01, 138.0, region);
+    }),
+  );
+}

--- a/workers/catalog/test/catalog-api.spike.test.ts
+++ b/workers/catalog/test/catalog-api.spike.test.ts
@@ -56,6 +56,22 @@ async function seed(): Promise<void> {
     INSERT INTO aliases (work_id, alias, alias_normalized, source, priority)
     VALUES ('lucky-star', 'らき☆すた', 'らき☆すた', 'bangumi', 40)
   `);
+  await seedOverviewWork();
+}
+
+/** A numeric-id work with two co-located Kamakura points + one Hakone point, for
+ * the public animeOverview route (its input requires a numeric bangumi_id). */
+async function seedOverviewWork(): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO bangumi (id, title, points_count) VALUES ('3302', 'Overview Work', 3)
+  `);
+  await db.execute(sql`
+    INSERT INTO points (id, bangumi_id, name, latitude, longitude, city, image)
+    VALUES
+      ('ov-kama-1', '3302', '鎌倉A', 35.30660, 139.48890, 'Kamakura', 'https://img/ov1.jpg'),
+      ('ov-kama-2', '3302', '鎌倉B', 35.30661, 139.48891, 'Kamakura', NULL),
+      ('ov-hakone', '3302', '箱根',  35.23230, 139.10690, 'Hakone',   'https://img/ov3.jpg')
+  `);
 }
 
 /**
@@ -75,6 +91,18 @@ async function call<T>(method: string, payload: unknown, expectStatus = 200): Pr
   );
   expect(res.status).toBe(expectStatus);
   return (await res.json());
+}
+
+/** GET through the public OpenAPI wire (anonymous, no body). Returns the raw
+ * response so tests can assert both the JSON body and cache headers. */
+async function getPublic(path: string, expectStatus = 200): Promise<Response> {
+  const res = await app.request(
+    `/catalog/public/${path}`,
+    { method: "GET" },
+    { ENVIRONMENT: "test", DATABASE_URL: localDatabaseUrl() },
+  );
+  expect(res.status).toBe(expectStatus);
+  return res;
 }
 
 beforeAll(async () => {
@@ -149,6 +177,41 @@ async function assertRoute(): Promise<void> {
   expect(out.timed_itinerary.stops.length).toBeGreaterThan(0);
   expect(out.timed_itinerary.total_minutes).toBeGreaterThan(0);
 }
+
+interface OverviewBody {
+  bangumi_id: string;
+  points_length: number;
+  circles: { region: string; count: number; lat: number; lng: number }[];
+  scenes: { id: string; shot_count: number; screenshot_url: string; city?: string }[];
+  sample_routes: { region: string; point_ids: string[] }[];
+}
+
+async function assertOverviewHit(): Promise<void> {
+  const res = await getPublic("anime-overview/3302");
+  expect(res.headers.get("Cache-Control")).toContain("s-maxage");
+  const body = (await res.json()) as OverviewBody;
+  expect(body.points_length).toBe(3);
+  expect(body.circles.map((c) => [c.region, c.count])).toEqual([["Kamakura", 2], ["Hakone", 1]]);
+  expect(body.scenes[0]).toMatchObject({ id: "ov-kama-1", shot_count: 2, city: "Kamakura" });
+  expect(body.sample_routes[0]).toEqual({ region: "Kamakura", point_ids: ["ov-kama-1", "ov-kama-2"] });
+}
+
+async function assertOverviewEmpty(): Promise<void> {
+  const res = await getPublic("anime-overview/999999");
+  const body = (await res.json()) as OverviewBody;
+  expect(body).toEqual({
+    bangumi_id: "999999",
+    points_length: 0,
+    circles: [],
+    scenes: [],
+    sample_routes: [],
+  });
+}
+
+databaseDescribe("Catalog public animeOverview (anonymous GET, cache-tagged)", () => {
+  it("returns bubble aggregation + 名場面 ranking + sample routes for a known work", assertOverviewHit);
+  it("returns an empty-but-valid overview for an unknown work", assertOverviewEmpty);
+});
 
 databaseDescribe("Catalog API end-to-end (Hono app + OpenAPIHandler + Drizzle/PostGIS)", () => {
   it("search resolves the seeded alias to the work's points (plain-JSON wire)", assertSearchHit);

--- a/workers/catalog/test/contract-parity.worker.test.ts
+++ b/workers/catalog/test/contract-parity.worker.test.ts
@@ -26,6 +26,10 @@ import type {
   Origin as ContractOrigin,
   AnimeCandidate as ContractAnimeCandidate,
   ResolveOutcome as ContractResolveOutcome,
+  AnimeOverviewCircle as ContractAnimeOverviewCircle,
+  AnimeScene as ContractAnimeScene,
+  AnimeSampleRoute as ContractAnimeSampleRoute,
+  AnimeOverview as ContractAnimeOverview,
 } from "../../../packages/contract/src/models";
 
 import type {
@@ -61,6 +65,10 @@ import type {
   GeocodeResult as LocalGeocodeResult,
   AnimeCandidate as LocalAnimeCandidate,
   ResolveOutcome as LocalResolveOutcome,
+  AnimeOverviewCircle as LocalAnimeOverviewCircle,
+  AnimeScene as LocalAnimeScene,
+  AnimeSampleRoute as LocalAnimeSampleRoute,
+  AnimeOverview as LocalAnimeOverview,
 } from "../src/types";
 
 import type {
@@ -133,6 +141,16 @@ const _ac_b: LocalAnimeCandidate = null as unknown as ContractAnimeCandidate;
 const _ro_a: ContractResolveOutcome = null as unknown as LocalResolveOutcome;
 const _ro_b: LocalResolveOutcome = null as unknown as ContractResolveOutcome;
 
+// --- Anime overview (public read) ---
+const _aoc_a: ContractAnimeOverviewCircle = null as unknown as LocalAnimeOverviewCircle;
+const _aoc_b: LocalAnimeOverviewCircle = null as unknown as ContractAnimeOverviewCircle;
+const _asc_a: ContractAnimeScene = null as unknown as LocalAnimeScene;
+const _asc_b: LocalAnimeScene = null as unknown as ContractAnimeScene;
+const _asr_a: ContractAnimeSampleRoute = null as unknown as LocalAnimeSampleRoute;
+const _asr_b: LocalAnimeSampleRoute = null as unknown as ContractAnimeSampleRoute;
+const _aov_a: ContractAnimeOverview = null as unknown as LocalAnimeOverview;
+const _aov_b: LocalAnimeOverview = null as unknown as ContractAnimeOverview;
+
 // --- Geocode ---
 const _gc_a: ContractGeocodeCandidate = null as unknown as LocalGeocodeCandidate;
 const _gc_b: LocalGeocodeCandidate = null as unknown as ContractGeocodeCandidate;
@@ -167,6 +185,7 @@ void _pp_a; void _pp_b; void _ts_a; void _ts_b; void _tl_a; void _tl_b; void _tl
 void _ir_a; void _ir_b; void _r_a; void _r_b; void _pac_a; void _pac_b; void _orig_a; void _orig_b;
 void _sr_a; void _sr_b;
 void _ac_a; void _ac_b; void _ro_a; void _ro_b;
+void _aoc_a; void _aoc_b; void _asc_a; void _asc_b; void _asr_a; void _asr_b; void _aov_a; void _aov_b;
 void _gc_a; void _gc_b; void _gc_radius_a; void _gc_radius_b; void _gi_a; void _gi_b; void _gr_a; void _gr_b;
 void _ecc_a; void _ecc_b; void _ecat_a; void _ecat_b; void _err_spec_a; void _err_spec_b;
 void _ingest_err_a; void _ingest_err_b;

--- a/workers/catalog/test/router-shape-lock.type-test.ts
+++ b/workers/catalog/test/router-shape-lock.type-test.ts
@@ -4,6 +4,7 @@
  */
 import {
   catalogContract,
+  type AnimeOverview,
   type ResolveOutcome,
   type SearchResult,
 } from "@seichijunrei/contract";
@@ -22,6 +23,15 @@ const resolved: ResolveOutcome = {
   match: { bangumi_id: "3302", title: "らき☆すた" },
 };
 os.resolve.handler(() => resolved);
+
+const overview: AnimeOverview = {
+  bangumi_id: "3302",
+  points_length: 0,
+  circles: [],
+  scenes: [],
+  sample_routes: [],
+};
+os.animeOverview.handler(() => overview);
 
 // @ts-expect-error -- the contract requires synced_at; removing this directive must fail tsc.
 os.search.handler(() => ({ rows: [] }));


### PR DESCRIPTION
## Card E2 / issue #275 — S5.4 Catalog public-data enabler

Catalog's **first public exposure**: a new anonymous, read-only oRPC route feeding the anime page (bubble map, 名場面 ranking, sample routes). Data source for the discover line (#267/#269/#288/#278). Needs eng-review sign-off (first widening of `workers/catalog`'s exposure surface).

Branch base = `feat/frontend-rebuild`.

### New procedure
| Procedure | Wire | Auth | Shape |
|---|---|---|---|
| `catalog.animeOverview` | `GET /catalog/public/anime-overview/{bangumi_id}` | anonymous (public) | `AnimeOverview` → `{ bangumi_id, points_length, circles[], scenes[], sample_routes[] }` |

- **circles** — bubble aggregation grouped by region (city) with count + centroid (sorted count desc).
- **scenes** — 名場面 ranking: co-located points collapse via `clusterByLocation` (50m), ranked by shot count, capped at 20.
- **sample_routes** — top-3 regions with their member point ids (capped at 12).

All fields derive from already-public catalog data. Unknown/sparse works return an **empty-but-valid** overview (no error), so no error-registry change — the three error mirrors stay untouched.

### Contract discipline
- `packages/contract`: reuses existing `Latitude`/`Longitude`; new `AnimeOverview*` zod models + `AnimeOverviewInput` (strict `^\d+$`) + `animeOverview` procedure. OpenAPI re-emitted byte-stable (`pnpm run emit:openapi` → `openapi.json` +142 lines, `users-openapi.json` unchanged).
- `workers/catalog`: `implement(catalogContract)` compile-time shape-lock; `src/types.ts` mirror + `contract-parity.worker.test.ts` + `router-shape-lock.type-test.ts` extended.
- `zod`/`@orpc` exact-pins untouched.

### Security / caching
- `worker/app.ts`: `isPublicCatalog` allowlist forwards **only** `/catalog/public/*` to `env.CATALOG` (service binding, in-datacenter), strips client-forged `X-User-*`. Every other `/catalog/*` stays private (falls through to OpenNext — proven by test).
- `workers/catalog/src/index.ts`: `/catalog/public/*` responses tagged `Cache-Control: public, max-age=300, s-maxage=3600` (edge-cacheable public read).

### AC → tests
| AC | Type | Test |
|---|---|---|
| Happy path: known work → bubble aggregation + 名場面 ranking | integration | `catalog-api.spike.test.ts` (real DB, anonymous GET, cache header) |
| Empty: sparse data → empty-but-valid `circles` | unit | `anime-overview.worker.test.ts` |
| Security: only allowlisted `/catalog/public/*` exposed; other paths blocked | integration | `worker/entry.test.ts` (allowlist + private-path-stays-private) |

Handler unit tests also cover ranking, per-region sample routes, caps (scene 20 / region 3 / point 12), and city-omission.

### Gates
- `packages/contract` + `workers/catalog` typecheck ✅ · catalog oxlint ✅ · catalog worker tests 239 ✅ (coverage gate ✅) · spike suite compiles + skips without DB ✅ · root `test:worker` 36 ✅ · OpenAPI drift ✅ (re-emit byte-stable).
- **Note**: a local workspace-lint hook trips on a pre-existing, out-of-scope `apps/web/src/router.tsx` defect (stale `routeTree.gen.ts` from C0.0) — not touched by this card. CI's `web` lane is path-filtered to `apps/web/**` and does not run for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)