### PR TITLE
feat(shiori): S4.2 auto-generated planned/commemorative shiori + default EXIF strip (#215)

### DIFF
--- a/apps/web/src/features/shiori/ShioriGenerator.tsx
+++ b/apps/web/src/features/shiori/ShioriGenerator.tsx
@@ -1,0 +1,81 @@
+import { type ChangeEvent, useCallback, useState } from "react";
+import type { Locale } from "../../i18n/locales";
+import { composeShiori, type ComposedShiori, type ShioriSource } from "./compose";
+import { shioriLabels, type ShioriLabels } from "./labels";
+import { ShioriCard } from "./ShioriCard";
+
+export type ShioriGeneratorProps = Readonly<{
+  source: ShioriSource;
+  locale: Locale;
+  onRetainExifChange?: (retainExif: boolean) => void;
+}>;
+
+/** S4.2 generation screen: the route data alone picks planned vs commemorative. */
+export function ShioriGenerator({ source, locale, onRetainExifChange }: ShioriGeneratorProps) {
+  const composed = composeShiori(source);
+  return (
+    <section className="shiori-generator" aria-label={shioriLabels(locale).modeName[composed.mode]}>
+      <GeneratorSummary locale={locale} composed={composed} />
+      <GeneratorPreview composed={composed} />
+      <RetainExifOptIn label={shioriLabels(locale).retainExif} onChange={onRetainExifChange} />
+    </section>
+  );
+}
+
+type GeneratorSummaryProps = Readonly<{ locale: Locale; composed: ComposedShiori }>;
+
+function GeneratorSummary({ locale, composed }: GeneratorSummaryProps) {
+  const labels = shioriLabels(locale);
+  return (
+    <header className="shiori-generator__summary">
+      <h2 className="shiori-generator__mode">{labels.modeName[composed.mode]}</h2>
+      <p className="shiori-generator__stats">{labels.statsLine(composed.stats)}</p>
+      <CompletionLine labels={labels} composed={composed} />
+    </header>
+  );
+}
+
+type CompletionLineProps = Readonly<{ labels: ShioriLabels; composed: ComposedShiori }>;
+
+function CompletionLine({ labels, composed }: CompletionLineProps) {
+  if (!composed.completion) return null;
+  return (
+    <p className="shiori-generator__completion">{labels.completionLine(composed.completion)}</p>
+  );
+}
+
+function GeneratorPreview({ composed }: Readonly<{ composed: ComposedShiori }>) {
+  return (
+    <ShioriCard
+      status={composed.status}
+      meta={composed.meta}
+      itinerary={composed.itinerary}
+      photos={composed.photos}
+    />
+  );
+}
+
+function useRetainExif(onChange?: (retainExif: boolean) => void) {
+  const [retainExif, setRetainExif] = useState(false);
+  const handleChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setRetainExif(event.target.checked);
+    onChange?.(event.target.checked);
+  }, [onChange]);
+  return { retainExif, handleChange };
+}
+
+type RetainExifOptInProps = Readonly<{
+  label: string;
+  onChange?: (retainExif: boolean) => void;
+}>;
+
+/** Unchecked by default: EXIF stripping stays on unless the user opts in (X6). */
+function RetainExifOptIn({ label, onChange }: RetainExifOptInProps) {
+  const { retainExif, handleChange } = useRetainExif(onChange);
+  return (
+    <label className="shiori-generator__exif">
+      <input type="checkbox" checked={retainExif} onChange={handleChange} />
+      {label}
+    </label>
+  );
+}

