### PR TITLE
feat(contract): CT-checkin walk check-in contract (contract-first, owner workers/users)

### DIFF
--- a/packages/contract/scripts/emit-openapi.ts
+++ b/packages/contract/scripts/emit-openapi.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { OpenAPIGenerator } from "@orpc/openapi";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
+import { checkinContract } from "../src/checkin-contract.js";
 import { catalogContract } from "../src/contract.js";
 import { usersContract } from "../src/users-contract.js";
 
@@ -41,7 +42,7 @@ await emitOpenApi(catalogContract, "openapi.json", {
       "Read methods of the TS Catalog service, consumed by the Python Agent service.",
 });
 
-await emitOpenApi(usersContract, "users-openapi.json", {
+await emitOpenApi({ ...usersContract, ...checkinContract }, "users-openapi.json", {
   title: "Animichi Users Service",
   version: "0.1.0",
   description: "User-domain routes of the TS Users service, consumed by apps/web.",

--- a/packages/contract/src/checkin-contract.ts
+++ b/packages/contract/src/checkin-contract.ts
@@ -1,0 +1,179 @@
+/**
+ * Walk check-in contract owned by workers/users.
+ *
+ * Auth: every procedure requires the users-service Neon Auth JWT bearer pattern;
+ * anonymous reads and writes are forbidden.
+ * Replay: client_id is the offline idempotency key. Reusing it with the same
+ * payload returns the original stored result, never a new record; a changed
+ * payload is an idempotency conflict.
+ * Privacy: API and storage coordinates retain full precision. Before coordinates
+ * enter observability, project them through TraceGpsCoordinates, which truncates
+ * toward zero to 3 decimal places (roughly 100 m) per iter-3 S3.3/S3.7.
+ * photo_ref is an opaque reference only; upload/presign belongs to card #249.
+ */
+
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+
+/** Full-precision GPS coordinates retained by the API and storage layer. */
+export const GpsCoordinates = z.strictObject({
+  latitude: z.number().finite().min(-90).max(90),
+  longitude: z.number().finite().min(-180).max(180),
+});
+/** Full-precision GPS coordinates. */
+export type GpsCoordinates = z.infer<typeof GpsCoordinates>;
+
+function truncateCoordinate(value: number): number {
+  return Math.trunc(value * 1_000) / 1_000;
+}
+
+function hasTracePrecision(value: number): boolean {
+  return value === truncateCoordinate(value);
+}
+
+/** GPS coordinates already safe for observability (at most 3 decimal places). */
+export const TruncatedGpsCoordinates = z.strictObject({
+  latitude: z.number().min(-90).max(90).refine(hasTracePrecision),
+  longitude: z.number().min(-180).max(180).refine(hasTracePrecision),
+});
+/** GPS coordinates safe for observability. */
+export type TruncatedGpsCoordinates = z.infer<typeof TruncatedGpsCoordinates>;
+
+/** Project full-precision GPS coordinates to the trace-safe representation. */
+export const TraceGpsCoordinates = GpsCoordinates.transform(({ latitude, longitude }) => ({
+  latitude: truncateCoordinate(latitude),
+  longitude: truncateCoordinate(longitude),
+})).pipe(TruncatedGpsCoordinates);
+
+/** Walk check-in returned by workers/users. */
+export const WalkCheckin = z.strictObject({
+  id: z.uuid(),
+  route_id: z.uuid(),
+  point_id: z.string().min(1).max(128),
+  client_id: z.uuid(),
+  coordinates: GpsCoordinates,
+  checked_in_at: z.iso.datetime({ offset: true }),
+  synced_at: z.iso.datetime({ offset: true }),
+  photo_ref: z.string().min(1).max(512).optional(),
+});
+/** Walk check-in returned by workers/users. */
+export type WalkCheckin = z.infer<typeof WalkCheckin>;
+
+/** Offline-replay-safe input for submitting a walk check-in. */
+export const SubmitCheckinInput = z.strictObject({
+  route_id: z.uuid(),
+  point_id: z.string().min(1).max(128),
+  client_id: z.uuid(),
+  coordinates: GpsCoordinates,
+  checked_in_at: z.iso.datetime({ offset: true }),
+  photo_ref: z.string().min(1).max(512).optional(),
+});
+/** Offline-replay-safe input for submitting a walk check-in. */
+export type SubmitCheckinInput = z.infer<typeof SubmitCheckinInput>;
+
+/** Optional route filter when listing the authenticated user's check-ins. */
+export const ListCheckinsInput = z.strictObject({ route_id: z.uuid().optional() });
+/** Optional route filter for listing check-ins. */
+export type ListCheckinsInput = z.infer<typeof ListCheckinsInput>;
+
+/** Check-ins owned by the authenticated user; an empty result is an empty array. */
+export const ListCheckinsResult = z.strictObject({ checkins: z.array(WalkCheckin) });
+/** Result of listing the authenticated user's check-ins. */
+export type ListCheckinsResult = z.infer<typeof ListCheckinsResult>;
+
+/** Check-in error category semantics; categories never cross the wire. */
+export const CheckinErrorCategory = z.enum(["user_actionable", "retryable", "system"]);
+/** Inferred check-in error category. */
+export type CheckinErrorCategory = z.infer<typeof CheckinErrorCategory>;
+
+/** Data returned when an idempotency key is replayed with changed input. */
+export const CheckinReplayConflictData = z.strictObject({ client_id: z.uuid() });
+/** Inferred replay-conflict data. */
+export type CheckinReplayConflictData = z.infer<typeof CheckinReplayConflictData>;
+
+/** Data returned when a route is unavailable to the authenticated user. */
+export const CheckinRouteNotFoundData = z.strictObject({ route_id: z.uuid() });
+/** Inferred route-not-found data. */
+export type CheckinRouteNotFoundData = z.infer<typeof CheckinRouteNotFoundData>;
+
+/** Data returned when a pilgrimage point does not exist. */
+export const CheckinPointNotFoundData = z.strictObject({ point_id: z.string() });
+/** Inferred point-not-found data. */
+export type CheckinPointNotFoundData = z.infer<typeof CheckinPointNotFoundData>;
+
+type CheckinErrorDefItem = {
+  readonly status: number;
+  readonly category: CheckinErrorCategory;
+  readonly message: string;
+  readonly data: z.ZodType<unknown>;
+};
+
+/** Check-in error registry with registry-only categories omitted from responses. */
+export const CHECKIN_ERROR_DEFS = {
+  CHECKIN_REPLAY_CONFLICT: {
+    status: 409,
+    category: "user_actionable",
+    message: "Idempotency key was already used with a different payload",
+    data: CheckinReplayConflictData,
+  },
+  CHECKIN_ROUTE_NOT_FOUND: {
+    status: 404,
+    category: "user_actionable",
+    message: "No such user route",
+    data: CheckinRouteNotFoundData,
+  },
+  CHECKIN_POINT_NOT_FOUND: {
+    status: 404,
+    category: "user_actionable",
+    message: "No such pilgrimage point",
+    data: CheckinPointNotFoundData,
+  },
+} as const satisfies Record<string, CheckinErrorDefItem>;
+
+/** Check-in error registry type. */
+export type CheckinErrorDefs = typeof CHECKIN_ERROR_DEFS;
+/** Check-in error code union. */
+export type CheckinErrorCode = keyof CheckinErrorDefs;
+
+type CheckinErrorMapItem<Code extends CheckinErrorCode> = {
+  status: CheckinErrorDefs[Code]["status"];
+  message: CheckinErrorDefs[Code]["message"];
+  data: CheckinErrorDefs[Code]["data"];
+};
+type CheckinErrorMap<Code extends CheckinErrorCode> = {
+  [Key in Code]: CheckinErrorMapItem<Key>;
+};
+
+function checkinErrorEntry<Code extends CheckinErrorCode>(
+  code: Code,
+): readonly [Code, CheckinErrorMapItem<Code>] {
+  const { status, message, data } = CHECKIN_ERROR_DEFS[code];
+  return [code, { status, message, data }];
+}
+
+/** Pick oRPC error entries while dropping registry-only category metadata. */
+export function pickCheckinErrors<const Code extends CheckinErrorCode>(
+  codes: readonly Code[],
+): CheckinErrorMap<Code> {
+  return Object.fromEntries(codes.map(checkinErrorEntry)) as CheckinErrorMap<Code>;
+}
+
+/** oRPC contract for authenticated walk check-in operations. */
+export const checkinContract = {
+  submitCheckin: oc
+    .route({ method: "POST", path: "/v1/users/checkins", summary: "Submit a walk check-in" })
+    .input(SubmitCheckinInput)
+    .errors(pickCheckinErrors([
+      "CHECKIN_REPLAY_CONFLICT",
+      "CHECKIN_ROUTE_NOT_FOUND",
+      "CHECKIN_POINT_NOT_FOUND",
+    ]))
+    .output(WalkCheckin),
+  listCheckins: oc
+    .route({ method: "GET", path: "/v1/users/checkins", summary: "List the caller's check-ins" })
+    .input(ListCheckinsInput)
+    .output(ListCheckinsResult),
+};
+
+/** Walk check-in oRPC contract type. */
+export type CheckinContract = typeof checkinContract;

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -6,6 +6,7 @@
 
 export * from "./models.js";
 export * from "./chat-data-parts.js";
+export * from "./checkin-contract.js";
 export * from "./constants.js";
 export * from "./contract.js";
 export * from "./errors.js";

--- a/packages/contract/test/checkin-contract.test.ts
+++ b/packages/contract/test/checkin-contract.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  GpsCoordinates,
+  SubmitCheckinInput,
+  TraceGpsCoordinates,
+  TruncatedGpsCoordinates,
+} from "../src/checkin-contract.js";
+
+const VALID_INPUT = {
+  route_id: "019b984f-1a52-7000-8000-000000000001",
+  point_id: "point-kanda-myojin",
+  client_id: "019b984f-1a52-7000-8000-000000000002",
+  coordinates: { latitude: 35.702_123_4, longitude: 139.767_654_3 },
+  checked_in_at: "2026-07-19T09:30:00+09:00",
+  photo_ref: "walk-checkins/photo-01.webp",
+} as const;
+
+describe("SubmitCheckinInput", () => {
+  it("accepts a full-precision check-in with an optional photo reference", () => {
+    expect(SubmitCheckinInput.parse(VALID_INPUT)).toEqual(VALID_INPUT);
+  });
+
+  it.each([
+    { latitude: 90.000_1, longitude: 139.7 },
+    { latitude: 35.7, longitude: -180.000_1 },
+  ])("rejects out-of-range GPS coordinates", (coordinates) => {
+    expect(SubmitCheckinInput.safeParse({ ...VALID_INPUT, coordinates }).success).toBe(false);
+  });
+
+  it("rejects a missing idempotency key", () => {
+    const { client_id: _clientId, ...withoutClientId } = VALID_INPUT;
+    expect(SubmitCheckinInput.safeParse(withoutClientId).success).toBe(false);
+  });
+
+  it.each(["offline-queue-1", "019b984f-1a52-7000-8000"])(
+    "rejects malformed idempotency key %s",
+    (client_id) => {
+      expect(SubmitCheckinInput.safeParse({ ...VALID_INPUT, client_id }).success).toBe(false);
+    },
+  );
+});
+
+describe("GPS privacy schemas", () => {
+  it("retains full precision for API and storage coordinates", () => {
+    expect(GpsCoordinates.parse(VALID_INPUT.coordinates)).toEqual(VALID_INPUT.coordinates);
+  });
+
+  it("rejects trace coordinates exceeding 3 decimal places", () => {
+    expect(TruncatedGpsCoordinates.safeParse(VALID_INPUT.coordinates).success).toBe(false);
+  });
+
+  it("truncates positive and negative coordinates toward zero to 3 decimal places", () => {
+    const precise = { latitude: -35.702_987, longitude: 139.767_987 };
+    expect(TraceGpsCoordinates.parse(precise)).toEqual({ latitude: -35.702, longitude: 139.767 });
+  });
+});

--- a/packages/contract/users-openapi.json
+++ b/packages/contract/users-openapi.json
@@ -548,6 +548,433 @@
           }
         }
       }
