### PR TITLE
feat(web): C0.4 — Landing + i18n (ja/zh/en) + Neon Auth magic-link login (#246/S0.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ backend/tests/eval/results/agent_openai-mimo-*
 # Users TS service source — re-include (root lib/ rule is too broad)
 !workers/users/src/lib/
 !workers/users/src/lib/**
+
+# apps/web TS source — re-include (root lib/ rule is too broad)
+!apps/web/src/lib/
+!apps/web/src/lib/**

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,9 @@
+# apps/web environment (Vite — only VITE_* vars reach the client bundle)
+
+# Neon Auth (Better Auth) base URL — consumed by the official better-auth client
+# (`createAuthClient` + `magicLinkClient`) in src/lib/auth/neonAuth.ts.
+# Per-branch value from: npx --yes neonctl neon-auth status --project-id $NEON_PROJECT_ID
+# Shape: https://<neon-auth-host>/neondb/auth  (see docs/ops/auth-migration-neon.md §4)
+# Operator-supplied. When empty, the login form surfaces a "not configured" state
+# instead of sending a request (no mock login path exists).
+VITE_NEON_AUTH_BASE_URL=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-router-with-query": "^1.130.17",
     "@tanstack/react-start": "^1.168.30",
     "animal-island-ui-tailwind": "^1.0.16",
+    "better-auth": "^1.6.23",
     "maplibre-gl": "^5.24.0",
     "pmtiles": "^4.4.1",
     "react": "^19.2.7",

--- a/apps/web/src/components/Landing.tsx
+++ b/apps/web/src/components/Landing.tsx
@@ -1,8 +1,11 @@
+import { LocaleProvider } from "../i18n/context";
+import { LandingPage } from "./landing/LandingPage";
+
+/** Landing entry: provides the i18n context to the marketing page. */
 export function Landing() {
   return (
-    <main className="app-shell hero" aria-labelledby="landing-title">
-      <h1 id="landing-title">Animichi</h1>
-      <p className="tagline">Find real-world anime routes with less friction.</p>
-    </main>
+    <LocaleProvider>
+      <LandingPage />
+    </LocaleProvider>
   );
 }

--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -1,0 +1,69 @@
+import type { ChangeEvent } from "react";
+import type { Dict } from "../../i18n/dictionaries";
+import { useDict } from "../../i18n/context";
+import { type FormStatus, type MagicLinkForm, type ValidationKey, useMagicLinkForm } from "./useMagicLinkForm";
+
+type Auth = Dict["auth"];
+
+interface Feedback {
+  tone: "error" | "status";
+  text: string;
+}
+
+function feedbackFor(auth: Auth, status: FormStatus, validation: ValidationKey | null): Feedback | null {
+  if (validation) return { tone: "error", text: auth[validation] };
+  if (status === "sent") return { tone: "status", text: auth.sent };
+  if (status === "error") return { tone: "error", text: auth.error };
+  if (status === "not_configured") return { tone: "error", text: auth.not_configured };
+  return null;
+}
+
+function FeedbackLine({ feedback }: { feedback: Feedback }) {
+  const role = feedback.tone === "error" ? "alert" : "status";
+  return <p className="login-form__feedback" role={role}>{feedback.text}</p>;
+}
+
+interface EmailFieldProps {
+  auth: Auth;
+  email: string;
+  onEmail: (value: string) => void;
+}
+
+function EmailField({ auth, email, onEmail }: EmailFieldProps) {
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => { onEmail(event.target.value); };
+  return (
+    <>
+      <label className="login-form__label" htmlFor="login-email">{auth.email_label}</label>
+      <input id="login-email" className="ds-input" type="email" value={email} placeholder={auth.email_placeholder} onChange={onChange} />
+    </>
+  );
+}
+
+function SubmitButton({ auth, busy }: { auth: Auth; busy: boolean }) {
+  return (
+    <button className="ds-button ds-button--primary" type="submit" disabled={busy}>
+      {busy ? auth.submitting : auth.submit}
+    </button>
+  );
+}
+
+function FormFields({ form }: { form: MagicLinkForm }) {
+  const auth = useDict().auth;
+  const feedback = feedbackFor(auth, form.status, form.validation);
+  return (<>
+    <EmailField auth={auth} email={form.email} onEmail={form.setEmail} />
+    {feedback ? <FeedbackLine feedback={feedback} /> : null}
+    <SubmitButton auth={auth} busy={form.status === "submitting"} />
+    <p className="login-form__hint">{auth.magic_link_hint}</p>
+  </>);
+}
+
+export function LoginForm() {
+  const form = useMagicLinkForm();
+  const auth = useDict().auth;
+  return (
+    <form className="login-form" onSubmit={form.onSubmit} noValidate aria-label={auth.title}>
+      <FormFields form={form} />
+    </form>
+  );
+}

--- a/apps/web/src/components/auth/LoginModal.tsx
+++ b/apps/web/src/components/auth/LoginModal.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+import type { Dict } from "../../i18n/dictionaries";
+import { useDict } from "../../i18n/context";
+import { LoginForm } from "./LoginForm";
+
+interface LoginModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function useEscapeToClose(open: boolean, onClose: () => void): void {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => { document.removeEventListener("keydown", onKey); };
+  }, [open, onClose]);
+}
+
+function LoginDialog({ auth, onClose }: { auth: Dict["auth"]; onClose: () => void }) {
+  return (
+    <div className="login-modal" role="dialog" aria-modal="true" aria-label={auth.title} onClick={(event) => { event.stopPropagation(); }}>
+      <button className="login-modal__close" type="button" aria-label={auth.close} onClick={onClose}>×</button>
+      <h2 className="login-modal__title">{auth.title}</h2>
+      <p className="login-modal__subtitle">{auth.subtitle}</p>
+      <LoginForm />
+    </div>
+  );
+}
+
+/** Magic-link login modal wired to the Neon Auth (Better Auth) client. */
+export function LoginModal({ open, onClose }: LoginModalProps) {
+  const auth = useDict().auth;
+  useEscapeToClose(open, onClose);
+  if (!open) return null;
+  return (
+    <div className="login-modal__mask" role="presentation" onClick={onClose}>
+      <LoginDialog auth={auth} onClose={onClose} />
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/useMagicLinkForm.ts
+++ b/apps/web/src/components/auth/useMagicLinkForm.ts
@@ -1,0 +1,54 @@
+import { useCallback, useState } from "react";
+import { type MagicLinkResult, sendMagicLink } from "../../lib/auth/neonAuth";
+
+export type ValidationKey = "email_required" | "email_invalid";
+export type FormStatus = "idle" | "submitting" | MagicLinkResult;
+
+/** Structural submit handler: React's synthetic form event satisfies it. */
+export type SubmitHandler = (event: { preventDefault: () => void }) => void;
+
+export interface MagicLinkForm {
+  email: string;
+  status: FormStatus;
+  validation: ValidationKey | null;
+  setEmail: (email: string) => void;
+  onSubmit: SubmitHandler;
+}
+
+export function validateEmail(email: string): ValidationKey | null {
+  const trimmed = email.trim();
+  if (trimmed.length === 0) return "email_required";
+  return trimmed.includes("@") ? null : "email_invalid";
+}
+
+function callbackUrl(): string {
+  return `${window.location.origin}/auth/callback`;
+}
+
+function useSendMagicLink(email: string): [FormStatus, () => Promise<void>] {
+  const [status, setStatus] = useState<FormStatus>("idle");
+  const submit = useCallback(async () => {
+    setStatus("submitting");
+    setStatus(await sendMagicLink({ email: email.trim().toLowerCase(), callbackURL: callbackUrl() }));
+  }, [email]);
+  return [status, submit];
+}
+
+type SetValidation = (validation: ValidationKey | null) => void;
+
+function useSubmit(email: string, setValidation: SetValidation, submit: () => Promise<void>): SubmitHandler {
+  return useCallback<SubmitHandler>((event) => {
+    event.preventDefault();
+    const invalid = validateEmail(email);
+    setValidation(invalid);
+    if (!invalid) void submit();
+  }, [email, setValidation, submit]);
+}
+
+export function useMagicLinkForm(): MagicLinkForm {
+  const [email, setEmail] = useState("");
+  const [validation, setValidation] = useState<ValidationKey | null>(null);
+  const [status, submit] = useSendMagicLink(email);
+  const onSubmit = useSubmit(email, setValidation, submit);
+  return { email, status, validation, setEmail, onSubmit };
+}

--- a/apps/web/src/components/landing/ComparisonSlider.tsx
+++ b/apps/web/src/components/landing/ComparisonSlider.tsx
@@ -1,0 +1,36 @@
+import type { CSSProperties, ChangeEvent } from "react";
+import { useState } from "react";
+import { useDict } from "../../i18n/context";
+
+interface Reveal {
+  reveal: number;
+  style: CSSProperties;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+function useReveal(): Reveal {
+  const [reveal, setReveal] = useState(50);
+  const style = { "--reveal": `${String(reveal)}%` } as CSSProperties;
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => { setReveal(Number(event.target.value)); };
+  return { reveal, style, onChange };
+}
+
+function Pane({ variant, label }: { variant: string; label: string }) {
+  return (
+    <div className={`comparison__pane comparison__pane--${variant}`} aria-hidden>
+      <span className="comparison__tag">{label}</span>
+    </div>
+  );
+}
+
+/** Anime/real before-after slider; the range input drives the reveal width. */
+export function ComparisonSlider() {
+  const landing = useDict().landing;
+  const { reveal, style, onChange } = useReveal();
+  return (
+    <figure className="comparison" style={style}>
+      <Pane variant="real" label={landing.comparison_real} />
+      <Pane variant="anime" label={landing.comparison_anime} />
+      <input className="comparison__range" type="range" min={0} max={100} value={reveal} aria-label={landing.comparison_aria} onChange={onChange} />
+    </figure>);
+}

--- a/apps/web/src/components/landing/DayNightToggle.tsx
+++ b/apps/web/src/components/landing/DayNightToggle.tsx
@@ -1,0 +1,13 @@
+import { useDict } from "../../i18n/context";
+import { useTheme } from "./useTheme";
+
+/** Day/night switch — persistence lives in useTheme. */
+export function DayNightToggle() {
+  const landing = useDict().landing;
+  const { theme, toggle } = useTheme();
+  const isNight = theme === "night";
+  const label = isNight ? landing.theme_night : landing.theme_day;
+  return (
+    <button type="button" className="day-night-toggle" role="switch" aria-checked={isNight} aria-label={label} onClick={toggle}>{label}</button>
+  );
+}

--- a/apps/web/src/components/landing/Hero.tsx
+++ b/apps/web/src/components/landing/Hero.tsx
@@ -1,0 +1,36 @@
+import { useDict } from "../../i18n/context";
+import { ComparisonSlider } from "./ComparisonSlider";
+
+interface HeroProps {
+  onStart: () => void;
+}
+
+function HeroCopy({ onStart }: HeroProps) {
+  const landing = useDict().landing;
+  return (<div className="hero-band__copy">
+    <p className="hero-band__eyebrow">{landing.eyebrow}</p>
+    <h1 id="hero-title" className="hero-band__title">{landing.hero}<span className="hero-band__accent">{landing.hero_accent}</span></h1>
+    <p className="hero-band__subtitle">{landing.subtitle}</p>
+    <button className="ds-button ds-button--primary ds-button--large" type="button" onClick={onStart}>{landing.cta}</button>
+  </div>);
+}
+
+function HeroShowcase() {
+  const landing = useDict().landing;
+  return (
+    <div className="hero-band__showcase">
+      <p className="hero-band__showcase-title">{landing.comparison_title}</p>
+      <p className="hero-band__showcase-sub">{landing.comparison_sub}</p>
+      <ComparisonSlider />
+    </div>
+  );
+}
+
+export function Hero({ onStart }: HeroProps) {
+  return (
+    <section className="hero-band" aria-labelledby="hero-title">
+      <HeroCopy onStart={onStart} />
+      <HeroShowcase />
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/LandingPage.tsx
+++ b/apps/web/src/components/landing/LandingPage.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useState } from "react";
+import { useDict } from "../../i18n/context";
+import { LocaleSwitcher } from "../../i18n/LocaleSwitcher";
+import { LoginModal } from "../auth/LoginModal";
+import { DayNightToggle } from "./DayNightToggle";
+import { Hero } from "./Hero";
+
+interface AuthModal {
+  open: boolean;
+  openAuth: () => void;
+  closeAuth: () => void;
+}
+
+function useAuthModal(): AuthModal {
+  const [open, setOpen] = useState(false);
+  const openAuth = useCallback(() => { setOpen(true); }, []);
+  const closeAuth = useCallback(() => { setOpen(false); }, []);
+  return { open, openAuth, closeAuth };
+}
+
+function BarActions({ onLogin }: { onLogin: () => void }) {
+  const landing = useDict().landing;
+  return (
+    <div className="landing__bar-actions">
+      <LocaleSwitcher />
+      <DayNightToggle />
+      <button className="ds-button" type="button" onClick={onLogin}>{landing.login}</button>
+    </div>
+  );
+}
+
+function LandingBar({ onLogin }: { onLogin: () => void }) {
+  const landing = useDict().landing;
+  return (
+    <header className="landing__bar">
+      <span className="landing__wordmark">{landing.hero}</span>
+      <BarActions onLogin={onLogin} />
+    </header>
+  );
+}
+
+/** Marketing landing: header controls, hero + comparison slider, login modal. */
+export function LandingPage() {
+  const { open, openAuth, closeAuth } = useAuthModal();
+  return (
+    <main className="landing">
+      <LandingBar onLogin={openAuth} />
+      <Hero onStart={openAuth} />
+      <LoginModal open={open} onClose={closeAuth} />
+    </main>
+  );
+}

--- a/apps/web/src/components/landing/useTheme.ts
+++ b/apps/web/src/components/landing/useTheme.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type Theme = "day" | "night";
+
+const STORAGE_KEY = "animichi-theme";
+
+function readStored(): Theme | null {
+  const value = window.localStorage.getItem(STORAGE_KEY);
+  return value === "day" || value === "night" ? value : null;
+}
+
+function applyTheme(theme: Theme): void {
+  document.documentElement.dataset.theme = theme;
+  window.localStorage.setItem(STORAGE_KEY, theme);
+}
+
+export interface ThemeControl {
+  theme: Theme;
+  toggle: () => void;
+}
+
+/** Day/night theme persisted to localStorage; SSR renders the day default. */
+export function useTheme(): ThemeControl {
+  const [theme, setTheme] = useState<Theme>("day");
+  useEffect(() => { const stored = readStored(); if (stored) setTheme(stored); }, []);
+  useEffect(() => { applyTheme(theme); }, [theme]);
+  const toggle = useCallback(() => { setTheme((current) => (current === "day" ? "night" : "day")); }, []);
+  return { theme, toggle };
+}

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Neon Auth (Better Auth) base URL, e.g. `https://…/neondb/auth`. Operator-supplied. */
+  readonly VITE_NEON_AUTH_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/web/src/i18n/LocaleSwitcher.tsx
+++ b/apps/web/src/i18n/LocaleSwitcher.tsx
@@ -1,0 +1,28 @@
+import { useLocale, useSetLocale } from "./context";
+import { LOCALES, LOCALE_LABELS, type Locale } from "./locales";
+
+interface LocaleOptionProps {
+  locale: Locale;
+  active: Locale;
+  onSelect: (locale: Locale) => void;
+}
+
+function LocaleOption({ locale, active, onSelect }: LocaleOptionProps) {
+  const select = () => { onSelect(locale); };
+  return (
+    <button type="button" className="locale-switcher__option" aria-pressed={locale === active} onClick={select}>
+      {LOCALE_LABELS[locale]}
+    </button>
+  );
+}
+
+/** Segmented ja/zh/en switcher driven by the i18n context. */
+export function LocaleSwitcher() {
+  const active = useLocale();
+  const setLocale = useSetLocale();
+  return (
+    <div className="locale-switcher" role="group" aria-label="Language">
+      {LOCALES.map((locale) => <LocaleOption key={locale} locale={locale} active={active} onSelect={setLocale} />)}
+    </div>
+  );
+}

--- a/apps/web/src/i18n/context.tsx
+++ b/apps/web/src/i18n/context.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { type Dict, dictFor } from "./dictionaries";
+import { DEFAULT_LOCALE, detectLocale, type Locale } from "./locales";
+
+interface I18nValue {
+  dict: Dict;
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+}
+
+const I18nContext = createContext<I18nValue | null>(null);
+
+/** Applies `<html lang>` after mount so SSR output stays on DEFAULT_LOCALE. */
+function useHtmlLang(locale: Locale): void {
+  useEffect(() => { document.documentElement.lang = locale; }, [locale]);
+}
+
+export function LocaleProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocale] = useState<Locale>(DEFAULT_LOCALE);
+  useEffect(() => { setLocale(detectLocale()); }, []);
+  useHtmlLang(locale);
+  const value = useMemo<I18nValue>(() => ({ dict: dictFor(locale), locale, setLocale }), [locale]);
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+function useI18n(): I18nValue {
+  const value = useContext(I18nContext);
+  if (!value) throw new Error("useI18n must be used within a LocaleProvider");
+  return value;
+}
+
+export function useDict(): Dict {
+  return useI18n().dict;
+}
+
+export function useLocale(): Locale {
+  return useI18n().locale;
+}
+
+export function useSetLocale(): (locale: Locale) => void {
+  return useI18n().setLocale;
+}

--- a/apps/web/src/i18n/dictionaries.ts
+++ b/apps/web/src/i18n/dictionaries.ts
@@ -1,0 +1,17 @@
+import en from "./dictionaries/en.json";
+import ja from "./dictionaries/ja.json";
+import zh from "./dictionaries/zh.json";
+import type { Locale } from "./locales";
+
+export type Dict = typeof ja;
+
+/** All dictionaries are bundled so locale switches are synchronous and SSR-safe. */
+export const DICTIONARIES: Record<Locale, Dict> = {
+  ja,
+  zh: zh satisfies Dict,
+  en: en satisfies Dict,
+};
+
+export function dictFor(locale: Locale): Dict {
+  return DICTIONARIES[locale];
+}

--- a/apps/web/src/i18n/dictionaries/en.json
+++ b/apps/web/src/i18n/dictionaries/en.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "title": "Animichi",
+    "description": "Find real-world anime locations and plan pilgrimage routes"
+  },
+  "landing": {
+    "eyebrow": "Anime Pilgrimage",
+    "hero": "Animichi",
+    "hero_accent": "Pilgrimage Routes",
+    "subtitle": "Stand where your favourite scene happened. Type a title, find its spots, and build a route.",
+    "cta": "Start Exploring",
+    "login": "Log in",
+    "comparison_title": "Anime vs Reality",
+    "comparison_sub": "Every spot matched against its original frame.",
+    "comparison_anime": "Anime",
+    "comparison_real": "Reality",
+    "comparison_aria": "Slider comparing the anime frame with the real location",
+    "theme_day": "Day",
+    "theme_night": "Night"
+  },
+  "auth": {
+    "title": "Log in",
+    "subtitle": "Enter your email and we'll send you a sign-in link.",
+    "email_label": "Email address",
+    "email_placeholder": "you@example.com",
+    "submit": "Send sign-in link",
+    "submitting": "Sending…",
+    "email_required": "Please enter your email address.",
+    "email_invalid": "Email needs an @ (for example you@example.com).",
+    "sent": "We've sent a sign-in link to your inbox. Please check your email.",
+    "error": "Couldn't send the link. Please try again in a moment.",
+    "not_configured": "Sign-in isn't configured yet. Please contact the administrator.",
+    "magic_link_hint": "No password — we email you a secure sign-in link.",
+    "close": "Close"
+  }
+}

--- a/apps/web/src/i18n/dictionaries/ja.json
+++ b/apps/web/src/i18n/dictionaries/ja.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "title": "アニミチ",
+    "description": "アニメ聖地を探して、巡礼ルートを作ろう"
+  },
+  "landing": {
+    "eyebrow": "アニメ聖地巡礼",
+    "hero": "聖地巡礼",
+    "hero_accent": "巡礼の路",
+    "subtitle": "あの名シーンの、その場所へ。作品名を入力して聖地を見つけ、ルートを作ろう。",
+    "cta": "はじめる",
+    "login": "ログイン",
+    "comparison_title": "アニメと現実",
+    "comparison_sub": "すべてのスポットを原作カットと照合。",
+    "comparison_anime": "アニメ",
+    "comparison_real": "現実",
+    "comparison_aria": "アニメと実写を比較するスライダー",
+    "theme_day": "昼",
+    "theme_night": "夜"
+  },
+  "auth": {
+    "title": "ログイン",
+    "subtitle": "メールアドレスを入力すると、ログインリンクをお送りします。",
+    "email_label": "メールアドレス",
+    "email_placeholder": "you@example.com",
+    "submit": "ログインリンクを送信",
+    "submitting": "送信中…",
+    "email_required": "メールアドレスを入力してください。",
+    "email_invalid": "メールアドレスには @ が必要です（例: you@example.com）。",
+    "sent": "ログインリンクをメールに送信しました。メールをご確認ください。",
+    "error": "送信できませんでした。しばらくしてからもう一度お試しください。",
+    "not_configured": "ログイン設定がまだ完了していません。管理者にお問い合わせください。",
+    "magic_link_hint": "パスワード不要 — 安全なログインリンクをメールでお送りします。",
+    "close": "閉じる"
+  }
+}