--- a/apps/web/src/features/shiori/compose.ts
+++ b/apps/web/src/features/shiori/compose.ts
@@ -1,0 +1,75 @@
+import type { TimedItinerary } from "@seichijunrei/contract";
+import { selectShioriLayout, type ShioriLayout, type ShioriStatus } from "./layoutSelector";
+import { shioriTimeWindow } from "./timeWindow";
+import type { ShioriMeta, ShioriPhoto } from "./types";
+
+export type ShioriMode = "planned" | "commemorative";
+
+/** Everything the auto-composer needs; the caller decides "day over" (mock the clock). */
+export interface ShioriSource {
+  meta: ShioriMeta;
+  itinerary: TimedItinerary;
+  photos: readonly ShioriPhoto[];
+  checkedStopIds: readonly string[];
+  isRouteDayOver: boolean;
+}
+
+export interface ShioriStats {
+  walkMinutes: number;
+  distanceKm: number;
+  timeWindow: string | null;
+}
+
+export interface ShioriCompletion {
+  checkedCount: number;
+  stopCount: number;
+  ratePercent: number;
+}
+
+export interface ComposedShiori {
+  mode: ShioriMode;
+  status: ShioriStatus;
+  layout: ShioriLayout;
+  meta: ShioriMeta;
+  itinerary: TimedItinerary;
+  photos: readonly ShioriPhoto[];
+  stats: ShioriStats;
+  completion: ShioriCompletion | null;
+}
+
+/** Auto-generates the しおり: the route's data state picks the mode, never the user (S4.2). */
+export function composeShiori(source: ShioriSource): ComposedShiori {
+  const mode = resolveMode(source);
+  const status: ShioriStatus = mode === "commemorative" ? "completed" : "planned";
+  const { meta, itinerary, photos } = source;
+  const completion = mode === "commemorative" ? composeCompletion(source) : null;
+  const layout = selectShioriLayout(status, photos.length);
+  return { mode, status, layout, meta, itinerary, photos, stats: composeStats(itinerary), completion };
+}
+
+function resolveMode(source: ShioriSource): ShioriMode {
+  const stopCount = source.itinerary.stops.length;
+  const checked = countCheckedStops(source);
+  if (stopCount === 0 || checked === 0) return "planned";
+  if (checked === stopCount) return "commemorative";
+  return source.isRouteDayOver ? "commemorative" : "planned";
+}
+
+function countCheckedStops({ itinerary, checkedStopIds }: ShioriSource): number {
+  const checked = new Set(checkedStopIds);
+  return itinerary.stops.filter((stop) => checked.has(stop.cluster_id)).length;
+}
+
+function composeCompletion(source: ShioriSource): ShioriCompletion {
+  const checkedCount = countCheckedStops(source);
+  const stopCount = source.itinerary.stops.length;
+  return { checkedCount, stopCount, ratePercent: Math.round((checkedCount / stopCount) * 100) };
+}
+
+function composeStats(itinerary: TimedItinerary): ShioriStats {
+  return {
+    walkMinutes: itinerary.total_minutes,
+    distanceKm: Math.round(itinerary.total_distance_m / 100) / 10,
+    timeWindow: shioriTimeWindow(itinerary),
+  };
+}

