### PR TITLE
fix(catalog): P1 harden anonymous public endpoint + soft-404 + broken-img

### DIFF
--- a/packages/contract/openapi.json
+++ b/packages/contract/openapi.json
@@ -1711,7 +1711,14 @@
                             "type": "string"
                           },
                           "screenshot_url": {
-                            "type": "string"
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           },
                           "shot_count": {
                             "type": "integer",
@@ -1770,6 +1777,77 @@
                     "circles",
                     "scenes",
                     "sample_routes"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": true
+                        },
+                        "code": {
+                          "const": "WORK_NOT_FOUND"
+                        },
+                        "status": {
+                          "const": 404
+                        },
+                        "message": {
+                          "type": "string",
+                          "default": "No pilgrimage points for this work"
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "bangumi_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "bangumi_id"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message",
+                        "data"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "defined": {
+                          "const": false
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      },
+                      "required": [
+                        "defined",
+                        "code",
+                        "status",
+                        "message"
+                      ]
+                    }
                   ]
                 }
               }

--- a/packages/contract/src/contract.ts
+++ b/packages/contract/src/contract.ts
@@ -173,6 +173,7 @@ export const catalogContract = {
       summary: "Public anime overview: bubble aggregation, 名場面 ranking, and sample routes",
     })
     .input(AnimeOverviewInput)
+    .errors(pickCatalogErrors(["WORK_NOT_FOUND"]))
     .output(AnimeOverview),
 };
 