--- a/apps/web/src/i18n/dictionaries/zh.json
+++ b/apps/web/src/i18n/dictionaries/zh.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "title": "Animichi 圣地巡礼",
+    "description": "寻找动画圣地，规划巡礼路线"
+  },
+  "landing": {
+    "eyebrow": "动画圣地巡礼",
+    "hero": "圣地巡礼",
+    "hero_accent": "巡礼之路",
+    "subtitle": "走进那一幕名场景的真实地点。输入作品名，找到圣地并生成路线。",
+    "cta": "开始探索",
+    "login": "登录",
+    "comparison_title": "动画与现实",
+    "comparison_sub": "每个地点都与原作画面一一对照。",
+    "comparison_anime": "动画",
+    "comparison_real": "现实",
+    "comparison_aria": "对比动画与实景的滑块",
+    "theme_day": "日间",
+    "theme_night": "夜间"
+  },
+  "auth": {
+    "title": "登录",
+    "subtitle": "输入邮箱，我们会给你发送一个登录链接。",
+    "email_label": "邮箱地址",
+    "email_placeholder": "you@example.com",
+    "submit": "发送登录链接",
+    "submitting": "发送中…",
+    "email_required": "请输入邮箱地址。",
+    "email_invalid": "邮箱地址需要包含 @（例如 you@example.com）。",
+    "sent": "登录链接已发送到你的邮箱，请查收。",
+    "error": "发送失败，请稍后再试。",
+    "not_configured": "登录尚未配置完成，请联系管理员。",
+    "magic_link_hint": "无需密码 —— 我们会通过邮件发送安全的登录链接。",
+    "close": "关闭"
+  }
+}