--- a/apps/web/src/features/shiori/exifStrip.ts
+++ b/apps/web/src/features/shiori/exifStrip.ts
@@ -1,0 +1,84 @@
+/**
+ * EXIF stripping for photos entering the しおり pipeline (X6 hard AC).
+ * Default = strip; retaining metadata is an explicit opt-in.
+ *
+ * JPEG: lossless APPn/COM segment removal (no re-encode, no quality loss,
+ * deterministic and unit-verifiable). Other formats: canvas redraw, which
+ * drops all metadata during re-encode.
+ */
+
+const SOI = 0xffd8;
+const SOS = 0xffda;
+const APP0 = 0xffe0;
+const APP15 = 0xffef;
+const COM = 0xfffe;
+
+export interface SanitizePhotoOptions {
+  retainExif?: boolean;
+}
+
+export async function sanitizePhoto(
+  photo: Blob,
+  options: SanitizePhotoOptions = {},
+): Promise<Blob> {
+  if (options.retainExif) return photo;
+  if (photo.type === "image/jpeg") return stripJpegBlob(photo);
+  return redrawWithoutMetadata(photo);
+}
+
+/** Removes APP1–APP15 + COM segments; keeps APP0 (JFIF), tables and scan data intact. */
+export function stripJpegMetadata(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  const view = toView(bytes);
+  if (bytes.length < 2 || view.getUint16(0) !== SOI) throw new Error("not a JPEG");
+  const kept: Uint8Array[] = [bytes.subarray(0, 2)];
+  kept.push(collectKeptSegments(bytes, view, kept));
+  return concatBytes(kept);
+}
+
+function toView(bytes: Uint8Array): DataView {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function collectKeptSegments(bytes: Uint8Array, view: DataView, kept: Uint8Array[]): Uint8Array {
+  let offset = 2;
+  while (offset + 4 <= bytes.length && view.getUint16(offset) !== SOS) {
+    const end = segmentEnd(bytes, view, offset);
+    if (!isMetadataMarker(view.getUint16(offset))) kept.push(bytes.subarray(offset, end));
+    offset = end;
+  }
+  return bytes.subarray(offset);
+}
+
+function segmentEnd(bytes: Uint8Array, view: DataView, offset: number): number {
+  const end = offset + 2 + view.getUint16(offset + 2);
+  if (end > bytes.length) throw new Error("truncated JPEG segment");
+  return end;
+}
+
+function isMetadataMarker(marker: number): boolean {
+  return (marker > APP0 && marker <= APP15) || marker === COM;
+}
+
+function concatBytes(parts: readonly Uint8Array[]): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+async function stripJpegBlob(photo: Blob): Promise<Blob> {
+  const bytes = new Uint8Array(await photo.arrayBuffer());
+  return new Blob([stripJpegMetadata(bytes)], { type: "image/jpeg" });
+}
+
+async function redrawWithoutMetadata(photo: Blob): Promise<Blob> {
+  const bitmap = await createImageBitmap(photo);
+  const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("2d canvas context unavailable");
+  context.drawImage(bitmap, 0, 0);
+  return canvas.convertToBlob({ type: photo.type });
+}

--- a/apps/web/src/features/shiori/labels.ts
+++ b/apps/web/src/features/shiori/labels.ts
@@ -1,0 +1,48 @@
+import type { Locale } from "../../i18n/locales";
+import type { ShioriCompletion, ShioriMode, ShioriStats } from "./compose";
+
+/**
+ * Feature-local ja/zh/en copy for the generation screen (S4.2 i18n AC).
+ * Kept beside the feature: this card only touches src/features/shiori/.
+ */
+export interface ShioriLabels {
+  modeName: Record<ShioriMode, string>;
+  statsLine: (stats: ShioriStats) => string;
+  completionLine: (completion: ShioriCompletion) => string;
+  retainExif: string;
+}
+
+function joinStats(parts: readonly (string | null)[]): string {
+  return parts.filter((part) => part !== null).join(" · ");
+}
+
+const JA: ShioriLabels = {
+  modeName: { planned: "計画しおり", commemorative: "完走記念しおり" },
+  statsLine: (stats) =>
+    joinStats([`徒歩${String(stats.walkMinutes)}分`, `${String(stats.distanceKm)}km`, stats.timeWindow]),
+  completionLine: (c) => `完走 ${String(c.checkedCount)}/${String(c.stopCount)} · ${String(c.ratePercent)}%`,
+  retainExif: "写真の位置情報（EXIF）を残す",
+};
+
+const ZH: ShioriLabels = {
+  modeName: { planned: "行程计划书签", commemorative: "完走纪念书签" },
+  statsLine: (stats) =>
+    joinStats([`步行${String(stats.walkMinutes)}分`, `${String(stats.distanceKm)}km`, stats.timeWindow]),
+  completionLine: (c) => `完走 ${String(c.checkedCount)}/${String(c.stopCount)} · ${String(c.ratePercent)}%`,
+  retainExif: "保留照片位置信息（EXIF）",
+};
+
+const EN: ShioriLabels = {
+  modeName: { planned: "Planned shiori", commemorative: "Commemorative shiori" },
+  statsLine: (stats) =>
+    joinStats([`${String(stats.walkMinutes)} min walk`, `${String(stats.distanceKm)} km`, stats.timeWindow]),
+  completionLine: (c) =>
+    `Completed ${String(c.checkedCount)}/${String(c.stopCount)} · ${String(c.ratePercent)}%`,
+  retainExif: "Keep photo location data (EXIF)",
+};
+
+const LABELS: Record<Locale, ShioriLabels> = { ja: JA, zh: ZH, en: EN };
+
+export function shioriLabels(locale: Locale): ShioriLabels {
+  return LABELS[locale];
+}

--- a/apps/web/tests/unit/shiori/compose.test.ts
+++ b/apps/web/tests/unit/shiori/compose.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  composeShiori,
+  type ShioriSource,
+} from "../../../src/features/shiori/compose";
+import { makeItinerary, makeMeta, makePhotos, makeStop } from "./_factories";
+
+function makeSource(overrides: Partial<ShioriSource> = {}): ShioriSource {
+  return {
+    meta: makeMeta(),
+    itinerary: makeItinerary(),
+    photos: makePhotos(2),
+    checkedStopIds: [],
+    isRouteDayOver: false,
+    ...overrides,
+  };
+}
+
+const ALL_CHECKED = ["stop-station", "stop-shrine"];
+
+describe("composeShiori mode decision", () => {
+  it("generates the planned version when no stop is checked in", () => {
+    const composed = composeShiori(makeSource());
+
+    expect(composed.mode).toBe("planned");
+    expect(composed.status).toBe("planned");
+    expect(composed.completion).toBeNull();
+  });
+
+  it("stays planned with zero check-ins even when the route day is over", () => {
+    const composed = composeShiori(makeSource({ isRouteDayOver: true }));
+
+    expect(composed.mode).toBe("planned");
+  });
+
+  it("generates the commemorative version when every stop is checked in", () => {
+    const composed = composeShiori(makeSource({ checkedStopIds: ALL_CHECKED }));
+
+    expect(composed.mode).toBe("commemorative");
+    expect(composed.status).toBe("completed");
+    expect(composed.completion).toEqual({ checkedCount: 2, stopCount: 2, ratePercent: 100 });
+  });
+
+  it("generates the commemorative version for a partial run once the day is over", () => {
+    const composed = composeShiori(
+      makeSource({ checkedStopIds: ["stop-shrine"], isRouteDayOver: true }),
+    );
+
+    expect(composed.mode).toBe("commemorative");
+    expect(composed.completion).toEqual({ checkedCount: 1, stopCount: 2, ratePercent: 50 });
+  });
+
+  it("stays planned for a partial run while the day is still running", () => {
+    const composed = composeShiori(makeSource({ checkedStopIds: ["stop-shrine"] }));
+
+    expect(composed.mode).toBe("planned");
+  });
+
+  it("ignores duplicate and unknown check-in ids", () => {
+    const composed = composeShiori(
+      makeSource({
+        checkedStopIds: ["stop-shrine", "stop-shrine", "ghost-stop"],
+        isRouteDayOver: true,
+      }),
+    );
+
+    expect(composed.completion).toEqual({ checkedCount: 1, stopCount: 2, ratePercent: 50 });
+  });
+
+  it("stays planned for an itinerary with zero stops", () => {
+    const itinerary = makeItinerary({ stops: [] });
+    const composed = composeShiori(
+      makeSource({ itinerary, checkedStopIds: ["ghost-stop"], isRouteDayOver: true }),
+    );
+
+    expect(composed.mode).toBe("planned");
+    expect(composed.stats.timeWindow).toBeNull();
+  });
+});
+
+describe("composeShiori layout and stats", () => {
+  it("keeps the ticket layout for planned routes regardless of photos", () => {
+    const composed = composeShiori(makeSource({ photos: makePhotos(5) }));
+
+    expect(composed.layout).toBe("ticket");
+  });
+
+  it.each([
+    [0, "poster-fallback"],
+    [1, "single-panel"],
+    [3, "album-grid"],
+  ] as const)("routes a completed run with %i photos to %s", (count, layout) => {
+    const composed = composeShiori(
+      makeSource({ photos: makePhotos(count), checkedStopIds: ALL_CHECKED }),
+    );
+
+    expect(composed.layout).toBe(layout);
+  });
+
+  it("summarises walking time, distance and time window", () => {
+    const composed = composeShiori(makeSource());
+
+    expect(composed.stats).toEqual({ walkMinutes: 210, distanceKm: 2.8, timeWindow: "09:31→12:58" });
+  });
+
+  it("rounds the distance to one decimal", () => {
+    const itinerary = makeItinerary({ total_distance_m: 1234 });
+
+    expect(composeShiori(makeSource({ itinerary })).stats.distanceKm).toBe(1.2);
+  });
+
+  it("passes meta, itinerary and photos through for rendering", () => {
+    const single = composeShiori(
+      makeSource({ photos: makePhotos(1), checkedStopIds: ALL_CHECKED }),
+    );
+
+    expect(single.meta.routeTitle).toBe("飛騨古川 半日ルート");
+    expect(single.itinerary.stops[0]).toEqual(makeStop());
+    expect(single.photos).toHaveLength(1);
+  });
+});

