### PR TITLE
feat(web): S0.4 map spike — MapLibre GL + PMTiles _dev route (C0.3, #237)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,9 +13,12 @@
     "preview": "wrangler dev"
   },
   "dependencies": {
+    "@protomaps/basemaps": "^5.7.2",
     "@tanstack/react-router": "^1.170.18",
     "@tanstack/react-start": "^1.168.30",
     "animal-island-ui-tailwind": "^1.0.16",
+    "maplibre-gl": "^5.24.0",
+    "pmtiles": "^4.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/apps/web/src/features/map-spike/IllustrationBasemap.tsx
+++ b/apps/web/src/features/map-spike/IllustrationBasemap.tsx
@@ -1,0 +1,29 @@
+import { illustrationSpotPoints, polylinePoints, svgTranslate, type Point } from "./geometry";
+import { pinFill, pinLabel, pinRadius, pinStroke, pinTextFill } from "./pins";
+import { STATIC_SIZE, type Spot } from "./spots";
+
+type PinMarkProps = Readonly<{ spot: Spot; point: Point; index: number }>;
+
+const VIEW_BOX = `0 0 ${STATIC_SIZE.width.toString()} ${STATIC_SIZE.height.toString()}`;
+
+function RouteLine({ points }: Readonly<{ points: readonly Point[] }>) {
+  const line = polylinePoints(points);
+  return <polyline points={line} fill="none" stroke="var(--color-map-pin-brand)" strokeWidth={8} strokeLinecap="round" strokeDasharray="18 16" />;
+}
+
+function PinMark({ spot, point, index }: PinMarkProps) {
+  return (
+    <g transform={svgTranslate(point)}>
+      <circle r={pinRadius(spot.kind)} fill={pinFill(spot.kind)} stroke={pinStroke(spot.kind)} strokeWidth={3} />
+      <text y={6} textAnchor="middle" fontSize={18} fontWeight={800} fill={pinTextFill(spot.kind)}>{pinLabel(spot, index)}</text>
+    </g>
+  );
+}
+
+export function IllustrationBasemap() {
+  const spots = illustrationSpotPoints();
+  return (<svg className="map-spike__illustration" viewBox={VIEW_BOX} role="img" aria-label="宇治エリアの巡礼ルート図">
+    <RouteLine points={spots.map((pair) => pair.point)} />
+    {spots.map((pair, i) => <PinMark key={pair.spot.id} spot={pair.spot} point={pair.point} index={i} />)}
+  </svg>);
+}

--- a/apps/web/src/features/map-spike/MapSpike.tsx
+++ b/apps/web/src/features/map-spike/MapSpike.tsx
@@ -1,0 +1,37 @@
+import type { Ref } from "react";
+import { IllustrationBasemap } from "./IllustrationBasemap";
+import type { SourceMode } from "./sourceMode";
+
+export type MapStatus = "loading" | "ready" | "fallback";
+
+type MapSpikeProps = Readonly<{
+  mapContainerRef: Ref<HTMLDivElement>;
+  status: MapStatus;
+  sourceMode: SourceMode;
+}>;
+
+const STATUS_MESSAGE: Record<MapStatus, string> = {
+  loading: "Loading Uji tiles…",
+  ready: "Interactive map ready.",
+  fallback: "Showing the illustrated basemap — tiles are unavailable.",
+};
+
+function MapSpikeHeader({ status, sourceMode }: Omit<MapSpikeProps, "mapContainerRef">) {
+  return (<header className="map-spike__head">
+    <p className="eyebrow">Dev spike</p>
+    <h1 id="map-spike-title">Map spike</h1>
+    <p className="tagline">MapLibre GL + Protomaps PMTiles over Uji (Kansai).</p>
+    <p aria-live="polite">{STATUS_MESSAGE[status]}</p>
+    <p className="map-spike__source">Tile source: {sourceMode}</p>
+  </header>);
+}
+
+export function MapSpike({ mapContainerRef, status, sourceMode }: MapSpikeProps) {
+  return (<main className="map-spike" aria-labelledby="map-spike-title">
+    <MapSpikeHeader status={status} sourceMode={sourceMode} />
+    <div className="map-spike__stage" data-status={status}>
+      <IllustrationBasemap />
+      <div ref={mapContainerRef} className="map-spike__gl" aria-hidden={status !== "ready"} />
+    </div>
+  </main>);
+}

--- a/apps/web/src/features/map-spike/geometry.ts
+++ b/apps/web/src/features/map-spike/geometry.ts
@@ -1,0 +1,44 @@
+import { SPOTS, STATIC_BOUNDS, STATIC_SIZE } from "./spots";
+import type { Bounds, LngLat, Size, Spot } from "./spots";
+
+export interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface SpotPoint {
+  readonly spot: Spot;
+  readonly point: Point;
+}
+
+const mercatorY = (lat: number): number => {
+  const radians = (lat * Math.PI) / 180;
+  return Math.log(Math.tan(Math.PI / 4 + radians / 2));
+};
+
+export const projectWebMercator = ([lon, lat]: LngLat, bounds: Bounds, size: Size): Point => {
+  const x = ((lon - bounds.west) / (bounds.east - bounds.west)) * size.width;
+  const top = mercatorY(bounds.north);
+  const bottom = mercatorY(bounds.south);
+  const y = ((top - mercatorY(lat)) / (top - bottom)) * size.height;
+  return { x, y };
+};
+
+export const illustrationSpotPoints = (): readonly SpotPoint[] => {
+  return SPOTS.map((spot) => ({
+    spot,
+    point: projectWebMercator(spot.coord, STATIC_BOUNDS, STATIC_SIZE),
+  }));
+};
+
+export const illustrationPoints = (): readonly Point[] => {
+  return illustrationSpotPoints().map((pair) => pair.point);
+};
+
+export const polylinePoints = (points: readonly Point[]): string => {
+  return points.map((point) => `${point.x.toFixed(1)},${point.y.toFixed(1)}`).join(" ");
+};
+
+export const svgTranslate = (point: Point): string => {
+  return `translate(${point.x.toFixed(1)} ${point.y.toFixed(1)})`;
+};

--- a/apps/web/src/features/map-spike/mapController.ts
+++ b/apps/web/src/features/map-spike/mapController.ts
@@ -1,0 +1,104 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import type { Map as MapLibreMap, Marker } from "maplibre-gl";
+import { createMapStyle } from "./mapStyle";
+import { routeLayer, ROUTE_SOURCE_ID, routeSource } from "./mapLayers";
+import { pinLabel } from "./pins";
+import type { MapStatus } from "./MapSpike";
+import type { SourceMode } from "./sourceMode";
+import { SPOTS, UJI_CENTER, UJI_ZOOM, type Spot } from "./spots";
+
+export type MountOptions = Readonly<{
+  container: HTMLElement;
+  mode: SourceMode;
+  onStatus: (status: MapStatus) => void;
+}>;
+
+export type MapHandle = Readonly<{ destroy: () => void }>;
+
+let protocolReady = false;
+
+const registerProtocol = async (gl: typeof import("maplibre-gl")): Promise<void> => {
+  if (protocolReady) {
+    return;
+  }
+  const { Protocol } = await import("pmtiles");
+  gl.addProtocol("pmtiles", new Protocol({ metadata: true }).tile);
+  protocolReady = true;
+};
+
+const markerElement = (spot: Spot, index: number): HTMLElement => {
+  const element = document.createElement("div");
+  element.className = `map-spike__pin map-spike__pin--${spot.kind}`;
+  element.textContent = pinLabel(spot, index);
+  element.title = spot.label;
+  return element;
+};
+
+const addRoute = (map: MapLibreMap): void => {
+  map.addSource(ROUTE_SOURCE_ID, routeSource());
+  map.addLayer(routeLayer());
+};
+
+const addMarkers = (gl: typeof import("maplibre-gl"), map: MapLibreMap): Marker[] => {
+  return SPOTS.map((spot, index) =>
+    new gl.Marker({ element: markerElement(spot, index), anchor: "bottom" })
+      .setLngLat([...spot.coord])
+      .addTo(map),
+  );
+};
+
+const createMap = (gl: typeof import("maplibre-gl"), options: MountOptions): MapLibreMap => {
+  return new gl.Map({
+    container: options.container,
+    style: createMapStyle(options.mode),
+    center: [...UJI_CENTER],
+    zoom: UJI_ZOOM,
+    attributionControl: { compact: true },
+  });
+};
+
+const onMapLoad = (gl: typeof import("maplibre-gl"), map: MapLibreMap, onStatus: MountOptions["onStatus"]): void => {
+  addRoute(map);
+  addMarkers(gl, map);
+  onStatus("ready");
+};
+
+const wireEvents = (gl: typeof import("maplibre-gl"), map: MapLibreMap, options: MountOptions): void => {
+  map.on("load", () => { onMapLoad(gl, map, options.onStatus); });
+  map.on("error", () => { options.onStatus("fallback"); });
+};
+
+const buildHandle = (map: MapLibreMap): MapHandle => ({ destroy: () => { map.remove(); } });
+
+export const mountMapSpike = async (options: MountOptions): Promise<MapHandle> => {
+  const gl = await import("maplibre-gl");
+  await registerProtocol(gl);
+  const map = createMap(gl, options);
+  wireEvents(gl, map, options);
+  return buildHandle(map);
+};
+
+interface Attachment {
+  handle: MapHandle | null;
+  active: boolean;
+}
+
+const storeHandle = (attachment: Attachment, handle: MapHandle): void => {
+  if (!attachment.active) {
+    handle.destroy();
+    return;
+  }
+  attachment.handle = handle;
+};
+
+// Bridges the async mount into React's synchronous effect-cleanup contract.
+export const attachMapSpike = (options: MountOptions): (() => void) => {
+  const attachment: Attachment = { handle: null, active: true };
+  void mountMapSpike(options).then((handle) => {
+    storeHandle(attachment, handle);
+  });
+  return () => {
+    attachment.active = false;
+    attachment.handle?.destroy();
+  };
+};

--- a/apps/web/src/features/map-spike/mapLayers.ts
+++ b/apps/web/src/features/map-spike/mapLayers.ts
@@ -1,0 +1,33 @@
+import type { GeoJSONSourceSpecification, LineLayerSpecification } from "maplibre-gl";
+import { SPOTS, type LngLat } from "./spots";
+
+export const ROUTE_SOURCE_ID = "uji-route";
+
+// MapLibre style-spec paint values must be literal colors (CSS vars are not resolved
+// by the GL renderer); this mirrors the `--color-map-pin-brand` token value.
+const ROUTE_COLOR = "#c1440e";
+
+export const routeCoordinates = (): readonly LngLat[] => {
+  return SPOTS.map((spot) => spot.coord);
+};
+
+export const routeSource = (): GeoJSONSourceSpecification => {
+  return {
+    type: "geojson",
+    data: {
+      type: "Feature",
+      properties: {},
+      geometry: { type: "LineString", coordinates: routeCoordinates().map((coord) => [...coord]) },
+    },
+  };
+};
+
+export const routeLayer = (): LineLayerSpecification => {
+  return {
+    id: ROUTE_SOURCE_ID,
+    type: "line",
+    source: ROUTE_SOURCE_ID,
+    layout: { "line-cap": "round", "line-join": "round" },
+    paint: { "line-color": ROUTE_COLOR, "line-width": 4, "line-dasharray": [1.2, 1.2] },
+  };
+};

--- a/apps/web/src/features/map-spike/mapStyle.ts
+++ b/apps/web/src/features/map-spike/mapStyle.ts
@@ -1,0 +1,31 @@
+import { LIGHT, type Flavor, layers } from "@protomaps/basemaps";
+import type { StyleSpecification } from "maplibre-gl";
+import { TILE_PMTILES_URL, TILE_ZXY_URL } from "./spots";
+import type { SourceMode } from "./sourceMode";
+
+const ATTRIBUTION = "© OpenStreetMap contributors, Protomaps";
+const SOURCE_ID = "protomaps";
+// Protomaps basemap assets; production copies these to R2 same-origin with the tiles.
+const BASEMAP_ASSETS = "https://protomaps.github.io/basemaps-assets";
+
+const workerSource = () => {
+  return { type: "vector" as const, tiles: [TILE_ZXY_URL], minzoom: 0, maxzoom: 15, attribution: ATTRIBUTION };
+};
+
+const pmtilesSource = (tilePath: string) => {
+  return { type: "vector" as const, url: `pmtiles://${tilePath}`, attribution: ATTRIBUTION };
+};
+
+// MapLibre style-spec needs a literal background color; mirrors the `--color-card` cream token.
+const brandLight = (): Flavor => ({ ...LIGHT, background: "#f8f8f0", pois: undefined });
+
+export const createMapStyle = (mode: SourceMode, tilePath: string = TILE_PMTILES_URL): StyleSpecification => {
+  return {
+    version: 8,
+    name: "animichi-map-spike",
+    glyphs: `${BASEMAP_ASSETS}/fonts/{fontstack}/{range}.pbf`,
+    sprite: `${BASEMAP_ASSETS}/sprites/v4/light`,
+    sources: { [SOURCE_ID]: mode === "worker" ? workerSource() : pmtilesSource(tilePath) },
+    layers: layers(SOURCE_ID, brandLight(), { lang: "ja" }),
+  };
+};

--- a/apps/web/src/features/map-spike/pins.ts
+++ b/apps/web/src/features/map-spike/pins.ts
@@ -1,0 +1,35 @@
+import type { Spot, SpotKind } from "./spots";
+
+// Pin visual language (teal/gold, per DESIGN.md map-pin tokens + user-journey §6.6).
+// SVG fills reference semantic CSS variables so the palette stays token-driven.
+export const pinFill = (kind: SpotKind): string => {
+  if (kind === "start") {
+    return "var(--color-map-pin-teal)";
+  }
+  if (kind === "highlight") {
+    return "var(--color-map-pin-orange)";
+  }
+  return "var(--color-bg)";
+};
+
+export const pinStroke = (kind: SpotKind): string => {
+  return kind === "normal" ? "var(--color-map-pin-teal)" : "var(--color-fg)";
+};
+
+export const pinTextFill = (kind: SpotKind): string => {
+  return kind === "normal" ? "var(--color-map-pin-teal)" : "var(--color-primary-fg)";
+};
+
+export const pinRadius = (kind: SpotKind): number => {
+  return kind === "highlight" ? 21 : 18;
+};
+
+export const pinLabel = (spot: Spot, index: number): string => {
+  if (spot.kind === "start") {
+    return "出";
+  }
+  if (spot.kind === "highlight") {
+    return "★";
+  }
+  return String(index + 1);
+};

--- a/apps/web/src/features/map-spike/sourceMode.ts
+++ b/apps/web/src/features/map-spike/sourceMode.ts
@@ -1,0 +1,12 @@
+// `pmtiles` reads the range-served .pmtiles archive directly; `worker` hits the
+// edge Worker's ZXY endpoint. The demo route lets a `?source=` query flip between them.
+export type SourceMode = "pmtiles" | "worker";
+
+const isSourceMode = (value: string | null): value is SourceMode => {
+  return value === "pmtiles" || value === "worker";
+};
+
+export const parseSourceMode = (search: string): SourceMode => {
+  const mode = new URLSearchParams(search).get("source");
+  return isSourceMode(mode) ? mode : "pmtiles";
+};

--- a/apps/web/src/features/map-spike/spots.ts
+++ b/apps/web/src/features/map-spike/spots.ts
@@ -1,0 +1,47 @@
+export type LngLat = readonly [number, number];
+
+export type SpotKind = "start" | "normal" | "highlight";
+
+export interface Spot {
+  readonly id: string;
+  readonly label: string;
+  readonly coord: LngLat;
+  readonly kind: SpotKind;
+}
+
+export interface Bounds {
+  readonly west: number;
+  readonly south: number;
+  readonly east: number;
+  readonly north: number;
+}
+
+export interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+// Uji (Kansai) — the "響け！ユーフォニアム" pilgrimage cluster used across the spike.
+export const UJI_CENTER: LngLat = [135.811, 34.8937];
+export const UJI_ZOOM = 13.9;
+
+export const STATIC_BOUNDS: Bounds = {
+  west: 135.8038,
+  south: 34.8892,
+  east: 135.821,
+  north: 34.897,
+};
+
+export const STATIC_SIZE: Size = { width: 1000, height: 620 };
+
+// Same-origin tile endpoints served by the edge Worker from the R2 `seichijunrei-assets` bucket.
+export const TILE_PMTILES_URL = "/tiles/uji-kyoto.pmtiles";
+export const TILE_ZXY_URL = "/tiles/{z}/{x}/{y}.mvt";
+
+export const SPOTS: readonly Spot[] = [
+  { id: "ujibashi", label: "宇治橋", coord: [135.8077, 34.893], kind: "start" },
+  { id: "omotesando", label: "平等院表参道", coord: [135.8064, 34.8912], kind: "normal" },
+  { id: "ujijinja", label: "宇治神社", coord: [135.8118, 34.8918], kind: "normal" },
+  { id: "daikichiyama", label: "大吉山展望台", coord: [135.8189, 34.8951], kind: "highlight" },
+  { id: "keihan-uji", label: "京阪宇治駅", coord: [135.8079, 34.8945], kind: "normal" },
+] as const;

--- a/apps/web/src/routes/_dev/map-spike.tsx
+++ b/apps/web/src/routes/_dev/map-spike.tsx
@@ -1,0 +1,38 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { MapSpike, type MapStatus } from "../../features/map-spike/MapSpike";
+import { attachMapSpike } from "../../features/map-spike/mapController";
+import { parseSourceMode, type SourceMode } from "../../features/map-spike/sourceMode";
+
+export const Route = createFileRoute("/_dev/map-spike")({
+  component: MapSpikeRoute,
+});
+
+const initialSourceMode = (): SourceMode => {
+  if (typeof window === "undefined") {
+    return "pmtiles";
+  }
+  return parseSourceMode(window.location.search);
+};
+
+type StatusSetter = (status: MapStatus) => void;
+
+const attachToContainer = (container: HTMLDivElement | null, mode: SourceMode, onStatus: StatusSetter): (() => void) | undefined => {
+  if (!container) {
+    return undefined;
+  }
+  return attachMapSpike({ container, mode, onStatus });
+};
+
+function useMapSpikeMount(ref: RefObject<HTMLDivElement | null>, mode: SourceMode, onStatus: StatusSetter): void {
+  useEffect(() => attachToContainer(ref.current, mode, onStatus), [ref, mode, onStatus]);
+}
+
+function MapSpikeRoute() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState<MapStatus>("loading");
+  const [sourceMode] = useState<SourceMode>(initialSourceMode);
+  useMapSpikeMount(containerRef, sourceMode, setStatus);
+  return <MapSpike mapContainerRef={containerRef} status={status} sourceMode={sourceMode} />;
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -111,3 +111,73 @@ h1 {
     font-size: 1.25rem;
   }
 }
