### PR TITLE
test(web): make neon-auth "not configured" cases hermetic

### DIFF
--- a/apps/web/tests/unit/neon-auth.test.ts
+++ b/apps/web/tests/unit/neon-auth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { magicLink } = vi.hoisted(() => ({ magicLink: vi.fn() }));
 
@@ -10,6 +10,13 @@ vi.mock("better-auth/client/plugins", () => ({ magicLinkClient: () => ({}) }));
 import { isNeonAuthConfigured, sendMagicLink } from "../../src/lib/auth/neonAuth";
 
 const request = { email: "fan@example.com", callbackURL: "https://app.test/auth/callback" };
+
+beforeEach(() => {
+  // Hermetic baseline: neutralize any ambient VITE_NEON_AUTH_BASE_URL (e.g. a dev
+  // machine's apps/web/.env.local) so "unset" cases don't false-red. Passing
+  // undefined deletes the key from import.meta.env (vitest vi.stubEnv contract).
+  vi.stubEnv("VITE_NEON_AUTH_BASE_URL", undefined);
+});
 
 afterEach(() => {
   vi.unstubAllEnvs();


### PR DESCRIPTION
## Problem
`tests/unit/neon-auth.test.ts` → "reports not configured when the base URL is unset" depended on the machine happening to lack `VITE_NEON_AUTH_BASE_URL`. A dev machine's legitimate, operator-configured `apps/web/.env.local` sets that var, which Vite loads into `import.meta.env`, so `isNeonAuthConfigured()` returned `true` and the case false-red'd. Reproduced locally (this worktree has an `.env.local`): 1 failed / 4 passed before the fix.

## Fix
Add a `beforeEach` that stubs `VITE_NEON_AUTH_BASE_URL` to `undefined` — the official vitest `vi.stubEnv` contract, where passing `undefined` deletes the key from `import.meta.env`. Every case now starts from a known-empty baseline regardless of ambient `.env.local`; the "configured" cases still override with an explicit value, and `afterEach` `vi.unstubAllEnvs()` restores. Deterministic on any machine / any `.env.local` content.

## Gates (all green)
- typecheck OK, oxlint --deny-warnings OK
- unit: 163 passed; coverage 100% stmts / 99.15% branch / 100% fns / 100% lines (floor 90)
- integration: 5 passed
- Verified: the "not configured" case now passes WITH an .env.local present (the exact false-red condition).

Scope: single test file, no production changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)