--- a/apps/web/tests/unit/shiori/exif-strip.test.ts
+++ b/apps/web/tests/unit/shiori/exif-strip.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sanitizePhoto, stripJpegMetadata } from "../../../src/features/shiori/exifStrip";
+
+function segment(marker: number, body: readonly number[]): number[] {
+  return [0xff, marker, (body.length + 2) >> 8, (body.length + 2) & 0xff, ...body];
+}
+
+const ascii = (text: string): number[] => Array.from(text, (char) => char.charCodeAt(0));
+const APP0_JFIF = segment(0xe0, [...ascii("JFIF\0"), 1, 2]);
+const APP1_EXIF_GPS = segment(0xe1, ascii("Exif\0\0GPSLAT35.68"));
+const DQT = segment(0xdb, [0, 1, 2, 3]);
+const SCAN_TAIL = [...segment(0xda, [1, 0]), 0xaa, 0xbb, 0xff, 0xd9];
+
+function makeJpegWithExif(): Uint8Array {
+  return Uint8Array.from([0xff, 0xd8, ...APP0_JFIF, ...APP1_EXIF_GPS, ...DQT, ...SCAN_TAIL]);
+}
+
+const bytesToText = (bytes: Uint8Array): string => String.fromCharCode(...bytes);
+
+describe("stripJpegMetadata", () => {
+  it("removes the EXIF APP1 segment including GPS payload", () => {
+    const stripped = stripJpegMetadata(makeJpegWithExif());
+
+    expect(bytesToText(stripped)).not.toContain("Exif");
+    expect(bytesToText(stripped)).not.toContain("GPSLAT");
+  });
+
+  it("keeps the JFIF header, tables and scan data byte-for-byte", () => {
+    const stripped = stripJpegMetadata(makeJpegWithExif());
+
+    expect([...stripped]).toEqual([0xff, 0xd8, ...APP0_JFIF, ...DQT, ...SCAN_TAIL]);
+  });
+
+  it("removes comment segments alongside APPn metadata", () => {
+    const jpeg = Uint8Array.from([
+      0xff, 0xd8, ...segment(0xfe, ascii("shot on phone")), ...DQT, ...SCAN_TAIL,
+    ]);
+
+    expect([...stripJpegMetadata(jpeg)]).toEqual([0xff, 0xd8, ...DQT, ...SCAN_TAIL]);
+  });
+
+  it("rejects bytes that are not a JPEG", () => {
+    expect(() => stripJpegMetadata(Uint8Array.from(ascii("PNG?")))).toThrow("not a JPEG");
+  });
+
+  it("rejects a truncated segment instead of looping past the end", () => {
+    const truncated = Uint8Array.from([0xff, 0xd8, 0xff, 0xdb, 0xff, 0xff]);
+
+    expect(() => stripJpegMetadata(truncated)).toThrow("truncated JPEG");
+  });
+});
+
+describe("sanitizePhoto", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("strips EXIF from JPEG photos by default", async () => {
+    const photo = new Blob([makeJpegWithExif().slice().buffer], { type: "image/jpeg" });
+
+    const sanitized = await sanitizePhoto(photo);
+
+    const bytes = new Uint8Array(await sanitized.arrayBuffer());
+    expect(bytesToText(bytes)).not.toContain("GPSLAT");
+    expect(sanitized.type).toBe("image/jpeg");
+  });
+
+  it("returns the original photo only when retaining EXIF is opted in", async () => {
+    const photo = new Blob([makeJpegWithExif().slice().buffer], { type: "image/jpeg" });
+
+    const retained = await sanitizePhoto(photo, { retainExif: true });
+
+    expect(retained).toBe(photo);
+  });
+
+  it("redraws non-JPEG photos on a canvas to drop metadata", async () => {
+    const redrawn = new Blob(["clean"], { type: "image/png" });
+    const convertToBlob = vi.fn().mockResolvedValue(redrawn);
+    const drawImage = vi.fn();
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue({ width: 4, height: 3 }));
+    vi.stubGlobal(
+      "OffscreenCanvas",
+      class {
+        getContext = () => ({ drawImage });
+        convertToBlob = convertToBlob;
+      },
+    );
+
+    const sanitized = await sanitizePhoto(new Blob(["png-with-eXIf"], { type: "image/png" }));
+
+    expect(sanitized).toBe(redrawn);
+    expect(drawImage).toHaveBeenCalledWith({ width: 4, height: 3 }, 0, 0);
+    expect(convertToBlob).toHaveBeenCalledWith({ type: "image/png" });
+  });
+
+  it("fails loudly when the canvas context is unavailable", async () => {
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue({ width: 4, height: 3 }));
+    vi.stubGlobal(
+      "OffscreenCanvas",
+      class {
+        getContext = () => null;
+      },
+    );
+
+    await expect(sanitizePhoto(new Blob(["x"], { type: "image/webp" }))).rejects.toThrow(
+      "2d canvas context unavailable",
+    );
+  });
+});

