### PR TITLE
fix(agent): P0 session IDOR — conversation ownership guard + immutable owner

### DIFF
--- a/apps/agent/agent/domain/ports.py
+++ b/apps/agent/agent/domain/ports.py
@@ -102,6 +102,8 @@ class SessionRepo(Protocol):
         user_id: str | None = None,
     ) -> None: ...
 
+    async def check_session_owner(self, session_id: str, user_id: str) -> bool: ...
+
 
 class RoutesRepo(Protocol):
     """Route persistence operations used by persistence helpers."""

--- a/apps/agent/agent/infrastructure/supabase/repositories/session.py
+++ b/apps/agent/agent/infrastructure/supabase/repositories/session.py
@@ -49,7 +49,6 @@ class SessionRepository:
             INSERT INTO conversations (session_id, user_id, first_query)
             VALUES ($1, $2, $3)
             ON CONFLICT (session_id) DO UPDATE SET
-                user_id = EXCLUDED.user_id,
                 updated_at = now()
             """,
             session_id,

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 import httpx
 import structlog
+from fastapi import HTTPException
 from pydantic_ai import ModelMessagesTypeAdapter
 from pydantic_ai.exceptions import FallbackExceptionGroup, ModelHTTPError
 from pydantic_ai.messages import ModelMessage
@@ -43,7 +44,7 @@ from agent.agents.translation import translate_text
 from agent.application.errors import ApplicationError, ErrorCode
 from agent.clients.catalog_client import CatalogClient, CatalogClientProtocol
 from agent.config.settings import Settings, get_settings
-from agent.domain.ports import DatabasePort
+from agent.domain.ports import DatabasePort, get_session_repo
 from agent.infrastructure.observability import (
     record_runtime_request,
     runtime_span,
@@ -147,6 +148,18 @@ class RuntimeAPI:
         """Return the required shared model transport."""
         return self._model_http_client
 
+    async def validate_session_owner(
+        self, session_id: str | None, user_id: str | None
+    ) -> None:
+        """Hide sessions that are not owned by the authenticated user."""
+        if session_id is None or user_id is None:
+            return
+        session_repo = get_session_repo(self._db)
+        if session_repo is None or not await session_repo.check_session_owner(
+            session_id, user_id
+        ):
+            raise HTTPException(status_code=404, detail="Conversation not found.")
+
     async def handle(
         self,
         request: PublicAPIRequest,
@@ -160,6 +173,7 @@ class RuntimeAPI:
         started_at = perf_counter()
         response: PublicAPIResponse | None = None
         effective_model = model if model is not None else request.model
+        await self.validate_session_owner(session_id, user_id)
 
         with runtime_span("runtime.handle") as span:
             _set_span_request_attrs(span, session_id, request, effective_model, user_id)

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -122,6 +122,7 @@ async def handle_chat(
     """Stream chat as an AI SDK UI message stream with tool + data parts."""
     api_request = _runtime_request(request, _decode_body(await request.body()))
     runtime_api = _get_runtime_api(request)
+    await runtime_api.validate_session_owner(api_request.session_id, auth.user_id)
 
     async def handler(on_step: OnStep) -> PublicAPIResponse:
         return await runtime_api.handle(

--- a/apps/agent/agent/tests/unit/conftest_public_api.py
+++ b/apps/agent/agent/tests/unit/conftest_public_api.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from typing import Literal
+
+import pytest
 
 from agent.agents.agent_result import (
     AgentResult,
@@ -162,7 +165,7 @@ def _provenance(intent: str, state: SessionState) -> TurnProvenance:
         ref = state.last_result_ref
         if ref is not None:
             payload = state.search_results[ref]
-            outcome = "ok" if payload.row_count else "empty"
+            outcome: Literal["ok", "empty"] = "ok" if payload.row_count else "empty"
             search = ProducedSearch(outcome=outcome, result_ref=ref)
     if intent in {"plan_route", "plan_selected", "plan_multi"} and state.route_lru:
         route = ProducedRoute(status="ok", route_ref=state.route_lru[-1])
@@ -193,7 +196,7 @@ def make_fake_agent(
     return _fake
 
 
-def install_mock_pipeline(monkeypatch: object) -> None:
+def install_mock_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "agent.interfaces.public_api.run_animichi_agent", make_fake_agent()
     )

--- a/apps/agent/agent/tests/unit/repositories/test_session_repo.py
+++ b/apps/agent/agent/tests/unit/repositories/test_session_repo.py
@@ -24,8 +24,8 @@ async def test_upsert_session_calls_execute_with_correct_params(
     repo: SessionRepository, pool: AsyncMock
 ) -> None:
     pool.execute.return_value = None
-    state = {"context": {"bangumi_id": "115908"}}
-    metadata = {"locale": "ja"}
+    state: dict[str, object] = {"context": {"bangumi_id": "115908"}}
+    metadata: dict[str, object] = {"locale": "ja"}
     await repo.upsert_session("sess-1", state, metadata)
     pool.execute.assert_awaited_once()
     call_args = pool.execute.await_args.args
@@ -69,6 +69,8 @@ async def test_upsert_conversation_calls_execute(
     pool.execute.assert_awaited_once()
     sql = pool.execute.await_args.args[0]
     assert "INSERT INTO conversations" in sql
+    update_sql = sql.split("DO UPDATE SET", maxsplit=1)[1]
+    assert "user_id" not in update_sql
 
 
 async def test_get_session_state_returns_dict(

--- a/apps/agent/agent/tests/unit/test_chat_ownership.py
+++ b/apps/agent/agent/tests/unit/test_chat_ownership.py
@@ -1,0 +1,90 @@
+"""Regression coverage for chat session ownership."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TypeAlias
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from agent.agents.agent_result import AgentResult
+from agent.agents.runtime_models import GreetingResponseModel
+from agent.agents.session_state import SessionState
+from agent.infrastructure.session.memory import InMemorySessionStore
+from agent.interfaces.public_api import RuntimeAPI
+from agent.tests.db_doubles import build_persistence_supabase_double
+from agent.tests.unit.conftest_fastapi import async_client, build_app
+
+SessionSnapshot: TypeAlias = tuple[str, dict[str, object], int, int]
+
+
+def _runtime(db: MagicMock, store: InMemorySessionStore) -> RuntimeAPI:
+    return RuntimeAPI(db, session_store=store, model_http_client=MagicMock())
+
+
+def _install_mock_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = AgentResult(
+        output=GreetingResponseModel(message="hello"),
+        intent="greet_user",
+        session_state=SessionState(),
+    )
+    monkeypatch.setattr(
+        "agent.interfaces.public_api.run_animichi_agent",
+        AsyncMock(return_value=result),
+    )
+
+
+class _ChatOwnershipHarness:
+    def __init__(self) -> None:
+        self.owners: dict[str, str] = {}
+        self.store = InMemorySessionStore()
+        self.db = build_persistence_supabase_double()
+        self.db.session.check_session_owner = AsyncMock(side_effect=self._owns)
+        self.db.session.upsert_conversation.side_effect = self._claim
+        self.db.insert_message = AsyncMock()
+        self.db.insert_request_log = AsyncMock()
+        self.app, _ = build_app(runtime_api=_runtime(self.db, self.store), db=self.db)
+
+    async def _owns(self, session_id: str, user_id: str) -> bool:
+        return self.owners.get(session_id) == user_id
+
+    async def _claim(self, session_id: str, user_id: str, _query: str) -> None:
+        self.owners[session_id] = user_id
+
+    async def post(self, user_id: str, session_id: str | None = None) -> httpx.Response:
+        headers = {"X-User-Id": user_id}
+        if session_id is not None:
+            headers["X-Session-Id"] = session_id
+        body = {
+            "messages": [{"role": "user", "parts": [{"type": "text", "text": "hi"}]}]
+        }
+        async with async_client(self.app) as client:
+            return await client.post("/v1/chat", json=body, headers=headers)
+
+    async def create(self) -> str:
+        response = await self.post("user-a")
+        assert response.status_code == 200
+        return next(iter(self.owners))
+
+    async def snapshot(self, session_id: str) -> SessionSnapshot:
+        state = await self.store.get(session_id)
+        assert state is not None
+        return (
+            self.owners[session_id],
+            deepcopy(state),
+            self.db.session.upsert_conversation.await_count,
+            self.db.insert_message.await_count,
+        )
+
+
+async def test_chat_rejects_cross_user_session_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_mock_pipeline(monkeypatch)
+    harness = _ChatOwnershipHarness()
+    session_id = await harness.create()
+    before = await harness.snapshot(session_id)
+    response = await harness.post("user-b", session_id)
+    assert (response.status_code, await harness.snapshot(session_id)) == (404, before)

