### PR TITLE
fix(shiori): wire EXIF stripping into the photo pipeline + fail-closed JPEG walker

### DIFF
--- a/apps/web/src/features/shiori/ShioriGenerator.tsx
+++ b/apps/web/src/features/shiori/ShioriGenerator.tsx
@@ -1,26 +1,95 @@
-import { type ChangeEvent, useCallback, useState } from "react";
+import { type ChangeEvent, useCallback, useEffect, useState } from "react";
 import type { Locale } from "../../i18n/locales";
 import { composeShiori, type ComposedShiori, type ShioriSource } from "./compose";
 import { shioriLabels, type ShioriLabels } from "./labels";
+import { ingestShioriPhotos, revokeShioriPhotoUrls } from "./photoIngestion";
 import { ShioriCard } from "./ShioriCard";
+import type { SanitizedShioriPhoto, ShioriPhotoInput } from "./types";
+
+/** Generator input: photos arrive as raw blobs and can only render after sanitization. */
+export interface ShioriGeneratorSource extends Omit<ShioriSource, "photos"> {
+  photos: readonly ShioriPhotoInput[];
+}
+
+type PhotosSanitizedHandler = (photos: readonly SanitizedShioriPhoto[]) => void;
 
 export type ShioriGeneratorProps = Readonly<{
-  source: ShioriSource;
+  source: ShioriGeneratorSource;
   locale: Locale;
   onRetainExifChange?: (retainExif: boolean) => void;
+  onPhotosSanitized?: PhotosSanitizedHandler;
 }>;
 
 /** S4.2 generation screen: the route data alone picks planned vs commemorative. */