+
+.map-spike {
+  display: grid;
+  gap: 20px;
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0 64px;
+}
+
+.map-spike__head {
+  display: grid;
+  gap: 8px;
+}
+
+.map-spike__source {
+  color: var(--color-muted-fg);
+  font-weight: 700;
+}
+
+.map-spike__stage {
+  position: relative;
+  overflow: hidden;
+  height: min(70vh, 620px);
+  border: 2px solid var(--color-fg);
+  border-radius: 24px;
+  background: var(--color-card);
+  isolation: isolate;
+}
+
+.map-spike__illustration,
+.map-spike__gl {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.map-spike__gl {
+  z-index: 1;
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.map-spike__stage[data-status="ready"] .map-spike__gl {
+  opacity: 1;
+}
+
+.map-spike__pin {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border: 3px solid var(--color-map-pin-teal);
+  border-radius: 999px;
+  background: var(--color-bg);
+  color: var(--color-map-pin-teal);
+  font-weight: 800;
+}
+
+.map-spike__pin--start {
+  border-color: var(--color-fg);
+  background: var(--color-map-pin-teal);
+  color: var(--color-primary-fg);
+}
+
+.map-spike__pin--highlight {
+  border-color: var(--color-fg);
+  background: var(--color-map-pin-orange);
+  color: var(--color-primary-fg);
+}

--- a/apps/web/tests/unit/map-spike-geometry.test.ts
+++ b/apps/web/tests/unit/map-spike-geometry.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  illustrationPoints,
+  polylinePoints,
+  projectWebMercator,
+} from "../../src/features/map-spike/geometry";
+import { SPOTS, STATIC_BOUNDS, STATIC_SIZE } from "../../src/features/map-spike/spots";
+
+describe("projectWebMercator", () => {
+  it("maps the west/north bounds corner to the top-left origin", () => {
+    const point = projectWebMercator([STATIC_BOUNDS.west, STATIC_BOUNDS.north], STATIC_BOUNDS, STATIC_SIZE);
+    expect(point.x).toBeCloseTo(0, 5);
+    expect(point.y).toBeCloseTo(0, 5);
+  });
+
+  it("maps the east/south bounds corner to the bottom-right extent", () => {
+    const point = projectWebMercator([STATIC_BOUNDS.east, STATIC_BOUNDS.south], STATIC_BOUNDS, STATIC_SIZE);
+    expect(point.x).toBeCloseTo(STATIC_SIZE.width, 5);
+    expect(point.y).toBeCloseTo(STATIC_SIZE.height, 5);
+  });
+
+  it("keeps interior longitudes inside the canvas width", () => {
+    const point = projectWebMercator([135.811, 34.8937], STATIC_BOUNDS, STATIC_SIZE);
+    expect(point.x).toBeGreaterThan(0);
+    expect(point.x).toBeLessThan(STATIC_SIZE.width);
+  });
+});
+
+describe("illustrationPoints", () => {
+  it("projects one point per pilgrimage spot", () => {
+    expect(illustrationPoints()).toHaveLength(SPOTS.length);
+  });
+});
+
+describe("polylinePoints", () => {
+  it("joins projected points as space-separated fixed coordinates", () => {
+    const value = polylinePoints([
+      { x: 1.234, y: 5.678 },
+      { x: 9, y: 10 },
+    ]);
+    expect(value).toBe("1.2,5.7 9.0,10.0");
+  });
+});

--- a/apps/web/tests/unit/map-spike-layers.test.ts
+++ b/apps/web/tests/unit/map-spike-layers.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  routeCoordinates,
+  routeLayer,
+  ROUTE_SOURCE_ID,
+  routeSource,
+} from "../../src/features/map-spike/mapLayers";
+import { SPOTS } from "../../src/features/map-spike/spots";
+import { parseSourceMode } from "../../src/features/map-spike/sourceMode";
+
+describe("routeCoordinates", () => {
+  it("routes through every spot coordinate in order", () => {
+    expect(routeCoordinates()).toEqual(SPOTS.map((spot) => spot.coord));
+  });
+});
+
+describe("routeSource", () => {
+  it("wraps the itinerary as an inline geojson source", () => {
+    expect(routeSource().type).toBe("geojson");
+  });
+});
+
+describe("routeLayer", () => {
+  it("draws a dashed line bound to the route source", () => {
+    const layer = routeLayer();
+    expect(layer).toMatchObject({ id: ROUTE_SOURCE_ID, type: "line", source: ROUTE_SOURCE_ID });
+    expect(layer.paint?.["line-dasharray"]).toEqual([1.2, 1.2]);
+  });
+});
+
+describe("parseSourceMode", () => {
+  it("reads an explicit worker mode from the query string", () => {
+    expect(parseSourceMode("?source=worker")).toBe("worker");
+  });
+
+  it("reads an explicit pmtiles mode from the query string", () => {
+    expect(parseSourceMode("?source=pmtiles")).toBe("pmtiles");
+  });
+
+  it("defaults to pmtiles for missing or unknown values", () => {
+    expect(parseSourceMode("")).toBe("pmtiles");
+    expect(parseSourceMode("?source=bogus")).toBe("pmtiles");
+  });
+});