--- a/packages/contract/src/models.ts
+++ b/packages/contract/src/models.ts
@@ -71,7 +71,7 @@ export type AnimeOverviewCircle = z.infer<typeof AnimeOverviewCircle>;
 export const AnimeScene = z.object({
   id: z.string(),
   name: z.string(),
-  screenshot_url: z.string(),
+  screenshot_url: z.string().nullable(),
   shot_count: z.number().int().nonnegative(),
   lat: Latitude,
   lng: Longitude,

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -13,28 +13,31 @@ export interface Env {
 }
 
 interface NextHandler {
-  fetch: (req: Request, env: unknown, ctx: ExecutionContext) => Promise<Response>;
+  fetch: (req: Request, env: unknown, ctx: WorkerExecutionContext) => Promise<Response>;
 }
+
+type WorkerExecutionContext = Pick<ExecutionContext, "waitUntil" | "passThroughOnException">;
 
 const PUBLIC_V1 = ["/v1/search/preview", "/v1/bangumi/popular"];
 function isPublicV1(pathname: string): boolean {
   return PUBLIC_V1.includes(pathname) || /^\/v1\/bangumi\/[^/]+\/guide$/.test(pathname);
 }
 
-/** Catalog's ONLY public prefix: anonymous, read-only overview reads. Every
- * other /catalog/* path stays private (falls through to OpenNext). */
-function isPublicCatalog(pathname: string): boolean {
-  return pathname.startsWith("/catalog/public/");
+const PUBLIC_CATALOG_HEADERS = ["Accept"] as const;
+
+/** Rebuild anonymous catalog headers from a minimal, non-sensitive allowlist. */
+function publicCatalogHeaders(request: Request): Headers {
+  const headers = new Headers();
+  for (const name of PUBLIC_CATALOG_HEADERS) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  return headers;
 }
 
-/** Forward an anonymous public-catalog read to the private CATALOG binding
- * (in-datacenter hop). Strips client-supplied X-User-* (anti-forgery); no auth,
- * no body mutation — read-only. */
+/** Forward an allowlisted anonymous GET to the private CATALOG binding. */
 function forwardPublicCatalog(env: Env, request: Request): Promise<Response> {
-  const headers = new Headers(request.headers);
-  headers.delete("X-User-Id");
-  headers.delete("X-User-Type");
-  return env.CATALOG.fetch(new Request(request, { headers }));
+  return env.CATALOG.fetch(new Request(request, { headers: publicCatalogHeaders(request) }));
 }
 
 /** Forward a /v1 request to the container's default instance. Always strips
@@ -61,7 +64,7 @@ export function catalogOutbound(request: Request, env: Env): Promise<Response> {
 }
 
 /** Image proxy + cache for image.anitabi.cn (unchanged behaviour, ported from entry.js). */
-async function handleImageProxy(request: Request, ctx: ExecutionContext): Promise<Response> {
+async function handleImageProxy(request: Request, ctx: WorkerExecutionContext): Promise<Response> {
   const imagePath = new URL(request.url).pathname.slice(5);
   if (!imagePath || imagePath.includes("..")) return new Response("Bad request", { status: 400 });
   const cacheKey = new Request(request.url, request);
@@ -73,7 +76,7 @@ async function handleImageProxy(request: Request, ctx: ExecutionContext): Promis
   if (!upstream.ok) {
     return new Response(upstream.body, {
       status: upstream.status,
-      headers: { "Content-Type": upstream.headers.get("Content-Type") || "image/jpeg" },
+      headers: { "Content-Type": upstream.headers.get("Content-Type") ?? "image/jpeg" },
     });
   }
   const headers = new Headers(upstream.headers);
@@ -89,7 +92,7 @@ async function handleImageProxy(request: Request, ctx: ExecutionContext): Promis
  * only via the container outboundByHost binding, never the public internet). */
 export function createWorkerApp(deps: {
   nextHandler: NextHandler;
-  authenticate?: (request: Request, env: Env, ctx: ExecutionContext) => Promise<AuthResult>;
+  authenticate?: (request: Request, env: Env, ctx: WorkerExecutionContext) => Promise<AuthResult>;
 }): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
   const authenticate = deps.authenticate ?? ((req, env, ctx) => realAuthenticate(req, env, fetch, ctx));
@@ -97,14 +100,10 @@ export function createWorkerApp(deps: {
     c.env.CONTAINER.get(c.env.CONTAINER.idFromName("default")).fetch(c.req.raw),
   );
   app.all("/img/*", (c) => handleImageProxy(c.req.raw, c.executionCtx));
-  // Catalog's first public exposure: /catalog/public/* is anonymous + read-only,
-  // forwarded to the private CATALOG binding. Anything else under /catalog/*
-  // stays private and falls through to OpenNext (never reaches env.CATALOG).
-  app.all("/catalog/public/*", (c) =>
-    isPublicCatalog(new URL(c.req.url).pathname)
-      ? forwardPublicCatalog(c.env, c.req.raw)
-      : c.notFound(),
+  app.get("/catalog/public/anime-overview/:bangumiId{[0-9]+}", (c) =>
+    forwardPublicCatalog(c.env, c.req.raw),
   );
+  app.all("/catalog/public/*", (c) => c.notFound());
   // Hono runs the first matching handler in registration order.
   // /v1/users/* bypasses the container entirely: the users service verifies the
   // Neon Auth JWT itself (jose JWKS), so the edge passes Authorization through

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -75,7 +75,12 @@ async function sha256Hex(raw: string): Promise<string> {
   return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-async function verifyApiKey(rawKey: string, env: AuthEnv, f: typeof fetch, ctx?: ExecutionContext): Promise<{ ok: true; userId: string } | { ok: false }> {
+async function verifyApiKey(
+  rawKey: string,
+  env: AuthEnv,
+  f: typeof fetch,
+  ctx?: Pick<ExecutionContext, "waitUntil">,
+): Promise<{ ok: true; userId: string } | { ok: false }> {
   try {
     const keyHash = await sha256Hex(rawKey);
     const sr = env.SUPABASE_SERVICE_ROLE_KEY;
@@ -85,21 +90,27 @@ async function verifyApiKey(rawKey: string, env: AuthEnv, f: typeof fetch, ctx?:
     );
     if (!resp.ok) return { ok: false };
     const rows = (await resp.json()) as { user_id: string }[];
-    if (!rows.length) return { ok: false };
+    const [row] = rows;
+    if (!row) return { ok: false };
     const patch = f(`${env.SUPABASE_URL}/rest/v1/api_keys?key_hash=eq.${keyHash}`, {
       method: "PATCH",
       headers: { apikey: sr, Authorization: `Bearer ${sr}`, "Content-Type": "application/json", Prefer: "return=minimal" },
       body: JSON.stringify({ last_used_at: new Date().toISOString() }),
     });
     if (ctx) ctx.waitUntil(patch); else void patch;
-    return { ok: true, userId: rows[0].user_id };
+    return { ok: true, userId: row.user_id };
   } catch {
     return { ok: false };
   }
 }
 
 /** Authenticate a /v1 request: `sk_*` -> api_keys (agent), else JWT -> issuer JWKS (human). */
-export async function authenticate(request: Request, env: AuthEnv, fetchImpl: typeof fetch = fetch, ctx?: ExecutionContext): Promise<AuthResult> {
+export async function authenticate(
+  request: Request,
+  env: AuthEnv,
+  fetchImpl: typeof fetch = fetch,
+  ctx?: Pick<ExecutionContext, "waitUntil">,
+): Promise<AuthResult> {
   const header = request.headers.get("Authorization") ?? "";
   if (!header.startsWith("Bearer ")) return { ok: false };
   const token = header.slice(7).trim();

--- a/worker/entry.test.ts
+++ b/worker/entry.test.ts
@@ -3,18 +3,21 @@ import assert from "node:assert/strict";
 import { createWorkerApp, catalogOutbound } from "./app.ts";
 
 const stubNext = {
-  fetch: async () => new Response("next", { status: 200 }),
+  fetch: () => Promise.resolve(new Response("next", { status: 200 })),
 };
 
-const stubCtx = { waitUntil() {}, passThroughOnException() {} } as unknown as ExecutionContext;
+const stubCtx = {
+  waitUntil(promise: Promise<unknown>) { void promise; },
+  passThroughOnException() { return undefined; },
+} as unknown as ExecutionContext;
 
-test("GET /healthz reaches the container, not OpenNext", async () => {
+void test("GET /healthz reaches the container, not OpenNext", async () => {
   const app = createWorkerApp({ nextHandler: stubNext });
   let containerHit = false;
   const env = {
     CONTAINER: {
       idFromName: () => "id",
-      get: () => ({ fetch: async () => { containerHit = true; return new Response("ok"); } }),
+      get: () => ({ fetch: () => { containerHit = true; return Promise.resolve(new Response("ok")); } }),
     },
   };
   const res = await app.request("/healthz", {}, env);
@@ -22,10 +25,10 @@ test("GET /healthz reaches the container, not OpenNext", async () => {
   assert.equal(await res.text(), "ok");
 });
 
-test("/catalog/* is NOT publicly routed (falls through to OpenNext)", async () => {
+void test("/catalog/* is NOT publicly routed (falls through to OpenNext)", async () => {
   const app = createWorkerApp({ nextHandler: stubNext });
   let catalogHit = false;
-  const env = { CATALOG: { fetch: async () => { catalogHit = true; return new Response("cat"); } } } as never;
+  const env = { CATALOG: { fetch: () => { catalogHit = true; return Promise.resolve(new Response("cat")); } } } as never;
   const res = await app.request("/catalog/search", { method: "POST" }, env, stubCtx);
   assert.equal(await res.text(), "next"); // hits OpenNext (404-able), never env.CATALOG
   assert.equal(catalogHit, false); // security: non-allowlisted catalog path stays private
@@ -33,42 +36,72 @@ test("/catalog/* is NOT publicly routed (falls through to OpenNext)", async () =
 
 function envWithCatalog(captured: { req?: Request }) {
   return {
-    CATALOG: { fetch: async (r: Request) => { captured.req = r; return new Response("cat"); } },
+    CATALOG: { fetch: (r: Request) => { captured.req = r; return Promise.resolve(new Response("cat")); } },
   } as never;
 }
 
-test("/catalog/public/* forwards anonymously to CATALOG, no auth called", async () => {
+void test("exact public anime overview GET forwards anonymously, no auth called", async () => {
   let authCalled = false;
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => { authCalled = true; return { ok: false }; } });
+  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false } as const); };
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate });
   const cap: { req?: Request } = {};
   const res = await app.request("/catalog/public/anime-overview/3302", {}, envWithCatalog(cap), stubCtx);
   assert.equal(await res.text(), "cat");
   assert.equal(authCalled, false);
 });
 
-test("/catalog/public/* strips client-forged X-User-Id before forwarding", async () => {
+void test("public catalog forwarding keeps only the minimal safe header allowlist", async () => {
   const app = createWorkerApp({ nextHandler: stubNext });
   const cap: { req?: Request } = {};
-  await app.request("/catalog/public/anime-overview/3302", { headers: { "X-User-Id": "forged" } }, envWithCatalog(cap), stubCtx);
-  assert.equal(cap.req?.headers.get("X-User-Id"), null);
+  const headers = {
+    Accept: "application/json", Authorization: "Bearer test-token-000",
+    Cookie: "session=test-token-000", "X-API-Key": "test-token-000",
+    "X-User-Id": "forged",
+  };
+  await app.request("/catalog/public/anime-overview/3302", { headers }, envWithCatalog(cap), stubCtx);
+  assert.ok(cap.req);
+  assert.deepEqual([...cap.req.headers], [["accept", "application/json"]]);
 });
 
-test("unknown path falls through to OpenNext", async () => {
+async function assertPublicCatalogRejected(path: string, method = "GET"): Promise<void> {
+  const app = createWorkerApp({ nextHandler: stubNext });
+  const cap: { req?: Request } = {};
+  const res = await app.request(path, { method }, envWithCatalog(cap), stubCtx);
+  assert.equal(res.status, 404);
+  assert.equal(cap.req, undefined);
+}
+
+void test("encoded path separator cannot extend the public route", () =>
+  assertPublicCatalogRejected("/catalog/public/anime-overview/3302%2Fsecret"));
+
+void test("dot-segment traversal cannot escape the exact public route", () =>
+  assertPublicCatalogRejected("/catalog/public/anime-overview/3302/../secret"));
+
+void test("sibling public path cannot bypass the exact route", () =>
+  assertPublicCatalogRejected("/catalog/public/anime-overviews/3302"));
+
+void test("POST cannot invoke the public anime overview", () =>
+  assertPublicCatalogRejected("/catalog/public/anime-overview/3302", "POST"));
+
+void test("PUT cannot invoke the public anime overview", () =>
+  assertPublicCatalogRejected("/catalog/public/anime-overview/3302", "PUT"));
+
+void test("unknown path falls through to OpenNext", async () => {
   const app = createWorkerApp({ nextHandler: stubNext });
   const res = await app.request("/anything", {}, {}, stubCtx);
   assert.equal(await res.text(), "next");
 });
 
-test("catalogOutbound forwards container requests to the CATALOG binding", async () => {
+void test("catalogOutbound forwards container requests to the CATALOG binding", async () => {
   let received: Request | null = null;
-  const env = { CATALOG: { fetch: async (req: Request) => { received = req; return new Response("cat"); } } };
+  const env = { CATALOG: { fetch: (req: Request) => { received = req; return Promise.resolve(new Response("cat")); } } };
   const req = new Request("http://catalog.internal/catalog/search", { method: "POST" });
   const res = await catalogOutbound(req, env as never);
   assert.equal(await res.text(), "cat");
   assert.equal(received, req);
 });
 
-test("/img/* routes to the image proxy (bad path → 400, not OpenNext)", async () => {
+void test("/img/* routes to the image proxy (bad path → 400, not OpenNext)", async () => {
   const app = createWorkerApp({ nextHandler: stubNext });
   // "a..b" survives URL normalization (dots not adjacent to slashes) and trips
   // handleImageProxy's ".." guard → 400, proving the request reached the image
@@ -82,23 +115,25 @@ function envWithContainer(captured: { req?: Request }) {
   return {
     CONTAINER: {
       idFromName: () => "id",
-      get: () => ({ fetch: async (r: Request) => { captured.req = r; return new Response("container"); } }),
+      get: () => ({ fetch: (r: Request) => { captured.req = r; return Promise.resolve(new Response("container")); } }),
     },
   } as never;
 }
 
-test("/v1 public route -> container, no auth called", async () => {
+void test("/v1 public route -> container, no auth called", async () => {
   let authCalled = false;
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => { authCalled = true; return { ok: false }; } });
+  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false } as const); };
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate });
   const cap: { req?: Request } = {};
   const res = await app.request("/v1/bangumi/popular", {}, envWithContainer(cap), stubCtx);
   assert.equal(await res.text(), "container");
   assert.equal(authCalled, false);
 });
 
-test("/v1 guide route (regex) is public -> container, no auth, client X-User stripped", async () => {
+void test("/v1 guide route (regex) is public -> container, no auth, client X-User stripped", async () => {
   let authCalled = false;
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => { authCalled = true; return { ok: false }; } });
+  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false } as const); };
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate });
   const cap: { req?: Request } = {};
   const res = await app.request("/v1/bangumi/12345/guide", { headers: { "X-User-Id": "forged" } }, envWithContainer(cap), stubCtx);
   assert.equal(await res.text(), "container");
@@ -106,47 +141,51 @@ test("/v1 guide route (regex) is public -> container, no auth, client X-User str
   assert.equal(cap.req?.headers.get("X-User-Id"), null);
 });
 
-test("/v1 authed route without creds -> 401, container not hit", async () => {
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => ({ ok: false }) });
+void test("/v1 authed route without creds -> 401, container not hit", async () => {
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
   const cap: { req?: Request } = {};
   const res = await app.request("/v1/chat", { method: "POST" }, envWithContainer(cap), stubCtx);
   assert.equal(res.status, 401);
   assert.equal(cap.req, undefined);
 });
 
-test("/v1 authed route with valid creds -> container gets X-User, no Authorization", async () => {
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => ({ ok: true, userId: "u1", userType: "human" }) });
+void test("/v1 authed route with valid creds -> container gets X-User, no Authorization", async () => {
+  const authenticate = () => Promise.resolve({ ok: true, userId: "u1", userType: "human" } as const);
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate });
   const cap: { req?: Request } = {};
   await app.request("/v1/chat", { method: "POST", headers: { Authorization: "Bearer jwt" } }, envWithContainer(cap), stubCtx);
-  assert.equal(cap.req?.headers.get("X-User-Id"), "u1");
-  assert.equal(cap.req?.headers.get("X-User-Type"), "human");
-  assert.equal(cap.req?.headers.get("Authorization"), null);
+  assert.ok(cap.req);
+  assert.equal(cap.req.headers.get("X-User-Id"), "u1");
+  assert.equal(cap.req.headers.get("X-User-Type"), "human");
+  assert.equal(cap.req.headers.get("Authorization"), null);
 });
 
-test("client-forged X-User-Id is stripped on authed route (worker value wins)", async () => {
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => ({ ok: true, userId: "real", userType: "human" }) });
+void test("client-forged X-User-Id is stripped on authed route (worker value wins)", async () => {
+  const authenticate = () => Promise.resolve({ ok: true, userId: "real", userType: "human" } as const);
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate });
   const cap: { req?: Request } = {};
   await app.request("/v1/chat", { method: "POST", headers: { Authorization: "Bearer jwt", "X-User-Id": "forged" } }, envWithContainer(cap), stubCtx);
   assert.equal(cap.req?.headers.get("X-User-Id"), "real");
 });
 
-test("client-forged X-User-Id is stripped on PUBLIC route too", async () => {
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => ({ ok: false }) });
+void test("client-forged X-User-Id is stripped on PUBLIC route too", async () => {
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
   const cap: { req?: Request } = {};
   await app.request("/v1/bangumi/popular", { headers: { "X-User-Id": "forged" } }, envWithContainer(cap), stubCtx);
   assert.equal(cap.req?.headers.get("X-User-Id"), null);
 });
 
-test("/v1/users/routes -> USERS with Authorization intact, no container or auth", async () => {
+void test("/v1/users/routes -> USERS with Authorization intact, no container or auth", async () => {
   let authCalled = false;
   let containerHit = false;
   let received: Request | undefined;
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => { authCalled = true; return { ok: false }; } });
+  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false } as const); };
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate });
   const env = {
-    USERS: { fetch: async (req: Request) => { received = req; return new Response("users"); } },
+    USERS: { fetch: (req: Request) => { received = req; return Promise.resolve(new Response("users")); } },
     CONTAINER: {
       idFromName: () => "id",
-      get: () => ({ fetch: async () => { containerHit = true; return new Response("container"); } }),
+      get: () => ({ fetch: () => { containerHit = true; return Promise.resolve(new Response("container")); } }),
     },
   } as never;
   const res = await app.request("/v1/users/routes", { headers: { Authorization: "Bearer x" } }, env, stubCtx);
@@ -156,11 +195,11 @@ test("/v1/users/routes -> USERS with Authorization intact, no container or auth"
   assert.equal(authCalled, false);
 });
 
-test("/v1/users/routes bypasses a rejecting authenticate stub", async () => {
+void test("/v1/users/routes bypasses a rejecting authenticate stub", async () => {
   let received = false;
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: async () => ({ ok: false }) });
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
   const env = {
-    USERS: { fetch: async () => { received = true; return new Response("users"); } },
+    USERS: { fetch: () => { received = true; return Promise.resolve(new Response("users")); } },
   } as never;
   const res = await app.request("/v1/users/routes", {}, env, stubCtx);
   assert.equal(res.status, 200);

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types", "node"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": false,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["app.ts", "auth.ts", "entry.test.ts"]
+}

--- a/workers/catalog/src/api/anime-overview.ts
+++ b/workers/catalog/src/api/anime-overview.ts
@@ -25,6 +25,7 @@ const SCENE_LIMIT = 20;
 const SAMPLE_ROUTE_REGION_LIMIT = 3;
 const SAMPLE_ROUTE_POINT_CAP = 12;
 const CLUSTER_RADIUS_M = 50;
+const SCENE_CLUSTER_INPUT_CAP = 500;
 
 /** The one DB capability this handler needs: run a query, get back `{ rows }`. */
 export interface OverviewDb {
@@ -41,12 +42,20 @@ interface OverviewRow {
   city: string | null;
 }
 
+/** Thrown only when the requested anime itself is absent from the catalog. */
+export class AnimeOverviewNotFoundError extends Error {
+  constructor(public readonly bangumiId: string) {
+    super(`catalog work not found for bangumi_id=${bangumiId}`);
+    this.name = "AnimeOverviewNotFoundError";
+  }
+}
+
 /** Assemble the public overview for one work; empty-but-valid when it has none. */
 export async function animeOverview(
   db: OverviewDb,
   input: { bangumi_id: string },
 ): Promise<AnimeOverview> {
-  const rows = await fetchRows(db, input.bangumi_id);
+  const rows = await loadOverviewRows(db, input.bangumi_id);
   return {
     bangumi_id: input.bangumi_id,
     points_length: rows.length,
@@ -54,6 +63,12 @@ export async function animeOverview(
     scenes: buildScenes(rows),
     sample_routes: buildSampleRoutes(rows),
   };
+}
+
+async function loadOverviewRows(db: OverviewDb, bangumiId: string): Promise<OverviewRow[]> {
+  const rows = await fetchRows(db, bangumiId);
+  if (rows.length > 0 || await workExists(db, bangumiId)) return rows;
+  throw new AnimeOverviewNotFoundError(bangumiId);
 }
 
 /** SELECT the work's points, id-ordered for deterministic downstream ordering. */
@@ -69,6 +84,11 @@ function overviewQuery(bangumiId: string) {
     WHERE bangumi_id = ${bangumiId}
     ORDER BY id ASC
   `;
+}
+
+async function workExists(db: OverviewDb, bangumiId: string): Promise<boolean> {
+  const result = await db.execute(sql`SELECT id FROM bangumi WHERE id = ${bangumiId} LIMIT 1`);
+  return result.rows.length > 0;
 }
 
 /** Group rows by non-empty region (city), preserving id order within a region. */
@@ -101,7 +121,7 @@ function centroid(members: OverviewRow[]): { lat: number; lng: number } {
 
 /** 名場面 ranking: co-located clusters ranked by shot count, capped. */
 function buildScenes(rows: OverviewRow[]): AnimeScene[] {
-  const scenes = clusterByLocation(rows, CLUSTER_RADIUS_M).map(toScene);
+  const scenes = clusterByLocation(rows.slice(0, SCENE_CLUSTER_INPUT_CAP), CLUSTER_RADIUS_M).map(toScene);
   scenes.sort((a, b) => b.shot_count - a.shot_count || a.id.localeCompare(b.id));
   return scenes.slice(0, SCENE_LIMIT);
 }
@@ -116,7 +136,7 @@ function sceneBase(rep: OverviewRow, shotCount: number): AnimeScene {
   return {
     id: rep.id,
     name: rep.name,
-    screenshot_url: rep.image ?? "",
+    screenshot_url: rep.image,
     shot_count: shotCount,
     lat: rep.latitude,
     lng: rep.longitude,
@@ -125,6 +145,8 @@ function sceneBase(rep: OverviewRow, shotCount: number): AnimeScene {
 
 /** The cluster's representative row (its `clusterId` member, always present). */
 function representative(cluster: LocationCluster<OverviewRow>): OverviewRow {
+  const withImage = cluster.points.find((point) => point.image);
+  if (withImage) return withImage;
   const rep = cluster.points.find((p) => p.id === cluster.clusterId);
   if (!rep) throw new Error(`cluster ${cluster.clusterId} has no representative row`);
   return rep;

--- a/workers/catalog/src/router.ts
+++ b/workers/catalog/src/router.ts
@@ -7,7 +7,7 @@ import { nearby as nearbyHandler } from "./api/nearby";
 import { geocode as geocodeHandler } from "./api/geocode";
 import { route as routeHandler } from "./api/route";
 import { spots as spotsHandler, SpotNotFoundError } from "./api/spots";
-import { animeOverview as animeOverviewHandler } from "./api/anime-overview";
+import { animeOverview as animeOverviewHandler, AnimeOverviewNotFoundError } from "./api/anime-overview";
 import type { CatalogDb, NeonSql } from "./db/client";
 import { ingestWork, type IngestResult as OrchestratorResult } from "./ingest/orchestrator";
 import { routeTooManyPoints, workNotFound } from "./lib/errors";
@@ -79,7 +79,7 @@ const ingest = os.ingest.handler(async ({ input, context }) =>
 );
 
 const animeOverview = os.animeOverview.handler(async ({ input, context }) =>
-  animeOverviewHandler(context.db, input),
+  callAnimeOverview(context.db, input),
 );
 
 /** Map the orchestrator union (camelCase) onto the snake_case wire shape. */
@@ -97,6 +97,16 @@ async function callSpots(db: CatalogDb, input: { bangumi_id: string; origin?: Or
     return await spotsHandler(db, input);
   } catch (err) {
     if (err instanceof SpotNotFoundError) throw workNotFound(err.bangumiId);
+    throw err;
+  }
+}
+
+/** Run anime overview, translating only an absent anime into the typed 404. */
+async function callAnimeOverview(db: CatalogDb, input: { bangumi_id: string }) {
+  try {
+    return await animeOverviewHandler(db, input);
+  } catch (err) {
+    if (err instanceof AnimeOverviewNotFoundError) throw workNotFound(err.bangumiId);
     throw err;
   }
 }

--- a/workers/catalog/src/types.ts
+++ b/workers/catalog/src/types.ts
@@ -73,7 +73,7 @@ export interface AnimeOverviewCircle {
 export interface AnimeScene {
   id: string;
   name: string;
-  screenshot_url: string;
+  screenshot_url: string | null;
   shot_count: number;
   lat: number;
   lng: number;

--- a/workers/catalog/test/anime-overview.worker.test.ts
+++ b/workers/catalog/test/anime-overview.worker.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { animeOverview, type OverviewDb } from "../src/api/anime-overview";
+import { describe, expect, it, vi } from "vitest";
+import {
+  animeOverview,
+  AnimeOverviewNotFoundError,
+  type OverviewDb,
+} from "../src/api/anime-overview";
 
 /**
  * Unit tests for the public `animeOverview` read handler
@@ -26,6 +30,13 @@ function row(id: string, lat: number, lng: number, city: string | null, image: s
 /** Fake db whose execute() returns the fixture rows once. */
 function fakeDb(rows: FixtureRow[]): OverviewDb {
   return { execute: () => Promise.resolve({ rows }) };
+}
+
+function knownEmptyDb(): OverviewDb {
+  const execute = vi.fn()
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [{ id: "999" }] });
+  return { execute };
 }
 
 // Two Kamakura points co-located (< 50m → one cluster of 2 shots) + one lone Hakone point.
@@ -68,9 +79,9 @@ describe("animeOverview (api/anime-overview.ts)", () => {
 
 });
 
-describe("animeOverview edge cases", () => {
-  it("returns an empty-but-valid overview when the work has no points", async () => {
-    const result = await animeOverview(fakeDb([]), { bangumi_id: "999" });
+describe("animeOverview empty and missing work behavior", () => {
+  it("returns an empty-but-valid overview when a known work has no points", async () => {
+    const result = await animeOverview(knownEmptyDb(), { bangumi_id: "999" });
     expect(result).toEqual({
       bangumi_id: "999",
       points_length: 0,
@@ -80,6 +91,14 @@ describe("animeOverview edge cases", () => {
     });
   });
 
+  it("throws a typed domain miss when the anime does not exist", async () => {
+    await expect(animeOverview(fakeDb([]), { bangumi_id: "404" }))
+      .rejects.toBeInstanceOf(AnimeOverviewNotFoundError);
+  });
+
+});
+
+describe("animeOverview scene edge cases", () => {
   it("returns empty circles (no region clustering) for spots lacking a city, without erroring", async () => {
     const noCity: FixtureRow[] = [row("n1", 35.0, 139.0, null), row("n2", 36.0, 140.0, "")];
     const result = await animeOverview(fakeDb(noCity), { bangumi_id: "200" });
@@ -92,9 +111,30 @@ describe("animeOverview edge cases", () => {
   it("omits city on a scene whose representative point has no city", async () => {
     const result = await animeOverview(fakeDb([row("x1", 34.0, 138.0, null)]), { bangumi_id: "300" });
     expect(result.scenes[0]?.city).toBeUndefined();
-    expect(result.scenes[0]?.screenshot_url).toBe("");
+    expect(result.scenes[0]?.screenshot_url).toBeNull();
   });
 
+  it("uses an image-bearing cluster member as the representative", async () => {
+    const rows = [
+      row("a-no-image", 35.0, 139.0, "Tokyo"),
+      row("b-image", 35.00001, 139.00001, "Tokyo", "https://img/scene.jpg"),
+    ];
+    const result = await animeOverview(fakeDb(rows), { bangumi_id: "301" });
+    expect(result.scenes[0]).toMatchObject({
+      id: "b-image", screenshot_url: "https://img/scene.jpg", shot_count: 2,
+    });
+  });
+
+  it("caps the quadratic clustering input while preserving the total count", async () => {
+    const rows = Array.from({ length: 501 }, (_, index) =>
+      row(`p-${String(index).padStart(3, "0")}`, 35.0, 139.0, "Tokyo"));
+    const result = await animeOverview(fakeDb(rows), { bangumi_id: "302" });
+    expect(result.points_length).toBe(501);
+    expect(result.scenes[0]?.shot_count).toBe(500);
+  });
+});
+
+describe("animeOverview output caps", () => {
   it("caps scenes at 20, sample routes at 3 regions, and point ids at 12 per route", async () => {
     const result = await animeOverview(fakeDb(cappedFixture()), { bangumi_id: "400" });
     expect(result.scenes).toHaveLength(20);

--- a/workers/catalog/test/catalog-api.spike.test.ts
+++ b/workers/catalog/test/catalog-api.spike.test.ts
@@ -62,7 +62,9 @@ async function seed(): Promise<void> {
  * the public animeOverview route (its input requires a numeric bangumi_id). */
 async function seedOverviewWork(): Promise<void> {
   await db.execute(sql`
-    INSERT INTO bangumi (id, title, points_count) VALUES ('3302', 'Overview Work', 3)
+    INSERT INTO bangumi (id, title, points_count) VALUES
+      ('3302', 'Overview Work', 3),
+      ('999998', 'Empty Overview Work', 0)
   `);
   await db.execute(sql`
     INSERT INTO points (id, bangumi_id, name, latitude, longitude, city, image)
@@ -181,7 +183,7 @@ interface OverviewBody {
   bangumi_id: string;
   points_length: number;
   circles: { region: string; count: number; lat: number; lng: number }[];
-  scenes: { id: string; shot_count: number; screenshot_url: string; city?: string }[];
+  scenes: { id: string; shot_count: number; screenshot_url: string | null; city?: string }[];
   sample_routes: { region: string; point_ids: string[] }[];
 }
 
@@ -196,10 +198,10 @@ async function assertOverviewHit(): Promise<void> {
 }
 
 async function assertOverviewEmpty(): Promise<void> {
-  const res = await getPublic("anime-overview/999999");
+  const res = await getPublic("anime-overview/999998");
   const body = (await res.json()) as OverviewBody;
   expect(body).toEqual({
-    bangumi_id: "999999",
+    bangumi_id: "999998",
     points_length: 0,
     circles: [],
     scenes: [],
@@ -207,9 +209,15 @@ async function assertOverviewEmpty(): Promise<void> {
   });
 }
 
+async function assertOverview404(): Promise<void> {
+  const res = await getPublic("anime-overview/999999", 404);
+  expect(await res.json()).toMatchObject({ code: "WORK_NOT_FOUND", status: 404 });
+}
+
 databaseDescribe("Catalog public animeOverview (anonymous GET, cache-tagged)", () => {
   it("returns bubble aggregation + 名場面 ranking + sample routes for a known work", assertOverviewHit);
-  it("returns an empty-but-valid overview for an unknown work", assertOverviewEmpty);
+  it("returns an empty-but-valid overview for a known zero-spot work", assertOverviewEmpty);
+  it("returns a typed 404 for an unknown work", assertOverview404);
 });
 
 databaseDescribe("Catalog API end-to-end (Hono app + OpenAPIHandler + Drizzle/PostGIS)", () => {

--- a/workers/catalog/test/errors-wire.worker.test.ts
+++ b/workers/catalog/test/errors-wire.worker.test.ts
@@ -48,6 +48,14 @@ async function call(path: string, body: unknown, context: CatalogContext): Promi
   return response;
 }
 
+async function callOverview(bangumiId: string, context: CatalogContext): Promise<Response> {
+  const req = new Request(`https://catalog.test/catalog/public/anime-overview/${bangumiId}`);
+  const { matched, response } = await handler.handle(req, { context });
+  expect(matched).toBe(true);
+  if (!response) throw new Error("expected OpenAPI handler response");
+  return response;
+}
+
 /** Context that wins ingest singleflight and records the subsequent failure. */
 function ingestContext(fetchImpl: typeof fetch): CatalogContext {
   let calls = 0;
@@ -150,6 +158,16 @@ describe("catalog route limits and typed errors on the OpenAPI wire", () => {
       defined: true, code: "WORK_NOT_FOUND", status: 404,
       message: "No pilgrimage points for this work",
       data: { bangumi_id: "missing-work" },
+    });
+  });
+
+  it("serializes WORK_NOT_FOUND for an unknown anime overview", async () => {
+    const res = await callOverview("999999", context([]));
+    expect(res.status).toBe(404);
+    expect(await json<WorkNotFoundData>(res)).toEqual({
+      defined: true, code: "WORK_NOT_FOUND", status: 404,
+      message: "No pilgrimage points for this work",
+      data: { bangumi_id: "999999" },
     });
   });
 


### PR DESCRIPTION
Campaign review fixes P1-5/P1-8/P2-5/P2-6 (Codex-authored, lead-committed).

- **worker/app.ts (security)**: exact `GET /catalog/public/anime-overview/:bangumiId{[0-9]+}` only; every other method/path → 404. Positive header allowlist (only `Accept` forwarded; Authorization/Cookie/X-User-* never cross into catalog). Negatives: encoded-separator, dot-segment, sibling-path, verb.
- **anime-overview**: unknown work → typed `WORK_NOT_FOUND` 404 (real zero-spot works still 200, no soft-404); `screenshot_url` nullable + prefer imaged cluster member; O(n²) clustering capped at 500 inputs.
- city empty-pipeline (P1-8): documented as known limitation — enrichment doesn't write city; recommend separate backfill card (not force-fixed to avoid hiding real ingest behaviour).

Gates (lead-run): contract typecheck ✓ · OpenAPI emit idempotent ✓ · catalog 243 + root worker 41 tests ✓ · suppressions 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)