--- a/apps/agent/agent/tests/unit/test_public_api_persistence.py
+++ b/apps/agent/agent/tests/unit/test_public_api_persistence.py
@@ -18,12 +18,12 @@ from agent.tests.unit.conftest_public_api import (
 
 
 @pytest.fixture(autouse=True)
-def _mock_pipeline(monkeypatch):
+def _mock_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
     install_mock_pipeline(monkeypatch)
 
 
 @pytest.fixture
-def mock_db():
+def mock_db() -> MagicMock:
     db = MagicMock(spec=SupabaseClient)
     pool = AsyncMock()
     pool.fetch = AsyncMock(return_value=[])
@@ -31,13 +31,14 @@ def mock_db():
     db.points.search_points_by_location = AsyncMock(return_value=[])
     db.session.upsert_session = AsyncMock()
     db.session.upsert_conversation = AsyncMock()
+    db.session.check_session_owner = AsyncMock(return_value=True)
     db.session.update_conversation_title = AsyncMock()
     db.routes.save_route = AsyncMock(return_value="route-1")
     return db
 
 
 class TestGreetingPersistence:
-    async def test_greeting_uses_dedicated_stage_and_persists(self):
+    async def test_greeting_uses_dedicated_stage_and_persists(self) -> None:
         output = GreetingResponseModel(
             message="こんにちは！聖地巡礼のお手伝いをします。"
         )
@@ -57,7 +58,7 @@ class TestGreetingPersistence:
             message_history: object | None = None,
             on_step: object | None = None,
             catalog: object | None = None,
-        ):
+        ) -> AgentResult:
             _ = (text, db, model, locale, context, message_history, on_step)
             return result
 