--- a/apps/web/tests/unit/map-spike-pins.test.ts
+++ b/apps/web/tests/unit/map-spike-pins.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { pinFill, pinLabel, pinRadius, pinStroke, pinTextFill } from "../../src/features/map-spike/pins";
+import type { Spot } from "../../src/features/map-spike/spots";
+
+const spot = (kind: Spot["kind"]): Spot => ({ id: kind, label: kind, coord: [0, 0], kind });
+
+describe("pinFill", () => {
+  it.each([
+    ["start", "var(--color-map-pin-teal)"],
+    ["highlight", "var(--color-map-pin-orange)"],
+    ["normal", "var(--color-bg)"],
+  ] as const)("uses a semantic token for the %s pin", (kind, token) => {
+    expect(pinFill(kind)).toBe(token);
+  });
+});
+
+describe("pinStroke and pinTextFill", () => {
+  it("outlines a normal pin in teal with teal text", () => {
+    expect(pinStroke("normal")).toBe("var(--color-map-pin-teal)");
+    expect(pinTextFill("normal")).toBe("var(--color-map-pin-teal)");
+  });
+
+  it("outlines a filled pin in ink with foreground text", () => {
+    expect(pinStroke("highlight")).toBe("var(--color-fg)");
+    expect(pinTextFill("start")).toBe("var(--color-primary-fg)");
+  });
+});
+
+describe("pinRadius", () => {
+  it("enlarges the highlight pin", () => {
+    expect(pinRadius("highlight")).toBe(21);
+    expect(pinRadius("normal")).toBe(18);
+  });
+});
+
+describe("pinLabel", () => {
+  it("marks the start spot with 出", () => {
+    expect(pinLabel(spot("start"), 0)).toBe("出");
+  });
+
+  it("marks the highlight spot with a star", () => {
+    expect(pinLabel(spot("highlight"), 3)).toBe("★");
+  });
+
+  it("numbers a normal spot from one", () => {
+    expect(pinLabel(spot("normal"), 1)).toBe("2");
+  });
+});

