### PR TITLE
feat(web): S5.1 anime-page shell (SSR) + SW network-first + fact-summary + hreflang bootstrap (#267)

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,68 @@
+/**
+ * Service worker for /anime pages — network-first (spec X7 hard AC).
+ *
+ * A navigation to /anime/:id always tries the network so the SW never serves
+ * stale HTML; the cache is only a fallback for network failure (offline).
+ * Standard Service Worker API, no libraries. Classic script served from
+ * public/, typed via JSDoc for the type-aware lint gate.
+ *
+ * @typedef {{ request: Request, respondWith: (response: Promise<Response>) => void, waitUntil: (task: Promise<unknown>) => void }} SwEvent
+ * @typedef {{ addEventListener: (type: string, listener: (event: SwEvent) => void) => void, skipWaiting: () => void, clients: { claim: () => Promise<void> }, caches: CacheStorage, fetch: (request: Request) => Promise<Response> }} SwScope
+ */
+const scope = /** @type {SwScope} */ (/** @type {unknown} */ (globalThis));
+
+const CACHE_NAME = "anime-html-v1";
+
+/** @param {Request} request */
+function isAnimeNavigation(request) {
+  return request.mode === "navigate" && new URL(request.url).pathname.startsWith("/anime/");
+}
+
+/**
+ * @param {Cache} cache
+ * @param {Request} request
+ * @param {Response} response
+ */
+async function refreshCache(cache, request, response) {
+  if (response.ok) {
+    await cache.put(request, response.clone());
+  }
+  return response;
+}
+
+/**
+ * @param {Cache} cache
+ * @param {Request} request
+ * @param {unknown} error
+ */
+async function fallbackToCache(cache, request, error) {
+  const cached = await cache.match(request);
+  if (cached) {
+    return cached;
+  }
+  throw error;
+}
+
+/** @param {Request} request */
+async function networkFirst(request) {
+  const cache = await scope.caches.open(CACHE_NAME);
+  try {
+    return await refreshCache(cache, request, await scope.fetch(request));
+  } catch (error) {
+    return await fallbackToCache(cache, request, error);
+  }
+}
+
+scope.addEventListener("install", () => {
+  scope.skipWaiting();
+});
+
+scope.addEventListener("activate", (event) => {
+  event.waitUntil(scope.clients.claim());
+});
+
+scope.addEventListener("fetch", (event) => {
+  if (isAnimeNavigation(event.request)) {
+    event.respondWith(networkFirst(event.request));
+  }
+});

--- a/apps/web/src/api/hooks/use-anime-overview.ts
+++ b/apps/web/src/api/hooks/use-anime-overview.ts
@@ -1,0 +1,15 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { catalog } from "../orpc";
+
+/**
+ * Query options for the public anime overview, shared by the route loader
+ * (`ensureQueryData` prefetch on the server) and the suspense hook (hydrated
+ * client read — no double fetch, wired by `routerWithQueryClient`).
+ */
+export function animeOverviewOptions(bangumiId: string) {
+  return catalog().animeOverview.queryOptions({ input: { bangumi_id: bangumiId } });
+}
+
+export function useAnimeOverview(bangumiId: string) {
+  return useSuspenseQuery(animeOverviewOptions(bangumiId));
+}

--- a/apps/web/src/features/anime/AnimePage.tsx
+++ b/apps/web/src/features/anime/AnimePage.tsx
@@ -1,0 +1,50 @@
+import type { AnimeOverview } from "@seichijunrei/contract";
+import type { Locale } from "../../i18n/locales";
+import { CirclesSection } from "./CirclesSection";
+import { FactSummaryBlock } from "./FactSummaryBlock";
+import { ScenesSection } from "./ScenesSection";
+import { type AnimeCopy, animeCopyFor } from "./copy";
+import { buildFactSummary, rankScenes } from "./fact-summary";
+
+export type AnimePageProps = Readonly<{ overview: AnimeOverview; locale: Locale }>;
+
+type ViewProps = Readonly<{ overview: AnimeOverview; copy: AnimeCopy }>;
+
+function AnimeHero({ overview, copy }: ViewProps) {
+  return (
+    <header>
+      <p className="eyebrow">Animichi</p>
+      <h1 className="mt-1 mb-2">{copy.h1}</h1>
+      <p className="mt-0 text-[var(--color-muted-fg)]">{copy.heroSubtitle(overview.bangumi_id)}</p>
+    </header>
+  );
+}
+
+function AnimeEmpty({ overview, copy }: ViewProps) {
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8">
+      <AnimeHero overview={overview} copy={copy} />
+      <section className="rounded-2xl bg-[var(--color-card)] p-6 text-center">
+        <p className="m-0 text-[var(--color-muted-fg)]">{copy.empty}</p>
+      </section>
+    </main>
+  );
+}
+
+function AnimeFull({ overview, copy }: ViewProps) {
+  return (
+    <main className="mx-auto grid max-w-3xl gap-6 px-4 py-8">
+      <AnimeHero overview={overview} copy={copy} />
+      <FactSummaryBlock summary={buildFactSummary(overview)} copy={copy} />
+      <ScenesSection scenes={rankScenes(overview.scenes)} copy={copy} />
+      <CirclesSection circles={overview.circles} copy={copy} />
+    </main>
+  );
+}
+
+/** `/anime/:id` presenter: empty-but-valid overviews get the graceful empty state. */
+export function AnimePage({ overview, locale }: AnimePageProps) {
+  const copy = animeCopyFor(locale);
+  if (overview.points_length === 0) return <AnimeEmpty overview={overview} copy={copy} />;
+  return <AnimeFull overview={overview} copy={copy} />;
+}

