### PR TITLE
fix: heal pnpm-lock after three-way merge skew (mainline CI unblocked)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,7 +360,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   worker: {}
 


### PR DESCRIPTION
**Mainline hotfix.** #375, #376 and #377 merged within five minutes; GitHub's textual merge left `pnpm-lock.yaml` with a 1-line semantic skew (no conflict markers) — `pnpm install --frozen-lockfile` fails at every job's setup step, blocking ALL PR CI (first surfaced on #378).

Fix: single `pnpm install --no-frozen-lockfile` re-resolution, lockfile-only diff. Verified locally: frozen install green, workers/users suite 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)