--- a/apps/web/tests/unit/map-spike-style.test.ts
+++ b/apps/web/tests/unit/map-spike-style.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { createMapStyle } from "../../src/features/map-spike/mapStyle";
+
+const source = (style: ReturnType<typeof createMapStyle>) => {
+  return style.sources.protomaps;
+};
+
+describe("createMapStyle", () => {
+  it("emits a version-8 style with a protomaps source and Japanese label layers", () => {
+    const style = createMapStyle("pmtiles");
+    expect(style.version).toBe(8);
+    expect(style.layers.length).toBeGreaterThan(0);
+    expect(source(style)).toBeDefined();
+  });
+
+  it("references the pmtiles archive via the pmtiles:// protocol by default", () => {
+    const built = source(createMapStyle("pmtiles"));
+    expect(built).toMatchObject({ type: "vector", url: "pmtiles:///tiles/uji-kyoto.pmtiles" });
+  });
+
+  it("points the worker mode at the ZXY endpoint instead", () => {
+    const built = source(createMapStyle("worker"));
+    expect(built).toMatchObject({ type: "vector", tiles: ["/tiles/{z}/{x}/{y}.mvt"] });
+  });
+
+  it("honors a custom pmtiles path for bbox-coverage checks", () => {
+    const built = source(createMapStyle("pmtiles", "/tiles/missing.pmtiles"));
+    expect(built).toMatchObject({ url: "pmtiles:///tiles/missing.pmtiles" });
+  });
+});

