### PR TITLE
fix(contract): P1 https-only share URLs + OpenAPI auth scheme + projection invariants + registry dedup

### DIFF
--- a/packages/contract/scripts/emit-openapi.ts
+++ b/packages/contract/scripts/emit-openapi.ts
@@ -7,9 +7,9 @@
  * Run: npm run emit:openapi
  */
 
+import { dirname, join } from "node:path";
 import { writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 import { OpenAPIGenerator } from "@orpc/openapi";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { checkinContract } from "../src/checkin-contract.js";
@@ -21,30 +21,46 @@ const generator = new OpenAPIGenerator({
   schemaConverters: [new ZodToJsonSchemaConverter()],
 });
 
+type Contract = Parameters<OpenAPIGenerator["generate"]>[0];
+type GenerateOptions = Parameters<OpenAPIGenerator["generate"]>[1];
+
+function describeEmission(contract: Contract, spec: Awaited<ReturnType<typeof generator.generate>>): void {
+  const methods = Object.keys(contract);
+  const schemas = Object.keys(spec.components?.schemas ?? {});
+  process.stdout.write(`Methods: ${methods.join(", ")}\n`);
+  process.stdout.write(`Schemas: ${schemas.join(", ") || "(inlined)"}\n`);
+}
+
 async function emitOpenApi(
-  contract: Parameters<OpenAPIGenerator["generate"]>[0],
+  contract: Contract,
   filename: string,
-  info: { title: string; version: string; description: string },
+  options: GenerateOptions,
 ): Promise<void> {
-  const spec = await generator.generate(contract, { info });
+  const spec = await generator.generate(contract, options);
   const outPath = join(dirname(fileURLToPath(import.meta.url)), "..", filename);
   writeFileSync(outPath, `${JSON.stringify(spec, null, 2)}\n`, "utf8");
-  const methods = Object.keys(contract);
-  const schemaNames = Object.keys(spec.components?.schemas ?? {});
   process.stdout.write(`Wrote ${outPath}\n`);
-  process.stdout.write(`Methods: ${methods.join(", ")}\n`);
-  process.stdout.write(`Schemas: ${schemaNames.join(", ") || "(inlined)"}\n`);
+  describeEmission(contract, spec);
 }
 
 await emitOpenApi(catalogContract, "openapi.json", {
+  info: {
     title: "Animichi Catalog Service",
     version: "0.1.0",
     description:
       "Read methods of the TS Catalog service, consumed by the Python Agent service.",
+  },
 });
 
 await emitOpenApi({ ...usersContract, ...checkinContract, ...shareContract }, "users-openapi.json", {
-  title: "Animichi Users Service",
-  version: "0.1.0",
-  description: "User-domain routes of the TS Users service, consumed by apps/web.",
+  info: {
+    title: "Animichi Users Service",
+    version: "0.1.0",
+    description: "User-domain routes of the TS Users service, consumed by apps/web.",
+  },
+  components: {
+    securitySchemes: {
+      bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+    },
+  },
 });

--- a/packages/contract/src/checkin-contract.ts
+++ b/packages/contract/src/checkin-contract.ts
@@ -14,6 +14,8 @@
 
 import { oc } from "@orpc/contract";
 import { z } from "zod";
+import { pickErrors } from "./error-registry.js";
+import { requireBearer } from "./openapi-security.js";
 
 /** Full-precision GPS coordinates retained by the API and storage layer. */
 export const GpsCoordinates = z.strictObject({
@@ -135,33 +137,22 @@ export type CheckinErrorDefs = typeof CHECKIN_ERROR_DEFS;
 /** Check-in error code union. */
 export type CheckinErrorCode = keyof CheckinErrorDefs;
 
-type CheckinErrorMapItem<Code extends CheckinErrorCode> = {
-  status: CheckinErrorDefs[Code]["status"];
-  message: CheckinErrorDefs[Code]["message"];
-  data: CheckinErrorDefs[Code]["data"];
-};
-type CheckinErrorMap<Code extends CheckinErrorCode> = {
-  [Key in Code]: CheckinErrorMapItem<Key>;
-};
-
-function checkinErrorEntry<Code extends CheckinErrorCode>(
-  code: Code,
-): readonly [Code, CheckinErrorMapItem<Code>] {
-  const { status, message, data } = CHECKIN_ERROR_DEFS[code];
-  return [code, { status, message, data }];
-}
-
 /** Pick oRPC error entries while dropping registry-only category metadata. */
 export function pickCheckinErrors<const Code extends CheckinErrorCode>(
   codes: readonly Code[],
-): CheckinErrorMap<Code> {
-  return Object.fromEntries(codes.map(checkinErrorEntry)) as CheckinErrorMap<Code>;
+): ReturnType<typeof pickErrors<CheckinErrorDefs, Code>> {
+  return pickErrors(CHECKIN_ERROR_DEFS, codes);
 }
 
 /** oRPC contract for authenticated walk check-in operations. */
 export const checkinContract = {
   submitCheckin: oc
-    .route({ method: "POST", path: "/v1/users/checkins", summary: "Submit a walk check-in" })
+    .route({
+      method: "POST",
+      path: "/v1/users/checkins",
+      summary: "Submit a walk check-in",
+      spec: requireBearer,
+    })
     .input(SubmitCheckinInput)
     .errors(pickCheckinErrors([
       "CHECKIN_REPLAY_CONFLICT",
@@ -170,7 +161,12 @@ export const checkinContract = {
     ]))
     .output(WalkCheckin),
   listCheckins: oc
-    .route({ method: "GET", path: "/v1/users/checkins", summary: "List the caller's check-ins" })
+    .route({
+      method: "GET",
+      path: "/v1/users/checkins",
+      summary: "List the caller's check-ins",
+      spec: requireBearer,
+    })
     .input(ListCheckinsInput)
     .output(ListCheckinsResult),
 };

--- a/packages/contract/src/error-registry.ts
+++ b/packages/contract/src/error-registry.ts
@@ -1,0 +1,40 @@
+import type { z } from "zod";
+
+/** Users-service error codes are feature-namespaced: ROUTE_*, CHECKIN_*, SHARE_*. */
+export type ErrorRegistryItem = {
+  readonly status: number;
+  readonly category: string;
+  readonly message: string;
+  readonly data: z.ZodType<unknown>;
+};
+
+type ErrorRegistry = Readonly<Record<string, ErrorRegistryItem>>;
+type ErrorCode<Registry extends ErrorRegistry> = keyof Registry & string;
+type PickedError<Registry extends ErrorRegistry, Code extends ErrorCode<Registry>> = Pick<
+  Registry[Code],
+  "status" | "message" | "data"
+>;
+type PickedErrors<Registry extends ErrorRegistry, Code extends ErrorCode<Registry>> = {
+  [Key in Code]: PickedError<Registry, Key>;
+};
+
+function registryItem<Registry extends ErrorRegistry>(
+  registry: Registry,
+  code: ErrorCode<Registry>,
+): ErrorRegistryItem {
+  const item = registry[code];
+  if (!item) throw new Error(`Unknown error code: ${code}`);
+  return item;
+}
+
+/** Pick oRPC error entries while dropping registry-only category metadata. */
+export function pickErrors<Registry extends ErrorRegistry, const Code extends ErrorCode<Registry>>(
+  registry: Registry,
+  codes: readonly Code[],
+): PickedErrors<Registry, Code> {
+  const entries = codes.map((code) => {
+    const { status, message, data } = registryItem(registry, code);
+    return [code, { status, message, data }] as const;
+  });
+  return Object.fromEntries(entries) as PickedErrors<Registry, Code>;
+}

--- a/packages/contract/src/openapi-security.ts
+++ b/packages/contract/src/openapi-security.ts
@@ -1,0 +1,11 @@
+import type { OpenAPI } from "@orpc/contract";
+
+/** Require an HTTP bearer token for an OpenAPI operation. */
+export function requireBearer(operation: OpenAPI.OperationObject): OpenAPI.OperationObject {
+  return { ...operation, security: [{ bearerAuth: [] }] };
+}
+
+/** Mark an OpenAPI operation as intentionally anonymous. */
+export function allowAnonymous(operation: OpenAPI.OperationObject): OpenAPI.OperationObject {
+  return { ...operation, security: [] };
+}

--- a/packages/contract/src/share-contract.ts
+++ b/packages/contract/src/share-contract.ts
@@ -13,6 +13,8 @@
 
 import { oc } from "@orpc/contract";
 import { z } from "zod";
+import { pickErrors } from "./error-registry.js";
+import { allowAnonymous, requireBearer } from "./openapi-security.js";
 
 /** A 256-bit, unpadded Base64URL bearer token (43 URL-safe characters). */
 export const ShareToken = z.string().regex(/^[A-Za-z0-9_-]{43}$/);
@@ -25,6 +27,9 @@ export const PublicItineraryState = z.enum(["planned", "partial", "completed"]);
 export type PublicItineraryState = z.infer<typeof PublicItineraryState>;
 
 const PublicClockTime = z.string().regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/);
+
+/** Public web URL; arbitrary image hosts are allowed, but transport must be HTTPS. */
+export const HttpsUrl = z.url({ protocol: /^https$/ });
 
 /** Public anime display metadata; the id is a catalog-facing public id. */
 export const PublicSharedAnime = z.strictObject({
@@ -42,7 +47,7 @@ export const PublicSharedStop = z.strictObject({
   scheduled_time: PublicClockTime.optional(),
   visited_time: PublicClockTime.optional(),
   completed: z.boolean(),
-  frame_image_url: z.url().optional(),
+  frame_image_url: HttpsUrl.optional(),
   frame_label: z.string().min(1).max(100).optional(),
 });
 /** Inferred public-safe stop data. */
@@ -51,7 +56,7 @@ export type PublicSharedStop = z.infer<typeof PublicSharedStop>;
 /** Public comparison artifact already approved for sharing. */
 export const PublicSharedComparison = z.strictObject({
   point_id: z.string().min(1).max(128),
-  image_url: z.url(),
+  image_url: HttpsUrl,
   caption: z.string().min(1).max(200),
 });
 /** Inferred public comparison artifact. */
@@ -60,13 +65,13 @@ export type PublicSharedComparison = z.infer<typeof PublicSharedComparison>;
 /** Attribution displayed with licensed frames and user-created comparisons. */
 export const PublicShareAttribution = z.strictObject({
   label: z.string().min(1).max(300),
-  url: z.url().optional(),
+  url: HttpsUrl.optional(),
 });
 /** Inferred public share attribution. */
 export type PublicShareAttribution = z.infer<typeof PublicShareAttribution>;
 
 /** Strict public projection consumed by the anonymous /s/:id page. */
-export const PublicSharedItinerary = z.strictObject({
+const PublicSharedItineraryBase = z.strictObject({
   title: z.string().min(1).max(200),
   anime: PublicSharedAnime,
   state: PublicItineraryState,
@@ -77,8 +82,65 @@ export const PublicSharedItinerary = z.strictObject({
   completed_stops: z.number().int().nonnegative(),
   stops: z.array(PublicSharedStop).max(500),
   comparisons: z.array(PublicSharedComparison).max(100),
-  hero_image_url: z.url().optional(),
+  hero_image_url: HttpsUrl.optional(),
   attributions: z.array(PublicShareAttribution).max(20),
+});
+
+type SharedItinerary = z.infer<typeof PublicSharedItineraryBase>;
+
+function addInvariant(ctx: z.RefinementCtx, path: PropertyKey[], message: string): void {
+  ctx.addIssue({ code: "custom", path, message });
+}
+
+function validateCompletedLimit(value: SharedItinerary, ctx: z.RefinementCtx): void {
+  if (value.completed_stops > value.total_stops) {
+    addInvariant(ctx, ["completed_stops"], "Completed stops exceed total stops");
+  }
+}
+
+function validateTotalCount(value: SharedItinerary, ctx: z.RefinementCtx): void {
+  if (value.total_stops !== value.stops.length) {
+    addInvariant(ctx, ["total_stops"], "Total stops must match stops");
+  }
+}
+
+function validateCompletedCount(value: SharedItinerary, ctx: z.RefinementCtx): void {
+  const completed = value.stops.filter((stop) => stop.completed).length;
+  if (value.completed_stops !== completed) {
+    addInvariant(ctx, ["completed_stops"], "Completed stops must match stops");
+  }
+}
+
+function validateCounts(value: SharedItinerary, ctx: z.RefinementCtx): void {
+  validateCompletedLimit(value, ctx);
+  validateTotalCount(value, ctx);
+  validateCompletedCount(value, ctx);
+}
+
+function expectedState(value: SharedItinerary): PublicItineraryState {
+  if (value.completed_stops === 0) return "planned";
+  if (value.completed_stops === value.total_stops) return "completed";
+  return "partial";
+}
+
+function validateState(value: SharedItinerary, ctx: z.RefinementCtx): void {
+  if (value.state !== expectedState(value)) {
+    addInvariant(ctx, ["state"], "State must match stop counts");
+  }
+}
+
+function validatePositions(value: SharedItinerary, ctx: z.RefinementCtx): void {
+  const positions = value.stops.map((stop) => stop.position);
+  if (new Set(positions).size !== positions.length) {
+    addInvariant(ctx, ["stops"], "Stop positions must be unique");
+  }
+}
+
+/** Strict public projection consumed by the anonymous /s/:id page. */
+export const PublicSharedItinerary = PublicSharedItineraryBase.superRefine((value, ctx) => {
+  validateCounts(value, ctx);
+  validatePositions(value, ctx);
+  validateState(value, ctx);
 });
 /** Inferred strict public itinerary projection. */
 export type PublicSharedItinerary = z.infer<typeof PublicSharedItinerary>;
@@ -188,43 +250,42 @@ export type ShareErrorDefs = typeof SHARE_ERROR_DEFS;
 /** Share error code union. */
 export type ShareErrorCode = keyof ShareErrorDefs;
 
-type ShareErrorMapItem<Code extends ShareErrorCode> = {
-  status: ShareErrorDefs[Code]["status"];
-  message: ShareErrorDefs[Code]["message"];
-  data: ShareErrorDefs[Code]["data"];
-};
-type ShareErrorMap<Code extends ShareErrorCode> = {
-  [Key in Code]: ShareErrorMapItem<Key>;
-};
-
-function shareErrorEntry<Code extends ShareErrorCode>(
-  code: Code,
-): readonly [Code, ShareErrorMapItem<Code>] {
-  const { status, message, data } = SHARE_ERROR_DEFS[code];
-  return [code, { status, message, data }];
-}
-
 /** Pick oRPC error entries while dropping registry-only category metadata. */
 export function pickShareErrors<const Code extends ShareErrorCode>(
   codes: readonly Code[],
-): ShareErrorMap<Code> {
-  return Object.fromEntries(codes.map(shareErrorEntry)) as ShareErrorMap<Code>;
+): ReturnType<typeof pickErrors<ShareErrorDefs, Code>> {
+  return pickErrors(SHARE_ERROR_DEFS, codes);
 }
 
 /** oRPC contract for authenticated issuance/revocation and anonymous resolution. */
 export const shareContract = {
   createShare: oc
-    .route({ method: "POST", path: "/v1/users/shares", summary: "Create a route share" })
+    .route({
+      method: "POST",
+      path: "/v1/users/shares",
+      summary: "Create a route share",
+      spec: requireBearer,
+    })
     .input(CreateShareInput)
     .errors(pickShareErrors(["SHARE_ROUTE_NOT_FOUND", "SHARE_ROUTE_NOT_OWNED"]))
     .output(CreateShareResult),
   revokeShare: oc
-    .route({ method: "DELETE", path: "/v1/users/shares/{share_id}", summary: "Revoke a share" })
+    .route({
+      method: "DELETE",
+      path: "/v1/users/shares/{share_id}",
+      summary: "Revoke a share",
+      spec: requireBearer,
+    })
     .input(RevokeShareInput)
     .errors(pickShareErrors(["SHARE_NOT_FOUND", "SHARE_REVOKED"]))
     .output(RevokeShareResult),
   resolveShare: oc
-    .route({ method: "GET", path: "/v1/users/shares/resolve/{token}", summary: "Resolve a public share" })
+    .route({
+      method: "GET",
+      path: "/v1/users/shares/resolve/{token}",
+      summary: "Resolve a public share",
+      spec: allowAnonymous,
+    })
     .input(ResolveShareInput)
     .errors(pickShareErrors(["SHARE_NOT_FOUND", "SHARE_EXPIRED", "SHARE_REVOKED"]))
     .output(ResolveShareResult),

--- a/packages/contract/src/users-contract.ts
+++ b/packages/contract/src/users-contract.ts
@@ -2,6 +2,8 @@
 
 import { oc } from "@orpc/contract";
 import { z } from "zod";
+import { pickErrors } from "./error-registry.js";
+import { requireBearer } from "./openapi-security.js";
 
 /** Users error category semantics; categories never cross the wire. */
 export const UsersErrorCategory = z.enum(["user_actionable", "retryable", "system"]);
@@ -46,27 +48,11 @@ export type UsersErrorDefs = typeof USERS_ERROR_DEFS;
 /** Users error code union. */
 export type UsersErrorCode = keyof UsersErrorDefs;
 
-type UsersErrorMapItem<Code extends UsersErrorCode> = {
-  status: UsersErrorDefs[Code]["status"];
-  message: UsersErrorDefs[Code]["message"];
-  data: UsersErrorDefs[Code]["data"];
-};
-type UsersErrorMap<Code extends UsersErrorCode> = {
-  [Key in Code]: UsersErrorMapItem<Key>;
-};
-
-function usersErrorEntry<Code extends UsersErrorCode>(
-  code: Code,
-): readonly [Code, UsersErrorMapItem<Code>] {
-  const { status, message, data } = USERS_ERROR_DEFS[code];
-  return [code, { status, message, data }];
-}
-
 /** Pick oRPC error entries while dropping registry-only category metadata. */
 export function pickUsersErrors<const Code extends UsersErrorCode>(
   codes: readonly Code[],
-): UsersErrorMap<Code> {
-  return Object.fromEntries(codes.map(usersErrorEntry)) as UsersErrorMap<Code>;
+): ReturnType<typeof pickErrors<UsersErrorDefs, Code>> {
+  return pickErrors(USERS_ERROR_DEFS, codes);
 }
 
 /** Lifecycle status for a user-owned route. */
@@ -124,20 +110,40 @@ export type ListRoutesResult = z.infer<typeof ListRoutesResult>;
 /** oRPC contract for authenticated user-route operations. */
 export const usersContract = {
   listRoutes: oc
-    .route({ method: "GET", path: "/v1/users/routes", summary: "List the caller's saved routes" })
+    .route({
+      method: "GET",
+      path: "/v1/users/routes",
+      summary: "List the caller's saved routes",
+      spec: requireBearer,
+    })
     .output(ListRoutesResult),
   saveRoute: oc
-    .route({ method: "POST", path: "/v1/users/routes", summary: "Create or update a saved route" })
+    .route({
+      method: "POST",
+      path: "/v1/users/routes",
+      summary: "Create or update a saved route",
+      spec: requireBearer,
+    })
     .input(SaveRouteInput)
     .errors(pickUsersErrors(["ROUTE_NOT_FOUND", "ROUTE_NOT_OWNED"]))
     .output(UserRoute),
   deleteRoute: oc
-    .route({ method: "DELETE", path: "/v1/users/routes/{id}", summary: "Delete a saved route" })
+    .route({
+      method: "DELETE",
+      path: "/v1/users/routes/{id}",
+      summary: "Delete a saved route",
+      spec: requireBearer,
+    })
     .input(DeleteRouteInput)
     .errors(pickUsersErrors(["ROUTE_NOT_FOUND", "ROUTE_NOT_OWNED"]))
     .output(DeleteRouteResult),
   claimRoutes: oc
-    .route({ method: "POST", path: "/v1/users/routes/claim", summary: "Claim anonymous routes" })
+    .route({
+      method: "POST",
+      path: "/v1/users/routes/claim",
+      summary: "Claim anonymous routes",
+      spec: requireBearer,
+    })
     .input(ClaimRoutesInput)
     .output(ClaimRoutesResult),
 };

--- a/packages/contract/test/share-contract.test.ts
+++ b/packages/contract/test/share-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CreateShareInput,
   CreateShareResult,
+  HttpsUrl,
   PublicSharedItinerary,
   ResolveShareResult,
   ResolveShareInput,
@@ -21,8 +22,8 @@ const PUBLIC_ITINERARY = {
   author_display_name: "ミツハ",
   planned_for: "2026-07-03",
   distance_meters: 2_800,
-  total_stops: 2,
-  completed_stops: 2,
+  total_stops: 1,
+  completed_stops: 1,
   stops: [
     {
       point_id: "point-hida-station",
@@ -90,6 +91,17 @@ describe("share expiry errors", () => {
 });
 
 describe("public share projection", () => {
+  it("accepts HTTPS public URLs", () => {
+    expect(HttpsUrl.parse("https://example.test/fake.webp")).toBe("https://example.test/fake.webp");
+  });
+
+  it.each(["javascript:fake", "ftp://example.test/fake", "http://example.test/fake"])(
+    "rejects non-HTTPS public URL %s",
+    (url) => {
+      expect(HttpsUrl.safeParse(url).success).toBe(false);
+    },
+  );
+
   it("accepts the public itinerary fields needed by the share page", () => {
     expect(PublicSharedItinerary.parse(PUBLIC_ITINERARY)).toEqual(PUBLIC_ITINERARY);
   });
@@ -118,5 +130,31 @@ describe("public share projection", () => {
   it("strictly rejects raw GPS nested inside a public stop", () => {
     const stops = [{ ...PUBLIC_ITINERARY.stops[0], latitude: 35.702_123 }];
     expect(PublicSharedItinerary.safeParse({ ...PUBLIC_ITINERARY, stops }).success).toBe(false);
+  });
+
+  it("rejects completed stop counts above the total", () => {
+    const invalid = { ...PUBLIC_ITINERARY, total_stops: 0 };
+    expect(PublicSharedItinerary.safeParse(invalid).success).toBe(false);
+  });
+
+  it("rejects duplicate stop positions", () => {
+    const duplicate = { ...PUBLIC_ITINERARY.stops[0], point_id: "point-library" };
+    const invalid = {
+      ...PUBLIC_ITINERARY,
+      total_stops: 2,
+      completed_stops: 2,
+      stops: [PUBLIC_ITINERARY.stops[0], duplicate],
+    };
+    expect(PublicSharedItinerary.safeParse(invalid).success).toBe(false);
+  });
+
+  it("rejects lifecycle state that contradicts the counts", () => {
+    const invalid = { ...PUBLIC_ITINERARY, state: "planned" };
+    expect(PublicSharedItinerary.safeParse(invalid).success).toBe(false);
+  });
+
+  it("rejects summary counts that contradict the stops", () => {
+    const invalid = { ...PUBLIC_ITINERARY, completed_stops: 0, state: "planned" };
+    expect(PublicSharedItinerary.safeParse(invalid).success).toBe(false);
   });
 });

--- a/packages/contract/test/users-openapi.test.ts
+++ b/packages/contract/test/users-openapi.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import usersOpenApi from "../users-openapi.json";
+
+const BEARER_SECURITY = [{ bearerAuth: [] }];
+
+describe("users OpenAPI security", () => {
+  it("defines HTTP bearer JWT authentication", () => {
+    expect(usersOpenApi.components.securitySchemes).toEqual({
+      bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+    });
+  });
+
+  it("requires bearer authentication for users, check-in, and share mutations", () => {
+    expect(usersOpenApi.paths["/v1/users/routes"].get.security).toEqual(BEARER_SECURITY);
+    expect(usersOpenApi.paths["/v1/users/routes"].post.security).toEqual(BEARER_SECURITY);
+    expect(usersOpenApi.paths["/v1/users/routes/{id}"].delete.security).toEqual(BEARER_SECURITY);
+    expect(usersOpenApi.paths["/v1/users/routes/claim"].post.security).toEqual(BEARER_SECURITY);
+    expect(usersOpenApi.paths["/v1/users/checkins"].post.security).toEqual(BEARER_SECURITY);
+    expect(usersOpenApi.paths["/v1/users/checkins"].get.security).toEqual(BEARER_SECURITY);
+    expect(usersOpenApi.paths["/v1/users/shares"].post.security).toEqual(BEARER_SECURITY);
+    expect(usersOpenApi.paths["/v1/users/shares/{share_id}"].delete.security).toEqual(BEARER_SECURITY);
+  });
+
+  it("marks public share resolution as explicitly anonymous", () => {
+    const resolve = usersOpenApi.paths["/v1/users/shares/resolve/{token}"].get;
+    expect(resolve.security).toEqual([]);
+  });
+});

--- a/packages/contract/users-openapi.json
+++ b/packages/contract/users-openapi.json
@@ -4,6 +4,15 @@
     "version": "0.1.0",
     "description": "User-domain routes of the TS Users service, consumed by apps/web."
   },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
   "openapi": "3.1.1",
   "paths": {
     "/v1/users/routes": {
@@ -76,7 +85,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "post": {
         "operationId": "saveRoute",
@@ -320,7 +334,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v1/users/routes/{id}": {
@@ -499,7 +518,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v1/users/routes/claim": {
@@ -546,7 +570,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v1/users/checkins": {
@@ -871,7 +900,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "get": {
         "operationId": "listCheckins",
@@ -973,7 +1007,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v1/users/shares": {
@@ -1182,7 +1221,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v1/users/shares/{share_id}": {
@@ -1362,7 +1406,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/v1/users/shares/resolve/{token}": {
@@ -1756,7 +1805,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     }
   }


### PR DESCRIPTION
Campaign review P1-9/P1-10/P2-3/P2-4 (Codex-authored, lead-committed).

- **share URLs (security)**: `HttpsUrl` (zod4 `protocol:/^https$/`) — rejects `javascript:`/`ftp:`/`http:`, negatives asserted
- **OpenAPI auth boundary**: bearer securityScheme; create/revoke/checkin-submit/list require it, anonymous share-resolve marked explicit empty security
- **projection invariants**: PublicSharedItinerary superRefine (completed≤total, unique positions, state/count self-consistent) + negatives
- **registry dedup**: shared `error-registry.ts` replaces 3 duplicated copies (users/checkin/share); feature-namespaced codes documented; `errors.ts` catalog mirror untouched

Gates (lead-run): typecheck ✓ · 48 tests ✓ · emit idempotent ✓ · suppressions 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)