+    },
+    "/v1/users/checkins": {
+      "post": {
+        "operationId": "submitCheckin",
+        "summary": "Submit a walk check-in",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "route_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "point_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "client_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "coordinates": {
+                    "type": "object",
+                    "properties": {
+                      "latitude": {
+                        "type": "number",
+                        "minimum": -90,
+                        "maximum": 90
+                      },
+                      "longitude": {
+                        "type": "number",
+                        "minimum": -180,
+                        "maximum": 180
+                      }
+                    },
+                    "required": [
+                      "latitude",
+                      "longitude"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "checked_in_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "photo_ref": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 512
+                  }
+                },
+                "required": [
+                  "route_id",
+                  "point_id",
+                  "client_id",
+                  "coordinates",
+                  "checked_in_at"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "route_id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "point_id": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 128
+                    },
+                    "client_id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "coordinates": {
+                      "type": "object",
+                      "properties": {
+                        "latitude": {
+                          "type": "number",
+                          "minimum": -90,
+                          "maximum": 90
+                        },
+                        "longitude": {
+                          "type": "number",
+                          "minimum": -180,
+                          "maximum": 180
+                        }
+                      },
+                      "required": [
+                        "latitude",
+                        "longitude"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "checked_in_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "synced_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "photo_ref": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 512
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "route_id",
+                    "point_id",
+                    "client_id",
+                    "coordinates",
+                    "checked_in_at",
+                    "synced_at"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "CHECKIN_ROUTE_NOT_FOUND"
+                        },
+                        "status": {
+                          "const": 404
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "No such user route"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "route_id": {
+                              "type": "string",
+                              "format": "uuid"
+                            }
+                          },
+                          "required": [
+                            "route_id"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "CHECKIN_POINT_NOT_FOUND"
+                        },
+                        "status": {
+                          "const": 404
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "No such pilgrimage point"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "point_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "point_id"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "409",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "CHECKIN_REPLAY_CONFLICT"
+                        },
+                        "status": {
+                          "const": 409
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "Idempotency key was already used with a different payload"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "client_id": {
+                              "type": "string",
+                              "format": "uuid"
+                            }
+                          },
+                          "required": [
+                            "client_id"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listCheckins",
+        "summary": "List the caller's check-ins",
+        "parameters": [
+          {
+            "name": "route_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "checkins": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "route_id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "point_id": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 128
+                          },
+                          "client_id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "coordinates": {
+                            "type": "object",
+                            "properties": {
+                              "latitude": {
+                                "type": "number",
+                                "minimum": -90,
+                                "maximum": 90
+                              },
+                              "longitude": {
+                                "type": "number",
+                                "minimum": -180,
+                                "maximum": 180
+                              }
+                            },
+                            "required": [
+                              "latitude",
+                              "longitude"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "checked_in_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "synced_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "photo_ref": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 512
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "route_id",
+                          "point_id",
+                          "client_id",
+                          "coordinates",
+                          "checked_in_at",
+                          "synced_at"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "checkins"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Campaign CT-checkin card. Codex-authored, lead-committed.

- `checkin-contract.ts`: submit (client_id idempotency, replay-conflict typed error) + list procedures; strict zod; error registry in house style
- Privacy per iter-3 SD-21: storage/API full precision; `TraceGpsCoordinates` transform truncates to 3dp for observability only
- `photo_ref` opaque (upload = #249); auth = Neon Auth JWT (users-service pattern)
- users-openapi.json regenerated (+427), emit re-run stable

Gates (lead-run): typecheck ✓ · 17/17 tests ✓ · emit stable ✓ · suppressions 0 · spec-conformance checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)