### PR TITLE
feat(web): S4.1 しおり layout family (#212)

### DIFF
--- a/apps/web/src/features/shiori/ShioriCard.tsx
+++ b/apps/web/src/features/shiori/ShioriCard.tsx
@@ -1,0 +1,26 @@
+import { selectShioriLayout, type ShioriLayout, type ShioriStatus } from "./layoutSelector";
+import { AlbumGrid } from "./layouts/AlbumGrid";
+import { PosterFallback } from "./layouts/PosterFallback";
+import { PosterSingle } from "./layouts/PosterSingle";
+import { Ticket } from "./layouts/Ticket";
+import type { ShioriPhoto, ShioriRouteProps } from "./types";
+
+export type ShioriCardProps = ShioriRouteProps &
+  Readonly<{ status: ShioriStatus; photos: readonly ShioriPhoto[] }>;
+
+/** Layout dispatcher: the route state and photo count pick the layout, never the user. */
+export function ShioriCard(props: ShioriCardProps) {
+  const layout = selectShioriLayout(props.status, props.photos.length);
+  return renderLayout(layout, props);
+}
+
+function renderLayout(layout: ShioriLayout, { meta, itinerary, photos }: ShioriCardProps) {
+  if (layout === "ticket") return <Ticket meta={meta} itinerary={itinerary} />;
+  if (layout === "album-grid") {
+    return <AlbumGrid meta={meta} itinerary={itinerary} photos={photos} />;
+  }
+  if (layout === "single-panel") {
+    return <PosterSingle meta={meta} itinerary={itinerary} photos={photos} />;
+  }
+  return <PosterFallback meta={meta} itinerary={itinerary} />;
+}

--- a/apps/web/src/features/shiori/layoutSelector.ts
+++ b/apps/web/src/features/shiori/layoutSelector.ts
@@ -1,0 +1,26 @@
+/**
+ * Photo-count-driven layout selection for the しおり family (S4.1).
+ * The data decides the layout — there is no manual layout switch.
+ */
+
+export type ShioriStatus = "planned" | "completed";
+
+export type ShioriLayout = "ticket" | "single-panel" | "album-grid" | "poster-fallback";
+
+/** Album grid shows at most this many tiles; the rest collapse into a +N badge. */
+export const ALBUM_GRID_CAPACITY = 4;
+
+export function selectShioriLayout(status: ShioriStatus, photoCount: number): ShioriLayout {
+  if (status === "planned") return "ticket";
+  if (photoCount >= 3) return "album-grid";
+  if (photoCount >= 1) return "single-panel";
+  return "poster-fallback";
+}
+
+export function visibleAlbumCount(photoCount: number): number {
+  return Math.min(photoCount, ALBUM_GRID_CAPACITY);
+}
+
+export function albumOverflowCount(photoCount: number): number {
+  return Math.max(photoCount - ALBUM_GRID_CAPACITY, 0);
+}

--- a/apps/web/src/features/shiori/layouts/AlbumGrid.tsx
+++ b/apps/web/src/features/shiori/layouts/AlbumGrid.tsx
@@ -1,0 +1,46 @@
+import type { ShioriPhoto, ShioriRouteProps } from "../types";
+import { albumOverflowCount, visibleAlbumCount } from "../layoutSelector";
+import { shioriTimeWindow } from "../timeWindow";
+import { PhotoTile } from "./PhotoTile";
+import { ShioriFrame, ShioriHeader } from "./ShioriChrome";
+
+type AlbumGridProps = ShioriRouteProps & Readonly<{ photos: readonly ShioriPhoto[] }>;
+
+/** アルバム格子: capacity-capped 対比図 grid with a +N overflow badge. */
+export function AlbumGrid({ meta, itinerary, photos }: AlbumGridProps) {
+  return (
+    <ShioriFrame layout="album-grid" label="完走記念しおり">
+      <ShioriHeader eyebrow="SEICHIJUNREI · 完走記念" meta={meta} />
+      <GridTiles photos={photos} />
+      <p className="shiori-window">{gridSummary(shioriTimeWindow(itinerary), photos.length)}</p>
+    </ShioriFrame>
+  );
+}
+
+function gridSummary(window: string | null, photoCount: number): string {
+  const photoLabel = `対比図${String(photoCount)}枚`;
+  return window ? `${window} · ${photoLabel}` : photoLabel;
+}
+
+function GridTiles({ photos }: Readonly<{ photos: readonly ShioriPhoto[] }>) {
+  const visible = photos.slice(0, visibleAlbumCount(photos.length));
+  return (
+    <ul className="shiori-grid">
+      {visible.map((photo, index) => (
+        <GridTile key={photo.id} photo={photo} isLast={index === visible.length - 1} total={photos.length} />
+      ))}
+    </ul>
+  );
+}
+
+type GridTileProps = Readonly<{ photo: ShioriPhoto; isLast: boolean; total: number }>;
+
+function GridTile({ photo, isLast, total }: GridTileProps) {
+  const overflow = isLast ? albumOverflowCount(total) : 0;
+  return (
+    <li className="shiori-grid__cell">
+      <PhotoTile photo={photo} />
+      {overflow > 0 ? <span className="shiori-grid__overflow">{`+${String(overflow)}`}</span> : null}
+    </li>
+  );
+}

--- a/apps/web/src/features/shiori/layouts/PhotoTile.tsx
+++ b/apps/web/src/features/shiori/layouts/PhotoTile.tsx
@@ -1,0 +1,22 @@
+import type { ShioriPhoto } from "../types";
+
+type PhotoTileProps = Readonly<{ photo: ShioriPhoto }>;
+
+/** One 対比図 tile: the composite image plus its scene attribution. */
+export function PhotoTile({ photo }: PhotoTileProps) {
+  return (
+    <figure className="shiori-tile">
+      <img src={photo.imageUrl} alt={`${photo.spotName} の対比図`} loading="lazy" />
+      <TileCaption photo={photo} />
+    </figure>
+  );
+}
+
+function TileCaption({ photo }: PhotoTileProps) {
+  return (
+    <figcaption className="shiori-tile__caption">
+      <span className="shiori-tile__scene">{photo.sceneLabel}</span>
+      <span className="shiori-tile__time">{photo.capturedAt}</span>
+    </figcaption>
+  );
+}

--- a/apps/web/src/features/shiori/layouts/PosterFallback.tsx
+++ b/apps/web/src/features/shiori/layouts/PosterFallback.tsx
@@ -1,0 +1,53 @@
+import type { TimedStop } from "@seichijunrei/contract";
+import type { ShioriRouteProps } from "../types";
+import { ShioriFrame, ShioriHeader } from "./ShioriChrome";
+
+/** ポスター: cover-poster fallback when no 対比図 exists yet. */
+export function PosterFallback({ meta, itinerary }: ShioriRouteProps) {
+  return (
+    <ShioriFrame layout="poster-fallback" label="完走ポスター">
+      <CompletionBadge stopCount={itinerary.stops.length} />
+      <ShioriHeader eyebrow="SEICHIJUNREI · 完走記念" meta={meta} />
+      <PosterStops stops={itinerary.stops} />
+    </ShioriFrame>
+  );
+}
+
+function CompletionBadge({ stopCount }: Readonly<{ stopCount: number }>) {
+  const count = String(stopCount);
+  return (
+    <p className="shiori-badge">
+      <strong className="shiori-badge__count">{`${count}/${count}`}</strong>
+      <span className="shiori-badge__label">完走</span>
+    </p>
+  );
+}
+
+function PosterStops({ stops }: Readonly<{ stops: TimedStop[] }>) {
+  if (stops.length === 0) return null;
+  return (
+    <ul className="shiori-poster-stops">
+      {stops.map((stop) => (
+        <PosterStopRow key={stop.cluster_id} stop={stop} />
+      ))}
+    </ul>
+  );
+}
+
+function PosterStopRow({ stop }: Readonly<{ stop: TimedStop }>) {
+  return (
+    <li className="shiori-poster-stop">
+      <span className="shiori-poster-stop__time">{stop.arrive}</span>
+      <span className="shiori-poster-stop__name">{stop.name}</span>
+      <VisitedCheck />
+    </li>
+  );
+}
+
+function VisitedCheck() {
+  return (
+    <span className="shiori-poster-stop__check" aria-label="訪問済み">
+      ✓
+    </span>
+  );
+}

--- a/apps/web/src/features/shiori/layouts/PosterSingle.tsx
+++ b/apps/web/src/features/shiori/layouts/PosterSingle.tsx
@@ -1,0 +1,46 @@
+import type { ShioriPhoto, ShioriRouteProps } from "../types";
+import { PhotoTile } from "./PhotoTile";
+import { ShioriFrame, ShioriHeader, ShioriTimeWindow } from "./ShioriChrome";
+
+type PosterSingleProps = ShioriRouteProps & Readonly<{ photos: readonly ShioriPhoto[] }>;
+
+/** 一枚看板: one hero 対比図 with an optional secondary thumbnail. */
+export function PosterSingle({ meta, itinerary, photos }: PosterSingleProps) {
+  return (
+    <ShioriFrame layout="single-panel" label="完走記念しおり">
+      <ShioriHeader eyebrow="SEICHIJUNREI · 完走記念" meta={meta} />
+      <SingleHero photo={photos[0]} total={photos.length} />
+      <SecondPhotoStrip photo={photos[1]} />
+      <ShioriTimeWindow itinerary={itinerary} />
+    </ShioriFrame>
+  );
+}
+
+function SingleHero({ photo, total }: Readonly<{ photo?: ShioriPhoto; total: number }>) {
+  if (!photo) return null;
+  return (
+    <div className="shiori-hero">
+      <PhotoTile photo={photo} />
+      <HeroCaption spotName={photo.spotName} total={total} />
+    </div>
+  );
+}
+
+function HeroCaption({ spotName, total }: Readonly<{ spotName: string; total: number }>) {
+  return (
+    <p className="shiori-hero__caption">
+      <span>{`${spotName} ここに立った!`}</span>
+      <span className="shiori-hero__counter">{`1/${String(total)}`}</span>
+    </p>
+  );
+}
+
+function SecondPhotoStrip({ photo }: Readonly<{ photo?: ShioriPhoto }>) {
+  if (!photo) return null;
+  return (
+    <div className="shiori-second">
+      <PhotoTile photo={photo} />
+      <p className="shiori-second__note">{`${photo.spotName} のもう1枚も収録`}</p>
+    </div>
+  );
+}

--- a/apps/web/src/features/shiori/layouts/ShioriChrome.tsx
+++ b/apps/web/src/features/shiori/layouts/ShioriChrome.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import type { TimedItinerary } from "@seichijunrei/contract";
+import type { ShioriLayout } from "../layoutSelector";
+import type { ShioriMeta } from "../types";
+import { shioriTimeWindow } from "../timeWindow";
+
+type ShioriFrameProps = Readonly<{
+  layout: ShioriLayout;
+  label: string;
+  children: ReactNode;
+}>;
+
+export function ShioriFrame({ layout, label, children }: ShioriFrameProps) {
+  return (
+    <article className={`shiori-card shiori-card--${layout}`} aria-label={label}>
+      {children}
+    </article>
+  );
+}
+
+type ShioriHeaderProps = Readonly<{ eyebrow: string; meta: ShioriMeta }>;
+
+export function ShioriHeader({ eyebrow, meta }: ShioriHeaderProps) {
+  return (
+    <header className="shiori-head">
+      <p className="shiori-head__eyebrow">{eyebrow}</p>
+      <h3 className="shiori-head__title">{meta.routeTitle}</h3>
+      <p className="shiori-head__sub">{`${meta.animeTitle} · ${meta.dateLabel}`}</p>
+    </header>
+  );
+}
+
+export function ShioriTimeWindow({ itinerary }: Readonly<{ itinerary: TimedItinerary }>) {
+  const window = shioriTimeWindow(itinerary);
+  if (!window) return null;
+  return <p className="shiori-window">{window}</p>;
+}

--- a/apps/web/src/features/shiori/layouts/Ticket.tsx
+++ b/apps/web/src/features/shiori/layouts/Ticket.tsx
@@ -1,0 +1,40 @@
+import type { TimedStop } from "@seichijunrei/contract";
+import type { ShioriRouteProps } from "../types";
+import { ShioriFrame, ShioriHeader, ShioriTimeWindow } from "./ShioriChrome";
+
+/** 計画版の切符スタイル: fixed timeline ticket for a planned route. */
+export function Ticket({ meta, itinerary }: ShioriRouteProps) {
+  return (
+    <ShioriFrame layout="ticket" label="計画しおり">
+      <ShioriHeader eyebrow="SEICHIJUNREI · しおり" meta={meta} />
+      <TicketStops stops={itinerary.stops} />
+      <ShioriTimeWindow itinerary={itinerary} />
+    </ShioriFrame>
+  );
+}
+
+function TicketStops({ stops }: Readonly<{ stops: TimedStop[] }>) {
+  if (stops.length === 0) {
+    return <p className="shiori-empty">スポットを選ぶと、ここに行程が出るよ</p>;
+  }
+  return <TicketStopList stops={stops} />;
+}
+
+function TicketStopList({ stops }: Readonly<{ stops: TimedStop[] }>) {
+  return (
+    <ol className="shiori-stops">
+      {stops.map((stop) => (
+        <TicketStopRow key={stop.cluster_id} stop={stop} />
+      ))}
+    </ol>
+  );
+}
+
+function TicketStopRow({ stop }: Readonly<{ stop: TimedStop }>) {
+  return (
+    <li className="shiori-stop">
+      <span className="shiori-stop__time">{stop.arrive}</span>
+      <span className="shiori-stop__name">{stop.name}</span>
+    </li>
+  );
+}

--- a/apps/web/src/features/shiori/timeWindow.ts
+++ b/apps/web/src/features/shiori/timeWindow.ts
@@ -1,0 +1,9 @@
+import type { TimedItinerary } from "@seichijunrei/contract";
+
+/** First arrival → last departure, e.g. "09:31→12:58"; null when there are no stops. */
+export function shioriTimeWindow(itinerary: TimedItinerary): string | null {
+  const [first] = itinerary.stops;
+  const last = itinerary.stops.at(-1);
+  if (!first || !last) return null;
+  return `${first.arrive}→${last.depart}`;
+}

--- a/apps/web/src/features/shiori/types.ts
+++ b/apps/web/src/features/shiori/types.ts
@@ -1,0 +1,24 @@
+import type { TimedItinerary } from "@seichijunrei/contract";
+
+/** A 対比図 composite selected onto the しおり. */
+export interface ShioriPhoto {
+  id: string;
+  spotName: string;
+  /** Scene attribution, e.g. 第8話 41:12. */
+  sceneLabel: string;
+  /** Capture time label, e.g. 10:48. */
+  capturedAt: string;
+  imageUrl: string;
+}
+
+/** Display metadata shared by every しおり layout. */
+export interface ShioriMeta {
+  routeTitle: string;
+  animeTitle: string;
+  dateLabel: string;
+}
+
+export type ShioriRouteProps = Readonly<{
+  meta: ShioriMeta;
+  itinerary: TimedItinerary;
+}>;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./fonts.css";
+@import "./shiori.css";
 
 :root {
   color-scheme: light;

--- a/apps/web/src/styles/shiori.css
+++ b/apps/web/src/styles/shiori.css
@@ -1,0 +1,237 @@
+/* しおり layout family (S4.1). Semantic tokens only; layout is pure CSS. */
+
+.shiori-card {
+  container-type: inline-size;
+  display: grid;
+  gap: 10px;
+  width: min(320px, 100%);
+  padding: 14px;
+  border: 1.5px solid var(--color-border);
+  border-radius: 16px;
+  background: var(--color-card);
+  box-shadow: var(--shadow-press);
+  font-family: var(--app-font-body);
+}
+
+.shiori-card--poster-fallback {
+  background: var(--color-fg);
+  color: var(--color-bg);
+}
+
+.shiori-head {
+  display: grid;
+  gap: 3px;
+}
+
+.shiori-head__eyebrow {
+  margin: 0;
+  color: var(--color-muted-fg);
+  font-size: 0.625rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+}
+
+.shiori-card--poster-fallback .shiori-head__eyebrow {
+  color: inherit;
+  opacity: 0.82;
+}
+
+.shiori-head__title {
+  margin: 0;
+  font-family: var(--app-font-display);
+  font-size: 1.125rem;
+  font-weight: 900;
+  line-height: 1.3;
+}
+
+.shiori-head__sub {
+  margin: 0;
+  color: var(--color-muted-fg);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.shiori-card--poster-fallback .shiori-head__sub {
+  color: inherit;
+  opacity: 0.82;
+}
+
+.shiori-stops,
+.shiori-poster-stops {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.shiori-stop,
+.shiori-poster-stop {
+  display: grid;
+  grid-template-columns: 44px 1fr auto;
+  align-items: baseline;
+  column-gap: 8px;
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.shiori-stop {
+  grid-template-columns: 44px 1fr;
+}
+
+.shiori-stop__time,
+.shiori-poster-stop__time {
+  color: var(--color-muted-fg);
+  font-family: var(--app-font-mono);
+  font-size: 0.6875rem;
+}
+
+.shiori-card--poster-fallback .shiori-poster-stop__time {
+  color: inherit;
+  opacity: 0.75;
+}
+
+.shiori-poster-stop__check {
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--color-primary);
+  color: var(--color-primary-fg);
+  font-size: 0.6875rem;
+  font-weight: 900;
+}
+
+.shiori-empty {
+  margin: 0;
+  padding: 12px;
+  border: 1.5px dashed var(--color-border);
+  border-radius: 12px;
+  background: var(--color-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.shiori-window {
+  margin: 0;
+  color: var(--color-muted-fg);
+  font-size: 0.6875rem;
+  font-weight: 800;
+}
+
+.shiori-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@container (min-width: 240px) {
+  .shiori-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.shiori-grid__cell {
+  position: relative;
+}
+
+.shiori-grid__overflow {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--color-fg) 55%, transparent);
+  color: var(--color-bg);
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.shiori-tile {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-bg);
+}
+
+.shiori-tile img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+.shiori-tile__caption {
+  display: flex;
+  justify-content: space-between;
+  gap: 4px;
+  padding: 3px 7px;
+  background: var(--color-muted);
+  font-size: 0.625rem;
+  font-weight: 800;
+}
+
+.shiori-tile__time {
+  color: var(--color-muted-fg);
+}
+
+.shiori-hero,
+.shiori-second {
+  display: grid;
+  gap: 6px;
+}
+
+.shiori-second {
+  grid-template-columns: 72px 1fr;
+  align-items: center;
+}
+
+.shiori-hero__caption {
+  display: flex;
+  justify-content: space-between;
+  margin: 0;
+  font-size: 0.8125rem;
+  font-weight: 900;
+}
+
+.shiori-hero__counter,
+.shiori-second__note {
+  color: var(--color-muted-fg);
+  font-size: 0.6875rem;
+  font-weight: 800;
+}
+
+.shiori-second__note {
+  margin: 0;
+}
+
+.shiori-badge {
+  display: grid;
+  justify-items: center;
+  gap: 2px;
+  justify-self: end;
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-bg) 16%, transparent);
+  border: 1.5px solid var(--color-focus);
+}
+
+.shiori-badge__count {
+  color: var(--color-focus);
+  font-size: 0.875rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.shiori-badge__label {
+  font-size: 0.625rem;
+  font-weight: 800;
+}

--- a/apps/web/tests/unit/shiori/_factories.ts
+++ b/apps/web/tests/unit/shiori/_factories.ts
@@ -1,0 +1,56 @@
+import type { TimedItinerary, TimedStop } from "@seichijunrei/contract";
+import type { ShioriMeta, ShioriPhoto } from "../../../src/features/shiori/types";
+
+export function makeStop(overrides: Partial<TimedStop> = {}): TimedStop {
+  return {
+    cluster_id: "stop-station",
+    name: "飛騨古川駅",
+    arrive: "09:31",
+    depart: "09:50",
+    dwell_minutes: 19,
+    lat: 36.238,
+    lng: 137.186,
+    photo_count: 12,
+    ...overrides,
+  };
+}
+
+export function makeItinerary(overrides: Partial<TimedItinerary> = {}): TimedItinerary {
+  return {
+    stops: [
+      makeStop(),
+      makeStop({ cluster_id: "stop-shrine", name: "気多若宮神社", arrive: "10:48", depart: "12:58" }),
+    ],
+    legs: [],
+    total_minutes: 210,
+    total_distance_m: 2800,
+    ...overrides,
+  };
+}
+
+export function makeMeta(overrides: Partial<ShioriMeta> = {}): ShioriMeta {
+  return {
+    routeTitle: "飛騨古川 半日ルート",
+    animeTitle: "君の名は。",
+    dateLabel: "2026.7.3",
+    ...overrides,
+  };
+}
+
+export function makePhoto(overrides: Partial<ShioriPhoto> = {}): ShioriPhoto {
+  return {
+    id: "photo-1",
+    spotName: "気多若宮神社",
+    sceneLabel: "第8話 41:12",
+    capturedAt: "10:48",
+    imageUrl: "https://assets.example/comparison-1.jpg",
+    ...overrides,
+  };
+}
+
+export function makePhotos(count: number): ShioriPhoto[] {
+  return Array.from({ length: count }, (_, index) => {
+    const label = String(index + 1);
+    return makePhoto({ id: `photo-${label}`, spotName: `スポット${label}` });
+  });
+}

--- a/apps/web/tests/unit/shiori/album-grid.test.tsx
+++ b/apps/web/tests/unit/shiori/album-grid.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AlbumGrid } from "../../../src/features/shiori/layouts/AlbumGrid";
+import { makeItinerary, makeMeta, makePhotos } from "./_factories";
+
+afterEach(cleanup);
+
+function renderGrid(photoCount: number) {
+  render(
+    <AlbumGrid meta={makeMeta()} itinerary={makeItinerary()} photos={makePhotos(photoCount)} />,
+  );
+}
+
+describe("AlbumGrid", () => {
+  it("renders one tile per photo when the count fits the grid", () => {
+    renderGrid(3);
+
+    expect(screen.getAllByRole("img")).toHaveLength(3);
+    expect(screen.queryByText(/^\+\d+$/)).toBeNull();
+  });
+
+  it("caps the grid at four tiles and shows the overflow badge", () => {
+    renderGrid(6);
+
+    expect(screen.getAllByRole("img")).toHaveLength(4);
+    expect(screen.getByText("+2")).toBeTruthy();
+  });
+
+  it("converges an unusually large photo count into the capped grid", () => {
+    renderGrid(500);
+
+    expect(screen.getAllByRole("img")).toHaveLength(4);
+    expect(screen.getByText("+496")).toBeTruthy();
+  });
+
+  it("summarises the photo count with the time window", () => {
+    renderGrid(5);
+
+    expect(screen.getByText("09:31→12:58 · 対比図5枚")).toBeTruthy();
+    expect(screen.getByText("SEICHIJUNREI · 完走記念")).toBeTruthy();
+  });
+
+  it("keeps the photo summary when the itinerary has no stops", () => {
+    render(
+      <AlbumGrid meta={makeMeta()} itinerary={makeItinerary({ stops: [] })} photos={makePhotos(3)} />,
+    );
+
+    expect(screen.getByText("対比図3枚")).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/shiori/layout-selector.test.ts
+++ b/apps/web/tests/unit/shiori/layout-selector.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALBUM_GRID_CAPACITY,
+  albumOverflowCount,
+  selectShioriLayout,
+  visibleAlbumCount,
+} from "../../../src/features/shiori/layoutSelector";
+
+describe("selectShioriLayout", () => {
+  it.each([0, 1, 2, 3, 500])(
+    "returns ticket for a planned route regardless of %i photos",
+    (photoCount) => {
+      expect(selectShioriLayout("planned", photoCount)).toBe("ticket");
+    },
+  );
+
+  it("returns poster-fallback for a completed route with zero photos", () => {
+    expect(selectShioriLayout("completed", 0)).toBe("poster-fallback");
+  });
+
+  it("returns poster-fallback for a completed route with a negative photo count", () => {
+    expect(selectShioriLayout("completed", -3)).toBe("poster-fallback");
+  });
+
+  it.each([1, 2])("returns single-panel for a completed route with %i photos", (photoCount) => {
+    expect(selectShioriLayout("completed", photoCount)).toBe("single-panel");
+  });
+
+  it.each([3, 4, 5, 10_000])(
+    "returns album-grid for a completed route with %i photos",
+    (photoCount) => {
+      expect(selectShioriLayout("completed", photoCount)).toBe("album-grid");
+    },
+  );
+});
+
+describe("album grid density", () => {
+  it("caps visible tiles at the grid capacity", () => {
+    expect(visibleAlbumCount(10_000)).toBe(ALBUM_GRID_CAPACITY);
+  });
+
+  it("shows every photo when the count fits the capacity", () => {
+    expect(visibleAlbumCount(3)).toBe(3);
+  });
+
+  it("reports how many photos overflow the grid", () => {
+    expect(albumOverflowCount(6)).toBe(6 - ALBUM_GRID_CAPACITY);
+  });
+
+  it("reports zero overflow when the count fits the capacity", () => {
+    expect(albumOverflowCount(ALBUM_GRID_CAPACITY)).toBe(0);
+  });
+});

--- a/apps/web/tests/unit/shiori/poster-fallback.test.tsx
+++ b/apps/web/tests/unit/shiori/poster-fallback.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PosterFallback } from "../../../src/features/shiori/layouts/PosterFallback";
+import { makeItinerary, makeMeta } from "./_factories";
+
+afterEach(cleanup);
+
+describe("PosterFallback", () => {
+  it("renders the completion badge over the route title", () => {
+    render(<PosterFallback meta={makeMeta()} itinerary={makeItinerary()} />);
+
+    expect(screen.getByText("2/2")).toBeTruthy();
+    expect(screen.getByText("完走")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "飛騨古川 半日ルート" })).toBeTruthy();
+  });
+
+  it("marks every visited stop with a completion check", () => {
+    render(<PosterFallback meta={makeMeta()} itinerary={makeItinerary()} />);
+
+    const stops = screen.getAllByRole("listitem");
+    expect(stops).toHaveLength(2);
+    expect(stops[0]?.textContent).toContain("飛騨古川駅");
+    expect(stops[0]?.textContent).toContain("✓");
+  });
+
+  it("still renders a valid poster when the itinerary has no stops", () => {
+    render(<PosterFallback meta={makeMeta()} itinerary={makeItinerary({ stops: [] })} />);
+
+    expect(screen.getByText("0/0")).toBeTruthy();
+    expect(screen.queryByRole("list")).toBeNull();
+    expect(screen.getByRole("heading", { name: "飛騨古川 半日ルート" })).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/shiori/poster-single.test.tsx
+++ b/apps/web/tests/unit/shiori/poster-single.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PosterSingle } from "../../../src/features/shiori/layouts/PosterSingle";
+import { makeItinerary, makeMeta, makePhoto, makePhotos } from "./_factories";
+
+afterEach(cleanup);
+
+describe("PosterSingle", () => {
+  it("renders the hero comparison photo with its spot caption", () => {
+    render(
+      <PosterSingle meta={makeMeta()} itinerary={makeItinerary()} photos={[makePhoto()]} />,
+    );
+
+    expect(screen.getByRole("img", { name: "気多若宮神社 の対比図" })).toBeTruthy();
+    expect(screen.getByText("気多若宮神社 ここに立った!")).toBeTruthy();
+  });
+
+  it("shows the photo counter for a single photo", () => {
+    render(
+      <PosterSingle meta={makeMeta()} itinerary={makeItinerary()} photos={[makePhoto()]} />,
+    );
+
+    expect(screen.getByText("1/1")).toBeTruthy();
+  });
+
+  it("shows a secondary thumbnail and its note when a second photo exists", () => {
+    render(<PosterSingle meta={makeMeta()} itinerary={makeItinerary()} photos={makePhotos(2)} />);
+
+    expect(screen.getByText("1/2")).toBeTruthy();
+    expect(screen.getByRole("img", { name: "スポット2 の対比図" })).toBeTruthy();
+    expect(screen.getByText("スポット2 のもう1枚も収録")).toBeTruthy();
+  });
+
+  it("renders the completion eyebrow and time window", () => {
+    render(
+      <PosterSingle meta={makeMeta()} itinerary={makeItinerary()} photos={[makePhoto()]} />,
+    );
+
+    expect(screen.getByText("SEICHIJUNREI · 完走記念")).toBeTruthy();
+    expect(screen.getByText("09:31→12:58")).toBeTruthy();
+  });
+
+  it("stays a valid card when defensively rendered without photos", () => {
+    render(<PosterSingle meta={makeMeta()} itinerary={makeItinerary()} photos={[]} />);
+
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByText("SEICHIJUNREI · 完走記念")).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/shiori/shiori-card.test.tsx
+++ b/apps/web/tests/unit/shiori/shiori-card.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ShioriCard } from "../../../src/features/shiori/ShioriCard";
+import type { ShioriStatus } from "../../../src/features/shiori/layoutSelector";
+import { makeItinerary, makeMeta, makePhotos } from "./_factories";
+
+afterEach(cleanup);
+
+function renderCard(status: ShioriStatus, photoCount: number) {
+  render(
+    <ShioriCard
+      status={status}
+      meta={makeMeta()}
+      itinerary={makeItinerary()}
+      photos={makePhotos(photoCount)}
+    />,
+  );
+}
+
+describe("ShioriCard", () => {
+  it("renders the planned ticket regardless of photos", () => {
+    renderCard("planned", 5);
+
+    expect(screen.getByRole("article", { name: "計画しおり" })).toBeTruthy();
+  });
+
+  it("renders the album grid when three or more photos are selected", () => {
+    renderCard("completed", 3);
+
+    expect(screen.getByRole("article", { name: "完走記念しおり" })).toBeTruthy();
+    expect(screen.getAllByRole("img")).toHaveLength(3);
+  });
+
+  it("renders the single panel when one photo is selected", () => {
+    renderCard("completed", 1);
+
+    expect(screen.getByRole("article", { name: "完走記念しおり" })).toBeTruthy();
+    expect(screen.getByText("1/1")).toBeTruthy();
+  });
+
+  it("falls back to the poster when zero photos are selected", () => {
+    renderCard("completed", 0);
+
+    expect(screen.getByRole("article", { name: "完走ポスター" })).toBeTruthy();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/shiori/ticket.test.tsx
+++ b/apps/web/tests/unit/shiori/ticket.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Ticket } from "../../../src/features/shiori/layouts/Ticket";
+import { makeItinerary, makeMeta, makeStop } from "./_factories";
+
+afterEach(cleanup);
+
+describe("Ticket", () => {
+  it("renders the route title and anime attribution", () => {
+    render(<Ticket meta={makeMeta()} itinerary={makeItinerary()} />);
+
+    expect(screen.getByRole("heading", { name: "飛騨古川 半日ルート" })).toBeTruthy();
+    expect(screen.getByText("君の名は。 · 2026.7.3")).toBeTruthy();
+  });
+
+  it("lists every stop with its arrival time", () => {
+    render(<Ticket meta={makeMeta()} itinerary={makeItinerary()} />);
+
+    const stops = screen.getAllByRole("listitem");
+    expect(stops).toHaveLength(2);
+    expect(stops[0]?.textContent).toContain("09:31");
+    expect(stops[0]?.textContent).toContain("飛騨古川駅");
+    expect(stops[1]?.textContent).toContain("気多若宮神社");
+  });
+
+  it("shows the route time window from first arrival to last departure", () => {
+    render(<Ticket meta={makeMeta()} itinerary={makeItinerary()} />);
+
+    expect(screen.getByText("09:31→12:58")).toBeTruthy();
+  });
+
+  it("renders a friendly placeholder instead of a broken ticket when there are no stops", () => {
+    render(<Ticket meta={makeMeta()} itinerary={makeItinerary({ stops: [] })} />);
+
+    expect(screen.queryByRole("list")).toBeNull();
+    expect(screen.getByText("スポットを選ぶと、ここに行程が出るよ")).toBeTruthy();
+  });
+
+  it("renders a single-stop window without crashing", () => {
+    render(<Ticket meta={makeMeta()} itinerary={makeItinerary({ stops: [makeStop()] })} />);
+
+    expect(screen.getByText("09:31→09:50")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Implements spec S4.1 (`docs/superpowers/specs/2026-07-06-frontend-rebuild/iter-4.md`): the four しおり layouts with photo-count-driven selection — the data decides the layout, there is no manual switch (parity with `しおり demo.html`).

- `selectShioriLayout(status, photoCount)`: planned → **ticket** (fixed); completed → 0 photos = **poster-fallback**, 1–2 = **single-panel** (一枚看板), ≥3 = **album-grid** (アルバム格子)
- `AlbumGrid` converges unusually large counts: display capped at 4 tiles + `+N` overflow badge
- `ShioriCard` dispatcher composes the family; route shapes imported from `@seichijunrei/contract` (`TimedItinerary`/`TimedStop`), 対比図 photos as a local `ShioriPhoto` type (contract table lands with S4.7)
- Styles: `src/styles/shiori.css` — semantic tokens only, CSS grid + container query for tile density, display serif / Zen Maru Gothic body stacks; poster variant inverts fg/bg tokens
- New workspace dep: `@seichijunrei/contract: workspace:*` in apps/web (contract package itself untouched)

## AC coverage (ac_total == ac_with_test)

| AC (spec S4.1) | Type | Test |
|---|---|---|
| Photo counts switch ticket/panel/grid correctly | unit (browser AC covered at gate by Tester) | `tests/unit/shiori/layout-selector.test.ts`, `shiori-card.test.tsx` |
| Zero photos → poster-fallback, not a broken empty ticket | unit (browser at gate) | `shiori-card.test.tsx`, `poster-fallback.test.tsx` |
| Unusually large photo count converges to album-grid high-density mode without crashing | unit | `layout-selector.test.ts` (10 000), `album-grid.test.tsx` (500 → 4 tiles + +496) |

Extra edges: empty itinerary (ticket placeholder, grid summary, 0/0 poster), defensive photo-less single-panel, single-stop time window.

## Gates (apps/web)

- `pnpm run build` ✅ (nitro/CF bundle emitted)
- `pnpm run typecheck` ✅
- `pnpm run lint:oxlint` ✅ (type-aware, deny-warnings, 10-line function cap)
- `pnpm test` ✅ 25 files / 119 tests; coverage 100/98.5/100/100 (only uncovered branch is pre-existing `src/api/config.ts:35` from C0.1; all shiori files 100%)

Rebased onto `feat/frontend-rebuild` after C0.1 merge; lockfile regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)