### PR TITLE
feat(ci): Phase C — Neon integration + catalog spike jobs, test-base refresh (spec §Phase C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
+# Neon-backed test jobs are non-gating and stay outside every deploy `needs:` chain.
+# Promote only after 10 consecutive greens on main-bound PRs; quota-class failures
+# are excluded from the streak but tracked separately (the agnix precedent below).
 name: CI
 
 on:
   push:
     branches: [main, develop]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -28,6 +32,9 @@ jobs:
       contract: ${{ steps.f.outputs.contract }}
       worker: ${{ steps.f.outputs.worker }}
       migrations: ${{ steps.f.outputs.migrations }}
+      neon_agent: ${{ steps.f.outputs.neon_agent }}
+      neon_catalog: ${{ steps.f.outputs.neon_catalog }}
+      neon_migrations: ${{ steps.f.outputs.neon_migrations }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -44,6 +51,9 @@ jobs:
             web: ['apps/web/**']
             worker: ['worker/**']
             migrations: ['supabase/migrations/**', 'db/**']
+            neon_agent: ['apps/agent/**']
+            neon_catalog: ['workers/catalog/**']
+            neon_migrations: ['db/migrations/**']
 
   # ── Stage 1: Component CI (reusable workflows, all parallel) ──
   # affected-only on PRs; full run on push/tag.
@@ -202,6 +212,103 @@ jobs:
         run: uv run pytest agent/tests/eval/test_translation.py -v -m integration --no-cov -x
         env:
           MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+
+  # ── Neon test infrastructure (non-gating during calibration) ──
+
+  python-integration:
+    name: Python integration (Neon)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: changes
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository)) &&
+        (github.event_name == 'workflow_dispatch' ||
+          needs.changes.outputs.neon_agent == 'true' ||
+          needs.changes.outputs.neon_migrations == 'true')
+      }}
+    concurrency:
+      group: neon-tests-${{ github.ref }}
+      cancel-in-progress: true
+    defaults:
+      run:
+        working-directory: apps/agent
+    env:
+      ATLAS_VERSION: "0.30.0"
+      NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+      NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+      # Settings requires presence; integration tests do not use these endpoints.
+      SUPABASE_DB_URL: postgresql://test:test@localhost:5432/test
+      MIMO_API_KEY: test-key
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+        with:
+          python: "true"
+
+      - run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - run: uv sync --all-extras
+
+      - name: Install pinned Atlas CLI
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/atlas-bin"
+          curl --proto '=https' --tlsv1.2 -sSfL \
+            "https://release.ariga.io/atlas/atlas-community-linux-amd64-v0.30.0" \
+            -o "$RUNNER_TEMP/atlas-bin/atlas"
+          # Keep synchronized with apps/agent/agent/tests/atlas_helper.py.
+          echo "dbaaf350634304d4bf92753559261a67afb399fe4ff0ea6ae5bb5d1ce6e0011a  $RUNNER_TEMP/atlas-bin/atlas" \
+            | sha256sum --check --strict
+          chmod +x "$RUNNER_TEMP/atlas-bin/atlas"
+          echo "$RUNNER_TEMP/atlas-bin" >> "$GITHUB_PATH"
+
+      - name: Run Neon integration tests
+        env:
+          TEST_DB: neon
+        run: uv run pytest agent/tests/integration -q --no-cov
+
+  catalog-spikes:
+    name: Catalog spikes (Neon)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: [changes, python-integration]
+    if: >-
+      ${{
+        always() &&
+        needs.changes.result == 'success' &&
+        (needs.python-integration.result == 'success' ||
+          needs.python-integration.result == 'skipped') &&
+        (github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository)) &&
+        (github.event_name == 'workflow_dispatch' ||
+          needs.changes.outputs.neon_catalog == 'true' ||
+          needs.changes.outputs.neon_migrations == 'true')
+      }}
+    concurrency:
+      group: neon-tests-${{ github.ref }}
+      cancel-in-progress: true
+    env:
+      NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+      NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Run catalog spike tests
+        run: pnpm run test:spike
+        working-directory: workers/catalog
 
   # ── Stage 3: Deploy (CI-green gated, push-main promotion path) ──
   # Promotion: push main → CI → staging → post-staging (api) → prod (human gate) → post-prod.

