### PR TITLE
feat(contract): CT-share public share-token contract (contract-first, owner workers/users)

### DIFF
--- a/packages/contract/scripts/emit-openapi.ts
+++ b/packages/contract/scripts/emit-openapi.ts
@@ -14,6 +14,7 @@ import { OpenAPIGenerator } from "@orpc/openapi";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { checkinContract } from "../src/checkin-contract.js";
 import { catalogContract } from "../src/contract.js";
+import { shareContract } from "../src/share-contract.js";
 import { usersContract } from "../src/users-contract.js";
 
 const generator = new OpenAPIGenerator({
@@ -42,7 +43,7 @@ await emitOpenApi(catalogContract, "openapi.json", {
       "Read methods of the TS Catalog service, consumed by the Python Agent service.",
 });
 
-await emitOpenApi({ ...usersContract, ...checkinContract }, "users-openapi.json", {
+await emitOpenApi({ ...usersContract, ...checkinContract, ...shareContract }, "users-openapi.json", {
   title: "Animichi Users Service",
   version: "0.1.0",
   description: "User-domain routes of the TS Users service, consumed by apps/web.",

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -7,6 +7,7 @@
 export * from "./models.js";
 export * from "./chat-data-parts.js";
 export * from "./checkin-contract.js";
+export * from "./share-contract.js";
 export * from "./constants.js";
 export * from "./contract.js";
 export * from "./errors.js";

--- a/packages/contract/src/share-contract.ts
+++ b/packages/contract/src/share-contract.ts
@@ -1,0 +1,234 @@
+/**
+ * Public itinerary-sharing contract owned by workers/users.
+ *
+ * Auth: create and revoke require the users-service Neon Auth JWT bearer
+ * pattern. Resolve is an anonymous, read-only endpoint for public SSR callers.
+ * Expiry/revocation: workers/users chooses an immutable expiry when issuing a
+ * token. Resolution after expiry or revocation fails with a typed terminal
+ * error; revocation is immediate and a new share must receive a new token.
+ * Privacy: resolve returns a strict, purpose-built public projection. It omits
+ * full-precision GPS, internal route/share ownership identifiers, and internal
+ * user identity IDs because possession of a share URL grants view access only.
+ */
+
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+
+/** A 256-bit, unpadded Base64URL bearer token (43 URL-safe characters). */
+export const ShareToken = z.string().regex(/^[A-Za-z0-9_-]{43}$/);
+/** Inferred share token. */
+export type ShareToken = z.infer<typeof ShareToken>;
+
+/** Public lifecycle state of a shared itinerary. */
+export const PublicItineraryState = z.enum(["planned", "partial", "completed"]);
+/** Inferred public itinerary state. */
+export type PublicItineraryState = z.infer<typeof PublicItineraryState>;
+
+const PublicClockTime = z.string().regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/);
+
+/** Public anime display metadata; the id is a catalog-facing public id. */
+export const PublicSharedAnime = z.strictObject({
+  id: z.string().min(1).max(128),
+  title: z.string().min(1).max(200),
+});
+/** Inferred public anime display metadata. */
+export type PublicSharedAnime = z.infer<typeof PublicSharedAnime>;
+
+/** Public-safe stop data, intentionally excluding GPS coordinates. */
+export const PublicSharedStop = z.strictObject({
+  point_id: z.string().min(1).max(128),
+  name: z.string().min(1).max(200),
+  position: z.number().int().nonnegative(),
+  scheduled_time: PublicClockTime.optional(),
+  visited_time: PublicClockTime.optional(),
+  completed: z.boolean(),
+  frame_image_url: z.url().optional(),
+  frame_label: z.string().min(1).max(100).optional(),
+});
+/** Inferred public-safe stop data. */
+export type PublicSharedStop = z.infer<typeof PublicSharedStop>;
+
+/** Public comparison artifact already approved for sharing. */
+export const PublicSharedComparison = z.strictObject({
+  point_id: z.string().min(1).max(128),
+  image_url: z.url(),
+  caption: z.string().min(1).max(200),
+});
+/** Inferred public comparison artifact. */
+export type PublicSharedComparison = z.infer<typeof PublicSharedComparison>;
+
+/** Attribution displayed with licensed frames and user-created comparisons. */
+export const PublicShareAttribution = z.strictObject({
+  label: z.string().min(1).max(300),
+  url: z.url().optional(),
+});
+/** Inferred public share attribution. */
+export type PublicShareAttribution = z.infer<typeof PublicShareAttribution>;
+
+/** Strict public projection consumed by the anonymous /s/:id page. */
+export const PublicSharedItinerary = z.strictObject({
+  title: z.string().min(1).max(200),
+  anime: PublicSharedAnime,
+  state: PublicItineraryState,
+  author_display_name: z.string().min(1).max(100).optional(),
+  planned_for: z.iso.date().optional(),
+  distance_meters: z.number().int().nonnegative().optional(),
+  total_stops: z.number().int().nonnegative(),
+  completed_stops: z.number().int().nonnegative(),
+  stops: z.array(PublicSharedStop).max(500),
+  comparisons: z.array(PublicSharedComparison).max(100),
+  hero_image_url: z.url().optional(),
+  attributions: z.array(PublicShareAttribution).max(20),
+});
+/** Inferred strict public itinerary projection. */
+export type PublicSharedItinerary = z.infer<typeof PublicSharedItinerary>;
+
+/** Authenticated input for sharing a caller-owned route. */
+export const CreateShareInput = z.strictObject({ route_id: z.uuid() });
+/** Inferred create-share input. */
+export type CreateShareInput = z.infer<typeof CreateShareInput>;
+
+/** Newly issued share credentials; expires_at is chosen by workers/users. */
+export const CreateShareResult = z.strictObject({
+  share_id: z.uuid(),
+  token: ShareToken,
+  created_at: z.iso.datetime({ offset: true }),
+  expires_at: z.iso.datetime({ offset: true }),
+});
+/** Inferred create-share result. */
+export type CreateShareResult = z.infer<typeof CreateShareResult>;
+
+/** Authenticated input for revoking a share without resending its bearer token. */
+export const RevokeShareInput = z.strictObject({ share_id: z.uuid() });
+/** Inferred revoke-share input. */
+export type RevokeShareInput = z.infer<typeof RevokeShareInput>;
+
+/** Confirmation that a share became terminally revoked. */
+export const RevokeShareResult = z.strictObject({
+  revoked: z.literal(true),
+  revoked_at: z.iso.datetime({ offset: true }),
+});
+/** Inferred revoke-share result. */
+export type RevokeShareResult = z.infer<typeof RevokeShareResult>;
+
+/** Anonymous input for resolving a public share token. */
+export const ResolveShareInput = z.strictObject({ token: ShareToken });
+/** Inferred resolve-share input. */
+export type ResolveShareInput = z.infer<typeof ResolveShareInput>;
+
+/** Anonymous public resolution result. */
+export const ResolveShareResult = z.strictObject({
+  expires_at: z.iso.datetime({ offset: true }),
+  itinerary: PublicSharedItinerary,
+});
+/** Inferred public resolution result. */
+export type ResolveShareResult = z.infer<typeof ResolveShareResult>;
+
+/** Share error category semantics; categories never cross the wire. */
+export const ShareErrorCategory = z.enum(["user_actionable", "retryable", "system"]);
+/** Inferred share error category. */
+export type ShareErrorCategory = z.infer<typeof ShareErrorCategory>;
+
+/** Data returned when a route cannot be shared. */
+export const ShareRouteData = z.strictObject({ route_id: z.uuid() });
+/** Data for a share token that has passed its immutable expiry. */
+export const ShareExpiredData = z.strictObject({
+  expires_at: z.iso.datetime({ offset: true }),
+});
+/** Data for a share token that has been explicitly revoked. */
+export const ShareRevokedData = z.strictObject({
+  revoked_at: z.iso.datetime({ offset: true }),
+});
+/** Empty public not-found data avoids reflecting bearer tokens. */
+export const ShareNotFoundData = z.strictObject({});
+
+type ShareErrorDefItem = {
+  readonly status: number;
+  readonly category: ShareErrorCategory;
+  readonly message: string;
+  readonly data: z.ZodType<unknown>;
+};
+
+/** Share error registry with registry-only categories omitted from responses. */
+export const SHARE_ERROR_DEFS = {
+  SHARE_ROUTE_NOT_FOUND: {
+    status: 404,
+    category: "user_actionable",
+    message: "No such saved route",
+    data: ShareRouteData,
+  },
+  SHARE_ROUTE_NOT_OWNED: {
+    status: 403,
+    category: "user_actionable",
+    message: "Route belongs to another user",
+    data: ShareRouteData,
+  },
+  SHARE_NOT_FOUND: {
+    status: 404,
+    category: "user_actionable",
+    message: "No such share",
+    data: ShareNotFoundData,
+  },
+  SHARE_EXPIRED: {
+    status: 410,
+    category: "user_actionable",
+    message: "Share has expired",
+    data: ShareExpiredData,
+  },
+  SHARE_REVOKED: {
+    status: 410,
+    category: "user_actionable",
+    message: "Share has been revoked",
+    data: ShareRevokedData,
+  },
+} as const satisfies Record<string, ShareErrorDefItem>;
+
+/** Share error registry type. */
+export type ShareErrorDefs = typeof SHARE_ERROR_DEFS;
+/** Share error code union. */
+export type ShareErrorCode = keyof ShareErrorDefs;
+
+type ShareErrorMapItem<Code extends ShareErrorCode> = {
+  status: ShareErrorDefs[Code]["status"];
+  message: ShareErrorDefs[Code]["message"];
+  data: ShareErrorDefs[Code]["data"];
+};
+type ShareErrorMap<Code extends ShareErrorCode> = {
+  [Key in Code]: ShareErrorMapItem<Key>;
+};
+
+function shareErrorEntry<Code extends ShareErrorCode>(
+  code: Code,
+): readonly [Code, ShareErrorMapItem<Code>] {
+  const { status, message, data } = SHARE_ERROR_DEFS[code];
+  return [code, { status, message, data }];
+}
+
+/** Pick oRPC error entries while dropping registry-only category metadata. */
+export function pickShareErrors<const Code extends ShareErrorCode>(
+  codes: readonly Code[],
+): ShareErrorMap<Code> {
+  return Object.fromEntries(codes.map(shareErrorEntry)) as ShareErrorMap<Code>;
+}
+
+/** oRPC contract for authenticated issuance/revocation and anonymous resolution. */
+export const shareContract = {
+  createShare: oc
+    .route({ method: "POST", path: "/v1/users/shares", summary: "Create a route share" })
+    .input(CreateShareInput)
+    .errors(pickShareErrors(["SHARE_ROUTE_NOT_FOUND", "SHARE_ROUTE_NOT_OWNED"]))
+    .output(CreateShareResult),
+  revokeShare: oc
+    .route({ method: "DELETE", path: "/v1/users/shares/{share_id}", summary: "Revoke a share" })
+    .input(RevokeShareInput)
+    .errors(pickShareErrors(["SHARE_NOT_FOUND", "SHARE_REVOKED"]))
+    .output(RevokeShareResult),
+  resolveShare: oc
+    .route({ method: "GET", path: "/v1/users/shares/resolve/{token}", summary: "Resolve a public share" })
+    .input(ResolveShareInput)
+    .errors(pickShareErrors(["SHARE_NOT_FOUND", "SHARE_EXPIRED", "SHARE_REVOKED"]))
+    .output(ResolveShareResult),
+};
+
+/** Route-sharing oRPC contract type. */
+export type ShareContract = typeof shareContract;

--- a/packages/contract/test/share-contract.test.ts
+++ b/packages/contract/test/share-contract.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  CreateShareInput,
+  CreateShareResult,
+  PublicSharedItinerary,
+  ResolveShareResult,
+  ResolveShareInput,
+  RevokeShareResult,
+  SHARE_ERROR_DEFS,
+  ShareExpiredData,
+  ShareToken,
+} from "../src/share-contract.js";
+
+const TOKEN = "token-fixture-token-fixture-token-fixture-x";
+const ROUTE_ID = "019b984f-1a52-7000-8000-000000000001";
+
+const PUBLIC_ITINERARY = {
+  title: "飛騨古川 半日ルート",
+  anime: { id: "your-name", title: "君の名は。" },
+  state: "completed",
+  author_display_name: "ミツハ",
+  planned_for: "2026-07-03",
+  distance_meters: 2_800,
+  total_stops: 2,
+  completed_stops: 2,
+  stops: [
+    {
+      point_id: "point-hida-station",
+      name: "飛騨古川駅",
+      position: 0,
+      scheduled_time: "09:30",
+      visited_time: "09:31",
+      completed: true,
+      frame_image_url: "https://images.example/frame.webp",
+      frame_label: "第1話 04:12",
+    },
+  ],
+  comparisons: [
+    {
+      point_id: "point-hida-station",
+      image_url: "https://images.example/comparison.webp",
+      caption: "飛騨古川駅",
+    },
+  ],
+  attributions: [{ label: "Anitabi (CC BY-NC-SA 4.0)", url: "https://anitabi.cn" }],
+} as const;
+
+describe("share token inputs", () => {
+  it("accepts a 256-bit unpadded Base64URL token", () => {
+    expect(ResolveShareInput.parse({ token: TOKEN })).toEqual({ token: TOKEN });
+  });
+
+  it.each(["short", `${TOKEN}=`, `${TOKEN.slice(0, -1)}+`, `${TOKEN}x`])(
+    "rejects malformed token %s",
+    (token) => {
+      expect(ShareToken.safeParse(token).success).toBe(false);
+    },
+  );
+
+  it("accepts an authenticated create request without client-controlled expiry", () => {
+    expect(CreateShareInput.parse({ route_id: ROUTE_ID })).toEqual({ route_id: ROUTE_ID });
+  });
+
+  it("accepts issued credentials with server-authored lifecycle timestamps", () => {
+    const result = {
+      share_id: "019b984f-1a52-7000-8000-000000000002",
+      token: TOKEN,
+      created_at: "2026-07-19T09:30:00+09:00",
+      expires_at: "2026-08-18T09:30:00+09:00",
+    };
+    expect(CreateShareResult.parse(result)).toEqual(result);
+  });
+
+  it("accepts an authenticated revocation confirmation", () => {
+    const result = { revoked: true, revoked_at: "2026-07-20T09:30:00+09:00" } as const;
+    expect(RevokeShareResult.parse(result)).toEqual(result);
+  });
+});
+
+describe("share expiry errors", () => {
+  it("accepts an expired-share error with an offset timestamp", () => {
+    const data = { expires_at: "2026-07-20T09:30:00+09:00" };
+    expect(ShareExpiredData.parse(data)).toEqual(data);
+    expect(SHARE_ERROR_DEFS.SHARE_EXPIRED.status).toBe(410);
+  });
+
+  it("rejects an expired-share error with a malformed timestamp", () => {
+    expect(ShareExpiredData.safeParse({ expires_at: "yesterday" }).success).toBe(false);
+  });
+});
+
+describe("public share projection", () => {
+  it("accepts the public itinerary fields needed by the share page", () => {
+    expect(PublicSharedItinerary.parse(PUBLIC_ITINERARY)).toEqual(PUBLIC_ITINERARY);
+  });
+
+  it("accepts an anonymous resolution envelope without internal identifiers", () => {
+    const result = { expires_at: "2026-08-18T09:30:00+09:00", itinerary: PUBLIC_ITINERARY };
+    expect(ResolveShareResult.parse(result)).toEqual(result);
+  });
+
+  it.each([
+    "user_id",
+    "internal_user_id",
+    "owner_id",
+    "created_by",
+    "latitude",
+    "longitude",
+    "coordinates",
+  ])(
+    "strictly rejects sensitive key %s",
+    (sensitiveKey) => {
+      const leaked = { ...PUBLIC_ITINERARY, [sensitiveKey]: "sensitive" };
+      expect(PublicSharedItinerary.safeParse(leaked).success).toBe(false);
+    },
+  );
+
+  it("strictly rejects raw GPS nested inside a public stop", () => {
+    const stops = [{ ...PUBLIC_ITINERARY.stops[0], latitude: 35.702_123 }];
+    expect(PublicSharedItinerary.safeParse({ ...PUBLIC_ITINERARY, stops }).success).toBe(false);
+  });
+});

--- a/packages/contract/users-openapi.json
+++ b/packages/contract/users-openapi.json
@@ -975,6 +975,789 @@
           }
         }
       }
+    },
+    "/v1/users/shares": {
+      "post": {
+        "operationId": "createShare",
+        "summary": "Create a route share",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "route_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "route_id"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "share_id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "token": {
+                      "type": "string",
+                      "pattern": "^[A-Za-z0-9_-]{43}$"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "expires_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "required": [
+                    "share_id",
+                    "token",
+                    "created_at",
+                    "expires_at"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "SHARE_ROUTE_NOT_OWNED"
+                        },
+                        "status": {
+                          "const": 403
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "Route belongs to another user"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "route_id": {
+                              "type": "string",
+                              "format": "uuid"
+                            }
+                          },
+                          "required": [
+                            "route_id"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "SHARE_ROUTE_NOT_FOUND"
+                        },
+                        "status": {
+                          "const": 404
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "No such saved route"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "route_id": {
+                              "type": "string",
+                              "format": "uuid"
+                            }
+                          },
+                          "required": [
+                            "route_id"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users/shares/{share_id}": {
+      "delete": {
+        "operationId": "revokeShare",
+        "summary": "Revoke a share",
+        "parameters": [
+          {
+            "name": "share_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "revoked": {
+                      "const": true
+                    },
+                    "revoked_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "required": [
+                    "revoked",
+                    "revoked_at"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "SHARE_NOT_FOUND"
+                        },
+                        "status": {
+                          "const": 404
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "No such share"
+                        },
+                        "data": {
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "410",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "SHARE_REVOKED"
+                        },
+                        "status": {
+                          "const": 410
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "Share has been revoked"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "revoked_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          },
+                          "required": [
+                            "revoked_at"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users/shares/resolve/{token}": {
+      "get": {
+        "operationId": "resolveShare",
+        "summary": "Resolve a public share",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_-]{43}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "expires_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "itinerary": {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 200
+                        },
+                        "anime": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 128
+                            },
+                            "title": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 200
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "title"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "state": {
+                          "enum": [
+                            "planned",
+                            "partial",
+                            "completed"
+                          ],
+                          "type": "string"
+                        },
+                        "author_display_name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 100
+                        },
+                        "planned_for": {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        "distance_meters": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "total_stops": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "completed_stops": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "stops": {
+                          "type": "array",
+                          "maxItems": 500,
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "point_id": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 128
+                              },
+                              "name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 200
+                              },
+                              "position": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 9007199254740991
+                              },
+                              "scheduled_time": {
+                                "type": "string",
+                                "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d$"
+                              },
+                              "visited_time": {
+                                "type": "string",
+                                "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d$"
+                              },
+                              "completed": {
+                                "type": "boolean"
+                              },
+                              "frame_image_url": {
+                                "type": "string",
+                                "format": "uri"
+                              },
+                              "frame_label": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 100
+                              }
+                            },
+                            "required": [
+                              "point_id",
+                              "name",
+                              "position",
+                              "completed"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "comparisons": {
+                          "type": "array",
+                          "maxItems": 100,
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "point_id": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 128
+                              },
+                              "image_url": {
+                                "type": "string",
+                                "format": "uri"
+                              },
+                              "caption": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 200
+                              }
+                            },
+                            "required": [
+                              "point_id",
+                              "image_url",
+                              "caption"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "hero_image_url": {
+                          "type": "string",
+                          "format": "uri"
+                        },
+                        "attributions": {
+                          "type": "array",
+                          "maxItems": 20,
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 300
+                              },
+                              "url": {
+                                "type": "string",
+                                "format": "uri"
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "title",
+                        "anime",
+                        "state",
+                        "total_stops",
+                        "completed_stops",
+                        "stops",
+                        "comparisons",
+                        "attributions"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "expires_at",
+                    "itinerary"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "SHARE_NOT_FOUND"
+                        },
+                        "status": {
+                          "const": 404
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "No such share"
+                        },
+                        "data": {
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "410",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "SHARE_EXPIRED"
+                        },
+                        "status": {
+                          "const": 410
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "Share has expired"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "expires_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          },
+                          "required": [
+                            "expires_at"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "SHARE_REVOKED"
+                        },
+                        "status": {
+                          "const": 410
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "Share has been revoked"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "revoked_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          },
+                          "required": [
+                            "revoked_at"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Campaign CT-share card. Codex-authored; recovered from Codex session log after gitleaks silently blocked the original commit (high-entropy sample token → replaced with zero-entropy fixture).

- `share-contract.ts`: create/revoke (authed) + resolve (anonymous); 43-char base64url non-enumerable token; immutable expiry, immediate revocation
- Public projection strict + GPS/identity-free (verified: PublicSharedStop carries no coordinates)
- users-openapi.json regenerated (+783), emit re-run stable

Gates (lead-run): typecheck ✓ · 37/37 ✓ · emit stable ✓ · suppressions 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)