--- a/apps/web/tests/unit/map-spike.test.tsx
+++ b/apps/web/tests/unit/map-spike.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { createRef } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MapSpike, type MapStatus } from "../../src/features/map-spike/MapSpike";
+import type { SourceMode } from "../../src/features/map-spike/sourceMode";
+
+afterEach(cleanup);
+
+const renderSpike = (status: MapStatus, sourceMode: SourceMode = "pmtiles") => {
+  const ref = createRef<HTMLDivElement>();
+  return render(<MapSpike mapContainerRef={ref} status={status} sourceMode={sourceMode} />);
+};
+
+describe("MapSpike", () => {
+  it("renders the dev-spike heading and description", () => {
+    renderSpike("loading");
+    expect(screen.getByRole("heading", { name: "Map spike" })).toBeTruthy();
+    expect(screen.getByText(/MapLibre GL \+ Protomaps/)).toBeTruthy();
+  });
+
+  it.each([
+    ["loading", "Loading Uji tiles…"],
+    ["ready", "Interactive map ready."],
+    ["fallback", "Showing the illustrated basemap — tiles are unavailable."],
+  ] as const)("announces the %s status", (status, message) => {
+    renderSpike(status);
+    expect(screen.getByText(message)).toBeTruthy();
+  });
+
+  it("shows the active tile source", () => {
+    renderSpike("ready", "worker");
+    expect(screen.getByText("Tile source: worker")).toBeTruthy();
+  });
+
+  it("always renders the illustrated basemap as the branded fallback layer", () => {
+    renderSpike("fallback");
+    expect(screen.getByRole("img", { name: "宇治エリアの巡礼ルート図" })).toBeTruthy();
+    expect(screen.getByText("出")).toBeTruthy();
+    expect(screen.getByText("★")).toBeTruthy();
+  });
+
+  it("hides the GL layer from assistive tech until the map is ready", () => {
+    const { container } = renderSpike("loading");
+    const gl = container.querySelector(".map-spike__gl");
+    expect(gl?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("exposes the GL layer once the map is ready", () => {
+    const { container } = renderSpike("ready");
+    const gl = container.querySelector(".map-spike__gl");
+    expect(gl?.getAttribute("aria-hidden")).toBe("false");
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
         "src/routeTree.gen.ts",
         "src/router.tsx",
         "src/routes/**",
+        // WebGL map glue: instantiates maplibre-gl (requires a real GL context + dynamic imports),
+        // unrunnable under jsdom. Its pure inputs (style/layers/pins/geometry) are unit-covered; the
+        // live mount is covered by S0.4's browser ACs (Tester). Per campaign plan §0.6 exclude ledger.
+        "src/features/map-spike/mapController.ts",
       ],
       // Iteration-0 measured floor (components-only surface, 2 statements) — repo rule: ratchet UP only; lowering requires explicit user approval.
       thresholds: { statements: 100, branches: 100, functions: 100, lines: 100 },

--- a/docs/adr/0001-map-stack-maplibre-protomaps.md
+++ b/docs/adr/0001-map-stack-maplibre-protomaps.md
@@ -41,4 +41,11 @@
 - 上游断供退路:planetiler 自建管线;应急切换:OpenFreeMap style URL。
 - S1.4/S1.5/S2.2/S5.2/S6.2 全部只依赖「MapLibre 实例 + 数据驱动样式 + DOM/SVG 叠加」,
   无商业 SDK 独有能力;S3.6 离线由自托管 PMTiles 唯一优雅满足——这是本选型的决定性理由。
-- apps/web 内 demo route、生产 `[[r2_buckets]]`、`perf-mobile-cold` 正式测量待 S0.2 合流后接线(issue #237 跟踪)。
+- **apps/web 接线已落地(C0.3 / issue #237)**:`src/routes/_dev/map-spike.tsx`(client-only 挂载,SSR 不炸)
+  + `src/features/map-spike/*`(纯逻辑 style/layers/pins/geometry + `MapSpike` 展示组件 + `mapController` 浏览器胶水)。
+  引擎按本 ADR 决策直用原生 `maplibre-gl@5` + `pmtiles@4` `addProtocol` + `@protomaps/basemaps@5`(非 React wrapper),
+  `maplibre-gl` 经动态 `import()` 独立分包(build 实测 `maplibre-gl.mjs` 与 route chunk 分离)。
+- **仍待接线**:生产 `[[r2_buckets]]` 绑定 + edge `/tiles/*` 端点(backend enabler,归 root `wrangler.toml`/edge worker,由并行基建/ops 卡负责)与
+  `perf-mobile-cold` 正式测量(S0.4 browser AC,Tester 后验:首 tile ≤3s、越界空 tile、R2 故障降级插画层)。
+- **coverage 例外账(计划 §0.6)**:`src/features/map-spike/mapController.ts` 因需真实 WebGL 上下文 + 动态 import,jsdom 下不可运行,
+  按文件从 unit coverage 排除;其纯输入(style/layers/pins/geometry)+ `MapSpike` 展示层已 100% 单测,live 挂载归 browser AC。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@protomaps/basemaps':
+        specifier: ^5.7.2
+        version: 5.7.2
       '@tanstack/react-router':
         specifier: ^1.170.18
         version: 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -55,6 +58,12 @@ importers:
       animal-island-ui-tailwind:
         specifier: ^1.0.16
         version: 1.0.16(0f6542d988433e5118d622ce924af014)
+      maplibre-gl:
+        specifier: ^5.24.0
+        version: 5.24.0
+      pmtiles:
+        specifier: ^4.4.1
+        version: 4.4.1
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -202,7 +211,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       react-map-gl:
         specifier: ^8.1.1
-        version: 8.1.1(mapbox-gl@3.26.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 8.1.1(mapbox-gl@3.26.0)(maplibre-gl@5.24.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
@@ -1593,12 +1602,41 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
   '@mapbox/unitbezier@0.0.1':
     resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/unitbezier@1.0.0':
+    resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
+
+  '@mapbox/vector-tile@2.0.5':
+    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@6.1.1':
+    resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
 
   '@maplibre/maplibre-gl-style-spec@19.3.3':
     resolution: {integrity: sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==}
     hasBin: true
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.12':
+    resolution: {integrity: sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==}
+
+  '@maplibre/vt-pbf@4.3.2':
+    resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
 
   '@mdx-js/react@3.1.1':
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
@@ -2373,6 +2411,10 @@ packages:
 
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@protomaps/basemaps@5.7.2':
+    resolution: {integrity: sha512-K1Yk6bWdULulYg+R2QRVXx4NzJZan5YQhpejEG0c1/sXruJrfPIPZuakpf3jwAgVmjIRVQwAv+yRafDeN0aaUQ==}
+    hasBin: true
 
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
@@ -3836,6 +3878,9 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
@@ -5280,6 +5325,9 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -5641,6 +5689,9 @@ packages:
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -5796,6 +5847,9 @@ packages:
   giget@3.3.0:
     resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
     hasBin: true
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -6344,6 +6398,9 @@ packages:
   json-stringify-pretty-compact@3.0.0:
     resolution: {integrity: sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -6362,6 +6419,9 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -6546,6 +6606,10 @@ packages:
 
   mapbox-gl@3.26.0:
     resolution: {integrity: sha512-N+Y8VmvpD6xDeP0hAbegPZeEMY5TtnLcV0gEUBZ/KHq3s/yUKQm0PVG9JEkId0QFMMe5/W+FEjoyV4NI3B/N7A==}
+
+  maplibre-gl@5.24.0:
+    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -6812,6 +6876,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
@@ -7133,6 +7200,14 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pbf@4.0.2:
+    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
+    hasBin: true
+
+  pbf@5.1.2:
+    resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
+    hasBin: true
+
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
@@ -7208,6 +7283,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  pmtiles@4.4.1:
+    resolution: {integrity: sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -7239,6 +7317,9 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
 
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
@@ -7293,6 +7374,9 @@ packages:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -7313,6 +7397,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   radash@12.1.1:
     resolution: {integrity: sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA==}
@@ -7480,6 +7567,9 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -7993,6 +8083,9 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -10199,7 +10292,25 @@ snapshots:
       - encoding
       - supports-color
 
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
   '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/unitbezier@1.0.0': {}
+
+  '@mapbox/vector-tile@2.0.5':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.2
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@6.1.1':
+    dependencies:
+      kdbush: 4.1.0
 
   '@maplibre/maplibre-gl-style-spec@19.3.3':
     dependencies:
@@ -10209,6 +10320,25 @@ snapshots:
       minimist: 1.2.8
       rw: 1.3.3
       sort-object: 3.0.3
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/unitbezier': 1.0.0
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.12':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.2':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
 
   '@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
@@ -10876,6 +11006,8 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.2': {}
+
+  '@protomaps/basemaps@5.7.2': {}
 
   '@radix-ui/number@1.1.2': {}
 
@@ -12366,6 +12498,8 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
@@ -12697,11 +12831,13 @@ snapshots:
     optionalDependencies:
       mapbox-gl: 3.26.0
 
-  '@vis.gl/react-maplibre@8.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@vis.gl/react-maplibre@8.1.1(maplibre-gl@5.24.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@maplibre/maplibre-gl-style-spec': 19.3.3
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      maplibre-gl: 5.24.0
 
   '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
@@ -13620,6 +13756,8 @@ snapshots:
 
   duplexer@0.1.2: {}
 
+  earcut@3.2.3: {}
+
   eastasianwidth@0.2.0: {}
 
   eciesjs@0.4.18:
@@ -14183,6 +14321,8 @@ snapshots:
 
   fetchdts@0.1.7: {}
 
+  fflate@0.8.3: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -14340,6 +14480,8 @@ snapshots:
   get-value@2.0.6: {}
 
   giget@3.3.0: {}
+
+  gl-matrix@3.4.4: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -14875,6 +15017,8 @@ snapshots:
 
   json-stringify-pretty-compact@3.0.0: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -14895,6 +15039,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  kdbush@4.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -15060,6 +15206,28 @@ snapshots:
       semver: 7.8.5
 
   mapbox-gl@3.26.0: {}
+
+  maplibre-gl@5.24.0:
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.5
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 6.1.1
+      '@maplibre/maplibre-gl-style-spec': 24.10.0
+      '@maplibre/mlt': 1.1.12
+      '@maplibre/vt-pbf': 4.3.2
+      '@types/geojson': 7946.0.16
+      earcut: 3.2.3
+      gl-matrix: 3.4.4
+      kdbush: 4.1.0
+      murmurhash-js: 1.0.0
+      pbf: 4.0.2
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
 
   markdown-table@3.0.4: {}
 
@@ -15558,6 +15726,8 @@ snapshots:
       - '@types/node'
     optional: true
 
+  murmurhash-js@1.0.0: {}
+
   mute-stream@3.0.0: {}
 
   nan@2.28.0:
@@ -16032,6 +16202,14 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pbf@4.0.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
+  pbf@5.1.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   perfect-debounce@2.1.0: {}
 
   pg-cloudflare@1.4.0:
@@ -16103,6 +16281,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  pmtiles@4.4.1:
+    dependencies:
+      fflate: 0.8.3
+
   possible-typed-array-names@1.1.0: {}
 
   postcss-selector-parser@6.0.10:
@@ -16130,6 +16312,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  potpack@2.1.0: {}
 
   powershell-utils@0.1.0: {}
 
@@ -16193,6 +16377,8 @@ snapshots:
       '@types/node': 26.1.1
       long: 5.3.2
 
+  protocol-buffers-schema@3.6.1: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -16213,6 +16399,8 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quickselect@3.0.0: {}
 
   radash@12.1.1: {}
 
@@ -16260,14 +16448,15 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-map-gl@8.1.1(mapbox-gl@3.26.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-map-gl@8.1.1(mapbox-gl@3.26.0)(maplibre-gl@5.24.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@vis.gl/react-mapbox': 8.1.1(mapbox-gl@3.26.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@vis.gl/react-maplibre': 8.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@vis.gl/react-maplibre': 8.1.1(maplibre-gl@5.24.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       mapbox-gl: 3.26.0
+      maplibre-gl: 5.24.0
 
   react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -16430,6 +16619,10 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
 
   resolve@1.22.12:
     dependencies:
@@ -17139,6 +17332,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@3.1.0: {}
 


### PR DESCRIPTION
## What

Lands the **apps/web** half of the S0.4 map-stack spike (campaign card **C0.3**, issue **#237**), implementing the decision already recorded in **ADR-0001** (`docs/adr/0001-map-stack-maplibre-protomaps.md`).

A client-only `/_dev/map-spike` TanStack route renders a **MapLibre GL v5** map with a **Protomaps PMTiles** vector source, DOM pin markers, a route line, an **Uji (Kansai)** view, and a **static branded illustration basemap** that remains visible when tiles fail (static-first per ADR §Decision.4).

## Research (best-practice obligation, plan §0.8)

Confirmed against the current stack and ADR-0001's decision matrix: native **`maplibre-gl@5.24`** + **`pmtiles@4.4`** via `addProtocol(..., new Protocol().tile)` + **`@protomaps/basemaps@5.7`** `layers(..., { lang: "ja" })`. This is the current recommended integration (not the `@vis.gl/react-maplibre` wrapper — the ADR chose the imperative engine for parity across all five map consumers + offline Walk). SSR safety: `maplibre-gl` is loaded only via a runtime `import()` inside the browser controller, so it never executes on the server and splits into its own chunk (build shows `maplibre-gl.mjs` separate from the route chunk).

## Design / clean architecture

- **Pure, framework-free logic** (`spots`, `geometry`, `pins`, `mapStyle`, `mapLayers`, `sourceMode`) — data + style builders, no DOM.
- **Presentational React** (`MapSpike`, `IllustrationBasemap`) — renders the branded fallback + GL mount point; no transport coupling.
- **Browser glue** (`mapController.ts`) — dynamic-imports maplibre/pmtiles, registers the protocol, wires load/error → status.
- **Route** (`routes/_dev/map-spike.tsx`) — client-only `useEffect` mount + `?source=pmtiles|worker` toggle.
- Semantic `--color-map-pin-*` tokens for pins/route; all functions ≤10 lines.

## Tests (AC coverage)

| S0.4 AC | Type | Where |
|---|---|---|
| Spike renders MapLibre + PMTiles source over Japan | unit + **browser** | `map-spike-style`/`-layers` unit; live render = Tester (browser) |
| bbox outside coverage → empty tile (bg color, no broken-tile icon) | **browser** | Tester on running app |
| R2 fetch failure → static branded illustration basemap (not blank) | unit + **browser** | `map-spike.test.tsx` (fallback layer always rendered + `error`→`fallback` status); live = Tester |

Unit suite: **50 tests, 100% coverage** (statements/branches/functions/lines) on all non-excluded map-spike modules; integration build-output suite green.

### Coverage-exclude ledger (plan §0.6)
- `src/features/map-spike/mapController.ts` — WebGL mount requires a real GL context + dynamic imports, unrunnable under jsdom. Its pure inputs are 100% unit-covered; the live mount is a **browser AC** for Tester. Excluded per-file in `vitest.config.ts` with an inline justification.

## Browser AC notes for Tester (S0.4, `perf-mobile-cold` profile)
1. Navigate `/_dev/map-spike` — first tile paints ≤3s from navigation start (Fast 3G / 4× CPU / cold cache / 390×844).
2. Pan outside the tile bbox — background cream shows, no broken-tile icons.
3. Force an R2 404/500 for `/tiles/*` — map degrades to the illustrated basemap; status announces "tiles are unavailable" (requires the R2 `[[r2_buckets]]` + `/tiles/*` edge endpoint from the backend-enabler card).

## Out of scope (per card instructions)
- Root `wrangler.toml` `[[r2_buckets]]` binding, edge `/tiles/*` endpoint, and `scripts/build-pmtiles.sh` are the **backend enabler** (owned by the parallel infra/ops card); ADR-0001 now records them as pending. `package.json`/lockfile additions are scoped to my deps — any conflict resolves at rebase.

## Gates
`apps/web` typecheck + oxlint (`--deny-warnings`) + unit (50, 100% cov) + integration (5) + build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)