--- a/.github/workflows/neon-test-base.yml
+++ b/.github/workflows/neon-test-base.yml
@@ -1,0 +1,46 @@
+# Refreshes only the protected test-base branch. The script's own identity rails
+# reject every other Neon branch and refresh mode never performs the wipe path.
+name: Neon test-base refresh
+
+on:
+  push:
+    branches: [main, feat/frontend-rebuild]
+    paths:
+      - db/migrations/**
+      - apps/agent/agent/tests/fixtures/seed.sql
+
+permissions:
+  contents: read
+
+env:
+  ATLAS_VERSION: "0.30.0"
+
+jobs:
+  test-base:
+    name: Refresh Neon test-base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+      NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install pinned Atlas CLI
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/atlas-bin"
+          curl --proto '=https' --tlsv1.2 -sSfL \
+            "https://release.ariga.io/atlas/atlas-community-linux-amd64-v0.30.0" \
+            -o "$RUNNER_TEMP/atlas-bin/atlas"
+          # Keep synchronized with apps/agent/agent/tests/atlas_helper.py.
+          echo "dbaaf350634304d4bf92753559261a67afb399fe4ff0ea6ae5bb5d1ce6e0011a  $RUNNER_TEMP/atlas-bin/atlas" \
+            | sha256sum --check --strict
+          chmod +x "$RUNNER_TEMP/atlas-bin/atlas"
+          echo "$RUNNER_TEMP/atlas-bin" >> "$GITHUB_PATH"
+
+      - name: Refresh test-base schema and seed
+        run: scripts/neon-test-base.sh refresh test-base


### PR DESCRIPTION
Phase C of the Neon test-infra spec (after Phases 0+A #356, B #364, and the #362 fix #368).

## Deliverables

- **`python-integration` (Neon)**: runs `TEST_DB=neon` agent integration tests on PRs touching `apps/agent/**` or `db/migrations/**`. Fork-safe skip; pinned Atlas 0.30.0 install with sha256 verification (constant kept in sync with `atlas_helper.py`); `workflow_dispatch` for manual validation; minimal `contents: read` permissions.
- **`catalog-spikes` (Neon)**: `needs: python-integration` so per-PR ephemeral-branch cost peaks at 1; `always()` + allowed-skip wiring lets catalog-only changes run spikes while a genuine integration failure still blocks them.
- **Concurrency**: both share `neon-tests-${{ github.ref }}` with cancel-in-progress — superseded pushes cancel; different PRs parallelize (each claims its own branch via the #356 rename-claim protocol).
- **`neon-test-base.yml`**: refresh-only job (`scripts/neon-test-base.sh refresh test-base`) on pushes to the mainline touching `db/migrations/**` or the seed — the wipe path is unreachable by the script's own rails.
- Neither job is in any deploy `needs:` list nor a required check. Promotion criterion in the header: 10 consecutive greens (quota-class failures excluded from the streak but tracked).

## Live validation (spec AC: green run link)

`workflow_dispatch` on this branch: **[run 29650784243](https://github.com/lifeodyssey/animichi/actions/runs/29650784243)** — `Python integration (Neon)` ✅ and `Catalog spikes (Neon)` ✅ (first-ever CI execution of neon_local + ephemeral cloud branch; branch created and deleted cleanly). The run's only red is `gitleaks`: dispatch mode scans FULL history and surfaces pre-existing 2026-07-02-era doc false-positives unrelated to this PR (history cleanup is tracked separately in #315); PR-mode gitleaks scans the diff and is green here.

Secrets/vars used: existing `NEON_API_KEY` (secret, re-verified valid today) + `NEON_PROJECT_ID` (repo variable). No new secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)