-export function ShioriGenerator({ source, locale, onRetainExifChange }: ShioriGeneratorProps) {
-  const composed = composeShiori(source);
+export function ShioriGenerator(props: ShioriGeneratorProps) {
+  const { retainExif, handleChange } = useRetainExif(props.onRetainExifChange);
+  const photos = useSanitizedPhotos(props.source.photos, retainExif, props.onPhotosSanitized);
+  const composed = composeShiori({ ...props.source, photos });
+  const view = { locale: props.locale, composed, retainExif, onToggle: handleChange };
+  return <GeneratorView {...view} />;
+}
+
+type GeneratorViewProps = Readonly<{
+  locale: Locale;
+  composed: ComposedShiori;
+  retainExif: boolean;
+  onToggle: (event: ChangeEvent<HTMLInputElement>) => void;
+}>;
+
+function GeneratorView({ locale, composed, retainExif, onToggle }: GeneratorViewProps) {
+  const labels = shioriLabels(locale);
   return (
-    <section className="shiori-generator" aria-label={shioriLabels(locale).modeName[composed.mode]}>
+    <section className="shiori-generator" aria-label={labels.modeName[composed.mode]}>
       <GeneratorSummary locale={locale} composed={composed} />
       <GeneratorPreview composed={composed} />
-      <RetainExifOptIn label={shioriLabels(locale).retainExif} onChange={onRetainExifChange} />
+      <RetainExifOptIn label={labels.retainExif} checked={retainExif} onChange={onToggle} />
     </section>
   );
 }
+
+function useSanitizedPhotos(
+  inputs: readonly ShioriPhotoInput[],
+  retainExif: boolean,
+  onPhotosSanitized?: PhotosSanitizedHandler,
+): readonly SanitizedShioriPhoto[] {
+  const { photos, deliver } = useDeliveredPhotos(onPhotosSanitized);
+  useEffect(() => runIngestion(inputs, retainExif, deliver), [inputs, retainExif, deliver]);
+  useEffect(() => () => { revokeShioriPhotoUrls(photos); }, [photos]);
+  return photos;
+}
+
+function useDeliveredPhotos(onPhotosSanitized?: PhotosSanitizedHandler) {
+  const [photos, setPhotos] = useState<readonly SanitizedShioriPhoto[]>([]);
+  const deliver = useCallback<PhotosSanitizedHandler>((next) => {
+    setPhotos(next);
+    onPhotosSanitized?.(next);
+  }, [onPhotosSanitized]);
+  return { photos, deliver };
+}
+
+function runIngestion(
+  inputs: readonly ShioriPhotoInput[],
+  retainExif: boolean,
+  deliver: PhotosSanitizedHandler,
+): () => void {
+  if (inputs.length === 0) return deliverEmpty(deliver);
+  return trackIngestion(ingestShioriPhotos(inputs, { retainExif }), deliver);
+}
+
+function deliverEmpty(deliver: PhotosSanitizedHandler): () => void {
+  deliver([]);
+  return () => undefined;
+}
+
+function trackIngestion(pending: PendingPhotos, deliver: PhotosSanitizedHandler): () => void {
+  let alive = true;
+  void pending.then((next) => {
+    if (alive) deliver(next);
+  });
+  return () => { alive = false; };
+}
+
+type PendingPhotos = Promise<readonly SanitizedShioriPhoto[]>;
 
 type GeneratorSummaryProps = Readonly<{ locale: Locale; composed: ComposedShiori }>;
 
@@ -66,15 +135,15 @@ function useRetainExif(onChange?: (retainExif: boolean) => void) {
 
 type RetainExifOptInProps = Readonly<{
   label: string;
-  onChange?: (retainExif: boolean) => void;
+  checked: boolean;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
 }>;
 
 /** Unchecked by default: EXIF stripping stays on unless the user opts in (X6). */
-function RetainExifOptIn({ label, onChange }: RetainExifOptInProps) {
-  const { retainExif, handleChange } = useRetainExif(onChange);
+function RetainExifOptIn({ label, checked, onChange }: RetainExifOptInProps) {
   return (
     <label className="shiori-generator__exif">
-      <input type="checkbox" checked={retainExif} onChange={handleChange} />
+      <input type="checkbox" checked={checked} onChange={onChange} />
       {label}
     </label>
   );

--- a/apps/web/src/features/shiori/exifStrip.ts
+++ b/apps/web/src/features/shiori/exifStrip.ts
@@ -2,13 +2,22 @@
  * EXIF stripping for photos entering the しおり pipeline (X6 hard AC).
  * Default = strip; retaining metadata is an explicit opt-in.
  *
- * JPEG: lossless APPn/COM segment removal (no re-encode, no quality loss,
- * deterministic and unit-verifiable). Other formats: canvas redraw, which
- * drops all metadata during re-encode.
+ * JPEG: lossless APPn/COM removal via a fail-closed segment walker that
+ * validates marker prefixes, segment lengths, byte stuffing, every scan
+ * (progressive included) and the EOI; malformed input is rejected, never
+ * passed through. Trailer bytes after EOI are discarded. Selection note:
+ * no maintained browser-grade lossless stripper exists on npm (exif-be-gone
+ * is Node-stream based; piexifjs/exifremove are unmaintained and naive), and
+ * canvas re-encode is lossy for JPEG, so the walker stays hand-written but
+ * strict. Other formats: canvas redraw, which drops all metadata.
  */
 
 const SOI = 0xffd8;
+const EOI = 0xffd9;
 const SOS = 0xffda;
+const TEM = 0xff01;
+const RST0 = 0xffd0;
+const RST7 = 0xffd7;
 const APP0 = 0xffe0;
 const APP15 = 0xffef;
 const COM = 0xfffe;
@@ -26,37 +35,90 @@ export async function sanitizePhoto(
   return redrawWithoutMetadata(photo);
 }
 
-/** Removes APP1–APP15 + COM segments; keeps APP0 (JFIF), tables and scan data intact. */
+interface JpegWalk {
+  bytes: Uint8Array;
+  view: DataView;
+  offset: number;
+  sawScan: boolean;
+  kept: Uint8Array[];
+}
+
+/** Removes APPn (except APP0/JFIF) + COM segments everywhere, incl. between scans. */
 export function stripJpegMetadata(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
-  const view = toView(bytes);
-  if (bytes.length < 2 || view.getUint16(0) !== SOI) throw new Error("not a JPEG");
-  const kept: Uint8Array[] = [bytes.subarray(0, 2)];
-  kept.push(collectKeptSegments(bytes, view, kept));
-  return concatBytes(kept);
+  const walk = startWalk(bytes);
+  while (readMarker(walk) !== EOI) stripNextSegment(walk);
+  finishAtEoi(walk);
+  return concatBytes(walk.kept);
 }
 
-function toView(bytes: Uint8Array): DataView {
-  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+function startWalk(bytes: Uint8Array): JpegWalk {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (bytes.length < 4 || view.getUint16(0) !== SOI) throw new Error("not a JPEG");
+  return { bytes, view, offset: 2, sawScan: false, kept: [bytes.subarray(0, 2)] };
 }
 
-function collectKeptSegments(bytes: Uint8Array, view: DataView, kept: Uint8Array[]): Uint8Array {
-  let offset = 2;
-  while (offset + 4 <= bytes.length && view.getUint16(offset) !== SOS) {
-    const end = segmentEnd(bytes, view, offset);
-    if (!isMetadataMarker(view.getUint16(offset))) kept.push(bytes.subarray(offset, end));
-    offset = end;
+function readMarker(walk: JpegWalk): number {
+  if (walk.offset + 2 > walk.bytes.length) throw new Error("truncated JPEG: missing EOI");
+  if (walk.bytes[walk.offset] !== 0xff) throw new Error("invalid JPEG: bad marker prefix");
+  return walk.view.getUint16(walk.offset);
+}
+
+function stripNextSegment(walk: JpegWalk): void {
+  const marker = readMarker(walk);
+  if (isStandalone(marker)) throw new Error("invalid JPEG: unexpected standalone marker");
+  const end = segmentEnd(walk);
+  if (marker === SOS) {
+    keepScan(walk, end);
+    return;
   }
-  return bytes.subarray(offset);
+  keepOrDropSegment(walk, marker, end);
 }
 
-function segmentEnd(bytes: Uint8Array, view: DataView, offset: number): number {
-  const end = offset + 2 + view.getUint16(offset + 2);
-  if (end > bytes.length) throw new Error("truncated JPEG segment");
+function isStandalone(marker: number): boolean {
+  return marker === SOI || marker === TEM || (marker >= RST0 && marker <= RST7);
+}
+
+function segmentEnd(walk: JpegWalk): number {
+  if (walk.offset + 4 > walk.bytes.length) throw new Error("truncated JPEG segment");
+  const length = walk.view.getUint16(walk.offset + 2);
+  if (length < 2) throw new Error("invalid JPEG: segment length too small");
+  const end = walk.offset + 2 + length;
+  if (end > walk.bytes.length) throw new Error("truncated JPEG segment");
   return end;
+}
+
+function keepOrDropSegment(walk: JpegWalk, marker: number, end: number): void {
+  if (!isMetadataMarker(marker)) walk.kept.push(walk.bytes.subarray(walk.offset, end));
+  walk.offset = end;
 }
 
 function isMetadataMarker(marker: number): boolean {
   return (marker > APP0 && marker <= APP15) || marker === COM;
+}
+
+function keepScan(walk: JpegWalk, headerEnd: number): void {
+  const dataEnd = entropyEnd(walk.bytes, headerEnd);
+  walk.kept.push(walk.bytes.subarray(walk.offset, dataEnd));
+  walk.offset = dataEnd;
+  walk.sawScan = true;
+}
+
+function entropyEnd(bytes: Uint8Array, from: number): number {
+  for (let i = from; i + 1 < bytes.length; i += 1) {
+    if (bytes[i] === 0xff && !isEntropyContinuation(bytes[i + 1])) return i;
+  }
+  throw new Error("truncated JPEG: unterminated scan");
+}
+
+function isEntropyContinuation(byteAfterFf: number | undefined): boolean {
+  if (byteAfterFf === undefined) return false;
+  if (byteAfterFf === 0x00 || byteAfterFf === 0xff) return true;
+  return byteAfterFf >= 0xd0 && byteAfterFf <= 0xd7;
+}
+
+function finishAtEoi(walk: JpegWalk): void {
+  if (!walk.sawScan) throw new Error("invalid JPEG: no scan data");
+  walk.kept.push(walk.bytes.subarray(walk.offset, walk.offset + 2));
 }
 
 function concatBytes(parts: readonly Uint8Array[]): Uint8Array<ArrayBuffer> {

--- a/apps/web/src/features/shiori/photoIngestion.ts
+++ b/apps/web/src/features/shiori/photoIngestion.ts
@@ -1,0 +1,39 @@
+/**
+ * The only place a renderable しおり photo URL is born (Codex P1-6).
+ * Every raw blob passes sanitizePhoto before URL.createObjectURL; a photo
+ * that fails sanitization is excluded (fail closed), never passed through.
+ */
+
+import { sanitizePhoto, type SanitizePhotoOptions } from "./exifStrip";
+import type { SanitizedShioriPhoto, ShioriPhotoInput } from "./types";
+
+export async function ingestShioriPhotos(
+  inputs: readonly ShioriPhotoInput[],
+  options: SanitizePhotoOptions = {},
+): Promise<readonly SanitizedShioriPhoto[]> {
+  const settled = await Promise.allSettled(inputs.map((input) => ingestPhoto(input, options)));
+  return settled.filter(isFulfilled).map((result) => result.value);
+}
+
+export function revokeShioriPhotoUrls(photos: readonly SanitizedShioriPhoto[]): void {
+  for (const photo of photos) URL.revokeObjectURL(photo.imageUrl);
+}
+
+async function ingestPhoto(
+  input: ShioriPhotoInput,
+  options: SanitizePhotoOptions,
+): Promise<SanitizedShioriPhoto> {
+  const blob = await sanitizePhoto(input.photo, options);
+  return { ...displayFields(input), blob, imageUrl: URL.createObjectURL(blob) };
+}
+
+function displayFields(input: ShioriPhotoInput): Omit<SanitizedShioriPhoto, "blob" | "imageUrl"> {
+  const { id, spotName, sceneLabel, capturedAt } = input;
+  return { id, spotName, sceneLabel, capturedAt };
+}
+
+function isFulfilled(
+  result: PromiseSettledResult<SanitizedShioriPhoto>,
+): result is PromiseFulfilledResult<SanitizedShioriPhoto> {
+  return result.status === "fulfilled";
+}

--- a/apps/web/src/features/shiori/types.ts
+++ b/apps/web/src/features/shiori/types.ts
@@ -11,6 +11,20 @@ export interface ShioriPhoto {
   imageUrl: string;
 }
 
+/** Raw photo entering the pipeline; bytes MUST pass sanitizePhoto before a render URL exists. */
+export interface ShioriPhotoInput {
+  id: string;
+  spotName: string;
+  sceneLabel: string;
+  capturedAt: string;
+  photo: Blob;
+}
+
+/** Pipeline output: imageUrl is minted from the sanitized blob only. */
+export interface SanitizedShioriPhoto extends ShioriPhoto {
+  blob: Blob;
+}
+
 /** Display metadata shared by every しおり layout. */
 export interface ShioriMeta {
   routeTitle: string;

--- a/apps/web/tests/unit/shiori/_factories.ts
+++ b/apps/web/tests/unit/shiori/_factories.ts
@@ -1,5 +1,6 @@
 import type { TimedItinerary, TimedStop } from "@seichijunrei/contract";
-import type { ShioriMeta, ShioriPhoto } from "../../../src/features/shiori/types";
+import type { ShioriMeta, ShioriPhoto, ShioriPhotoInput } from "../../../src/features/shiori/types";
+import { makeJpegBlobWithExif } from "./_jpegFixtures";
 
 export function makeStop(overrides: Partial<TimedStop> = {}): TimedStop {
   return {
@@ -44,6 +45,17 @@ export function makePhoto(overrides: Partial<ShioriPhoto> = {}): ShioriPhoto {
     sceneLabel: "第8話 41:12",
     capturedAt: "10:48",
     imageUrl: "https://assets.example/comparison-1.jpg",
+    ...overrides,
+  };
+}
+
+export function makePhotoInput(overrides: Partial<ShioriPhotoInput> = {}): ShioriPhotoInput {
+  return {
+    id: "photo-1",
+    spotName: "気多若宮神社",
+    sceneLabel: "第8話 41:12",
+    capturedAt: "10:48",
+    photo: makeJpegBlobWithExif(),
     ...overrides,
   };
 }

--- a/apps/web/tests/unit/shiori/_jpegFixtures.ts
+++ b/apps/web/tests/unit/shiori/_jpegFixtures.ts
@@ -26,3 +26,8 @@ export function makeMalformedJpegBlob(): Blob {
 }
 
 export const bytesToText = (bytes: Uint8Array): string => String.fromCharCode(...bytes);
+
+export async function blobText(blob: Blob | undefined): Promise<string> {
+  if (!blob) throw new Error("expected a sanitized photo blob");
+  return bytesToText(new Uint8Array(await blob.arrayBuffer()));
+}

--- a/apps/web/tests/unit/shiori/_jpegFixtures.ts
+++ b/apps/web/tests/unit/shiori/_jpegFixtures.ts
@@ -1,0 +1,28 @@
+/** Byte-level JPEG fixtures shared by the EXIF-strip test files. */
+
+export function segment(marker: number, body: readonly number[]): number[] {
+  return [0xff, marker, (body.length + 2) >> 8, (body.length + 2) & 0xff, ...body];
+}
+
+export const ascii = (text: string): number[] => Array.from(text, (char) => char.charCodeAt(0));
+
+export const APP0_JFIF = segment(0xe0, [...ascii("JFIF\0"), 1, 2]);
+export const APP1_EXIF_GPS = segment(0xe1, ascii("Exif\0\0GPSLAT35.68"));
+export const DQT = segment(0xdb, [0, 1, 2, 3]);
+export const SOS_HEADER = segment(0xda, [1, 0]);
+export const SCAN_TAIL = [...SOS_HEADER, 0xaa, 0xbb, 0xff, 0xd9];
+
+export function makeJpegWithExif(): Uint8Array {
+  return Uint8Array.from([0xff, 0xd8, ...APP0_JFIF, ...APP1_EXIF_GPS, ...DQT, ...SCAN_TAIL]);
+}
+
+export function makeJpegBlobWithExif(): Blob {
+  return new Blob([makeJpegWithExif().slice().buffer], { type: "image/jpeg" });
+}
+
+export function makeMalformedJpegBlob(): Blob {
+  const truncated = Uint8Array.from([0xff, 0xd8, 0xff, 0xdb, 0xff, 0xff]);
+  return new Blob([truncated.slice().buffer], { type: "image/jpeg" });
+}
+
+export const bytesToText = (bytes: Uint8Array): string => String.fromCharCode(...bytes);

--- a/apps/web/tests/unit/shiori/exif-strip.test.ts
+++ b/apps/web/tests/unit/shiori/exif-strip.test.ts
@@ -1,21 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sanitizePhoto, stripJpegMetadata } from "../../../src/features/shiori/exifStrip";
-
-function segment(marker: number, body: readonly number[]): number[] {
-  return [0xff, marker, (body.length + 2) >> 8, (body.length + 2) & 0xff, ...body];
-}
-
-const ascii = (text: string): number[] => Array.from(text, (char) => char.charCodeAt(0));
-const APP0_JFIF = segment(0xe0, [...ascii("JFIF\0"), 1, 2]);
-const APP1_EXIF_GPS = segment(0xe1, ascii("Exif\0\0GPSLAT35.68"));
-const DQT = segment(0xdb, [0, 1, 2, 3]);
-const SCAN_TAIL = [...segment(0xda, [1, 0]), 0xaa, 0xbb, 0xff, 0xd9];
-
-function makeJpegWithExif(): Uint8Array {
-  return Uint8Array.from([0xff, 0xd8, ...APP0_JFIF, ...APP1_EXIF_GPS, ...DQT, ...SCAN_TAIL]);
-}
-
-const bytesToText = (bytes: Uint8Array): string => String.fromCharCode(...bytes);
+import {
+  APP0_JFIF,
+  ascii,
+  bytesToText,
+  DQT,
+  makeJpegWithExif,
+  SCAN_TAIL,
+  segment,
+} from "./_jpegFixtures";
 
 describe("stripJpegMetadata", () => {
   it("removes the EXIF APP1 segment including GPS payload", () => {

--- a/apps/web/tests/unit/shiori/jpeg-strip-hardening.test.ts
+++ b/apps/web/tests/unit/shiori/jpeg-strip-hardening.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { stripJpegMetadata } from "../../../src/features/shiori/exifStrip";
+import { APP1_EXIF_GPS, bytesToText, DQT, segment, SOS_HEADER } from "./_jpegFixtures";
+
+const EOI = [0xff, 0xd9];
+const SCAN_WITH_STUFFING = [...SOS_HEADER, 0xaa, 0xff, 0x00, 0xbb];
+const RST0 = [0xff, 0xd0];
+
+const jpeg = (...parts: readonly (readonly number[])[]): Uint8Array =>
+  Uint8Array.from([0xff, 0xd8, ...parts.flat()]);
+
+describe("stripJpegMetadata fail-closed hardening", () => {
+  it("strips an APP1 segment inserted after a scan, before EOI", () => {
+    const input = jpeg(DQT, SCAN_WITH_STUFFING, APP1_EXIF_GPS, EOI);
+
+    const stripped = stripJpegMetadata(input);
+
+    expect(bytesToText(stripped)).not.toContain("GPSLAT");
+    expect([...stripped]).toEqual([...jpeg(DQT, SCAN_WITH_STUFFING, EOI)]);
+  });
+
+  it("strips metadata between the scans of a progressive JPEG", () => {
+    const secondScan = [...SOS_HEADER, 0xcc];
+    const input = jpeg(DQT, SCAN_WITH_STUFFING, APP1_EXIF_GPS, secondScan, EOI);
+
+    const stripped = stripJpegMetadata(input);
+
+    expect([...stripped]).toEqual([...jpeg(DQT, SCAN_WITH_STUFFING, secondScan, EOI)]);
+  });
+
+  it("keeps stuffed 0xFF00 bytes and restart markers inside scan data", () => {
+    const scan = [...SOS_HEADER, 0xff, 0x00, ...RST0, 0xee];
+    const input = jpeg(DQT, scan, EOI);
+
+    expect([...stripJpegMetadata(input)]).toEqual([...input]);
+  });
+
+  it("rejects a zero-length segment instead of resyncing on later bytes", () => {
+    const zeroLength = [0xff, 0xe1, 0x00, 0x00];
+    const input = jpeg(zeroLength, DQT, SCAN_WITH_STUFFING, EOI);
+
+    expect(() => stripJpegMetadata(input)).toThrow("segment length");
+  });
+
+  it("rejects a one-byte segment length", () => {
+    const oneByteLength = [0xff, 0xe1, 0x00, 0x01];
+    const input = jpeg(oneByteLength, DQT, SCAN_WITH_STUFFING, EOI);
+
+    expect(() => stripJpegMetadata(input)).toThrow("segment length");
+  });
+
+  it("rejects bytes without a 0xFF marker prefix between segments", () => {
+    const input = jpeg(DQT, [0x00, 0xe1], SCAN_WITH_STUFFING, EOI);
+
+    expect(() => stripJpegMetadata(input)).toThrow("marker prefix");
+  });
+
+  it("rejects a standalone restart marker outside scan data", () => {
+    const input = jpeg(RST0, DQT, SCAN_WITH_STUFFING, EOI);
+
+    expect(() => stripJpegMetadata(input)).toThrow("standalone marker");
+  });
+
+  it("rejects scan data that ends without any terminating marker", () => {
+    const input = jpeg(DQT, [...SOS_HEADER, 0xaa, 0xbb]);
+
+    expect(() => stripJpegMetadata(input)).toThrow("unterminated scan");
+  });
+
+  it("rejects a JPEG that reaches EOI without any scan", () => {
+    const input = jpeg(DQT, EOI);
+
+    expect(() => stripJpegMetadata(input)).toThrow("no scan");
+  });
+
+  it("discards trailer bytes appended after EOI", () => {
+    const clean = jpeg(DQT, SCAN_WITH_STUFFING, EOI);
+    const input = Uint8Array.from([...clean, ...segment(0xe1, [0x99])]);
+
+    expect([...stripJpegMetadata(input)]).toEqual([...clean]);
+  });
+});

--- a/apps/web/tests/unit/shiori/photo-ingestion.test.ts
+++ b/apps/web/tests/unit/shiori/photo-ingestion.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ingestShioriPhotos, revokeShioriPhotoUrls } from "../../../src/features/shiori/photoIngestion";
+import { makePhotoInput } from "./_factories";
+import { blobText, makeMalformedJpegBlob } from "./_jpegFixtures";
+
+const createObjectURL = vi.fn((_blob: Blob) => `blob:mock-${String(createObjectURL.mock.calls.length)}`);
+const revokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("ingestShioriPhotos", () => {
+  it("sanitizes every blob before minting the render URL", async () => {
+    const photos = await ingestShioriPhotos([makePhotoInput()]);
+
+    expect(photos).toHaveLength(1);
+    expect(photos[0]?.imageUrl).toBe("blob:mock-1");
+    expect(createObjectURL).toHaveBeenCalledWith(photos[0]?.blob);
+    expect(await blobText(photos[0]?.blob)).not.toContain("GPSLAT");
+  });
+
+  it("keeps the display fields from the input", async () => {
+    const photos = await ingestShioriPhotos([makePhotoInput({ id: "photo-9", spotName: "駅前" })]);
+
+    expect(photos[0]).toMatchObject({
+      id: "photo-9",
+      spotName: "駅前",
+      sceneLabel: "第8話 41:12",
+      capturedAt: "10:48",
+    });
+  });
+
+  it("excludes a malformed photo instead of passing it through", async () => {
+    const malformed = makePhotoInput({ id: "photo-bad", photo: makeMalformedJpegBlob() });
+
+    const photos = await ingestShioriPhotos([malformed, makePhotoInput({ id: "photo-ok" })]);
+
+    expect(photos.map((photo) => photo.id)).toEqual(["photo-ok"]);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes an explicit EXIF opt-in through the same boundary", async () => {
+    const input = makePhotoInput();
+
+    const photos = await ingestShioriPhotos([input], { retainExif: true });
+
+    expect(photos[0]?.blob).toBe(input.photo);
+    expect(photos[0]?.imageUrl).toBe("blob:mock-1");
+  });
+});
+
+describe("revokeShioriPhotoUrls", () => {
+  it("revokes the object URL of every photo", async () => {
+    const photos = await ingestShioriPhotos([makePhotoInput(), makePhotoInput({ id: "photo-2" })]);
+
+    revokeShioriPhotoUrls(photos);
+
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-1");
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-2");
+  });
+});

--- a/apps/web/tests/unit/shiori/shiori-generator-exif.test.tsx
+++ b/apps/web/tests/unit/shiori/shiori-generator-exif.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SanitizedShioriPhoto } from "../../../src/features/shiori/types";
+import { ShioriGenerator, type ShioriGeneratorSource } from "../../../src/features/shiori/ShioriGenerator";
+import { makeItinerary, makeMeta, makePhotoInput } from "./_factories";
+import { blobText, makeMalformedJpegBlob } from "./_jpegFixtures";
+
+const createObjectURL = vi.fn((_blob: Blob) => `blob:mock-${String(createObjectURL.mock.calls.length)}`);
+const revokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function makeCompletedSource(photos: ShioriGeneratorSource["photos"]): ShioriGeneratorSource {
+  return {
+    meta: makeMeta(),
+    itinerary: makeItinerary(),
+    photos,
+    checkedStopIds: ["stop-station", "stop-shrine"],
+    isRouteDayOver: false,
+  };
+}
+
+const lastPayload = (spy: ReturnType<typeof vi.fn>): readonly SanitizedShioriPhoto[] =>
+  spy.mock.calls.at(-1)?.[0] as readonly SanitizedShioriPhoto[];
+
+describe("ShioriGenerator EXIF pipeline", () => {
+  it("renders photos only from sanitized bytes and exports EXIF-free blobs", async () => {
+    const onPhotosSanitized = vi.fn();
+    render(
+      <ShioriGenerator
+        source={makeCompletedSource([makePhotoInput()])}
+        locale="ja"
+        onPhotosSanitized={onPhotosSanitized}
+      />,
+    );
+
+    const image = await screen.findByRole("img", { name: "気多若宮神社 の対比図" });
+    expect(image.getAttribute("src")).toBe("blob:mock-1");
+    const payload = lastPayload(onPhotosSanitized);
+    expect(payload).toHaveLength(1);
+    expect(await blobText(payload[0]?.blob)).not.toContain("Exif");
+    expect(await blobText(payload[0]?.blob)).not.toContain("GPSLAT");
+  });
+
+  it("excludes a malformed photo instead of rendering its raw bytes", async () => {
+    const onPhotosSanitized = vi.fn();
+    const malformed = makePhotoInput({ photo: makeMalformedJpegBlob() });
+    render(
+      <ShioriGenerator
+        source={makeCompletedSource([malformed])}
+        locale="ja"
+        onPhotosSanitized={onPhotosSanitized}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onPhotosSanitized).toHaveBeenCalled();
+    });
+    expect(lastPayload(onPhotosSanitized)).toHaveLength(0);
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("re-ingests with the original bytes only after the user opts in", async () => {
+    const onPhotosSanitized = vi.fn();
+    render(
+      <ShioriGenerator
+        source={makeCompletedSource([makePhotoInput()])}
+        locale="ja"
+        onPhotosSanitized={onPhotosSanitized}
+      />,
+    );
+    await screen.findByRole("img", { name: "気多若宮神社 の対比図" });
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "写真の位置情報（EXIF）を残す" }));
+
+    await waitFor(async () => {
+      expect(await blobText(lastPayload(onPhotosSanitized)[0]?.blob)).toContain("GPSLAT");
+    });
+  });
+});

--- a/apps/web/tests/unit/shiori/shiori-generator.test.tsx
+++ b/apps/web/tests/unit/shiori/shiori-generator.test.tsx
@@ -3,34 +3,43 @@
  */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ShioriSource } from "../../../src/features/shiori/compose";
-import { ShioriGenerator } from "../../../src/features/shiori/ShioriGenerator";
-import { makeItinerary, makeMeta, makePhotos } from "./_factories";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ShioriGenerator, type ShioriGeneratorSource } from "../../../src/features/shiori/ShioriGenerator";
+import { makeItinerary, makeMeta, makePhotoInput } from "./_factories";
 
-afterEach(cleanup);
+beforeEach(() => {
+  vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "blob:mock-1"), revokeObjectURL: vi.fn() });
+});
 
-function makeSource(overrides: Partial<ShioriSource> = {}): ShioriSource {
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function makeSource(overrides: Partial<ShioriGeneratorSource> = {}): ShioriGeneratorSource {
   return {
     meta: makeMeta(),
     itinerary: makeItinerary(),
-    photos: makePhotos(1),
+    photos: [],
     checkedStopIds: [],
     isRouteDayOver: false,
     ...overrides,
   };
 }
 
-const COMPLETED = { checkedStopIds: ["stop-station", "stop-shrine"] };
+const COMPLETED: Partial<ShioriGeneratorSource> = {
+  checkedStopIds: ["stop-station", "stop-shrine"],
+  photos: [makePhotoInput()],
+};
 
 describe("ShioriGenerator", () => {
-  it("auto-generates a commemorative preview with completion stats", () => {
+  it("auto-generates a commemorative preview with completion stats", async () => {
     render(<ShioriGenerator source={makeSource(COMPLETED)} locale="ja" />);
 
+    expect(await screen.findByRole("article", { name: "完走記念しおり" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "完走記念しおり" })).toBeTruthy();
     expect(screen.getByText("徒歩210分 · 2.8km · 09:31→12:58")).toBeTruthy();
     expect(screen.getByText("完走 2/2 · 100%")).toBeTruthy();
-    expect(screen.getByRole("article", { name: "完走記念しおり" })).toBeTruthy();
   });
 
   it("auto-generates a planned preview without completion stats", () => {
@@ -53,10 +62,10 @@ describe("ShioriGenerator", () => {
   it.each([
     ["zh", "完走纪念书签"],
     ["en", "Commemorative shiori"],
-  ] as const)("renders the %s mode label", (locale, heading) => {
+  ] as const)("renders the %s mode label", async (locale, heading) => {
     render(<ShioriGenerator source={makeSource(COMPLETED)} locale={locale} />);
 
-    expect(screen.getByRole("heading", { name: heading })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: heading })).toBeTruthy();
   });
 
   it("keeps EXIF stripping on by default", () => {


### PR DESCRIPTION
## Summary

Campaign review fix card **FIX-exif** — privacy red-line findings Codex **P1-6** and **P1-7**.

### P1-6 — EXIF strip was never in the production pipeline
- `sanitizePhoto` existed but had zero production callers; `compose.ts` passed photo URLs straight through, so GPS-bearing user photos reached preview/export while the UI claimed default stripping.
- Photos now enter `ShioriGenerator` as raw blobs (`ShioriPhotoInput`). The only place a renderable `imageUrl` is minted is `ingestShioriPhotos`, which forces every blob through `sanitizePhoto` before `URL.createObjectURL`. The retain-EXIF opt-in only changes semantics at that boundary — no photo can bypass it.
- Photos that fail sanitization are **excluded** (fail closed), never rendered raw.
- `onPhotosSanitized` exposes the sanitized blobs as the export payload; object URLs are revoked on replacement/unmount.
- End-to-end test renders `ShioriGenerator` with a real GPS-EXIF JPEG fixture and asserts the export-boundary bytes contain no `Exif`/GPS payload — not just the helper in isolation.

### P1-7 — JPEG parser did not fail closed
- Old walker trusted declared lengths and blind-copied from the first SOS, so malformed/underlength segments could be reinterpreted and metadata between progressive scans survived.
- Library survey (npm registry, per card): `exif-be-gone` is Node-stream based, `piexifjs` (2019) and `exifremove` (2020) are unmaintained/naive; canvas re-encode is lossy for JPEG (recompression + ICC loss). So the walker stays hand-written but strict, per the card's fallback clause:
  - marker-prefix (0xFF) validation between segments
  - standalone markers rejected outside scan data
  - minimum segment length (rejects zero/one-byte lengths)
  - byte stuffing (0xFF00) and RST markers honored inside entropy data
  - every scan walked (progressive JPEG), APPn/COM stripped **between scans** too
  - EOI required; post-EOI trailer bytes discarded
  - any malformed input throws — rejected, never passed through

## Tests (24 added)
- `jpeg-strip-hardening.test.ts` — 10 byte-fixture cases (post-SOS APP1, progressive scans, stuffing/RST, zero/one-byte lengths, bad prefix, standalone marker, unterminated scan, no-scan, trailer)
- `photo-ingestion.test.ts` — 5 boundary cases incl. fail-closed exclusion and opt-in-through-boundary
- `shiori-generator-exif.test.tsx` — 3 end-to-end component cases (sanitized render+export bytes, malformed exclusion, opt-in re-ingest)
- existing generator/exif tests updated to the blob-input source shape

## Gates
- `pnpm run build` green (nitro cloudflare bundle emitted)
- `pnpm run typecheck` green
- `pnpm run lint:oxlint` green (`--deny-warnings`)
- `pnpm test` green — 59 files, 321 tests; coverage 99.01% stmts / 93.84% branches / 100% funcs / 99.85% lines (floor 90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)