--- a/apps/web/tests/unit/shiori/labels.test.ts
+++ b/apps/web/tests/unit/shiori/labels.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { shioriLabels } from "../../../src/features/shiori/labels";
+import type { ShioriCompletion, ShioriStats } from "../../../src/features/shiori/compose";
+
+const STATS: ShioriStats = { walkMinutes: 210, distanceKm: 2.8, timeWindow: "09:31→12:58" };
+const COMPLETION: ShioriCompletion = { checkedCount: 2, stopCount: 2, ratePercent: 100 };
+
+describe("shioriLabels mode names", () => {
+  it.each([
+    ["ja", "計画しおり", "完走記念しおり"],
+    ["zh", "行程计划书签", "完走纪念书签"],
+    ["en", "Planned shiori", "Commemorative shiori"],
+  ] as const)("names both modes in %s", (locale, planned, commemorative) => {
+    const labels = shioriLabels(locale);
+
+    expect(labels.modeName.planned).toBe(planned);
+    expect(labels.modeName.commemorative).toBe(commemorative);
+  });
+});
+
+describe("shioriLabels stats line", () => {
+  it.each([
+    ["ja", "徒歩210分 · 2.8km · 09:31→12:58"],
+    ["zh", "步行210分 · 2.8km · 09:31→12:58"],
+    ["en", "210 min walk · 2.8 km · 09:31→12:58"],
+  ] as const)("renders the stats copy in %s", (locale, expected) => {
+    expect(shioriLabels(locale).statsLine(STATS)).toBe(expected);
+  });
+
+  it("omits the time window when the itinerary has no stops", () => {
+    const stats: ShioriStats = { ...STATS, timeWindow: null };
+
+    expect(shioriLabels("ja").statsLine(stats)).toBe("徒歩210分 · 2.8km");
+  });
+});
+
+describe("shioriLabels completion line", () => {
+  it.each([
+    ["ja", "完走 2/2 · 100%"],
+    ["zh", "完走 2/2 · 100%"],
+    ["en", "Completed 2/2 · 100%"],
+  ] as const)("renders the completion copy in %s", (locale, expected) => {
+    expect(shioriLabels(locale).completionLine(COMPLETION)).toBe(expected);
+  });
+});
+
+describe("shioriLabels EXIF opt-in", () => {
+  it.each([
+    ["ja", "写真の位置情報（EXIF）を残す"],
+    ["zh", "保留照片位置信息（EXIF）"],
+    ["en", "Keep photo location data (EXIF)"],
+  ] as const)("labels the retain-EXIF opt-in in %s", (locale, expected) => {
+    expect(shioriLabels(locale).retainExif).toBe(expected);
+  });
+});