--- a/apps/web/src/features/anime/CirclesSection.tsx
+++ b/apps/web/src/features/anime/CirclesSection.tsx
@@ -1,0 +1,25 @@
+import type { AnimeOverviewCircle } from "@seichijunrei/contract";
+import type { AnimeCopy } from "./copy";
+
+type Props = Readonly<{ circles: readonly AnimeOverviewCircle[]; copy: AnimeCopy }>;
+
+function CircleItem({ circle, copy }: Readonly<{ circle: AnimeOverviewCircle; copy: AnimeCopy }>) {
+  return (
+    <li className="flex items-center justify-between rounded-xl bg-[var(--color-card)] px-3 py-2">
+      <span className="font-bold">{circle.region}</span>
+      <span className="text-sm text-[var(--color-muted-fg)]">{copy.spotUnit(circle.count)}</span>
+    </li>
+  );
+}
+
+/** Region skeleton for the bubble map card (the map itself lands in S5.2). */
+export function CirclesSection({ circles, copy }: Props) {
+  return (
+    <section aria-labelledby="anime-areas">
+      <h2 id="anime-areas" className="text-lg">{copy.areasHeading}</h2>
+      <ul className="m-0 grid list-none gap-2 p-0">
+        {circles.map((circle) => <CircleItem key={circle.region} circle={circle} copy={copy} />)}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/features/anime/FactSummaryBlock.tsx
+++ b/apps/web/src/features/anime/FactSummaryBlock.tsx
@@ -1,0 +1,57 @@
+import type { AnimeCopy } from "./copy";
+import type { FactSummary } from "./fact-summary";
+
+interface FactEntry {
+  readonly label: string;
+  readonly sentence: string;
+}
+
+type Props = Readonly<{ summary: FactSummary; copy: AnimeCopy }>;
+
+function cityList(summary: FactSummary): string {
+  return summary.topCities.map((city) => city.region).join("、");
+}
+
+function headFacts(summary: FactSummary, copy: AnimeCopy): FactEntry[] {
+  return [
+    { label: copy.spotsLabel, sentence: copy.spotCountFact(summary.spotCount) },
+    { label: copy.citiesLabel, sentence: copy.topCitiesFact(cityList(summary)) },
+  ];
+}
+
+function durationFacts(summary: FactSummary, copy: AnimeCopy): FactEntry[] {
+  if (summary.durationMinutes === null) return [];
+  return [{ label: copy.durationLabel, sentence: copy.durationFact(summary.durationMinutes) }];
+}
+
+function tailFacts(summary: FactSummary, copy: AnimeCopy): FactEntry[] {
+  return [
+    { label: copy.routesLabel, sentence: copy.routesFact(summary.routeCount) },
+    { label: copy.sourceLabel, sentence: copy.attribution },
+  ];
+}
+
+function factEntries(summary: FactSummary, copy: AnimeCopy): FactEntry[] {
+  return [...headFacts(summary, copy), ...durationFacts(summary, copy), ...tailFacts(summary, copy)];
+}
+
+function Fact({ label, sentence }: FactEntry) {
+  return (
+    <div className="rounded-xl bg-[var(--color-bg)] px-3 py-2">
+      <dt className="text-sm font-bold text-[var(--color-muted-fg)]">{label}</dt>
+      <dd className="m-0 text-[var(--color-fg)]">{sentence}</dd>
+    </div>
+  );
+}
+
+/** Above-the-fold SEO/GEO fact block: `<section>+<dl>`, one citable sentence per fact. */
+export function FactSummaryBlock({ summary, copy }: Props) {
+  return (
+    <section aria-labelledby="anime-facts" className="rounded-2xl bg-[var(--color-card)] p-4">
+      <h2 id="anime-facts" className="mt-0 text-lg">{copy.factsHeading}</h2>
+      <dl className="m-0 grid gap-2">
+        {factEntries(summary, copy).map((fact) => <Fact key={fact.label} {...fact} />)}
+      </dl>
+    </section>
+  );
+}

--- a/apps/web/src/features/anime/ScenesSection.tsx
+++ b/apps/web/src/features/anime/ScenesSection.tsx
@@ -1,0 +1,44 @@
+import type { AnimeScene } from "@seichijunrei/contract";
+import type { AnimeCopy } from "./copy";
+
+type Props = Readonly<{ scenes: readonly AnimeScene[]; copy: AnimeCopy }>;
+
+type ItemProps = Readonly<{ scene: AnimeScene; copy: AnimeCopy }>;
+
+function SceneShot({ scene }: Readonly<{ scene: AnimeScene }>) {
+  return (
+    <img
+      src={scene.screenshot_url}
+      alt={scene.name}
+      loading="lazy"
+      className="aspect-video w-full rounded-lg object-cover"
+    />
+  );
+}
+
+function sceneMeta({ scene, copy }: ItemProps): string {
+  const suffix = scene.city ? ` · ${scene.city}` : "";
+  return `${copy.shotCountFact(scene.shot_count)}${suffix}`;
+}
+
+function SceneItem({ scene, copy }: ItemProps) {
+  return (
+    <li className="rounded-xl bg-[var(--color-card)] p-2">
+      <SceneShot scene={scene} />
+      <p className="mb-0 font-bold">{scene.name}</p>
+      <p className="my-0 text-sm text-[var(--color-muted-fg)]">{sceneMeta({ scene, copy })}</p>
+    </li>
+  );
+}
+
+/** 名場面 ranking: an ordered list, most-shot scene first. */
+export function ScenesSection({ scenes, copy }: Props) {
+  return (
+    <section aria-labelledby="anime-scenes">
+      <h2 id="anime-scenes" className="text-lg">{copy.scenesHeading}</h2>
+      <ol className="m-0 grid list-none gap-3 p-0 sm:grid-cols-2">
+        {scenes.map((scene) => <SceneItem key={scene.id} scene={scene} copy={copy} />)}
+      </ol>
+    </section>
+  );
+}

--- a/apps/web/src/features/anime/copy.ts
+++ b/apps/web/src/features/anime/copy.ts
@@ -1,0 +1,100 @@
+import type { Locale } from "../../i18n/locales";
+
+/**
+ * Trilingual copy for the anime page, local to the feature (the shared
+ * dictionary JSONs are a parallel-card hotspot; this keeps S5.1 conflict-free).
+ * Fact sentences are self-contained and independently citable (SD-27 GEO AC).
+ */
+export interface AnimeCopy {
+  readonly h1: string;
+  readonly heroSubtitle: (id: string) => string;
+  readonly factsHeading: string;
+  readonly scenesHeading: string;
+  readonly areasHeading: string;
+  readonly empty: string;
+  readonly spotsLabel: string;
+  readonly citiesLabel: string;
+  readonly durationLabel: string;
+  readonly routesLabel: string;
+  readonly sourceLabel: string;
+  readonly spotCountFact: (n: number) => string;
+  readonly topCitiesFact: (cities: string) => string;
+  readonly durationFact: (minutes: number) => string;
+  readonly routesFact: (n: number) => string;
+  readonly attribution: string;
+  readonly shotCountFact: (n: number) => string;
+  readonly spotUnit: (n: number) => string;
+}
+
+function hoursOf(minutes: number): number {
+  return Math.max(1, Math.round(minutes / 60));
+}
+
+const ja: AnimeCopy = {
+  h1: "聖地巡礼ガイド",
+  heroSubtitle: (id) => `作品ID ${id} の聖地スポットと名場面をまとめています。`,
+  factsHeading: "作品ファクト",
+  scenesHeading: "名場面ランキング",
+  areasHeading: "エリア別スポット",
+  empty: "この作品はまだ聖地情報がありません",
+  spotsLabel: "聖地スポット数",
+  citiesLabel: "主なエリア",
+  durationLabel: "所要時間の目安",
+  routesLabel: "モデルコース",
+  sourceLabel: "データ出典",
+  spotCountFact: (n) => `この作品の聖地スポットは全${String(n)}件が登録されています。`,
+  topCitiesFact: (cities) => `この作品の聖地が多いエリアは${cities}です。`,
+  durationFact: (minutes) => `モデルコースの所要時間は約${String(hoursOf(minutes))}時間が目安です。`,
+  routesFact: (n) => `エリア別のモデルコースが${String(n)}件用意されています。`,
+  attribution: "この作品の聖地データの出典はAnitabi（CC BY-NC-SA）です。",
+  shotCountFact: (n) => `カット数 ${String(n)}`,
+  spotUnit: (n) => `${String(n)}件`,
+};
+
+const zh: AnimeCopy = {
+  h1: "圣地巡礼指南",
+  heroSubtitle: (id) => `汇总作品ID ${id} 的圣地打卡点与名场面。`,
+  factsHeading: "作品事实",
+  scenesHeading: "名场面排行",
+  areasHeading: "按地区分布",
+  empty: "该作品暂无圣地巡礼信息",
+  spotsLabel: "圣地数量",
+  citiesLabel: "主要地区",
+  durationLabel: "预计耗时",
+  routesLabel: "示例路线",
+  sourceLabel: "数据来源",
+  spotCountFact: (n) => `该作品共登记了${String(n)}处圣地巡礼地点。`,
+  topCitiesFact: (cities) => `该作品圣地最集中的地区是${cities}。`,
+  durationFact: (minutes) => `示例路线预计耗时约${String(hoursOf(minutes))}小时。`,
+  routesFact: (n) => `按地区提供了${String(n)}条示例路线。`,
+  attribution: "该作品的圣地数据来源为Anitabi（CC BY-NC-SA）。",
+  shotCountFact: (n) => `镜头数 ${String(n)}`,
+  spotUnit: (n) => `${String(n)}处`,
+};
+
+const en: AnimeCopy = {
+  h1: "Anime Pilgrimage Guide",
+  heroSubtitle: (id) => `Real-life spots and famous scenes for title ID ${id}.`,
+  factsHeading: "Fact Summary",
+  scenesHeading: "Famous Scenes",
+  areasHeading: "Spots by Area",
+  empty: "No pilgrimage spots are recorded for this title yet",
+  spotsLabel: "Total spots",
+  citiesLabel: "Top areas",
+  durationLabel: "Suggested duration",
+  routesLabel: "Sample routes",
+  sourceLabel: "Data source",
+  spotCountFact: (n) => `This title has ${String(n)} pilgrimage spots on record.`,
+  topCitiesFact: (cities) => `Most of this title's spots are in ${cities}.`,
+  durationFact: (minutes) => `A sample route takes about ${String(hoursOf(minutes))} hour(s).`,
+  routesFact: (n) => `${String(n)} per-area sample routes are available.`,
+  attribution: "Spot data for this title is sourced from Anitabi (CC BY-NC-SA).",
+  shotCountFact: (n) => `${String(n)} shots`,
+  spotUnit: (n) => `${String(n)} spots`,
+};
+
+const COPY: Record<Locale, AnimeCopy> = { ja, zh, en };
+
+export function animeCopyFor(locale: Locale): AnimeCopy {
+  return COPY[locale];
+}

--- a/apps/web/src/features/anime/fact-summary.ts
+++ b/apps/web/src/features/anime/fact-summary.ts
@@ -1,0 +1,57 @@
+import type {
+  AnimeOverview,
+  AnimeOverviewCircle,
+  AnimeSampleRoute,
+  AnimeScene,
+} from "@seichijunrei/contract";
+
+/**
+ * Pure derivations for the anime-page fact-summary block (SD-27 v1).
+ *
+ * Every field is computed from `AnimeOverview` alone — no data is introduced
+ * that the public catalog contract does not already carry. The duration
+ * estimate mirrors the route planner's normal-pacing dwell floor
+ * (`computeDwellMinutes` base of 8 min/stop) plus its walk-leg buffer.
+ */
+const DWELL_FLOOR_MINUTES = 8;
+const WALK_BUFFER_MINUTES = 15;
+const TOP_CITY_LIMIT = 3;
+
+export interface CityCount {
+  readonly region: string;
+  readonly count: number;
+}
+
+export interface FactSummary {
+  readonly spotCount: number;
+  readonly topCities: readonly CityCount[];
+  readonly durationMinutes: number | null;
+  readonly routeCount: number;
+}
+
+function topCities(circles: readonly AnimeOverviewCircle[]): CityCount[] {
+  return [...circles]
+    .sort((a, b) => b.count - a.count)
+    .slice(0, TOP_CITY_LIMIT)
+    .map((circle) => ({ region: circle.region, count: circle.count }));
+}
+
+function estimateDurationMinutes(routes: readonly AnimeSampleRoute[]): number | null {
+  const largest = Math.max(0, ...routes.map((route) => route.point_ids.length));
+  if (largest === 0) return null;
+  return largest * DWELL_FLOOR_MINUTES + (largest - 1) * WALK_BUFFER_MINUTES;
+}
+
+export function buildFactSummary(overview: AnimeOverview): FactSummary {
+  return {
+    spotCount: overview.points_length,
+    topCities: topCities(overview.circles),
+    durationMinutes: estimateDurationMinutes(overview.sample_routes),
+    routeCount: overview.sample_routes.length,
+  };
+}
+
+/** 名場面 ranking: most-shot scenes first, defensively re-sorted client-side. */
+export function rankScenes(scenes: readonly AnimeScene[]): AnimeScene[] {
+  return [...scenes].sort((a, b) => b.shot_count - a.shot_count);
+}

--- a/apps/web/src/features/anime/head.ts
+++ b/apps/web/src/features/anime/head.ts
@@ -41,8 +41,8 @@ export function animeTitle(locale: Locale, bangumiId: string): string {
 }
 
 export interface AnimeHead {
-  readonly meta: readonly { readonly title: string }[];
-  readonly links: readonly HreflangLink[];
+  meta: { title: string }[];
+  links: HreflangLink[];
 }
 
 export function animeHead(locale: Locale, bangumiId: string, origin: string): AnimeHead {

--- a/apps/web/src/features/anime/head.ts
+++ b/apps/web/src/features/anime/head.ts
@@ -1,0 +1,53 @@
+import { DEFAULT_LOCALE, LOCALES, type Locale } from "../../i18n/locales";
+
+/**
+ * Head builder for `/anime/:id`: hreflang bootstrap + per-locale titles.
+ *
+ * SD-27C hard AC: each locale's `<title>` carries locale-native keyword sets
+ * (ja 聖地巡礼/名場面, zh 打卡指南, en real-life locations) — not one keyword
+ * set translated three ways — because AI answer engines have been observed to
+ * ignore hreflang tags; localized keywords are the signal that works.
+ */
+export interface HreflangLink {
+  readonly rel: "alternate";
+  readonly hrefLang: string;
+  readonly href: string;
+}
+
+const TITLE_BY_LOCALE: Record<Locale, (id: string) => string> = {
+  ja: (id) => `聖地巡礼マップと名場面ランキング｜作品${id} | Animichi`,
+  zh: (id) => `圣地巡礼地图与取景地打卡指南｜作品${id} | Animichi`,
+  en: (id) => `Anime Pilgrimage Map & Real-Life Locations | Title ${id} | Animichi`,
+};
+
+function animeUrl(origin: string, bangumiId: string, locale: Locale): string {
+  const path = `${origin}/anime/${bangumiId}`;
+  return locale === DEFAULT_LOCALE ? path : `${path}?hl=${locale}`;
+}
+
+function alternate(hrefLang: string, href: string): HreflangLink {
+  return { rel: "alternate", hrefLang, href };
+}
+
+export function animeAlternates(origin: string, bangumiId: string): HreflangLink[] {
+  const links = LOCALES.map((locale) =>
+    alternate(locale, animeUrl(origin, bangumiId, locale)),
+  );
+  return [...links, alternate("x-default", animeUrl(origin, bangumiId, DEFAULT_LOCALE))];
+}
+
+export function animeTitle(locale: Locale, bangumiId: string): string {
+  return TITLE_BY_LOCALE[locale](bangumiId);
+}
+
+export interface AnimeHead {
+  readonly meta: readonly { readonly title: string }[];
+  readonly links: readonly HreflangLink[];
+}
+
+export function animeHead(locale: Locale, bangumiId: string, origin: string): AnimeHead {
+  return {
+    meta: [{ title: animeTitle(locale, bangumiId) }],
+    links: animeAlternates(origin, bangumiId),
+  };
+}

--- a/apps/web/src/features/anime/register-sw.ts
+++ b/apps/web/src/features/anime/register-sw.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+/**
+ * Registers `/sw.js` (network-first for /anime navigations, spec X7).
+ * Structural navigator type: jsdom and older browsers lack `serviceWorker`,
+ * so the guard is a real runtime branch, not a type-level formality.
+ */
+export interface SwNavigator {
+  readonly serviceWorker?: { register(url: string): Promise<unknown> };
+}
+
+export function registerAnimeSw(nav: SwNavigator): void {
+  if (!nav.serviceWorker) return;
+  nav.serviceWorker.register("/sw.js").catch(() => undefined);
+}
+
+export function useRegisterAnimeSw(): void {
+  useEffect(() => {
+    registerAnimeSw(globalThis.navigator);
+  }, []);
+}

--- a/apps/web/src/routes/anime/$bangumiId.tsx
+++ b/apps/web/src/routes/anime/$bangumiId.tsx
@@ -3,6 +3,7 @@ import { resolveOrigin } from "../../api/config";
 import { animeOverviewOptions, useAnimeOverview } from "../../api/hooks/use-anime-overview";
 import { AnimePage } from "../../features/anime/AnimePage";
 import { animeHead } from "../../features/anime/head";
+import { useRegisterAnimeSw } from "../../features/anime/register-sw";
 import { DEFAULT_LOCALE, LOCALES, type Locale } from "../../i18n/locales";
 
 const BANGUMI_ID_PATTERN = /^\d+$/;
@@ -48,6 +49,7 @@ export const Route = createFileRoute("/anime/$bangumiId")({
 });
 
 function AnimeRoute() {
+  useRegisterAnimeSw();
   const { bangumiId } = Route.useParams();
   const { locale } = Route.useLoaderData();
   const { data } = useAnimeOverview(bangumiId);

--- a/apps/web/src/routes/anime/$bangumiId.tsx
+++ b/apps/web/src/routes/anime/$bangumiId.tsx
@@ -1,0 +1,55 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { resolveOrigin } from "../../api/config";
+import { animeOverviewOptions, useAnimeOverview } from "../../api/hooks/use-anime-overview";
+import { AnimePage } from "../../features/anime/AnimePage";
+import { animeHead } from "../../features/anime/head";
+import { DEFAULT_LOCALE, LOCALES, type Locale } from "../../i18n/locales";
+
+const BANGUMI_ID_PATTERN = /^\d+$/;
+
+/** A real `Error` carrying TanStack's not-found marker (`isNotFound: true`). */
+function notFoundError(): Error {
+  return Object.assign(new Error("unknown anime id"), notFound());
+}
+
+interface AnimeSearch {
+  readonly hl?: Locale;
+}
+
+function parseSearch(search: Record<string, unknown>): AnimeSearch {
+  const hl = search.hl;
+  if (typeof hl === "string" && (LOCALES as readonly string[]).includes(hl)) {
+    return { hl: hl as Locale };
+  }
+  return {};
+}
+
+/** Absolute origin for hreflang hrefs; relative fallback beats an SSR crash. */
+function siteOrigin(): string {
+  const location = typeof window === "undefined" ? undefined : window.location;
+  try {
+    return resolveOrigin(import.meta.env, location);
+  } catch {
+    return "";
+  }
+}
+
+export const Route = createFileRoute("/anime/$bangumiId")({
+  validateSearch: parseSearch,
+  loaderDeps: ({ search }) => ({ hl: search.hl }),
+  loader: async ({ params, deps, context }) => {
+    if (!BANGUMI_ID_PATTERN.test(params.bangumiId)) throw notFoundError();
+    await context.queryClient.ensureQueryData(animeOverviewOptions(params.bangumiId));
+    return { locale: deps.hl ?? DEFAULT_LOCALE };
+  },
+  head: ({ loaderData, params }) =>
+    animeHead(loaderData?.locale ?? DEFAULT_LOCALE, params.bangumiId, siteOrigin()),
+  component: AnimeRoute,
+});
+
+function AnimeRoute() {
+  const { bangumiId } = Route.useParams();
+  const { locale } = Route.useLoaderData();
+  const { data } = useAnimeOverview(bangumiId);
+  return <AnimePage overview={data} locale={locale} />;
+}

--- a/apps/web/tests/msw/anime-overview.ts
+++ b/apps/web/tests/msw/anime-overview.ts
@@ -1,0 +1,85 @@
+import { http, HttpResponse } from "msw";
+import type { HttpHandler, JsonBodyType } from "msw";
+import { AnimeOverview, AnimeOverviewInput } from "@seichijunrei/contract";
+import { orpcErrorResponse } from "./contract-handler";
+import { TEST_ORIGIN } from "./fixtures";
+
+/**
+ * Contract-typed MSW swimlane for the public `catalog.animeOverview` GET route.
+ *
+ * Same discipline as `contract-handler.ts`, adapted to a GET with a path
+ * param: the path segment is `parse()`d with the contract input schema and
+ * every body is `parse()`d with the output schema — no hand-written JSON.
+ */
+export const ANIME_OVERVIEW_PATH = `${TEST_ORIGIN}/catalog/public/anime-overview/:bangumi_id`;
+
+/** A known anime with spots across three cities; circles arrive unsorted. */
+export const fullOverviewFixture = {
+  bangumi_id: "123",
+  points_length: 6,
+  circles: [
+    { region: "Tokyo", count: 2, lat: 35.6812, lng: 139.7671 },
+    { region: "Takayama", count: 3, lat: 36.1408, lng: 137.2521 },
+    { region: "Hida", count: 1, lat: 36.2381, lng: 137.1863 },
+  ],
+  scenes: [
+    {
+      id: "scene-2",
+      name: "Hida Furukawa Station",
+      screenshot_url: "https://cdn.test/scene-2.jpg",
+      shot_count: 2,
+      lat: 36.2381,
+      lng: 137.1863,
+      city: "Hida",
+    },
+    {
+      id: "scene-1",
+      name: "Suga Shrine Stairs",
+      screenshot_url: "https://cdn.test/scene-1.jpg",
+      shot_count: 5,
+      lat: 35.6852,
+      lng: 139.7195,
+      city: "Tokyo",
+    },
+  ],
+  sample_routes: [
+    { region: "Takayama", point_ids: ["p1", "p2", "p3"] },
+    { region: "Tokyo", point_ids: ["p4", "p5"] },
+  ],
+} satisfies AnimeOverview;
+
+/** A cataloged id with zero pilgrimage spots: empty-but-valid, per contract. */
+export function emptyOverviewFixture(bangumiId: string): AnimeOverview {
+  return {
+    bangumi_id: bangumiId,
+    points_length: 0,
+    circles: [],
+    scenes: [],
+    sample_routes: [],
+  };
+}
+
+function overviewFor(bangumiId: string): AnimeOverview {
+  return bangumiId === fullOverviewFixture.bangumi_id
+    ? fullOverviewFixture
+    : emptyOverviewFixture(bangumiId);
+}
+
+function respond(rawId: string | readonly string[] | undefined): HttpResponse<JsonBodyType> {
+  const parsed = AnimeOverviewInput.safeParse({ bangumi_id: rawId });
+  if (!parsed.success) {
+    return orpcErrorResponse({ code: "BAD_REQUEST", status: 400, message: parsed.error.message });
+  }
+  const body = AnimeOverview.parse(overviewFor(parsed.data.bangumi_id));
+  return HttpResponse.json(body as JsonBodyType);
+}
+
+/** Default handler: the fixture anime for "123", empty-but-valid otherwise. */
+export const animeOverviewHandler: HttpHandler = http.get(ANIME_OVERVIEW_PATH, ({ params }) =>
+  respond(params.bangumi_id),
+);
+
+/** An always-failing handler for loader error-path tests. */
+export const animeOverviewOutageHandler: HttpHandler = http.get(ANIME_OVERVIEW_PATH, () =>
+  orpcErrorResponse({ code: "INTERNAL_SERVER_ERROR", status: 500, message: "catalog unavailable" }),
+);

--- a/apps/web/tests/types/sw.d.ts
+++ b/apps/web/tests/types/sw.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Ambient module declaration for the classic-script service worker.
+ * `public/` is outside the TS project (no allowJs); the unit suite imports
+ * `public/sw.js` purely for its listener side effects, so it has no exports.
+ */
+declare module "*/public/sw.js" {
+  const nothing: Record<string, never>;
+  export default nothing;
+}

--- a/apps/web/tests/unit/anime/anime-page.test.tsx
+++ b/apps/web/tests/unit/anime/anime-page.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AnimePage } from "../../../src/features/anime/AnimePage";
+import { emptyOverviewFixture, fullOverviewFixture } from "../../msw/anime-overview";
+
+afterEach(cleanup);
+
+function headingText(): string | null {
+  return screen.getByRole("heading", { level: 1 }).textContent;
+}
+
+describe("AnimePage full state", () => {
+  it("renders the localized ja heading with pilgrimage keywords", () => {
+    render(<AnimePage overview={fullOverviewFixture} locale="ja" />);
+    expect(headingText()).toContain("聖地巡礼");
+  });
+
+  it("renders the fact-summary block as a definition-list section", () => {
+    render(<AnimePage overview={fullOverviewFixture} locale="ja" />);
+    const facts = screen.getByRole("region", { name: "作品ファクト" });
+    expect(facts.querySelector("dl")).not.toBeNull();
+  });
+
+  it("states the total spot count as a self-contained sentence", () => {
+    render(<AnimePage overview={fullOverviewFixture} locale="ja" />);
+    expect(screen.getByText("この作品の聖地スポットは全6件が登録されています。")).toBeTruthy();
+  });
+
+  it("cites the top-3 cities and the Anitabi attribution", () => {
+    render(<AnimePage overview={fullOverviewFixture} locale="ja" />);
+    expect(screen.getByText(/Takayama、Tokyo、Hida/)).toBeTruthy();
+    expect(screen.getByText(/Anitabi/)).toBeTruthy();
+    expect(screen.getByText(/CC BY-NC-SA/)).toBeTruthy();
+  });
+
+  it("lists 名場面 sorted by shot count with accessible images", () => {
+    render(<AnimePage overview={fullOverviewFixture} locale="ja" />);
+    const names = screen.getAllByRole("listitem").map((item) => item.textContent);
+    const suga = names.findIndex((text) => text.includes("Suga Shrine Stairs"));
+    const hida = names.findIndex((text) => text.includes("Hida Furukawa Station"));
+    expect(suga).toBeGreaterThanOrEqual(0);
+    expect(suga).toBeLessThan(hida);
+    expect(screen.getByRole("img", { name: "Suga Shrine Stairs" })).toBeTruthy();
+  });
+
+  it("renders a region skeleton entry per circle", () => {
+    render(<AnimePage overview={fullOverviewFixture} locale="ja" />);
+    const areas = screen.getByRole("region", { name: "エリア別スポット" });
+    for (const region of ["Takayama", "Tokyo", "Hida"]) {
+      expect(areas.textContent).toContain(region);
+    }
+  });
+});
+
+describe("AnimePage locales", () => {
+  it("renders the zh heading with zh-native keywords", () => {
+    render(<AnimePage overview={fullOverviewFixture} locale="zh" />);
+    expect(headingText()).toContain("圣地巡礼");
+  });
+
+  it("renders the en heading with en-native keywords", () => {
+    render(<AnimePage overview={fullOverviewFixture} locale="en" />);
+    expect(headingText()).toContain("Pilgrimage");
+  });
+});
+
+describe("AnimePage empty state", () => {
+  it("renders the graceful ja empty message when the work has no spots", () => {
+    render(<AnimePage overview={emptyOverviewFixture("404404")} locale="ja" />);
+    expect(screen.getByText("この作品はまだ聖地情報がありません")).toBeTruthy();
+  });
+
+  it("keeps the localized heading in the empty state", () => {
+    render(<AnimePage overview={emptyOverviewFixture("404404")} locale="en" />);
+    expect(headingText()).toContain("Pilgrimage");
+  });
+});

--- a/apps/web/tests/unit/anime/anime-page.test.tsx
+++ b/apps/web/tests/unit/anime/anime-page.test.tsx
@@ -55,6 +55,19 @@ describe("AnimePage full state", () => {
   });
 });
 
+describe("AnimePage partial data", () => {
+  it("omits the duration fact when there are no sample routes", () => {
+    render(<AnimePage overview={{ ...fullOverviewFixture, sample_routes: [] }} locale="ja" />);
+    expect(screen.queryByText(/所要時間は約/)).toBeNull();
+  });
+
+  it("renders a scene without a city, with no dangling separator", () => {
+    const scenes = fullOverviewFixture.scenes.map(({ city: _city, ...scene }) => scene);
+    render(<AnimePage overview={{ ...fullOverviewFixture, scenes }} locale="ja" />);
+    expect(screen.getByText("カット数 2")).toBeTruthy();
+  });
+});
+
 describe("AnimePage locales", () => {
   it("renders the zh heading with zh-native keywords", () => {
     render(<AnimePage overview={fullOverviewFixture} locale="zh" />);

--- a/apps/web/tests/unit/anime/anime-route.test.tsx
+++ b/apps/web/tests/unit/anime/anime-route.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { RouterProvider } from "@tanstack/react-router";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { animeOverviewOptions } from "../../../src/api/hooks/use-anime-overview";
+import { getRouter } from "../../../src/router";
+import { animeOverviewHandler } from "../../msw/anime-overview";
+import { server } from "../../msw/node";
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  server.use(animeOverviewHandler);
+});
+
+type AnimeSearch = Readonly<{ hl?: "ja" | "zh" | "en" }>;
+
+async function openAnime(bangumiId: string, search: AnimeSearch = {}) {
+  const router = getRouter();
+  await router.navigate({ to: "/anime/$bangumiId", params: { bangumiId }, search });
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("/anime/$bangumiId loader", () => {
+  it("prefetches the overview into the per-request QueryClient", async () => {
+    const router = await openAnime("123");
+    await screen.findByRole("heading", { level: 1 });
+    const cached = router.options.context.queryClient.getQueryData(
+      animeOverviewOptions("123").queryKey,
+    );
+    expect(cached).toMatchObject({ bangumi_id: "123", points_length: 6 });
+  });
+
+  it("renders the full state from the loader data: facts and 名場面", async () => {
+    await openAnime("123");
+    expect(await screen.findByText(/Suga Shrine Stairs/)).toBeTruthy();
+    expect(screen.getByRole("region", { name: "作品ファクト" })).toBeTruthy();
+  });
+});
+
+describe("/anime/$bangumiId head", () => {
+  it("renders the localized document title for the default ja locale", async () => {
+    await openAnime("123");
+    await screen.findByRole("heading", { level: 1 });
+    await waitFor(() => {
+      expect(document.title).toContain("聖地巡礼マップ");
+    });
+  });
+
+  it("hoists the trilingual hreflang alternates into the document head", async () => {
+    await openAnime("123");
+    await screen.findByRole("heading", { level: 1 });
+    await waitFor(() => {
+      const langs = [...document.querySelectorAll("link[rel=alternate]")].map(
+        (link) => link.getAttribute("hreflang"),
+      );
+      expect(langs).toEqual(expect.arrayContaining(["ja", "zh", "en", "x-default"]));
+    });
+  });
+
+  it("switches content and title to zh when hl=zh is in the search", async () => {
+    await openAnime("123", { hl: "zh" });
+    const heading = await screen.findByRole("heading", { level: 1 });
+    expect(heading.textContent).toContain("圣地巡礼");
+    await waitFor(() => {
+      expect(document.title).toContain("圣地巡礼地图");
+    });
+  });
+});
+
+describe("/anime/$bangumiId degraded states", () => {
+  it("renders the empty state for a cataloged id with zero spots", async () => {
+    await openAnime("999");
+    expect(await screen.findByText("この作品はまだ聖地情報がありません")).toBeTruthy();
+  });
+
+  it("returns the branded 404 for a non-numeric bangumi id", async () => {
+    await openAnime("not-an-id");
+    expect(await screen.findByRole("heading", { name: "404" })).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/anime/fact-summary.test.ts
+++ b/apps/web/tests/unit/anime/fact-summary.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildFactSummary, rankScenes } from "../../../src/features/anime/fact-summary";
+import { emptyOverviewFixture, fullOverviewFixture } from "../../msw/anime-overview";
+
+describe("buildFactSummary", () => {
+  it("passes the spot count through from points_length", () => {
+    expect(buildFactSummary(fullOverviewFixture).spotCount).toBe(6);
+  });
+
+  it("ranks the top-3 cities by spot count, descending", () => {
+    expect(buildFactSummary(fullOverviewFixture).topCities).toEqual([
+      { region: "Takayama", count: 3 },
+      { region: "Tokyo", count: 2 },
+      { region: "Hida", count: 1 },
+    ]);
+  });
+
+  it("estimates the pilgrimage duration from the largest sample route", () => {
+    // 3 stops: 3 * 8 dwell-floor minutes + 2 * 15 walk-buffer minutes = 54.
+    expect(buildFactSummary(fullOverviewFixture).durationMinutes).toBe(54);
+  });
+
+  it("reports a null duration when there are no sample routes", () => {
+    expect(buildFactSummary(emptyOverviewFixture("404404")).durationMinutes).toBeNull();
+  });
+
+  it("counts the sample routes", () => {
+    expect(buildFactSummary(fullOverviewFixture).routeCount).toBe(2);
+  });
+});
+
+describe("rankScenes", () => {
+  it("orders scenes by shot count, descending", () => {
+    const ranked = rankScenes(fullOverviewFixture.scenes);
+    expect(ranked.map((scene) => scene.shot_count)).toEqual([5, 2]);
+  });
+});

--- a/apps/web/tests/unit/anime/head.test.ts
+++ b/apps/web/tests/unit/anime/head.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { animeAlternates, animeHead, animeTitle } from "../../../src/features/anime/head";
+
+const ORIGIN = "https://animichi.example";
+
+describe("animeAlternates", () => {
+  it("emits one alternate link per locale plus x-default", () => {
+    const links = animeAlternates(ORIGIN, "123");
+    expect(links.map((link) => link.hrefLang)).toEqual(["ja", "zh", "en", "x-default"]);
+  });
+
+  it("builds absolute hrefs with the locale carried in the hl param", () => {
+    const links = animeAlternates(ORIGIN, "123");
+    expect(links[0]?.href).toBe("https://animichi.example/anime/123");
+    expect(links[1]?.href).toBe("https://animichi.example/anime/123?hl=zh");
+    expect(links[2]?.href).toBe("https://animichi.example/anime/123?hl=en");
+    expect(links[3]?.href).toBe("https://animichi.example/anime/123");
+  });
+
+  it("marks every link as rel=alternate", () => {
+    for (const link of animeAlternates(ORIGIN, "9")) {
+      expect(link.rel).toBe("alternate");
+    }
+  });
+});
+
+describe("animeTitle", () => {
+  it.each([
+    ["ja", "聖地巡礼マップ"],
+    ["zh", "圣地巡礼地图"],
+    ["en", "Anime Pilgrimage Map"],
+  ] as const)("localizes the %s title with locale-native keywords", (locale, keyword) => {
+    expect(animeTitle(locale, "123")).toContain(keyword);
+  });
+
+  it("uses per-locale keyword sets, not one keyword set translated", () => {
+    expect(animeTitle("ja", "1")).toContain("名場面ランキング");
+    expect(animeTitle("zh", "1")).toContain("取景地打卡指南");
+    expect(animeTitle("en", "1")).toContain("Real-Life Locations");
+  });
+});
+
+describe("animeHead", () => {
+  it("bundles the localized title and hreflang links for the route head", () => {
+    const head = animeHead("zh", "123", ORIGIN);
+    expect(head.meta.some((entry) => entry.title === animeTitle("zh", "123"))).toBe(true);
+    expect(head.links).toHaveLength(4);
+  });
+});

--- a/apps/web/tests/unit/anime/register-sw.test.ts
+++ b/apps/web/tests/unit/anime/register-sw.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerAnimeSw } from "../../../src/features/anime/register-sw";
+
+describe("registerAnimeSw", () => {
+  it("registers /sw.js when the navigator supports service workers", () => {
+    const register = vi.fn(() => Promise.resolve({}));
+    registerAnimeSw({ serviceWorker: { register } });
+    expect(register).toHaveBeenCalledWith("/sw.js");
+  });
+
+  it("is a no-op when service workers are unsupported", () => {
+    expect(() => {
+      registerAnimeSw({});
+    }).not.toThrow();
+  });
+
+  it("swallows registration failures instead of crashing the page", async () => {
+    const register = vi.fn(() => Promise.reject(new Error("denied")));
+    registerAnimeSw({ serviceWorker: { register } });
+    await Promise.resolve();
+    expect(register).toHaveBeenCalledWith("/sw.js");
+  });
+});

--- a/apps/web/tests/unit/anime/sw.test.ts
+++ b/apps/web/tests/unit/anime/sw.test.ts
@@ -1,0 +1,94 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+type FetchListener = (event: FetchEventLike) => void;
+
+interface FetchEventLike {
+  request: RequestLike;
+  respondWith: ReturnType<typeof vi.fn>;
+}
+
+interface RequestLike {
+  url: string;
+  mode: string;
+}
+
+const listeners = new Map<string, (event: never) => void>();
+const cache = { put: vi.fn(), match: vi.fn() };
+const fetchMock = vi.fn();
+
+function fetchListener(): FetchListener {
+  const listener = listeners.get("fetch");
+  if (!listener) throw new Error("fetch listener not registered");
+  return listener as FetchListener;
+}
+
+function dispatchFetch(request: RequestLike): FetchEventLike {
+  const event: FetchEventLike = { request, respondWith: vi.fn() };
+  fetchListener()(event);
+  return event;
+}
+
+const animeRequest: RequestLike = { url: "https://animichi.example/anime/123", mode: "navigate" };
+
+beforeAll(async () => {
+  vi.stubGlobal("addEventListener", (type: string, listener: (event: never) => void) => {
+    listeners.set(type, listener);
+  });
+  vi.stubGlobal("caches", { open: vi.fn(() => Promise.resolve(cache)) });
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubGlobal("skipWaiting", vi.fn());
+  vi.stubGlobal("clients", { claim: vi.fn(() => Promise.resolve()) });
+  await import("../../../public/sw.js");
+});
+
+beforeEach(() => {
+  cache.put.mockReset();
+  cache.match.mockReset();
+  fetchMock.mockReset();
+});
+
+describe("sw.js registration surface", () => {
+  it("listens for install, activate, and fetch", () => {
+    expect([...listeners.keys()]).toEqual(expect.arrayContaining(["install", "activate", "fetch"]));
+  });
+});
+
+describe("sw.js network-first for /anime navigations", () => {
+  it("serves the fresh network response and refreshes the cache (never stale)", async () => {
+    const fresh = new Response("fresh html");
+    fetchMock.mockResolvedValue(fresh);
+    const event = dispatchFetch(animeRequest);
+    const respondArg: unknown = event.respondWith.mock.calls[0]?.[0];
+    await expect(respondArg).resolves.toBe(fresh);
+    expect(cache.put).toHaveBeenCalledWith(animeRequest, expect.any(Response));
+  });
+
+  it("falls back to the cached copy only when the network fails", async () => {
+    const cached = new Response("cached html");
+    fetchMock.mockRejectedValue(new Error("offline"));
+    cache.match.mockResolvedValue(cached);
+    const event = dispatchFetch(animeRequest);
+    const respondArg: unknown = event.respondWith.mock.calls[0]?.[0];
+    await expect(respondArg).resolves.toBe(cached);
+  });
+
+  it("propagates the network error when nothing is cached", async () => {
+    fetchMock.mockRejectedValue(new Error("offline"));
+    cache.match.mockResolvedValue(undefined);
+    const event = dispatchFetch(animeRequest);
+    const respondArg: unknown = event.respondWith.mock.calls[0]?.[0];
+    await expect(respondArg).rejects.toThrow("offline");
+  });
+});
+
+describe("sw.js scope", () => {
+  it("ignores non-navigation requests under /anime", () => {
+    const event = dispatchFetch({ url: "https://animichi.example/anime/123", mode: "cors" });
+    expect(event.respondWith).not.toHaveBeenCalled();
+  });
+
+  it("ignores navigations outside /anime", () => {
+    const event = dispatchFetch({ url: "https://animichi.example/chat", mode: "navigate" });
+    expect(event.respondWith).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Card

W1.3 / #267 — S5.1 Anime-page shell (図鑑型, SSR) + SW network-first (X7) + fact-summary block v1 + hreflang bootstrap. Dynamic OG is descoped to #229 per campaign plan (first release ships without it).

## What's here

- **`/anime/$bangumiId` SSR route** (`apps/web/src/routes/anime/$bangumiId.tsx`): loader prefetches the public `catalog.animeOverview` procedure (E2/#275 contract) via `queryClient.ensureQueryData` on the C0.1 per-request QueryClient — server-rendered, hydrated client-side with no double fetch (`useSuspenseQuery` over the same options). Non-numeric ids 404 through an `Error` carrying TanStack's `notFound` marker (`isNotFound: true`, keeps the `only-throw-error` lint honest). Unknown-but-numeric ids get an empty-but-valid `AnimeOverview` → graceful 「この作品はまだ聖地情報がありません」 state.
- **Fact-summary block v1** (`src/features/anime/FactSummaryBlock.tsx` + `fact-summary.ts`): above-the-fold `<section>+<dl>`, one self-contained citable sentence per fact — spot count, top-3 cities, duration estimate (derived from the route planner's normal-pacing dwell floor of 8 min/stop + walk buffer; no data invented outside the contract), sample-route count, Anitabi + CC BY-NC-SA attribution. Episode range is not in the `AnimeOverview` contract yet, so it is deliberately absent rather than fabricated.
- **hreflang bootstrap** (`src/features/anime/head.ts`): ja/zh/en alternates + `x-default`, absolute hrefs via the C0.1 origin resolver, locale carried in `?hl=`; per SD-27C each locale's `<title>`/`<h1>` uses locale-native keyword sets (ja 聖地巡礼マップ/名場面ランキング, zh 圣地巡礼地图/取景地打卡指南, en Anime Pilgrimage Map/Real-Life Locations), not one keyword set translated.
- **SW network-first (X7)** (`public/sw.js` + `src/features/anime/register-sw.ts`): standard Service Worker API, no libraries. `/anime/*` navigations always try the network first; the cache is only an offline fallback, so stale HTML can never be served while online. JSDoc-typed to pass the type-aware oxlint gate.
- Trilingual copy is feature-local (`src/features/anime/copy.ts`) to keep the shared dictionary JSONs untouched (parallel-card hotspot discipline); no shared files were modified.

## AC coverage (ac_total == ac_with_test)

| AC | Type | Test |
|---|---|---|
| Happy path: known id SSR-renders hero + 名場面 ranked by shot count | unit (browser AC at G2 Tester) | `anime-route.test.tsx` loader/full-state; `anime-page.test.tsx` scene ordering |
| Empty: zero-spot work renders graceful empty state | unit (browser at G2) | `anime-route.test.tsx` degraded states; `anime-page.test.tsx` empty state |
| Error: invalid id → 404, no crash | unit (browser at G2) | `anime-route.test.tsx` branded 404 |
| X7: SW never serves stale cached HTML (network-first) | unit (browser at G2) | `sw.test.ts` drives the real `sw.js` fetch listener: fresh-wins, offline fallback, scope guards |
| Fact-summary v1, trilingual, citable sentences | unit | `fact-summary.test.ts`, `anime-page.test.tsx` (facts, attribution, locales) |
| hreflang bootstrap + localized title/h1 keywords | unit | `head.test.ts` (alternates, per-locale keyword sets), `anime-route.test.tsx` (document.title + hoisted link tags) |
| Loader prefetch into per-request QueryClient (C0.1 reuse) | unit | `anime-route.test.tsx` prefetch assertion |

MSW handler for the GET route is contract-typed (`tests/msw/anime-overview.ts`): input parsed with `AnimeOverviewInput`, bodies parsed with `AnimeOverview`, oRPC error envelopes via the shared helper — no hand-written JSON.

## Gates

- `pnpm run build` — green (`.output/public/sw.js` emitted)
- `pnpm run typecheck` — no errors
- `pnpm run lint:oxlint` — clean (type-aware, deny-warnings)
- `pnpm test` — 205 passed; coverage stmts 99.78 / branches 97.9 / funcs 100 / lines 99.75 (floor 90)
- `pnpm run test:integration` — 5 passed

## Notes for reviewer

- Spec's OG-pipeline AC is descoped to #229 by the campaign plan (anime page ships first, OG plugs in after).
- Hero has no anime title/cover because `AnimeOverview` doesn't carry them; titles use keyword+id until the contract grows metadata (S5.6/#278 JSON-LD work will revisit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)