### PR TITLE
feat(contract): C0.2 chat-data-parts schema + stream fixture snapshot tests

### DIFF
--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -13,7 +13,8 @@
     "./constants": "./src/constants.ts"
   },
   "scripts": {
-    "emit:openapi": "tsx scripts/emit-openapi.ts",
+    "emit:openapi": "node --import tsx scripts/emit-openapi.ts",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsx": "^4.23.1",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/contract/src/chat-data-parts.ts
+++ b/packages/contract/src/chat-data-parts.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+import {
+  AnimeCandidate,
+  PilgrimagePoint,
+  ResolveOutcome,
+  Route,
+  TimedItinerary,
+} from "./models.js";
+
+const StreamPoint = PilgrimagePoint.partial().extend({
+  lat: z.number().optional(),
+  lng: z.number().optional(),
+  ep: z.number().int().optional(),
+}).strict();
+
+const SearchResults = z.object({
+  kind: z.enum(["bangumi", "nearby", "multi"]).optional(),
+  bangumi_id: z.union([z.string(), z.number().int()]).optional(),
+  title: z.string().optional(),
+  row_count: z.number().int().nonnegative().optional(),
+  status: z.string().optional(),
+  strategy: z.string().optional(),
+  summary: z.record(z.string(), z.unknown()).optional(),
+  rows: z.array(StreamPoint).optional(),
+}).strict();
+
+const StreamRoute = Route.partial().extend({
+  ordered_points: z.union([z.array(z.string()), z.array(StreamPoint)]).optional(),
+  point_count: z.number().int().nonnegative().optional(),
+  status: z.string().optional(),
+  total_walk_minutes: z.number().nonnegative().optional(),
+  timed_itinerary: TimedItinerary.optional(),
+}).strict();
+
+const ClarificationCandidate = AnimeCandidate.partial().extend({
+  id: z.string().optional(),
+  cover_url: z.string().nullable().optional(),
+  lat: z.number().optional(),
+  lng: z.number().optional(),
+}).strict();
+
+const ClarificationData = z.object({
+  reason: z.string().optional(),
+  clarification_id: z.number().int().optional(),
+  candidates: z.array(ClarificationCandidate).optional(),
+  outcome: ResolveOutcome.optional(),
+}).strict();
+
+const SearchData = z.object({ results: SearchResults.optional() }).strict();
+const RouteData = z.object({
+  results: SearchResults.optional(),
+  route: StreamRoute.optional(),
+}).strict();
+const EmptyData = z.object({}).strict();
+
+const PublicAPIError = z.object({
+  code: z.string(),
+  message: z.string(),
+  details: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+
+const ResponseEnvelope = z.object({
+  success: z.boolean().optional(),
+  status: z.string().optional(),
+  session_id: z.string().nullable().optional(),
+  message: z.string().optional(),
+  session: z.record(z.string(), z.unknown()).optional(),
+  route_history: z.array(z.record(z.string(), z.unknown())).optional(),
+  errors: z.array(PublicAPIError).optional(),
+  ui: z.object({ component: z.string() }).nullable().optional(),
+  generated_title: z.string().nullable().optional(),
+  debug: z.record(z.string(), z.unknown()).nullable().optional(),
+}).strict();
+
+const searchPart = (intent: "search_bangumi" | "search_nearby") =>
+  ResponseEnvelope.extend({ intent: z.literal(intent), data: SearchData.optional() });
+
+const routePart = (intent: "plan_route" | "plan_selected" | "plan_multi") =>
+  ResponseEnvelope.extend({ intent: z.literal(intent), data: RouteData.optional() });
+
+const prosePart = (intent: "general_qa" | "greet_user" | "blocked") =>
+  ResponseEnvelope.extend({ intent: z.literal(intent), data: EmptyData.optional() });
+
+export const ChatResponseDataPart = z.discriminatedUnion("intent", [
+  searchPart("search_bangumi"),
+  searchPart("search_nearby"),
+  routePart("plan_route"),
+  routePart("plan_selected"),
+  routePart("plan_multi"),
+  prosePart("general_qa"),
+  prosePart("greet_user"),
+  ResponseEnvelope.extend({ intent: z.literal("clarify"), data: ClarificationData.optional() }),
+  ResponseEnvelope.extend({ intent: z.literal("partial"), data: RouteData.optional() }),
+  prosePart("blocked"),
+  ResponseEnvelope.extend({ intent: z.literal("unknown"), data: EmptyData.optional() }),
+]);
+
+export const ChatDataPartSchema = ChatResponseDataPart;
+export type ChatDataPart = z.infer<typeof ChatDataPartSchema>;
+export type ChatResponseDataPart = z.infer<typeof ChatResponseDataPart>;

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from "./models.js";
+export * from "./chat-data-parts.js";
 export * from "./constants.js";
 export * from "./contract.js";
 export * from "./errors.js";

--- a/packages/contract/test/__snapshots__/chat-data-parts.test.ts.snap
+++ b/packages/contract/test/__snapshots__/chat-data-parts.test.ts.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`recorded AI SDK UI message streams > parses every clarify data-response and snapshots its v1 sequence 1`] = `
+[
+  "start",
+  "start-step",
+  "tool-input-start",
+  "tool-input-available",
+  "tool-output-available",
+  "data-response",
+  "data-response",
+  "finish-step",
+  "finish",
+  "[DONE]",
+]
+`;
+
+exports[`recorded AI SDK UI message streams > parses every error data-response and snapshots its v1 sequence 1`] = `
+[
+  "start",
+  "start-step",
+  "error",
+  "finish-step",
+  "finish",
+  "[DONE]",
+]
+`;
+
+exports[`recorded AI SDK UI message streams > parses every search data-response and snapshots its v1 sequence 1`] = `
+[
+  "start",
+  "start-step",
+  "tool-input-start",
+  "tool-input-available",
+  "tool-output-available",
+  "tool-input-start",
+  "tool-input-available",
+  "tool-output-available",
+  "tool-input-start",
+  "tool-input-available",
+  "tool-output-available",
+  "data-response",
+  "data-response",
+  "finish-step",
+  "finish",
+  "[DONE]",
+]
+`;

--- a/packages/contract/test/chat-data-parts.test.ts
+++ b/packages/contract/test/chat-data-parts.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { ChatResponseDataPart } from "../src/chat-data-parts.js";
+
+const FIXTURES = ["search", "clarify", "error"] as const;
+const STREAM_HEADER = { "x-vercel-ai-ui-message-stream": "v1" };
+type Frame = Record<string, unknown>;
+
+function fixturePath(name: string): URL {
+  return new URL(`../../../apps/agent/tests/fixtures/chat_stream/${name}.sse`, import.meta.url);
+}
+
+function isFrame(value: unknown): value is Frame {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseValue(value: string): Frame | "[DONE]" {
+  if (value === "[DONE]") return value;
+  const parsed: unknown = JSON.parse(value);
+  if (!isFrame(parsed)) throw new Error("SSE data must be a JSON object");
+  return parsed;
+}
+
+function parseEvent(event: string): Frame | "[DONE]" {
+  if (!event.startsWith("data: ")) throw new Error("Invalid SSE framing");
+  return parseValue(event.slice(6));
+}
+
+function parseFixture(name: string): Array<Frame | "[DONE]"> {
+  const raw = readFileSync(fixturePath(name), "utf8");
+  return raw.trim().split("\n\n").map(parseEvent);
+}
+
+function frameTypes(frames: Array<Frame | "[DONE]">): string[] {
+  return frames.map((frame) => frame === "[DONE]" ? frame : String(frame.type));
+}
+
+function dataResponses(frames: Array<Frame | "[DONE]">): Frame[] {
+  return frames.filter((frame): frame is Frame => frame !== "[DONE]" && frame.type === "data-response");
+}
+
+function assertDataResponses(frames: Array<Frame | "[DONE]">): void {
+  for (const frame of dataResponses(frames)) ChatResponseDataPart.parse(frame.data);
+}
+
+function assertTerminator(frames: Array<Frame | "[DONE]">): void {
+  expect(frames.at(-1)).toBe("[DONE]");
+  expect(frames.slice(0, -1)).not.toContain("[DONE]");
+}
+
+describe("recorded AI SDK UI message streams", () => {
+  it.each(FIXTURES)("parses every %s data-response and snapshots its v1 sequence", (name) => {
+    const frames = parseFixture(name);
+    expect(STREAM_HEADER).toEqual({ "x-vercel-ai-ui-message-stream": "v1" });
+    assertDataResponses(frames);
+    assertTerminator(frames);
+    expect(frameTypes(frames)).toMatchSnapshot();
+  });
+
+  it("accepts the intent-only first frame before the completed payload", () => {
+    const parts = dataResponses(parseFixture("search"));
+    expect(parts).toHaveLength(2);
+    expect(ChatResponseDataPart.parse(parts[0]?.data)).toEqual({ intent: "plan_route" });
+    expect(parts[0]?.id).toBe(parts[1]?.id);
+  });
+
+  it("pins the error part shape and error finish sequence", () => {
+    const frames = parseFixture("error");
+    const error = frames.find((frame) => frame !== "[DONE]" && frame.type === "error");
+    expect(error).toEqual({ type: "error", errorText: "Something went wrong. Please try again." });
+    expect(frameTypes(frames).slice(-4)).toEqual(["error", "finish-step", "finish", "[DONE]"]);
+  });
+});
+
+describe("ChatResponseDataPart rejects invalid data", () => {
+  it("rejects a missing intent", () => {
+    expect(() => ChatResponseDataPart.parse({ message: "missing" })).toThrow();
+  });
+
+  it("rejects an unknown intent", () => {
+    expect(() => ChatResponseDataPart.parse({ intent: "dance" })).toThrow();
+  });
+
+  it("rejects a malformed payload", () => {
+    const malformed = { intent: "plan_route", data: { route: { ordered_points: "bad" } } };
+    expect(() => ChatResponseDataPart.parse(malformed)).toThrow();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   worker: {}
 


### PR DESCRIPTION
Campaign card C0.2 (Wave 0). Codex-authored, lead-committed (sandbox .git readonly).

- `packages/contract/src/chat-data-parts.ts`: intent-first zod discriminated union over 11 intents; strict envelopes; models reused from `models.ts`
- Snapshot contract tests over E1's recorded real streams (`search`/`clarify`/`error` .sse fixtures): per-frame `data-response` parse, intent-only first frame, same-ID overwrite, [DONE] terminator, error part shape
- Negatives: missing/unknown intent, malformed payload
- OpenAPI: byte-stable (chat-data-parts is not an oRPC procedure)
- contract package gains `vitest` devDep + `test` script

Gates (lead-run): typecheck ✓ · 8/8 tests ✓ · emit:openapi byte-stable ✓ · suppressions 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)