@@ -90,7 +91,9 @@ class TestGreetingPersistence:
 
 
 class TestRuntimeAPISession:
-    async def test_handle_creates_and_persists_session(self, mock_db):
+    async def test_handle_creates_and_persists_session(
+        self, mock_db: MagicMock
+    ) -> None:
         store = InMemorySessionStore()
         api = RuntimeAPI(mock_db, session_store=store, model_http_client=MagicMock())
 
@@ -103,7 +106,7 @@ class TestRuntimeAPISession:
         assert saved_state["last_intent"] == "search_bangumi"
         mock_db.session.upsert_session.assert_awaited_once()
 
-    async def test_handle_reuses_existing_session(self, mock_db):
+    async def test_handle_reuses_existing_session(self, mock_db: MagicMock) -> None:
         store = InMemorySessionStore()
         api = RuntimeAPI(mock_db, session_store=store, model_http_client=MagicMock())
 
@@ -130,8 +133,8 @@ class TestConversationPersistence:
 
     async def test_does_not_schedule_title_generation_for_existing_session(
         self,
-        mock_db,
-    ):
+        mock_db: MagicMock,
+    ) -> None:
         store = InMemorySessionStore()
         session_id = "session-1"
         await store.set(
@@ -170,7 +173,7 @@ class TestConversationPersistence:
 # TODO: re-enable when session compaction is wired back
 class _DisabledTestCompactThresholdTrigger:
     async def test_handle_triggers_compact_when_session_reaches_threshold(
-        self, mock_db
+        self, mock_db: MagicMock
     ) -> None:
         from unittest.mock import patch
 


### PR DESCRIPTION
Campaign review P0-1 (Codex-authored, lead-committed). Fixes cross-user session hijack + ownership takeover.

- `RuntimeAPI.validate_session_owner`: rejects (session_id,user_id) mismatch with 404 (no existence leak); anonymous/new-session path (session_id None on first turn) unaffected — server assigns + claims
- `check_session_owner` port + repo impl (SELECT ownership)
- upsert drops `user_id = EXCLUDED.user_id` → ownership immutable
- two-user regression: B posting A's session → 404 + zero state mutation; new-session create still 200

Gates (lead-run): make lint ✓ · typecheck ✓ · 1178 tests / 87.4% cov ✓ · suppressions 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)