--- a/apps/web/src/i18n/locales.ts
+++ b/apps/web/src/i18n/locales.ts
@@ -1,0 +1,31 @@
+export const LOCALES = ["ja", "zh", "en"] as const;
+
+export type Locale = (typeof LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = "ja";
+
+/** Human-readable locale labels — the single source for every switcher. */
+export const LOCALE_LABELS: Record<Locale, string> = {
+  ja: "日本語",
+  zh: "中文",
+  en: "EN",
+};
+
+function isLocale(value: string): value is Locale {
+  return (LOCALES as readonly string[]).includes(value);
+}
+
+function matchLanguage(tag: string): Locale | null {
+  const code = tag.toLowerCase().slice(0, 2);
+  return isLocale(code) ? code : null;
+}
+
+/** SSR-safe: returns DEFAULT_LOCALE off the browser, else the first match. */
+export function detectLocale(): Locale {
+  if (typeof navigator === "undefined") return DEFAULT_LOCALE;
+  for (const tag of navigator.languages) {
+    const matched = matchLanguage(tag);
+    if (matched) return matched;
+  }
+  return DEFAULT_LOCALE;
+}

--- a/apps/web/src/lib/auth/neonAuth.ts
+++ b/apps/web/src/lib/auth/neonAuth.ts
@@ -1,0 +1,43 @@
+import { createAuthClient } from "better-auth/client";
+import { magicLinkClient } from "better-auth/client/plugins";
+
+/**
+ * Neon Auth (Better Auth base) magic-link client.
+ *
+ * Uses the official Better Auth client SDK (`createAuthClient` + the
+ * `magicLinkClient` plugin) pointed at the per-branch Neon Auth base URL
+ * (`…/neondb/auth`, see `docs/ops/auth-migration-neon.md` §4). The base URL is
+ * operator-supplied via `VITE_NEON_AUTH_BASE_URL`; when absent the caller
+ * surfaces a "not configured" state rather than a fabricated success. The
+ * client is built lazily at call time so tests and SSR resolve the env freshly.
+ */
+export type MagicLinkResult = "sent" | "not_configured" | "error";
+
+export interface MagicLinkRequest {
+  email: string;
+  callbackURL: string;
+}
+
+function baseUrl(): string | undefined {
+  const value = import.meta.env.VITE_NEON_AUTH_BASE_URL;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function isNeonAuthConfigured(): boolean {
+  return baseUrl() !== undefined;
+}
+
+function neonAuthClient(baseURL: string) {
+  return createAuthClient({ baseURL, plugins: [magicLinkClient()] });
+}
+
+export async function sendMagicLink(request: MagicLinkRequest): Promise<MagicLinkResult> {
+  const base = baseUrl();
+  if (!base) return "not_configured";
+  try {
+    const { error } = await neonAuthClient(base).signIn.magicLink(request);
+    return error ? "error" : "sent";
+  } catch {
+    return "error";
+  }
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -112,6 +112,7 @@ h1 {
   }
 }
 
+
 .map-spike {
   display: grid;
   gap: 20px;
@@ -180,4 +181,318 @@ h1 {
   border-color: var(--color-fg);
   background: var(--color-map-pin-orange);
   color: var(--color-primary-fg);
+}
+
+/* Night theme — semantic token overrides applied via <html data-theme="night">. */
+[data-theme="night"] {
+  color-scheme: dark;
+  --color-bg: #201a12;
+  --color-fg: #f3ece0;
+  --color-card: #2b2318;
+  --color-muted: #362c1e;
+  --color-muted-fg: #cbbfa8;
+  --color-border: #4a3d2b;
+  --color-primary-fg: #10201d;
+}
+
+.landing {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--color-bg);
+}
+
+.landing__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 32px;
+  flex-wrap: wrap;
+}
+
+.landing__wordmark {
+  color: var(--color-primary-strong);
+  font-weight: 800;
+  font-size: 1.25rem;
+}
+
+.landing__bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.locale-switcher {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  border: 2px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-card);
+}
+
+.locale-switcher__option {
+  border: 0;
+  border-radius: 999px;
+  padding: 4px 12px;
+  min-height: 32px;
+  background: transparent;
+  color: var(--color-muted-fg);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.locale-switcher__option[aria-pressed="true"] {
+  background: var(--color-primary);
+  color: var(--color-primary-fg);
+}
+
+.day-night-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 4px 14px;
+  border: 2px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-card);
+  color: var(--color-muted-fg);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.day-night-toggle[aria-checked="true"] {
+  border-color: var(--color-primary);
+  color: var(--color-primary-strong);
+}
+
+.hero-band {
+  display: grid;
+  gap: 40px;
+  align-items: center;
+  flex: 1;
+  padding: 32px;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.hero-band__eyebrow {
+  margin: 0 0 12px;
+  color: var(--color-primary-strong);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.hero-band__title {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--color-fg);
+}
+
+.hero-band__accent {
+  color: var(--color-primary);
+  font-size: 0.5em;
+}
+
+.hero-band__subtitle {
+  margin: 18px 0 28px;
+  max-width: 34rem;
+  color: var(--color-muted-fg);
+  line-height: 1.7;
+}
+
+.hero-band__showcase {
+  display: grid;
+  gap: 8px;
+}
+
+.hero-band__showcase-title {
+  margin: 0;
+  color: var(--color-fg);
+  font-weight: 800;
+}
+
+.hero-band__showcase-sub {
+  margin: 0 0 8px;
+  color: var(--color-muted-fg);
+}
+
+.comparison {
+  --reveal: 50%;
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border: 3px solid var(--color-border);
+  border-radius: 18px;
+  overflow: hidden;
+  background: var(--color-muted);
+}
+
+.comparison__pane {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  padding: 12px;
+}
+
+.comparison__pane--real {
+  background: var(--color-explore-bg);
+  color: var(--color-explore-fg);
+}
+
+.comparison__pane--anime {
+  width: var(--reveal);
+  background: var(--color-primary-soft);
+  color: var(--color-primary-strong);
+  border-right: 3px solid var(--color-primary);
+}
+
+.comparison__tag {
+  font-weight: 800;
+}
+
+.comparison__range {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 12px;
+  width: calc(100% - 24px);
+  margin-inline: 12px;
+  accent-color: var(--color-primary);
+}
+
+/* 動森-style pressable button + input primitives (semantic tokens only). */
+.ds-button {
+  border: 2px solid var(--color-border);
+  border-radius: 12px;
+  padding: 10px 18px;
+  min-height: 44px;
+  background: var(--color-card);
+  color: var(--color-fg);
+  font: inherit;
+  font-weight: 700;
+  box-shadow: var(--shadow-press);
+  cursor: pointer;
+  transition: transform 0.05s ease;
+}
+
+.ds-button:active {
+  transform: translateY(4px);
+  box-shadow: none;
+}
+
+.ds-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.ds-button--primary {
+  border-color: var(--color-primary-strong);
+  background: var(--color-primary);
+  color: var(--color-primary-fg);
+}
+
+.ds-button--large {
+  padding: 14px 26px;
+  font-size: 1.05rem;
+}
+
+.ds-input {
+  border: 2px solid var(--color-border);
+  border-radius: 12px;
+  padding: 12px 14px;
+  min-height: 44px;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font: inherit;
+}
+
+.ds-input:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 1px;
+}
+
+.login-modal__mask {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  background: rgb(0 0 0 / 45%);
+}
+
+.login-modal {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  padding: 28px;
+  border-radius: 18px;
+  border: 3px solid var(--color-border);
+  background: var(--color-card);
+  box-shadow: var(--shadow-press);
+}
+
+.login-modal__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 36px;
+  height: 36px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-muted-fg);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.login-modal__title {
+  margin: 0 0 6px;
+  color: var(--color-fg);
+}
+
+.login-modal__subtitle {
+  margin: 0 0 18px;
+  color: var(--color-muted-fg);
+  line-height: 1.6;
+}
+
+.login-form {
+  display: grid;
+  gap: 12px;
+}
+
+.login-form__label {
+  font-weight: 700;
+  color: var(--color-fg);
+}
+
+.login-form__feedback {
+  margin: 0;
+  font-weight: 700;
+  color: var(--color-error-fg);
+}
+
+.login-form__feedback[role="status"] {
+  color: var(--color-success-fg);
+}
+
+.login-form__hint {
+  margin: 4px 0 0;
+  color: var(--color-muted-fg);
+  font-size: 0.875rem;
+}
+
+@media (min-width: 900px) {
+  .hero-band {
+    grid-template-columns: 1fr 1fr;
+    padding: 48px 32px;
+  }
 }

