### PR TITLE
fix(web): cream triad restore + night token coverage + chat bubble sizing + SSR html lang

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -5,8 +5,10 @@ import {
   Outlet,
   Scripts,
   createRootRouteWithContext,
+  useMatches,
 } from "@tanstack/react-router";
 import { NotFound } from "../components/NotFound";
+import { DEFAULT_LOCALE, LOCALES, type Locale } from "../i18n/locales";
 import globalsUrl from "../styles/globals.css?url";
 
 interface RouterContext {
@@ -41,9 +43,32 @@ function RootComponent() {
   );
 }
 
+interface LocaleBearingMatch {
+  readonly loaderData?: unknown;
+}
+
+function isLocale(value: unknown): value is Locale {
+  return typeof value === "string" && (LOCALES as readonly string[]).includes(value);
+}
+
+function localeOf(data: unknown): Locale | null {
+  if (typeof data !== "object" || data === null || !("locale" in data)) return null;
+  return isLocale(data.locale) ? data.locale : null;
+}
+
+/** SSR lang source: deepest locale-bearing match wins, else DEFAULT_LOCALE. */
+export function langFromMatches(matches: readonly LocaleBearingMatch[]): Locale {
+  for (const match of [...matches].reverse()) {
+    const locale = localeOf(match.loaderData);
+    if (locale) return locale;
+  }
+  return DEFAULT_LOCALE;
+}
+
 function RootDocument({ children }: RootDocumentProps) {
+  const lang = langFromMatches(useMatches());
   return (
-    <html lang="en">
+    <html lang={lang}>
       <head><HeadContent /></head>
       <body>{children}<Scripts /></body>
     </html>

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -11,6 +11,9 @@
 .chat-body {
   flex: 1;
   overflow-y: auto;
+  width: 100%;
+  max-width: 48rem;
+  margin-inline: auto;
   padding: 1rem;
   display: flex;
   flex-direction: column;
@@ -18,6 +21,7 @@
 }
 
 .chat-bubble {
+  width: fit-content;
   max-width: 42rem;
   padding: 0.75rem 1rem;
   border-radius: 18px;
@@ -30,6 +34,7 @@
 }
 
 .chat-message--user .chat-bubble {
+  align-self: flex-end;
   margin-left: auto;
   border-bottom-right-radius: 6px;
   background: var(--color-primary);

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -12,11 +12,12 @@
   --color-primary-fg: #ffffff;
   /* Accessible teal from ds-审计.md; white text clears WCAG AA. */
   --color-primary-strong: #0e7d72;
-  --color-bg: #ffffff;
+  /* 動森 cream triad: page < card < muted (spec 2026-05-31 + legacy globals). */
+  --color-bg: #f8f8f0;
   --color-fg: #725d42;
-  --color-card: #f8f8f0;
-  --color-muted: #f0e8d8;
-  /* Accessible secondary text from ds-审计.md; clears WCAG AA on white. */
+  --color-card: #f7f3df;
+  --color-muted: #e8ddc8;
+  /* Accessible secondary text from ds-审计.md; clears WCAG AA on cream. */
   --color-muted-fg: #7d6f5a;
   --color-border: #aaa69d;
   --color-focus: #ffcc00;
@@ -32,7 +33,7 @@
   --color-map-pin-orange: #ff9800;
   --color-map-pin-brand: #c1440e;
   --shadow-3d: #bdaea0;
-  --shadow-press: 0 5px 0 0 #bdaea0;
+  --shadow-press: 0 5px 0 0 var(--shadow-3d);
   --app-font-display: "Noto Serif JP", "Hiragino Mincho ProN", Georgia, serif;
   --app-font-body: "Nunito", "Zen Maru Gothic", "Noto Sans SC", "Hiragino Sans", "Yu Gothic UI", system-ui, sans-serif;
   --app-font-mono: "IBM Plex Mono", "SFMono-Regular", monospace;
@@ -195,6 +196,13 @@ h1 {
   --color-muted-fg: #cbbfa8;
   --color-border: #4a3d2b;
   --color-primary-fg: #10201d;
+  --color-primary-soft: #123f39;
+  --color-explore-bg: #0f3531;
+  --color-explore-fg: #7fdcd2;
+  --color-walk-bg: #1c3320;
+  --color-walk-fg: #a8d5ab;
+  /* Press shadow follows via var(--shadow-3d) in :root. */
+  --shadow-3d: #120d07;
 }
 
 .landing {

--- a/apps/web/tests/unit/_token-helpers.ts
+++ b/apps/web/tests/unit/_token-helpers.ts
@@ -13,11 +13,12 @@ export interface FontFace {
   readonly unicodeRange: string | null;
 }
 
-export function parseTokens(css: string): TokenMap {
-  const rootBody = /:root[^{]*\{([^}]*)\}/u.exec(css)?.[1];
-  if (rootBody === undefined) throw new Error("Missing :root block");
+export function parseBlockTokens(css: string, selector: string): TokenMap {
+  const escaped = selector.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+  const body = new RegExp(`${escaped}[^{]*\\{([^}]*)\\}`, "u").exec(css)?.[1];
+  if (body === undefined) throw new Error(`Missing block: ${selector}`);
   const tokens: Record<string, string> = {};
-  const declarations = rootBody.matchAll(/(--[\w-]+)\s*:\s*([^;}]+)/gu);
+  const declarations = body.matchAll(/(--[\w-]+)\s*:\s*([^;}]+)/gu);
   for (const declaration of declarations) {
     const [, name, value] = declaration;
     if (name !== undefined && value !== undefined) tokens[name] = value.trim();
@@ -25,8 +26,19 @@ export function parseTokens(css: string): TokenMap {
   return tokens;
 }
 
+export function parseTokens(css: string): TokenMap {
+  return parseBlockTokens(css, ":root");
+}
+
 function declarationValue(body: string, property: string): string | null {
   return new RegExp(`${property}\\s*:\\s*([^;]+)`, "u").exec(body)?.[1]?.trim() ?? null;
+}
+
+export function ruleDeclaration(css: string, selector: string, property: string): string | null {
+  const escaped = selector.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+  const body = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, "u").exec(css)?.[1];
+  if (body === undefined) throw new Error(`Missing rule: ${selector}`);
+  return declarationValue(body, property);
 }
 
 function requiredDeclaration(body: string, property: string): string {

--- a/apps/web/tests/unit/chat-css.test.ts
+++ b/apps/web/tests/unit/chat-css.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import chatCss from "../../src/styles/chat.css?raw";
+import { ruleDeclaration } from "./_token-helpers";
+
+describe("chat bubble sizing", () => {
+  it("shrinks bubbles to their content instead of the full column", () => {
+    expect(ruleDeclaration(chatCss, ".chat-bubble", "width")).toBe("fit-content");
+  });
+
+  it("keeps a readable max width on bubbles", () => {
+    expect(ruleDeclaration(chatCss, ".chat-bubble", "max-width")).toBe("42rem");
+  });
+
+  it("aligns user bubbles to the end of the column", () => {
+    const selector = ".chat-message--user .chat-bubble";
+    expect(ruleDeclaration(chatCss, selector, "align-self")).toBe("flex-end");
+    expect(ruleDeclaration(chatCss, selector, "margin-left")).toBe("auto");
+  });
+});
+
+describe("chat body column", () => {
+  it("centers the message column on wide viewports", () => {
+    expect(ruleDeclaration(chatCss, ".chat-body", "max-width")).toBe("48rem");
+    expect(ruleDeclaration(chatCss, ".chat-body", "margin-inline")).toBe("auto");
+    expect(ruleDeclaration(chatCss, ".chat-body", "width")).toBe("100%");
+  });
+});

--- a/apps/web/tests/unit/design-token-alignment.test.ts
+++ b/apps/web/tests/unit/design-token-alignment.test.ts
@@ -5,6 +5,7 @@ import globalsCss from "../../src/styles/globals.css?raw";
 import {
   alignmentMismatches,
   contrastRatio,
+  parseBlockTokens,
   parseFontFaces,
   parseTokens,
   srcForCodepoint,
@@ -14,6 +15,7 @@ import {
 
 const semanticTokens = parseTokens(globalsCss);
 const animalTokens = parseTokens(animalCss);
+const nightTokens = parseBlockTokens(globalsCss, '[data-theme="night"]');
 const fontFaces = parseFontFaces(fontsCss);
 
 const alignment: TokenMap = {
@@ -22,8 +24,8 @@ const alignment: TokenMap = {
   "--color-primary-active": "--animal-primary-color-active",
   "--color-primary-soft": "--animal-primary-color-bg",
   "--color-fg": "--animal-text-color-body",
-  "--color-card": "--animal-bg-color",
-  "--color-muted": "--animal-bg-color-secondary",
+  "--color-bg": "--animal-bg-color",
+  "--color-card": "--animal-bg-color-content",
   "--color-border": "--animal-border-color",
   "--color-focus": "--animal-focus-yellow",
   "--color-success-fg": "--animal-success-color",
@@ -67,6 +69,45 @@ describe("semantic token backfills", () => {
     "--color-map-pin-brand",
   ])("defines %s", (token) => {
     expect(tokenValue(semanticTokens, token)).not.toBe("");
+  });
+});
+
+describe("cream base triad (動森 spec)", () => {
+  it.each([
+    ["--color-bg", "#f8f8f0"],
+    ["--color-card", "#f7f3df"],
+    ["--color-muted", "#e8ddc8"],
+  ])("pins %s to %s", (token, expected) => {
+    expect(tokenValue(semanticTokens, token)).toBe(expected);
+  });
+
+  it("derives the press shadow from the 3d shadow token", () => {
+    expect(tokenValue(semanticTokens, "--shadow-press")).toContain("var(--shadow-3d)");
+  });
+});
+
+describe("night theme coverage", () => {
+  it.each([
+    "--color-primary-soft",
+    "--color-explore-bg",
+    "--color-explore-fg",
+    "--color-walk-bg",
+    "--color-walk-fg",
+    "--shadow-3d",
+  ])("overrides %s at night", (token) => {
+    expect(tokenValue(nightTokens, token)).not.toBe(tokenValue(semanticTokens, token));
+  });
+
+  it("keeps explore text readable on the night explore background", () => {
+    const foreground = tokenValue(nightTokens, "--color-explore-fg");
+    const background = tokenValue(nightTokens, "--color-explore-bg");
+    expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("keeps walk text readable on the night walk background", () => {
+    const foreground = tokenValue(nightTokens, "--color-walk-fg");
+    const background = tokenValue(nightTokens, "--color-walk-bg");
+    expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(4.5);
   });
 });
 

--- a/apps/web/tests/unit/root-lang.test.ts
+++ b/apps/web/tests/unit/root-lang.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_LOCALE } from "../../src/i18n/locales";
+import { langFromMatches } from "../../src/routes/__root";
+
+describe("langFromMatches", () => {
+  it("falls back to the default locale when no match carries one", () => {
+    expect(langFromMatches([])).toBe(DEFAULT_LOCALE);
+    expect(langFromMatches([{ loaderData: undefined }])).toBe("ja");
+  });
+
+  it("uses the locale from the deepest locale-bearing match", () => {
+    const matches = [
+      { loaderData: { locale: "zh" } },
+      { loaderData: { locale: "en" } },
+    ];
+    expect(langFromMatches(matches)).toBe("en");
+  });
+
+  it("ignores loader data without a valid locale", () => {
+    const matches = [
+      { loaderData: { locale: "en" } },
+      { loaderData: { locale: "xx" } },
+      { loaderData: { points: 3 } },
+    ];
+    expect(langFromMatches(matches)).toBe("en");
+  });
+});


### PR DESCRIPTION
Battle-review fix card **FIX-design**. Scope limited to `apps/web/src/styles/globals.css`, `apps/web/src/styles/chat.css`, `apps/web/src/routes/__root.tsx` (+ their tests). No chat/anime/shiori `.tsx` touched.

## Findings fixed

### P1-3 — cream triad restored (token before → after)
| Token | Before | After | Source |
|---|---|---|---|
| `--color-bg` | `#ffffff` | `#f8f8f0` | `--animal-bg-color` (pkg) + legacy |
| `--color-card` | `#f8f8f0` | `#f7f3df` | `--animal-bg-color-content` (pkg) + legacy |
| `--color-muted` | `#f0e8d8` | `#e8ddc8` | legacy/spec value (no pkg primitive; pinned directly in test) |

Alignment map updated accordingly: `--color-bg`→`--animal-bg-color`, `--color-card`→`--animal-bg-color-content`; `--color-muted` left off the primitive map (package has no `#e8ddc8`) and pinned by a direct value test instead. `--color-muted-fg` on the new cream bg still clears WCAG AA (4.58:1, asserted).

### P1-4 — chat bubbles no longer full-width
- `.chat-bubble` gains `width: fit-content` (one word no longer renders a 672px slab)
- `.chat-message--user .chat-bubble` gains `align-self: flex-end`
- `.chat-body` becomes a centered column: `width: 100%; max-width: 48rem; margin-inline: auto` — desktop messages no longer hug the viewport edge

### P1-5 — SSR `<html lang>` from route context
`__root.tsx` hardcoded `lang="en"`. Now `langFromMatches(useMatches())` reads the deepest locale-bearing match's `loaderData.locale` during SSR (TanStack Router matches are fully loaded before render on the server), falling back to `DEFAULT_LOCALE` (`ja`). `/anime/:id?hl=zh` now SSRs `lang="zh"`, honoring the SD-27C locale-native SEO AC.

### P2-3 — night theme token coverage
Added to `[data-theme="night"]`: `--color-primary-soft: #123f39`, `--color-explore-bg: #0f3531`, `--color-walk-bg: #1c3320`, `--shadow-3d: #120d07`; `--shadow-press` now derives from `var(--shadow-3d)` in `:root` so it follows automatically. Also overrode `--color-explore-fg`/`--color-walk-fg` (light variants) — without them the segment text would sit at ~1.6:1 on the new dark panels; both pairs assert ≥4.5:1 in tests.

### Item 5 (globals.css split) — skipped
Splitting requires creating new css files outside the card's allowed file list; left as-is per "不强求" and scope discipline.

## Tests (TDD, red→green)
- `design-token-alignment.test.ts`: cream triad pins, shadow-press derivation, night override + contrast assertions, updated alignment map
- `chat-css.test.ts` (new): bubble fit-content/max-width/user alignment, body centering
- `root-lang.test.ts` (new): `langFromMatches` fallback, deepest-match wins, invalid locale ignored
- `_token-helpers.ts`: `parseBlockTokens` + `ruleDeclaration` helpers (parseTokens now delegates)

## Gate tail
```
build: exit 0
typecheck: tsc --noEmit — clean
lint:oxlint: --type-aware --deny-warnings — clean
test: Test Files 58 passed (58) / Tests 322 passed (322)
coverage: Stmts 99.32% / Branch 94.71% / Funcs 100% / Lines 99.84%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)