### PR TITLE
fix(web): branded anime route states, screenshot placeholder, soft-404 defense

### DIFF
--- a/apps/web/src/features/anime/ScenesSection.tsx
+++ b/apps/web/src/features/anime/ScenesSection.tsx
@@ -5,7 +5,24 @@ type Props = Readonly<{ scenes: readonly AnimeScene[]; copy: AnimeCopy }>;
 
 type ItemProps = Readonly<{ scene: AnimeScene; copy: AnimeCopy }>;
 
-function SceneShot({ scene }: Readonly<{ scene: AnimeScene }>) {
+/** Only real http(s) URLs may hit `<img src>`: `src=""` requests the page itself. */
+function hasRenderableShot(url: string): boolean {
+  if (!URL.canParse(url)) return false;
+  const protocol = new URL(url).protocol;
+  return protocol === "https:" || protocol === "http:";
+}
+
+function SceneShotPlaceholder({ scene }: Readonly<{ scene: AnimeScene }>) {
+  return (
+    <div
+      role="img"
+      aria-label={scene.name}
+      className="aspect-video w-full rounded-lg bg-[var(--color-muted)]"
+    />
+  );
+}
+
+function SceneImage({ scene }: Readonly<{ scene: AnimeScene }>) {
   return (
     <img
       src={scene.screenshot_url}
@@ -14,6 +31,11 @@ function SceneShot({ scene }: Readonly<{ scene: AnimeScene }>) {
       className="aspect-video w-full rounded-lg object-cover"
     />
   );
+}
+
+function SceneShot({ scene }: Readonly<{ scene: AnimeScene }>) {
+  if (!hasRenderableShot(scene.screenshot_url)) return <SceneShotPlaceholder scene={scene} />;
+  return <SceneImage scene={scene} />;
 }
 
 function sceneMeta({ scene, copy }: ItemProps): string {

--- a/apps/web/src/features/anime/head.ts
+++ b/apps/web/src/features/anime/head.ts
@@ -40,14 +40,31 @@ export function animeTitle(locale: Locale, bangumiId: string): string {
   return TITLE_BY_LOCALE[locale](bangumiId);
 }
 
+export interface AnimeHeadMeta {
+  readonly title?: string;
+  readonly name?: string;
+  readonly content?: string;
+}
+
 export interface AnimeHead {
-  meta: { title: string }[];
+  meta: AnimeHeadMeta[];
   links: HreflangLink[];
 }
 
-export function animeHead(locale: Locale, bangumiId: string, origin: string): AnimeHead {
+export interface AnimeHeadOptions {
+  readonly indexable: boolean;
+}
+
+/** Empty overviews are served but flagged noindex — no indexable soft-404s. */
+function robotsMeta(options: AnimeHeadOptions): AnimeHeadMeta[] {
+  return options.indexable ? [] : [{ name: "robots", content: "noindex" }];
+}
+
+const INDEXABLE: AnimeHeadOptions = { indexable: true };
+
+export function animeHead(locale: Locale, bangumiId: string, origin: string, options: AnimeHeadOptions = INDEXABLE): AnimeHead {
   return {
-    meta: [{ title: animeTitle(locale, bangumiId) }],
+    meta: [{ title: animeTitle(locale, bangumiId) }, ...robotsMeta(options)],
     links: animeAlternates(origin, bangumiId),
   };
 }

--- a/apps/web/src/features/anime/route-states.tsx
+++ b/apps/web/src/features/anime/route-states.tsx
@@ -1,0 +1,59 @@
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+import { useRouter } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+/**
+ * Branded error + pending states for `/anime/:id` (NotFound style). The
+ * caught error is intentionally never rendered: technical text (env vars,
+ * upstream messages, stack traces) must not reach the user.
+ *
+ * Retry follows the official Router x Query integration: reset the query
+ * error boundary on mount, then `router.invalidate()` reruns the loader.
+ */
+function useRetry(): () => void {
+  const router = useRouter();
+  const boundary = useQueryErrorResetBoundary();
+  useEffect(() => {
+    boundary.reset();
+  }, [boundary]);
+  return () => void router.invalidate();
+}
+
+function AnimeErrorActions({ onRetry }: Readonly<{ onRetry: () => void }>) {
+  return (
+    <p className="m-0 flex items-center justify-center gap-4">
+      <button type="button" className="home-link" onClick={onRetry}>Try again</button>
+      <a className="home-link" href="/">Return home</a>
+    </p>
+  );
+}
+
+function AnimeErrorHeading() {
+  return (
+    <>
+      <p className="eyebrow">Animichi</p>
+      <h1 id="anime-error-title">Something went wrong</h1>
+      <p className="tagline">We could not load this title right now. Please try again.</p>
+    </>
+  );
+}
+
+export function AnimeErrorState() {
+  const handleRetry = useRetry();
+  return (
+    <main className="app-shell hero compact" aria-labelledby="anime-error-title">
+      <AnimeErrorHeading />
+      <AnimeErrorActions onRetry={handleRetry} />
+    </main>
+  );
+}
+
+export function AnimePendingState() {
+  return (
+    <main role="status" aria-label="Loading" className="mx-auto grid max-w-3xl gap-6 px-4 py-8">
+      <div className="h-24 animate-pulse rounded-2xl bg-[var(--color-card)]" />
+      <div className="h-40 animate-pulse rounded-2xl bg-[var(--color-card)]" />
+      <div className="h-64 animate-pulse rounded-2xl bg-[var(--color-card)]" />
+    </main>
+  );
+}

--- a/apps/web/src/routes/anime/$bangumiId.tsx
+++ b/apps/web/src/routes/anime/$bangumiId.tsx
@@ -1,9 +1,13 @@
+import { ORPCError } from "@orpc/client";
+import type { QueryClient } from "@tanstack/react-query";
 import { createFileRoute, notFound } from "@tanstack/react-router";
+import type { AnimeOverview } from "@seichijunrei/contract";
 import { resolveOrigin } from "../../api/config";
 import { animeOverviewOptions, useAnimeOverview } from "../../api/hooks/use-anime-overview";
 import { AnimePage } from "../../features/anime/AnimePage";
 import { animeHead } from "../../features/anime/head";
 import { useRegisterAnimeSw } from "../../features/anime/register-sw";
+import { AnimeErrorState, AnimePendingState } from "../../features/anime/route-states";
 import { DEFAULT_LOCALE, LOCALES, type Locale } from "../../i18n/locales";
 
 const BANGUMI_ID_PATTERN = /^\d+$/;
@@ -35,16 +39,34 @@ function siteOrigin(): string {
   }
 }
 
+/** The catalog 404s unknown works (WORK_NOT_FOUND); echo it as a router 404. */
+function isWorkNotFound(error: unknown): boolean {
+  return error instanceof ORPCError && error.status === 404;
+}
+
+async function loadOverview(queryClient: QueryClient, bangumiId: string): Promise<AnimeOverview> {
+  try {
+    return await queryClient.ensureQueryData(animeOverviewOptions(bangumiId));
+  } catch (error) {
+    if (isWorkNotFound(error)) throw notFoundError();
+    throw error;
+  }
+}
+
 export const Route = createFileRoute("/anime/$bangumiId")({
   validateSearch: parseSearch,
   loaderDeps: ({ search }) => ({ hl: search.hl }),
   loader: async ({ params, deps, context }) => {
     if (!BANGUMI_ID_PATTERN.test(params.bangumiId)) throw notFoundError();
-    await context.queryClient.ensureQueryData(animeOverviewOptions(params.bangumiId));
-    return { locale: deps.hl ?? DEFAULT_LOCALE };
+    const overview = await loadOverview(context.queryClient, params.bangumiId);
+    return { locale: deps.hl ?? DEFAULT_LOCALE, indexable: overview.points_length > 0 };
   },
   head: ({ loaderData, params }) =>
-    animeHead(loaderData?.locale ?? DEFAULT_LOCALE, params.bangumiId, siteOrigin()),
+    animeHead(loaderData?.locale ?? DEFAULT_LOCALE, params.bangumiId, siteOrigin(), {
+      indexable: loaderData?.indexable ?? true,
+    }),
+  errorComponent: AnimeErrorState,
+  pendingComponent: AnimePendingState,
   component: AnimeRoute,
 });
 

--- a/apps/web/tests/msw/anime-overview.ts
+++ b/apps/web/tests/msw/anime-overview.ts
@@ -79,6 +79,15 @@ export const animeOverviewHandler: HttpHandler = http.get(ANIME_OVERVIEW_PATH, (
   respond(params.bangumi_id),
 );
 
+/** A catalog that 404s every id, as it will for unknown works (WORK_NOT_FOUND). */
+export const animeOverviewNotFoundHandler: HttpHandler = http.get(ANIME_OVERVIEW_PATH, () =>
+  orpcErrorResponse({
+    code: "WORK_NOT_FOUND",
+    status: 404,
+    message: "No pilgrimage points for this work",
+  }),
+);
+
 /** An always-failing handler for loader error-path tests. */
 export const animeOverviewOutageHandler: HttpHandler = http.get(ANIME_OVERVIEW_PATH, () =>
   orpcErrorResponse({ code: "INTERNAL_SERVER_ERROR", status: 500, message: "catalog unavailable" }),

--- a/apps/web/tests/unit/anime/anime-route-defense.test.tsx
+++ b/apps/web/tests/unit/anime/anime-route-defense.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { RouterProvider } from "@tanstack/react-router";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRouter } from "../../../src/router";
+import { animeOverviewHandler, animeOverviewNotFoundHandler } from "../../msw/anime-overview";
+import { server } from "../../msw/node";
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  server.use(animeOverviewHandler);
+});
+
+async function openAnime(bangumiId: string) {
+  const router = getRouter();
+  router.options.context.queryClient.setDefaultOptions({ queries: { retry: false } });
+  await router.navigate({ to: "/anime/$bangumiId", params: { bangumiId }, search: {} });
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+function robotsContent(): string | null {
+  return document.querySelector("meta[name=robots]")?.getAttribute("content") ?? null;
+}
+
+describe("/anime/$bangumiId soft-404 defense", () => {
+  it("renders the branded 404 when the catalog reports an unknown work", async () => {
+    server.use(animeOverviewNotFoundHandler);
+    await openAnime("654321");
+    expect(await screen.findByRole("heading", { name: "404" })).toBeTruthy();
+    expect(screen.queryByText(/WORK_NOT_FOUND/)).toBeNull();
+  });
+
+  it("marks the empty-overview page as noindex for crawlers", async () => {
+    await openAnime("999");
+    await screen.findByText("この作品はまだ聖地情報がありません");
+    await waitFor(() => {
+      expect(robotsContent()).toBe("noindex");
+    });
+  });
+
+  it("keeps the full overview page indexable", async () => {
+    await openAnime("123");
+    await screen.findByText(/Suga Shrine Stairs/);
+    await waitFor(() => {
+      expect(document.title).toContain("聖地巡礼マップ");
+    });
+    expect(robotsContent()).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/anime/head.test.ts
+++ b/apps/web/tests/unit/anime/head.test.ts
@@ -46,4 +46,14 @@ describe("animeHead", () => {
     expect(head.meta.some((entry) => entry.title === animeTitle("zh", "123"))).toBe(true);
     expect(head.links).toHaveLength(4);
   });
+
+  it("omits the robots meta for an indexable overview", () => {
+    const head = animeHead("ja", "123", ORIGIN, { indexable: true });
+    expect(head.meta.some((entry) => entry.name === "robots")).toBe(false);
+  });
+
+  it("adds robots noindex for a non-indexable empty overview", () => {
+    const head = animeHead("ja", "999", ORIGIN, { indexable: false });
+    expect(head.meta).toContainEqual({ name: "robots", content: "noindex" });
+  });
 });

--- a/apps/web/tests/unit/anime/route-states.test.tsx
+++ b/apps/web/tests/unit/anime/route-states.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { RouterProvider } from "@tanstack/react-router";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AnimePendingState } from "../../../src/features/anime/route-states";
+import { getRouter } from "../../../src/router";
+import { animeOverviewHandler, animeOverviewOutageHandler } from "../../msw/anime-overview";
+import { server } from "../../msw/node";
+
+afterEach(cleanup);
+
+async function openAnime(bangumiId: string) {
+  const router = getRouter();
+  router.options.context.queryClient.setDefaultOptions({ queries: { retry: false } });
+  await router.navigate({ to: "/anime/$bangumiId", params: { bangumiId }, search: {} });
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("AnimePendingState", () => {
+  it("announces a loading status while the overview loads", () => {
+    render(<AnimePendingState />);
+    expect(screen.getByRole("status", { name: "Loading" })).toBeTruthy();
+  });
+});
+
+describe("/anime/$bangumiId error state", () => {
+  it("renders the branded error screen when the catalog is unreachable", async () => {
+    server.use(animeOverviewOutageHandler);
+    await openAnime("123");
+    expect(await screen.findByText("Animichi")).toBeTruthy();
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Return home" }).getAttribute("href")).toBe("/");
+  });
+
+  it("never leaks the technical error text to the user", async () => {
+    server.use(animeOverviewOutageHandler);
+    await openAnime("123");
+    await screen.findByText("Something went wrong");
+    expect(screen.queryByText(/catalog unavailable/)).toBeNull();
+    expect(screen.queryByText(/INTERNAL_SERVER_ERROR/)).toBeNull();
+  });
+
+  it("recovers via the try-again button once the catalog is back", async () => {
+    server.use(animeOverviewOutageHandler);
+    await openAnime("123");
+    await screen.findByRole("button", { name: "Try again" });
+    server.use(animeOverviewHandler);
+    // Re-query at click time: the boundary recreates the subtree after the catch.
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(await screen.findByText(/Suga Shrine Stairs/)).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/anime/scenes-section.test.tsx
+++ b/apps/web/tests/unit/anime/scenes-section.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { AnimeScene } from "@seichijunrei/contract";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ScenesSection } from "../../../src/features/anime/ScenesSection";
+import { animeCopyFor } from "../../../src/features/anime/copy";
+
+afterEach(cleanup);
+
+function makeScene(overrides: Partial<AnimeScene>): AnimeScene {
+  return {
+    id: "scene-1",
+    name: "Suga Shrine Stairs",
+    screenshot_url: "https://cdn.test/scene-1.jpg",
+    shot_count: 5,
+    lat: 35.6852,
+    lng: 139.7195,
+    city: "Tokyo",
+    ...overrides,
+  };
+}
+
+function renderScenes(scene: AnimeScene) {
+  render(<ScenesSection scenes={[scene]} copy={animeCopyFor("ja")} />);
+}
+
+describe("ScenesSection screenshots", () => {
+  it("renders the screenshot image for a valid https url", () => {
+    renderScenes(makeScene({}));
+    const img = screen.getByRole("img", { name: "Suga Shrine Stairs" });
+    expect(img.tagName).toBe("IMG");
+    expect(img.getAttribute("src")).toBe("https://cdn.test/scene-1.jpg");
+  });
+
+  it("renders an accessible placeholder instead of an img when the url is empty", () => {
+    renderScenes(makeScene({ screenshot_url: "" }));
+    const shot = screen.getByRole("img", { name: "Suga Shrine Stairs" });
+    expect(shot.tagName).not.toBe("IMG");
+    expect(document.querySelector("img")).toBeNull();
+  });
+
+  it("renders the placeholder for a non-http screenshot url", () => {
+    renderScenes(makeScene({ screenshot_url: "not a url" }));
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.getByRole("img", { name: "Suga Shrine Stairs" })).toBeTruthy();
+  });
+
+  it("keeps the scene name and shot count next to the placeholder", () => {
+    renderScenes(makeScene({ screenshot_url: "" }));
+    expect(screen.getByText("Suga Shrine Stairs")).toBeTruthy();
+    expect(screen.getByText(/カット数 5/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Campaign review fix card **FIX-anime**. Scope: `apps/web/src/routes/anime/**` + `apps/web/src/features/anime/**` (+ their tests). No changes to chat/shiori/globals.css/api/config.ts.

## Findings fixed

### P1-2 — bare crash screen (unit)
`/anime/$bangumiId` had no `errorComponent`/`pendingComponent`; a backend outage surfaced TanStack's dev red screen including the raw error text. Now:
- `AnimeErrorState` — branded (NotFound style), generic copy; the caught error is never rendered, so env/upstream text cannot reach the user. Retry follows the official Router x Query pattern: `useQueryErrorResetBoundary().reset()` on mount + `router.invalidate()` on click (route-level `reset` is `undefined` for loader errors in the installed `@tanstack/react-router` — verified in `Match.js`).
- `AnimePendingState` — token-based skeleton, `role="status"` / `aria-label="Loading"`.

### P2-5 (Codex) — `screenshot_url=""` broken image (unit)
`ScenesSection` rendered `<img src="">` unconditionally (broken image + request to the current page). Empty or non-http(s) URLs now render an accessible placeholder (`role="img"`, scene name preserved) and issue no request.

### Soft-404 client echo (unit) — pairs with the catalog card
- Loader maps a catalog 404 (`WORK_NOT_FOUND`, `ORPCError.status === 404`) to the router's `notFound()` → branded 404, so the coming catalog-side 404 renders correctly instead of the error screen.
- Empty overviews (`points_length === 0`) keep the graceful empty state (still correct for cataloged zero-spot works) but are served with `<meta name="robots" content="noindex">` — no indexable soft-404 pages.

## Tests (11 new)
- `tests/unit/anime/route-states.test.tsx` — pending status, branded error, no-technical-text-leak, retry recovery interaction
- `tests/unit/anime/scenes-section.test.tsx` — img vs placeholder branches, accessibility
- `tests/unit/anime/anime-route-defense.test.tsx` — 404 mapping, noindex on empty, indexable full page
- `tests/unit/anime/head.test.ts` — robots meta option

## Gates (all from `apps/web/`)
- `npm run build` — Nitro Cloudflare build OK
- `npm run typecheck` — clean
- `npm run lint:oxlint` — clean (10-line function budget respected)
- `npm test` — 316 passed (59 files), coverage 99.34% stmts / 94.78% branch / 100% funcs / 99.84% lines (floor 90)
- `npm run test:integration` — 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)