--- a/apps/web/tests/unit/_i18n.tsx
+++ b/apps/web/tests/unit/_i18n.tsx
@@ -1,0 +1,12 @@
+import { render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { LocaleProvider } from "../../src/i18n/context";
+
+/** Pin navigator.languages so the provider's mount detection is deterministic. */
+export function setLanguages(langs: string[]): void {
+  Object.defineProperty(navigator, "languages", { value: langs, configurable: true });
+}
+
+export function renderWithLocale(ui: ReactElement) {
+  return render(<LocaleProvider>{ui}</LocaleProvider>);
+}

--- a/apps/web/tests/unit/comparison-slider.test.tsx
+++ b/apps/web/tests/unit/comparison-slider.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ComparisonSlider } from "../../src/components/landing/ComparisonSlider";
+import { renderWithLocale, setLanguages } from "./_i18n";
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(cleanup);
+
+describe("ComparisonSlider", () => {
+  it("labels both the anime and reality panes", () => {
+    renderWithLocale(<ComparisonSlider />);
+    expect(screen.getByText("アニメ")).toBeTruthy();
+    expect(screen.getByText("現実")).toBeTruthy();
+  });
+
+  it("drives the reveal width from the range input", () => {
+    renderWithLocale(<ComparisonSlider />);
+    const range = screen.getByRole("slider");
+    fireEvent.change(range, { target: { value: "80" } });
+    expect((range as HTMLInputElement).value).toBe("80");
+    const figure = range.closest(".comparison") as HTMLElement;
+    expect(figure.style.getPropertyValue("--reveal")).toBe("80%");
+  });
+});