--- a/apps/web/tests/unit/shiori/shiori-generator.test.tsx
+++ b/apps/web/tests/unit/shiori/shiori-generator.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ShioriSource } from "../../../src/features/shiori/compose";
+import { ShioriGenerator } from "../../../src/features/shiori/ShioriGenerator";
+import { makeItinerary, makeMeta, makePhotos } from "./_factories";
+
+afterEach(cleanup);
+
+function makeSource(overrides: Partial<ShioriSource> = {}): ShioriSource {
+  return {
+    meta: makeMeta(),
+    itinerary: makeItinerary(),
+    photos: makePhotos(1),
+    checkedStopIds: [],
+    isRouteDayOver: false,
+    ...overrides,
+  };
+}
+
+const COMPLETED = { checkedStopIds: ["stop-station", "stop-shrine"] };
+
+describe("ShioriGenerator", () => {
+  it("auto-generates a commemorative preview with completion stats", () => {
+    render(<ShioriGenerator source={makeSource(COMPLETED)} locale="ja" />);
+
+    expect(screen.getByRole("heading", { name: "完走記念しおり" })).toBeTruthy();
+    expect(screen.getByText("徒歩210分 · 2.8km · 09:31→12:58")).toBeTruthy();
+    expect(screen.getByText("完走 2/2 · 100%")).toBeTruthy();
+    expect(screen.getByRole("article", { name: "完走記念しおり" })).toBeTruthy();
+  });
+
+  it("auto-generates a planned preview without completion stats", () => {
+    render(<ShioriGenerator source={makeSource()} locale="ja" />);
+
+    expect(screen.getByRole("heading", { name: "計画しおり" })).toBeTruthy();
+    expect(screen.queryByText("完走 2/2 · 100%")).toBeNull();
+    expect(screen.getByRole("article", { name: "計画しおり" })).toBeTruthy();
+  });
+
+  it("still renders a valid planned preview for zero check-ins on a past day", () => {
+    render(
+      <ShioriGenerator source={makeSource({ photos: [], isRouteDayOver: true })} locale="ja" />,
+    );
+
+    expect(screen.getByRole("heading", { name: "計画しおり" })).toBeTruthy();
+    expect(screen.getByText("飛騨古川駅")).toBeTruthy();
+  });
+
+  it.each([
+    ["zh", "完走纪念书签"],
+    ["en", "Commemorative shiori"],
+  ] as const)("renders the %s mode label", (locale, heading) => {
+    render(<ShioriGenerator source={makeSource(COMPLETED)} locale={locale} />);
+
+    expect(screen.getByRole("heading", { name: heading })).toBeTruthy();
+  });
+
+  it("keeps EXIF stripping on by default", () => {
+    render(<ShioriGenerator source={makeSource()} locale="ja" />);
+
+    const optIn = screen.getByRole("checkbox", { name: "写真の位置情報（EXIF）を残す" });
+    expect((optIn as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("reports the opt-in when the user chooses to retain EXIF", () => {
+    const onRetainExifChange = vi.fn();
+    render(
+      <ShioriGenerator source={makeSource()} locale="en" onRetainExifChange={onRetainExifChange} />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Keep photo location data (EXIF)" }));
+
+    expect(onRetainExifChange).toHaveBeenCalledWith(true);
+    const optIn = screen.getByRole("checkbox", { name: "Keep photo location data (EXIF)" });
+    expect((optIn as HTMLInputElement).checked).toBe(true);
+  });
+});


### PR DESCRIPTION
## Card

#215 = spec S4.2 (docs/superpowers/specs/2026-07-06-frontend-rebuild/iter-4.md): auto-compose a しおり from route + check-in data with zero manual input, planned vs commemorative decided by the route's data state, plus the X6 hard AC (EXIF stripped by default before photos enter the pipeline).

Scope respected: only `apps/web/src/features/shiori/` + `apps/web/tests/unit/shiori/`; no contract changes; layout selection reuses #212's `selectShioriLayout`.

## What's in

- `compose.ts` — pure auto-generation: mode decision (zero check-ins → planned always, covering the "zero check-ins and not today" empty AC; all stops checked → commemorative; partial + route day over → commemorative with partial rate), stats (walk minutes · km · time window), layout via `selectShioriLayout`. The "day is over" clock decision is injected by the caller (no timing-dependent asserts).
- `labels.ts` — feature-local ja/zh/en copy (mode names, stats line, completion rate, EXIF opt-in label). Kept beside the feature because this card may not touch `src/i18n/`.
- `exifStrip.ts` — **EXIF strip default-on**; `sanitizePhoto(blob, { retainExif })` where retaining is an explicit opt-in.
- `ShioriGenerator.tsx` — generation screen: composed preview (mode heading + stats + completion) rendering `ShioriCard`, plus the X6 opt-in checkbox (unchecked by default, reports opt-in via callback).

## EXIF approach — selection rationale

Options surveyed:
- **Canvas redraw** (most-cited community answer): strips everything, zero deps — but re-encodes (quality loss, drops ICC), and is untestable under jsdom, so the security AC ("output has no EXIF") could only be asserted against mocks.
- **piexifjs**: unmaintained for years; adds a dependency for what is a ~40-line segment walk.
- **exifr**: read-only parser, cannot strip.

Chosen: **lossless JPEG APP1–APP15 + COM segment removal** (same technique as `exif-be-gone`): dependency-free, no re-encode/quality loss, deterministic, and the unit test asserts against real bytes — a fixture JPEG carrying an `Exif\0\0…GPSLAT…` APP1 payload goes in, the output provably contains no APP1/GPS bytes while JFIF/DQT/scan data survive byte-for-byte. Non-JPEG inputs (PNG `eXIf`, WebP EXIF) fall back to canvas redraw (`createImageBitmap` + `OffscreenCanvas.convertToBlob`), which drops all metadata during re-encode; that path is covered with stubbed canvas globals. Malformed/truncated JPEGs fail loudly instead of leaking bytes.

## AC ↔ test map (all `unit`)

| AC (spec S4.2) | Test |
|---|---|
| Completed route → commemorative with ✓ + completion stats | `compose.test.ts`, `shiori-generator.test.tsx` |
| Incomplete/planned route → planned version, no ✓ | `compose.test.ts`, `shiori-generator.test.tsx` |
| Zero check-ins + not today → still a valid planned preview | `compose.test.ts` ("stays planned with zero check-ins even when the route day is over"), `shiori-generator.test.tsx` |
| X6: EXIF (GPS) stripped by default; retain = opt-in checkbox | `exif-strip.test.ts` (real-bytes fixture), `shiori-generator.test.tsx` (checkbox default off + opt-in callback) |
| i18n ja/zh/en labels + stats copy | `labels.test.ts`, `shiori-generator.test.tsx` |
| Boundaries: 0/1/many photos, empty itinerary, malformed input | `compose.test.ts`, `exif-strip.test.ts` |

Browser-type ACs (preview screens) remain Tester scope per the harness.

## Gates (all from `apps/web/`)

- `npm run build` — exit 0
- `npm run typecheck` — clean
- `npm run lint:oxlint` — clean (`--deny-warnings`)
- `npm test` — 43 shiori-suite tests green; coverage **100% stmts / 99.34% branch / 100% funcs / 100% lines** (floor 90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)