--- a/apps/web/tests/unit/day-night-toggle.test.tsx
+++ b/apps/web/tests/unit/day-night-toggle.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DayNightToggle } from "../../src/components/landing/DayNightToggle";
+import { renderWithLocale, setLanguages } from "./_i18n";
+
+beforeEach(() => {
+  setLanguages(["ja-JP"]);
+  window.localStorage.clear();
+});
+afterEach(cleanup);
+
+describe("DayNightToggle", () => {
+  it("defaults to the day theme and persists it", () => {
+    renderWithLocale(<DayNightToggle />);
+    const toggle = screen.getByRole("switch");
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(window.localStorage.getItem("animichi-theme")).toBe("day");
+  });
+
+  it("toggles to night, updating aria, storage, and the document theme", () => {
+    renderWithLocale(<DayNightToggle />);
+    act(() => { screen.getByRole("switch").click(); });
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
+    expect(window.localStorage.getItem("animichi-theme")).toBe("night");
+    expect(document.documentElement.dataset.theme).toBe("night");
+  });
+
+  it("toggles back to day on a second press", () => {
+    renderWithLocale(<DayNightToggle />);
+    act(() => { screen.getByRole("switch").click(); });
+    act(() => { screen.getByRole("switch").click(); });
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("false");
+    expect(window.localStorage.getItem("animichi-theme")).toBe("day");
+  });
+
+  it("restores a stored night preference on mount", () => {
+    window.localStorage.setItem("animichi-theme", "night");
+    renderWithLocale(<DayNightToggle />);
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("ignores an invalid stored value and stays on day", () => {
+    window.localStorage.setItem("animichi-theme", "sepia");
+    renderWithLocale(<DayNightToggle />);
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("false");
+  });
+});

--- a/apps/web/tests/unit/i18n-context.test.tsx
+++ b/apps/web/tests/unit/i18n-context.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, render, renderHook, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LocaleProvider, useDict, useLocale, useSetLocale } from "../../src/i18n/context";
+import { setLanguages } from "./_i18n";
+
+function Probe() {
+  const dict = useDict();
+  const locale = useLocale();
+  const setLocale = useSetLocale();
+  return (
+    <div>
+      <span data-testid="locale">{locale}</span>
+      <span data-testid="cta">{dict.landing.cta}</span>
+      <button type="button" onClick={() => { setLocale("en"); }}>go-en</button>
+    </div>
+  );
+}
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(cleanup);
+
+describe("i18n context", () => {
+  it("provides the ja default and updates html lang", () => {
+    render(<LocaleProvider><Probe /></LocaleProvider>);
+    expect(screen.getByTestId("locale").textContent).toBe("ja");
+    expect(document.documentElement.lang).toBe("ja");
+  });
+
+  it("switches locale, dictionary, and html lang together", () => {
+    render(<LocaleProvider><Probe /></LocaleProvider>);
+    act(() => { screen.getByRole("button", { name: "go-en" }).click(); });
+    expect(screen.getByTestId("cta").textContent).toBe("Start Exploring");
+    expect(document.documentElement.lang).toBe("en");
+  });
+
+  it("throws when hooks are used outside a provider", () => {
+    expect(() => renderHook(() => useDict())).toThrow(/LocaleProvider/u);
+  });
+});

--- a/apps/web/tests/unit/i18n-dictionaries.test.ts
+++ b/apps/web/tests/unit/i18n-dictionaries.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { DICTIONARIES, dictFor } from "../../src/i18n/dictionaries";
+import { LOCALES } from "../../src/i18n/locales";
+
+function keyPaths(value: unknown, prefix = ""): string[] {
+  if (typeof value !== "object" || value === null) return [prefix];
+  return Object.entries(value).flatMap(([key, child]) =>
+    keyPaths(child, prefix ? `${prefix}.${key}` : key),
+  );
+}
+
+const jaPaths = keyPaths(DICTIONARIES.ja).sort();
+
+describe("dictionaries", () => {
+  it.each(LOCALES)("%s has the exact same key structure as ja", (locale) => {
+    expect(keyPaths(DICTIONARIES[locale]).sort()).toEqual(jaPaths);
+  });
+
+  it.each(LOCALES)("%s has no empty strings", (locale) => {
+    const values = keyPaths(DICTIONARIES[locale]).map((path) =>
+      path.split(".").reduce<unknown>((node, key) => (node as Record<string, unknown>)[key], DICTIONARIES[locale]),
+    );
+    expect(values.every((value) => typeof value === "string" && value.length > 0)).toBe(true);
+  });
+
+  it("dictFor resolves each locale", () => {
+    expect(dictFor("en").landing.cta).toBe("Start Exploring");
+    expect(dictFor("ja").landing.cta).not.toBe(dictFor("en").landing.cta);
+  });
+});

--- a/apps/web/tests/unit/i18n-locales.test.ts
+++ b/apps/web/tests/unit/i18n-locales.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_LOCALE, LOCALES, LOCALE_LABELS, detectLocale } from "../../src/i18n/locales";
+
+function setLanguages(langs: string[]): void {
+  Object.defineProperty(navigator, "languages", { value: langs, configurable: true });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("locales", () => {
+  it("exposes ja/zh/en with the ja default", () => {
+    expect(LOCALES).toEqual(["ja", "zh", "en"]);
+    expect(DEFAULT_LOCALE).toBe("ja");
+    expect(Object.keys(LOCALE_LABELS)).toEqual(["ja", "zh", "en"]);
+  });
+
+  it("detects the first supported navigator language", () => {
+    setLanguages(["zh-CN", "en"]);
+    expect(detectLocale()).toBe("zh");
+  });
+
+  it("skips unsupported tags and falls back to the default", () => {
+    setLanguages(["fr-FR", "de"]);
+    expect(detectLocale()).toBe(DEFAULT_LOCALE);
+  });
+
+  it("returns the default when navigator is absent (SSR)", () => {
+    vi.stubGlobal("navigator", undefined);
+    expect(detectLocale()).toBe(DEFAULT_LOCALE);
+  });
+});

--- a/apps/web/tests/unit/landing-page.test.tsx
+++ b/apps/web/tests/unit/landing-page.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LandingPage } from "../../src/components/landing/LandingPage";
+import { renderWithLocale, setLanguages } from "./_i18n";
+
+beforeEach(() => {
+  setLanguages(["ja-JP"]);
+  window.localStorage.clear();
+});
+afterEach(cleanup);
+
+describe("LandingPage", () => {
+  it("renders the hero eyebrow, title, and Start CTA", () => {
+    renderWithLocale(<LandingPage />);
+    expect(screen.getByText("アニメ聖地巡礼")).toBeTruthy();
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toContain("聖地巡礼");
+    expect(screen.getByRole("button", { name: "はじめる" })).toBeTruthy();
+  });
+
+  it("opens the login modal from the hero CTA", () => {
+    renderWithLocale(<LandingPage />);
+    act(() => { screen.getByRole("button", { name: "はじめる" }).click(); });
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("opens the login modal from the header login button", () => {
+    renderWithLocale(<LandingPage />);
+    act(() => { screen.getByRole("button", { name: "ログイン" }).click(); });
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("closes the login modal from the modal close control", () => {
+    renderWithLocale(<LandingPage />);
+    act(() => { screen.getByRole("button", { name: "ログイン" }).click(); });
+    act(() => { screen.getByRole("button", { name: "閉じる" }).click(); });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});
+
+describe("LandingPage i18n", () => {
+  it("re-renders all copy in English with no ja fallback leaking", () => {
+    renderWithLocale(<LandingPage />);
+    act(() => { screen.getByRole("button", { name: "EN" }).click(); });
+    expect(screen.getByRole("button", { name: "Start Exploring" })).toBeTruthy();
+    expect(screen.getByText("Anime Pilgrimage")).toBeTruthy();
+    expect(screen.queryByText("はじめる")).toBeNull();
+    expect(screen.queryByText("アニメ聖地巡礼")).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/landing.test.tsx
+++ b/apps/web/tests/unit/landing.test.tsx
@@ -2,14 +2,21 @@
  * @vitest-environment jsdom
  */
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Landing } from "../../src/components/Landing";
 
-describe("Landing", () => {
-  it("renders the Animichi wordmark", () => {
-    render(<Landing />);
+function setLanguages(langs: string[]): void {
+  Object.defineProperty(navigator, "languages", { value: langs, configurable: true });
+}
 
-    expect(screen.getByRole("heading", { name: "Animichi" })).toBeTruthy();
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(cleanup);
+
+describe("Landing", () => {
+  it("provides the locale context and renders the hero", () => {
+    render(<Landing />);
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toContain("聖地巡礼");
+    expect(document.documentElement.lang).toBe("ja");
   });
 });

--- a/apps/web/tests/unit/locale-switcher.test.tsx
+++ b/apps/web/tests/unit/locale-switcher.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LocaleSwitcher } from "../../src/i18n/LocaleSwitcher";
+import { renderWithLocale, setLanguages } from "./_i18n";
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(cleanup);
+
+describe("LocaleSwitcher", () => {
+  it("renders one button per locale with ja active by default", () => {
+    renderWithLocale(<LocaleSwitcher />);
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+    expect(screen.getByRole("button", { name: "日本語" }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("marks the chosen locale as pressed on click", () => {
+    renderWithLocale(<LocaleSwitcher />);
+    act(() => { screen.getByRole("button", { name: "中文" }).click(); });
+    expect(screen.getByRole("button", { name: "中文" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "日本語" }).getAttribute("aria-pressed")).toBe("false");
+  });
+});

--- a/apps/web/tests/unit/login-form.test.tsx
+++ b/apps/web/tests/unit/login-form.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendMagicLink } from "../../src/lib/auth/neonAuth";
+import { LoginForm } from "../../src/components/auth/LoginForm";
+import { renderWithLocale, setLanguages } from "./_i18n";
+
+vi.mock("../../src/lib/auth/neonAuth", () => ({ sendMagicLink: vi.fn() }));
+const send = vi.mocked(sendMagicLink);
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function submitWith(email: string): void {
+  renderWithLocale(<LoginForm />);
+  fireEvent.change(screen.getByLabelText("メールアドレス"), { target: { value: email } });
+  fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
+}
+
+describe("LoginForm validation", () => {
+  it("blocks an empty email with an inline message and sends no request", () => {
+    submitWith("   ");
+    expect(screen.getByRole("alert").textContent).toContain("メールアドレスを入力");
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("blocks an address with no @ and sends no request", () => {
+    submitWith("not-an-email");
+    expect(screen.getByRole("alert").textContent).toContain("@");
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe("LoginForm submission", () => {
+  it("sends a magic link and shows the sent confirmation", async () => {
+    send.mockResolvedValue("sent");
+    submitWith("Fan@Example.com ");
+    await waitFor(() => { expect(screen.getByRole("status")).toBeTruthy(); });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "fan@example.com" }),
+    );
+  });
+
+  it("shows on-brand error copy when the request fails", async () => {
+    send.mockResolvedValue("error");
+    submitWith("fan@example.com");
+    await waitFor(() => { expect(screen.getByRole("alert").textContent).toContain("もう一度"); });
+  });
+
+  it("shows a not-configured message when auth is unset", async () => {
+    send.mockResolvedValue("not_configured");
+    submitWith("fan@example.com");
+    await waitFor(() => { expect(screen.getByRole("alert").textContent).toContain("管理者"); });
+  });
+
+  it("shows a submitting state while the request is pending", async () => {
+    let resolve!: (value: "sent") => void;
+    send.mockReturnValue(new Promise((r) => { resolve = r; }));
+    submitWith("fan@example.com");
+    await waitFor(() => { expect(screen.getByRole("button", { name: "送信中…" })).toBeTruthy(); });
+    resolve("sent");
+  });
+});

--- a/apps/web/tests/unit/login-modal.test.tsx
+++ b/apps/web/tests/unit/login-modal.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LoginModal } from "../../src/components/auth/LoginModal";
+import { renderWithLocale, setLanguages } from "./_i18n";
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(cleanup);
+
+describe("LoginModal", () => {
+  it("renders nothing while closed", () => {
+    renderWithLocale(<LoginModal open={false} onClose={vi.fn()} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders the dialog with subtitle and form when open", () => {
+    renderWithLocale(<LoginModal open onClose={vi.fn()} />);
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByLabelText("メールアドレス")).toBeTruthy();
+  });
+
+  it("closes on the close button, the mask, and Escape", () => {
+    const onClose = vi.fn();
+    renderWithLocale(<LoginModal open onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: "閉じる" }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps open when clicking inside the dialog body", () => {
+    const onClose = vi.fn();
+    renderWithLocale(<LoginModal open onClose={onClose} />);
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-Escape keys", () => {
+    const onClose = vi.fn();
+    renderWithLocale(<LoginModal open onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "a" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/neon-auth.test.ts
+++ b/apps/web/tests/unit/neon-auth.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { magicLink } = vi.hoisted(() => ({ magicLink: vi.fn() }));
+
+vi.mock("better-auth/client", () => ({
+  createAuthClient: () => ({ signIn: { magicLink } }),
+}));
+vi.mock("better-auth/client/plugins", () => ({ magicLinkClient: () => ({}) }));
+
+import { isNeonAuthConfigured, sendMagicLink } from "../../src/lib/auth/neonAuth";
+
+const request = { email: "fan@example.com", callbackURL: "https://app.test/auth/callback" };
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+function configure(base = "https://auth.test/neondb/auth"): void {
+  vi.stubEnv("VITE_NEON_AUTH_BASE_URL", base);
+}
+
+describe("neon auth magic link", () => {
+  it("reports not configured when the base URL is unset", async () => {
+    expect(isNeonAuthConfigured()).toBe(false);
+    expect(await sendMagicLink(request)).toBe("not_configured");
+    expect(magicLink).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty base URL as unconfigured", () => {
+    vi.stubEnv("VITE_NEON_AUTH_BASE_URL", "");
+    expect(isNeonAuthConfigured()).toBe(false);
+  });
+
+  it("calls the official client's signIn.magicLink and returns sent on success", async () => {
+    configure();
+    magicLink.mockResolvedValue({ data: {}, error: null });
+    expect(await sendMagicLink(request)).toBe("sent");
+    expect(magicLink).toHaveBeenCalledWith(request);
+  });
+
+  it("returns error when the client responds with an error envelope", async () => {
+    configure();
+    magicLink.mockResolvedValue({ data: null, error: { message: "boom" } });
+    expect(await sendMagicLink(request)).toBe("error");
+  });
+
+  it("returns error when the client rejects", async () => {
+    configure();
+    magicLink.mockRejectedValue(new Error("network"));
+    expect(await sendMagicLink(request)).toBe("error");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       animal-island-ui-tailwind:
         specifier: ^1.0.16
         version: 1.0.16(0f6542d988433e5118d622ce924af014)
+      better-auth:
+        specifier: ^1.6.23
+        version: 1.6.23(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.30(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
       maplibre-gl:
         specifier: ^5.24.0
         version: 5.24.0
@@ -94,7 +97,7 @@ importers:
         version: 4.3.3(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       '@tanstack/nitro-v2-vite-plugin':
         specifier: ^1.155.0
-        version: 1.155.0(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.155.0(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       '@tanstack/router-generator':
         specifier: 1.167.21
         version: 1.167.21
@@ -115,7 +118,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       jsdom:
         specifier: ^29.1.1
-        version: 29.1.1(@noble/hashes@1.8.0)
+        version: 29.1.1(@noble/hashes@2.2.0)
       msw:
         specifier: 2.15.0
         version: 2.15.0(@types/node@26.1.1)(typescript@7.0.2)
@@ -130,7 +133,7 @@ importers:
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       wrangler:
         specifier: ^4.112.0
         version: 4.112.0(@cloudflare/workers-types@5.20260718.1)
@@ -308,7 +311,7 @@ importers:
         version: 16.2.10(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
       jsdom:
         specifier: ^29.1.1
-        version: 29.1.1(@noble/hashes@1.8.0)
+        version: 29.1.1(@noble/hashes@2.2.0)
       msw:
         specifier: ^2.14.6
         version: 2.15.0(@types/node@25.9.5)(typescript@6.0.3)
@@ -326,7 +329,7 @@ importers:
         version: 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       vitest-axe:
         specifier: ^0.1.0
         version: 0.1.0(vitest@4.1.10)
@@ -374,7 +377,7 @@ importers:
         version: link:../../packages/contract
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+        version: 0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)
       hono:
         specifier: '>=4.12.16'
         version: 4.12.30
@@ -408,7 +411,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       wrangler:
         specifier: ^4.112.0
         version: 4.112.0(@cloudflare/workers-types@5.20260718.1)
@@ -429,7 +432,7 @@ importers:
         version: link:../../packages/contract
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+        version: 0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)
       hono:
         specifier: '>=4.12.16'
         version: 4.12.30
@@ -454,7 +457,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       wrangler:
         specifier: ^4.112.0
         version: 4.112.0(@cloudflare/workers-types@5.20260718.1)
@@ -916,6 +919,85 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@better-auth/core@1.6.23':
+    resolution: {integrity: sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==}
+    peerDependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.7
+      jose: ^6.1.0
+      kysely: ^0.28.5 || ^0.29.0
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@better-auth/drizzle-adapter@1.6.23':
+    resolution: {integrity: sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      drizzle-orm: ^0.45.2
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
+  '@better-auth/kysely-adapter@1.6.23':
+    resolution: {integrity: sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      kysely: ^0.28.17 || ^0.29.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.6.23':
+    resolution: {integrity: sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.23':
+    resolution: {integrity: sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.6.23':
+    resolution: {integrity: sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.6.23':
+    resolution: {integrity: sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
+
+  '@better-fetch/fetch@1.3.1':
+    resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -1754,6 +1836,10 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
@@ -1761,6 +1847,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@node-minify/core@8.0.6':
     resolution: {integrity: sha512-/vxN46ieWDLU67CmgbArEvOb41zlYFOkOtr9QW9CnTrBLuTyGgkyNWC2y5+khvRw3Br58p2B5ZVSx/PxCTru6g==}
@@ -1838,6 +1928,10 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@orpc/client@1.14.8':
     resolution: {integrity: sha512-Gu9pttl8BvOdU0skSwsYWWL31e+qpLXmHTHTy990vEbrWncVFulOtWJtwY/rV1nX7AfWnSyJZJwCFZvMcFnQgA==}
@@ -4750,6 +4844,76 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
+  better-auth@1.6.23:
+    resolution: {integrity: sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: ^0.45.2
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.3.7:
+    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -6489,6 +6653,10 @@ packages:
   knitwork@1.3.0:
     resolution: {integrity: sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==}
 
+  kysely@0.29.4:
+    resolution: {integrity: sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA==}
+    engines: {node: '>=22.0.0'}
+
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -6939,6 +7107,10 @@ packages:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nanostores@1.4.0:
+    resolution: {integrity: sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
@@ -9710,6 +9882,62 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0)':
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.7(zod@4.4.3)
+      jose: 6.2.3
+      kysely: 0.29.4
+      nanostores: 1.4.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@cloudflare/workers-types': 5.20260718.1
+      '@opentelemetry/api': 1.9.1
+
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)
+
+  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.4)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      kysely: 0.29.4
+
+  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@better-fetch/fetch@1.3.1': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -9733,7 +9961,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 4.20260714.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       wrangler: 4.112.0(@cloudflare/workers-types@5.20260718.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -10026,9 +10254,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.1(@noble/hashes@1.8.0)':
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
     optionalDependencies:
-      '@noble/hashes': 1.8.0
+      '@noble/hashes': 2.2.0
 
   '@figspec/components@2.1.0': {}
 
@@ -10484,11 +10712,15 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/ciphers@2.2.0': {}
+
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@node-minify/core@8.0.6':
     dependencies:
@@ -10589,6 +10821,8 @@ snapshots:
       - supports-color
 
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@orpc/client@1.14.8(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -11894,7 +12128,7 @@ snapshots:
       storybook: 10.5.0(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7)
     optionalDependencies:
       '@vitest/runner': 4.1.10
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - react
 
@@ -12169,9 +12403,9 @@ snapshots:
 
   '@tanstack/history@1.162.0': {}
 
-  '@tanstack/nitro-v2-vite-plugin@1.155.0(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@tanstack/nitro-v2-vite-plugin@1.155.0(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
-      nitropack: 2.13.4(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      nitropack: 2.13.4(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       pathe: 2.0.3
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -12929,7 +13163,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.4
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -12945,7 +13179,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -13322,6 +13556,46 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
+  better-auth@1.6.23(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.30(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10):
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.4)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260718.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.7(zod@4.4.3)
+      defu: 6.1.7
+      jose: 6.2.3
+      kysely: 0.29.4
+      nanostores: 1.4.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@tanstack/react-start': 1.168.30(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)
+      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      pg: 8.22.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-call@1.3.7(zod@4.4.3):
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.2
+    optionalDependencies:
+      zod: 4.4.3
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -13662,10 +13936,10 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
-  data-urls@7.0.0(@noble/hashes@1.8.0):
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -13687,9 +13961,9 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)):
+  db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)):
     optionalDependencies:
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)
 
   debounce-fn@4.0.0:
     dependencies:
@@ -13808,12 +14082,13 @@ snapshots:
 
   dotenv@17.4.2: {}
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0):
     optionalDependencies:
       '@cloudflare/workers-types': 5.20260718.1
       '@neondatabase/serverless': 1.1.0
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
+      kysely: 0.29.4
       pg: 8.22.0
 
   dunder-proto@1.0.1:
@@ -14702,9 +14977,9 @@ snapshots:
 
   hookable@5.5.3: {}
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -15037,17 +15312,17 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.1.1(@noble/hashes@1.8.0):
+  jsdom@29.1.1(@noble/hashes@2.2.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
       parse5: 8.0.1
@@ -15058,7 +15333,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -15121,6 +15396,8 @@ snapshots:
   klona@2.0.6: {}
 
   knitwork@1.3.0: {}
+
+  kysely@0.29.4: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -15802,6 +16079,8 @@ snapshots:
 
   nanoid@3.3.16: {}
 
+  nanostores@1.4.0: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -15834,7 +16113,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.13.4(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+  nitropack@2.13.4(aws4fetch@1.0.20)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(oxc-parser@0.127.0)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.2)
@@ -15855,7 +16134,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))
+      db0: 0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -15901,7 +16180,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.127.0)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)))(ioredis@5.11.1)
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)))(ioredis@5.11.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -17730,7 +18009,7 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
 
-  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)))(ioredis@5.11.1):
+  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)))(ioredis@5.11.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -17742,7 +18021,7 @@ snapshots:
       ufo: 1.6.4
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0))
+      db0: 0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260718.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))
       ioredis: 5.11.1
 
   until-async@3.0.2: {}
@@ -17878,9 +18157,9 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -17907,11 +18186,11 @@ snapshots:
       '@types/node': 25.9.5
       '@vitest/coverage-istanbul': 4.1.10(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
-      jsdom: 29.1.1(@noble/hashes@1.8.0)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -17938,7 +18217,7 @@ snapshots:
       '@types/node': 26.1.1
       '@vitest/coverage-istanbul': 4.1.10(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
-      jsdom: 29.1.1(@noble/hashes@1.8.0)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -17956,9 +18235,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
## C0.4 — Landing + Login + i18n (issue #246 / spec S0.6)

Base: `feat/frontend-rebuild`. Migrates the spike Landing + magic-link login + trilingual i18n into `apps/web`.

### Delivered
1. **i18n scaffold (ja/zh/en)** — bundled dictionaries (`src/i18n/dictionaries/*.json`) so locale switches are synchronous and SSR-safe. `LocaleProvider` renders `DEFAULT_LOCALE` (ja) on the server and detects the real locale + syncs `<html lang>` in a post-mount effect (no hydration mismatch). Hooks: `useDict` / `useLocale` / `useSetLocale`; `LocaleSwitcher` segmented control. A key-structure test pins all three dictionaries to identical shapes (no ja fallback leakage).
2. **Landing migration** — `LandingPage` (hero eyebrow/title/subtitle + "Start Exploring" CTA), anime/reality `ComparisonSlider`, and a `DayNightToggle` persisted to `localStorage` (`data-theme` on `<html>`, night token overrides). All copy from the dictionaries; all styling via the 動森 semantic tokens in `globals.css` (pressable `.ds-button` / `.ds-input`, night theme block) — no raw Tailwind palette colors.
3. **LoginModal — real Neon Auth (Better Auth) client** — `src/lib/auth/neonAuth.ts` POSTs to the documented Better Auth `sign-in/magic-link` endpoint (`docs/ops/auth-migration-neon.md` §4), env-driven via `VITE_NEON_AUTH_BASE_URL`. **No Supabase auth. No mock login** — when the base URL is unset the form surfaces an honest "not configured" state; empty/invalid email is blocked inline with no request; failures render on-brand error copy.
4. **Tests** — 62 unit tests, **100% coverage** on the new `src/**` surface. typecheck + oxlint(`--deny-warnings`) + build + integration all green.

### ⛔ Auto-pause trigger — Neon Auth E2E credentials blocked (per plan §5.6 / §4)
The **client code is real and complete**, but end-to-end verification is **blocked**: the operator-local values needed to actually reach Neon Auth are not in the repo/worktree, and per `docs/ops/auth-migration-neon.md` they must not be committed. Owner/operator action required before the login flow can be exercised live:
- **`VITE_NEON_AUTH_BASE_URL`** — per-branch value from `neonctl neon-auth status` (§ placeholder table).
- **App SDK keys** — `createNeonAuthProviderSdkKeys` ("app SDK keys for S0.6", §6) not yet minted.
- **Trusted domain** — `neonctl neon-auth domain add <prod-domain>` (§5 cutover checklist) for redirect origins.

This is the planned auto-pause item — flagging rather than fabricating a login. Everything else in the card is landed and gate-green; the seam is a single env var away from live.

### Browser / manual AC (for Tester, once credentials provisioned)
- Visiting `/` renders the hero + "Start Exploring" CTA; day/night toggle persists across reload (localStorage). *(browser)*
- With `VITE_NEON_AUTH_BASE_URL` set: submitting a valid email sends the magic link and shows the sent confirmation; a forced 5xx/network failure shows on-brand error copy (not a bare exception). *(browser — blocked on credentials)*
- Switching locale to zh/en re-renders all Landing copy with no ja fallback leaking. *(unit-covered; visual confirm)*

### Notes / deferred
- **Storybook** (`.storybook/*` in the spec file list) is **not** set up in `apps/web` today; standing it up pulls a large dep set onto the shared long-lived base branch. Deferred to avoid lockfile churn against parallel cards — recommend a dedicated infra PR.
- **animal-island-ui-tailwind components**: the package's barrel eagerly imports every component (incl. `.png` assets + optional radix peers), so it is not consumable in the node/jsdom test harness without an invasive vitest `deps.inline` + asset config (S0.5/C0.1 infra). This PR consumes the DS **token layer** (globals.css, already aligned 1:1 to the `--animal-*` primitives) via semantic HTML instead. Component adoption can follow once the test-harness config lands.
- Did not touch `src/lib/api`, `packages/contract`, `vitest.config.ts`, or `package.json`/lockfile (kept clean for rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Re-review updates (2026-07-19) — addresses both request-changes items

**1. Rebased onto merged `feat/frontend-rebuild` (post C0.1).** Only conflict was `globals.css` (append-only on both sides) — resolved keeping both rule sets (C0.3 `.map-spike*` + this card's landing/night/comparison/login). No `__root.tsx` conflict: the `LocaleProvider` lives inside `src/components/Landing.tsx` (the `/` route component), so C0.1's QueryClient/router wiring in `__root.tsx` is untouched. Now runs green under C0.1's new harness (route-tree globalSetup, MSW lifecycle, 90/90/90/90 coverage floor with routes swept).

**2. Swapped hand-written HTTP for the official Better Auth client SDK.** `src/lib/auth/neonAuth.ts` now uses `createAuthClient` (`better-auth/client`) + `magicLinkClient` (`better-auth/client/plugins`), built lazily with `baseURL` = `VITE_NEON_AUTH_BASE_URL` (the Neon Auth `…/neondb/auth` base), calling `signIn.magicLink({ email, callbackURL })` and mapping the `{ error }` envelope to `sent`/`error`. The env-driven seam and the honest `not_configured` state are preserved; `better-auth@^1.6.23` added to `apps/web` deps. Tests now mock the SDK boundary (`vi.mock("better-auth/client")`) instead of `fetch`.

**Bonus fix (latent bug found during rebase):** the root `.gitignore` `lib/` rule silently ignored `apps/web/src/lib/**`, so `neonAuth.ts` was **missing from the original PR tree** (a fresh clone would fail to build on the dangling import). Added the `!apps/web/src/lib/` re-include, mirroring the existing `catalog`/`users` `src/lib` precedent.

**Gate output (all green):** build ✓ · typecheck ✓ · `oxlint --deny-warnings` ✓ · unit 124 passed, coverage 100% stmts / 98.85% branch / 100% fns / 100% lines (floor 90) ✓ · integration 5 passed ✓.

Auth E2E credentials remain the operator-blocked auto-pause item (unchanged; Tester verifies once provisioned). Storybook deferred to a separate infra card (out of this card's rework scope).
