### PR TITLE
fix(agent): P1 chat-stream tool-call correlation + terminal-error finalization

### DIFF
--- a/apps/agent/agent/agents/animichi_runner.py
+++ b/apps/agent/agent/agents/animichi_runner.py
@@ -23,6 +23,7 @@ from agent.agents.runtime_deps import (
     StepEvent,
     TitleTranslator,
     WebSearcher,
+    new_step_call_id,
 )
 from agent.agents.runtime_models import (
     AgentResultOutput,
@@ -279,4 +280,5 @@ async def _record_terminal_clarify(
         )
     )
     if deps.on_step is not None:
-        await deps.on_step(StepEvent(tool="clarify", status="done", data=data))
+        call_id = new_step_call_id("clarify")
+        await deps.on_step(StepEvent("clarify", call_id, "done", data))

--- a/apps/agent/agent/agents/animichi_tools.py
+++ b/apps/agent/agent/agents/animichi_tools.py
@@ -14,7 +14,12 @@ from agent.agents.catalog_tools import (
     run_resolve,
     run_work_search,
 )
-from agent.agents.runtime_deps import RuntimeDeps, StepEvent
+from agent.agents.runtime_deps import (
+    RuntimeDeps,
+    StepEvent,
+    StepStatus,
+    new_step_call_id,
+)
 from agent.agents.tool_outcomes import (
     NearbyToolResult,
     ResolveResult,
@@ -37,9 +42,10 @@ async def resolve_anime(
     title. For `upstream_unavailable`, emit `qa_response` asking the user to retry.
     Never infer ambiguity from query length.
     """
-    await _emit(ctx, "resolve_anime", "running", {})
+    call_id = _call_id(ctx, "resolve_anime")
+    await _emit(ctx, call_id, "resolve_anime", "running", {})
     result = await run_resolve(ctx, ctx.deps.catalog, title)
-    await _emit(ctx, "resolve_anime", "done", result.model_dump())
+    await _emit(ctx, call_id, "resolve_anime", "done", result.model_dump())
     return result
 
 
@@ -48,9 +54,10 @@ async def search_bangumi(
     bangumi_id: Annotated[str, Field(pattern=r"^\d+$")],
 ) -> SearchToolResult:
     """Fetch points by work ID; upstream_unavailable means ask the user to retry."""
-    await _emit(ctx, "search_bangumi", "running", {})
+    call_id = _call_id(ctx, "search_bangumi")
+    await _emit(ctx, call_id, "search_bangumi", "running", {})
     result = await run_work_search(ctx, ctx.deps.catalog, bangumi_id)
-    await _emit(ctx, "search_bangumi", "done", result.model_dump())
+    await _emit(ctx, call_id, "search_bangumi", "done", result.model_dump())
     return result
 
 
@@ -60,11 +67,12 @@ async def search_nearby(
     radius_m: Annotated[int | None, Field(gt=0)] = None,
 ) -> NearbyToolResult:
     """Search near a place or GPS; upstream_unavailable means retry later."""
-    await _emit(ctx, "search_nearby", "running", {})
+    call_id = _call_id(ctx, "search_nearby")
+    await _emit(ctx, call_id, "search_nearby", "running", {})
     result = await run_nearby_search(
         ctx, ctx.deps.catalog, location=location, radius_m=radius_m
     )
-    await _emit(ctx, "search_nearby", "done", result.model_dump())
+    await _emit(ctx, call_id, "search_nearby", "done", result.model_dump())
     return result
 
 
@@ -74,17 +82,26 @@ async def plan_route(
     pacing: Literal["chill", "normal", "packed"] | None = None,
 ) -> RouteToolResult:
     """Plan one stored result; upstream_unavailable means retry later."""
-    await _emit(ctx, "plan_route", "running", {})
+    call_id = _call_id(ctx, "plan_route")
+    await _emit(ctx, call_id, "plan_route", "running", {})
     result = await run_route(ctx, ctx.deps.catalog, search_result_ref, pacing)
-    await _emit(ctx, "plan_route", "done", result.model_dump())
+    await _emit(ctx, call_id, "plan_route", "done", result.model_dump())
     return result
 
 
 async def _emit(
-    ctx: RunContext[RuntimeDeps], tool: str, status: str, data: dict[str, object]
+    ctx: RunContext[RuntimeDeps],
+    call_id: str,
+    tool: str,
+    status: StepStatus,
+    data: dict[str, object],
 ) -> None:
     if ctx.deps.on_step is not None:
-        await ctx.deps.on_step(StepEvent(tool=tool, status=status, data=data))
+        await ctx.deps.on_step(StepEvent(tool, call_id, status, data))
+
+
+def _call_id(ctx: RunContext[RuntimeDeps], tool: str) -> str:
+    return ctx.tool_call_id or new_step_call_id(tool)
 
 
 TOOLS: list[Tool[RuntimeDeps] | ToolFuncEither[RuntimeDeps]] = [

--- a/apps/agent/agent/agents/runtime_deps.py
+++ b/apps/agent/agent/agents/runtime_deps.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
+from typing import Literal
+from uuid import uuid4
 
 from agent.agents.agent_result import StepRecord
 from agent.agents.tool_state import ToolState
@@ -12,13 +14,16 @@ from agent.agents.web_trust import WebResult
 from agent.clients.catalog_client import CatalogClientProtocol
 from agent.domain.ports import DatabasePort
 
+StepStatus = Literal["running", "done", "error"]
+
 
 @dataclass(frozen=True)
 class StepEvent:
     """One immutable progress event delivered to runtime adapters."""
 
     tool: str
-    status: str
+    call_id: str
+    status: StepStatus
     data: dict[str, object]
     thought: str = ""
     observation: str = ""
@@ -27,6 +32,11 @@ class StepEvent:
 OnStep = Callable[[StepEvent], Awaitable[None]]
 WebSearcher = Callable[[str], Awaitable[list[WebResult]]]
 TitleTranslator = Callable[[str, str], Awaitable[TranslationResult]]
+
+
+def new_step_call_id(tool: str) -> str:
+    """Mint an identity for one deterministic, server-side tool operation."""
+    return f"{tool}-{uuid4()}"
 
 
 @dataclass

--- a/apps/agent/agent/agents/selected_route.py
+++ b/apps/agent/agent/agents/selected_route.py
@@ -8,7 +8,7 @@ import structlog
 from agent.agents.agent_result import AgentResult, ProducedRoute, StepRecord
 from agent.agents.catalog_adapter import build_route_payload, build_route_state
 from agent.agents.error_messages import build_error_message
-from agent.agents.runtime_deps import OnStep, StepEvent
+from agent.agents.runtime_deps import OnStep, StepEvent, StepStatus, new_step_call_id
 from agent.agents.runtime_models import RouteResponseModel
 from agent.agents.selection_messages import selected_route_message
 from agent.agents.session_state import SessionState
@@ -34,12 +34,14 @@ async def execute_selected_route(
         return _error_result("point_ids is required", locale, state)
 
     params = _build_params(point_ids, origin)
-    await _emit_step(on_step, "running", {})
+    call_id = new_step_call_id("plan_selected")
+    await _emit_step(on_step, call_id, "running", {})
 
     try:
         route = await catalog.route(point_ids, origin=_parse_coordinate_origin(origin))
     except _TRANSIENT_ERRORS as exc:
         logger.warning("selected_route_catalog_error", error=str(exc))
+        await _emit_step(on_step, call_id, "error", {})
         # Typed CatalogError -> localized, actionable text from OUR mapping
         # table (SD-19); anything else keeps the legacy generic fallback.
         return _error_result(
@@ -50,8 +52,9 @@ async def execute_selected_route(
 
     step, payload = _build_step(route, params)
     if not step.success:
+        await _emit_step(on_step, call_id, "error", {})
         return _error_result("No catalog route data", locale, state)
-    await _emit_step(on_step, "done", payload)
+    await _emit_step(on_step, call_id, "done", payload)
     return _build_success_result(route, step, locale, state)
 
 
@@ -64,12 +67,15 @@ def _build_params(point_ids: list[str], origin: str | None) -> dict[str, object]
 
 
 async def _emit_step(
-    on_step: OnStep | None, status: str, payload: dict[str, object]
+    on_step: OnStep | None,
+    call_id: str,
+    status: StepStatus,
+    payload: dict[str, object],
 ) -> None:
     """Notify the on_step callback, if any, of plan_selected progress."""
     if on_step is None:
         return
-    await on_step(StepEvent(tool="plan_selected", status=status, data=payload))
+    await on_step(StepEvent("plan_selected", call_id, status, payload))
 
 
 def _build_step(

--- a/apps/agent/agent/agents/selection.py
+++ b/apps/agent/agent/agents/selection.py
@@ -17,7 +17,7 @@ from agent.agents.agent_result import (
 )
 from agent.agents.catalog_adapter import build_route_state, build_search_state
 from agent.agents.geo_names import localized_city_name
-from agent.agents.runtime_deps import OnStep, StepEvent
+from agent.agents.runtime_deps import OnStep, StepEvent, StepStatus, new_step_call_id
 from agent.agents.runtime_models import RouteResponseModel, SearchResponseModel
 from agent.agents.selection_messages import PLACE_MESSAGES, multi_message
 from agent.agents.session_state import (
@@ -87,7 +87,8 @@ async def execute_multi_selection(
     on_step: OnStep | None = None,
 ) -> AgentResult:
     """Fetch selected works in parallel, merge deterministically, then route."""
-    await _emit(on_step, "plan_multi", "running", {})
+    call_id = new_step_call_id("plan_multi")
+    await _emit(on_step, call_id, "plan_multi", "running", {})
     fetched = await asyncio.gather(
         *(catalog.points_by_work_id(item) for item in candidate_ids),
         return_exceptions=True,
@@ -95,7 +96,9 @@ async def execute_multi_selection(
     steps = _fetch_steps(candidate_ids, fetched)
     successful = _successful_results(candidate_ids, fetched)
     if not successful:
-        return await _multi_terminal_event(state, steps, locale, "error", on_step)
+        return await _multi_terminal_event(
+            state, steps, locale, "error", on_step, call_id
+        )
     merged = _merge_results(candidate_ids, successful, locale)
     result_ref = state.next_search_ref("multi", state.clarification_revision)
     state.store_search_result(result_ref, merged)
@@ -104,30 +107,30 @@ async def execute_multi_selection(
     )
     if any(result.partial for _, result in successful):
         return await _multi_terminal_event(
-            state, steps, locale, "partial", on_step, search=provenance
+            state, steps, locale, "partial", on_step, call_id, search=provenance
         )
     if not merged.rows:
         status = "error" if len(successful) < len(candidate_ids) else "empty"
         return await _multi_terminal_event(
-            state, steps, locale, status, on_step, search=provenance
+            state, steps, locale, status, on_step, call_id, search=provenance
         )
     if len(merged.rows) > MAX_ROUTE_POINT_IDS:
         return await _multi_terminal_event(
-            state, steps, locale, "too_large", on_step, search=provenance
+            state, steps, locale, "too_large", on_step, call_id, search=provenance
         )
     try:
         route = await catalog.route([point.id for point in merged.rows if point.id])
     except (RouteTooManyClustersError, RouteTooManyPointsError):
         return await _multi_terminal_event(
-            state, steps, locale, "too_large", on_step, search=provenance
+            state, steps, locale, "too_large", on_step, call_id, search=provenance
         )
     except _FETCH_ERRORS:
         return await _multi_terminal_event(
-            state, steps, locale, "error", on_step, search=provenance
+            state, steps, locale, "error", on_step, call_id, search=provenance
         )
     if route.point_count < 1:
         return await _multi_terminal_event(
-            state, steps, locale, "error", on_step, search=provenance
+            state, steps, locale, "error", on_step, call_id, search=provenance
         )
     route_ref = state.next_route_ref("multi", state.clarification_revision)
     state.store_route(route_ref, build_route_state(route, result_ref, locale=locale))
@@ -135,7 +138,7 @@ async def execute_multi_selection(
     omitted = _omitted_titles(state, merged.omitted_work_ids)
     _consume_pending(state)
     steps.append(_server_step("plan_multi", True, {"route_ref": str(route_ref)}))
-    await _emit(on_step, "plan_multi", "done", {"route_ref": str(route_ref)})
+    await _emit(on_step, call_id, "plan_multi", "done", {"route_ref": str(route_ref)})
     return AgentResult(
         output=RouteResponseModel(message=multi_message(locale, "ok", omitted)),
         intent="plan_multi",
@@ -270,10 +273,12 @@ async def _multi_terminal_event(
     locale: str,
     status: str,
     on_step: OnStep | None,
+    call_id: str,
     search: ProducedSearch | None = None,
 ) -> AgentResult:
     result = _multi_terminal(state, steps, locale, status, search)
-    await _emit(on_step, "plan_multi", "done", {"status": status})
+    event_status: StepStatus = "error" if status == "error" else "done"
+    await _emit(on_step, call_id, "plan_multi", event_status, {"status": status})
     return result
 
 
@@ -292,7 +297,8 @@ async def execute_place_selection(
     on_step: OnStep | None = None,
 ) -> AgentResult:
     """Consume staged place coordinates without re-geocoding."""
-    await _emit(on_step, "search_nearby", "running", {})
+    call_id = new_step_call_id("search_nearby")
+    await _emit(on_step, call_id, "search_nearby", "running", {})
     pending = state.pending_clarification
     candidate = (
         next(
@@ -309,7 +315,7 @@ async def execute_place_selection(
         points = await catalog.nearby(candidate.lat, candidate.lng, radius_m=radius_m)
     except _FETCH_ERRORS:
         result = _place_error(state, locale)
-        await _emit(on_step, "search_nearby", "done", {"status": "error"})
+        await _emit(on_step, call_id, "search_nearby", "error", {})
         return result
     payload = build_search_state(points, kind="nearby", locale=locale)
     ref = state.next_search_ref("place", state.clarification_revision)
@@ -319,7 +325,7 @@ async def execute_place_selection(
         outcome="ok" if payload.row_count else "empty", result_ref=ref
     )
     step = _server_step("search_nearby", True, {"result_ref": str(ref)}, provenance)
-    await _emit(on_step, "search_nearby", "done", {"result_ref": str(ref)})
+    await _emit(on_step, call_id, "search_nearby", "done", {"result_ref": str(ref)})
     status = "ok" if payload.row_count else "empty"
     return AgentResult(
         output=SearchResponseModel(message=PLACE_MESSAGES[locale][status]),
@@ -341,7 +347,11 @@ def _place_error(state: SessionState, locale: str) -> AgentResult:
 
 
 async def _emit(
-    on_step: OnStep | None, tool: str, status: str, data: dict[str, object]
+    on_step: OnStep | None,
+    call_id: str,
+    tool: str,
+    status: StepStatus,
+    data: dict[str, object],
 ) -> None:
     if on_step is not None:
-        await on_step(StepEvent(tool=tool, status=status, data=data))
+        await on_step(StepEvent(tool, call_id, status, data))

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -31,7 +31,7 @@ from agent.agents.base import (
     resolve_model,
     resolve_model_alias,
 )
-from agent.agents.runtime_deps import OnStep, StepEvent
+from agent.agents.runtime_deps import OnStep, StepEvent, StepStatus, new_step_call_id
 from agent.agents.selected_route import execute_selected_route
 from agent.agents.selection import (
     SelectionError,
@@ -597,8 +597,10 @@ async def _apply_translation_gate(
     detected = resolve_reply_language(message, locale)
     if detected == locale:
         return
+    call_id = new_step_call_id("translate")
     if on_step is not None:
-        await on_step(StepEvent(tool="translate", status="running", data={}))
+        await on_step(StepEvent("translate", call_id, "running", {}))
+    status: StepStatus = "done"
     try:
         translated = await translate_text(
             message,
@@ -609,8 +611,9 @@ async def _apply_translation_gate(
         object.__setattr__(result.output, "message", translated)
     except (OSError, RuntimeError, ValueError, TypeError):
         logger.warning("translation_gate_failed", locale=locale)
+        status = "error"
     if on_step is not None:
-        await on_step(StepEvent(tool="translate", status="done", data={}))
+        await on_step(StepEvent("translate", call_id, status, {}))
 
 
 def _translation_context(

--- a/apps/agent/agent/interfaces/routes/chat_stream.py
+++ b/apps/agent/agent/interfaces/routes/chat_stream.py
@@ -24,6 +24,7 @@ from pydantic_ai.ui.vercel_ai.response_types import (
     ToolInputAvailableChunk,
     ToolInputStartChunk,
     ToolOutputAvailableChunk,
+    ToolOutputErrorChunk,
 )
 
 from agent.agents.runtime_deps import OnStep, StepEvent
@@ -43,28 +44,37 @@ class _ToolPartTranslator:
     """Map running/done step events onto AI SDK tool parts with stable IDs."""
 
     def __init__(self) -> None:
-        self._call_ids: dict[str, str] = {}
-        self._count = 0
+        self._active: set[str] = set()
 
     def translate(self, step: StepEvent) -> list[BaseChunk]:
         if step.status == "running":
             return self._begin(step)
-        return self._finish(step)
+        if step.status == "done":
+            return self._finish(step)
+        return self._error(step.call_id)
 
     def _begin(self, step: StepEvent) -> list[BaseChunk]:
-        self._count += 1
-        call_id = f"{step.tool}-{self._count}"
-        self._call_ids[step.tool] = call_id
+        self._active.add(step.call_id)
         return [
-            ToolInputStartChunk(tool_call_id=call_id, tool_name=step.tool),
+            ToolInputStartChunk(tool_call_id=step.call_id, tool_name=step.tool),
             ToolInputAvailableChunk(
-                tool_call_id=call_id, tool_name=step.tool, input=step.data
+                tool_call_id=step.call_id, tool_name=step.tool, input=step.data
             ),
         ]
 
     def _finish(self, step: StepEvent) -> list[BaseChunk]:
-        call_id = self._call_ids.get(step.tool, f"{step.tool}-0")
-        return [ToolOutputAvailableChunk(tool_call_id=call_id, output=step.data)]
+        self._active.discard(step.call_id)
+        return [ToolOutputAvailableChunk(tool_call_id=step.call_id, output=step.data)]
+
+    def _error(self, call_id: str) -> list[BaseChunk]:
+        self._active.discard(call_id)
+        return [ToolOutputErrorChunk(tool_call_id=call_id, error_text=_ERROR_TEXT)]
+
+    def terminal_errors(self) -> list[BaseChunk]:
+        chunks = [
+            chunk for call_id in list(self._active) for chunk in self._error(call_id)
+        ]
+        return chunks
 
 
 def _data_parts(response: PublicAPIResponse) -> list[BaseChunk]:
@@ -103,22 +113,27 @@ async def _put_all(queue: _Queue, chunks: Sequence[BaseChunk]) -> None:
         await queue.put(chunk)
 
 
-def _make_on_step(queue: _Queue) -> OnStep:
-    translator = _ToolPartTranslator()
-
+def _make_on_step(queue: _Queue, translator: _ToolPartTranslator) -> OnStep:
     async def on_step(step: StepEvent) -> None:
         await _put_all(queue, translator.translate(step))
 
     return on_step
 
 
+async def _handle_error(
+    queue: _Queue, translator: _ToolPartTranslator, exc: Exception
+) -> None:
+    logger.exception("chat_stream_error", error=str(exc))
+    await _put_all(queue, [*translator.terminal_errors(), *_error_chunks()])
+
+
 async def _produce(handler: ChatHandler, queue: _Queue) -> None:
+    translator = _ToolPartTranslator()
     await _put_all(queue, [StartChunk(), StartStepChunk()])
     try:
-        response = await handler(_make_on_step(queue))
+        response = await handler(_make_on_step(queue, translator))
     except Exception as exc:
-        logger.exception("chat_stream_error", error=str(exc))
-        await _put_all(queue, _error_chunks())
+        await _handle_error(queue, translator, exc)
     else:
         await _put_all(queue, _response_chunks(response))
     await queue.put(None)

--- a/apps/agent/agent/tests/integration/conftest.py
+++ b/apps/agent/agent/tests/integration/conftest.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from agent.agents.agent_result import AgentResult, StepRecord
-from agent.agents.runtime_deps import OnStep, StepEvent
+from agent.agents.runtime_deps import OnStep, StepEvent, new_step_call_id
 from agent.agents.runtime_models import (
     ClarifyResponseModel,
     QAResponseModel,
@@ -310,7 +310,9 @@ def sse_client(tc_db: SupabaseClient) -> AsyncIterator[_SSEClient]:
         result = _make_agent_result(text, locale)
         if on_step is not None:
             data = result.session_state.model_dump(mode="json", exclude_none=True)
-            await on_step(StepEvent(tool=result.intent, status="done", data=data))
+            await on_step(
+                StepEvent(result.intent, new_step_call_id(result.intent), "done", data)
+            )
         return result
 
     app = _build_test_app(tc_db)

--- a/apps/agent/agent/tests/integration/test_sse_contract.py
+++ b/apps/agent/agent/tests/integration/test_sse_contract.py
@@ -86,6 +86,7 @@ def _build_runtime_api_mock(
             await on_step(
                 StepEvent(
                     tool="search_bangumi",
+                    call_id="integration-call",
                     status="running",
                     data={"bangumi_id": "12345"},
                     thought="Searching...",
@@ -94,6 +95,7 @@ def _build_runtime_api_mock(
             await on_step(
                 StepEvent(
                     tool="search_bangumi",
+                    call_id="integration-call",
                     status="done",
                     data={"rows": [], "row_count": 0},
                     observation="Found 0 results",

--- a/apps/agent/agent/tests/unit/test_chat_endpoint.py
+++ b/apps/agent/agent/tests/unit/test_chat_endpoint.py
@@ -198,8 +198,8 @@ def _frame_types(body: str) -> list[str]:
 
 async def test_chat_stream_frame_structure_and_header() -> None:
     steps = [
-        StepEvent(tool="resolve_anime", status="running", data={}),
-        StepEvent(tool="resolve_anime", status="done", data={"bangumi_id": 1}),
+        StepEvent("resolve_anime", "endpoint-call", "running", {}),
+        StepEvent("resolve_anime", "endpoint-call", "done", {"bangumi_id": 1}),
     ]
     response_body = PublicAPIResponse(
         success=True, status="ok", intent="search_bangumi", message="Found."

--- a/apps/agent/agent/tests/unit/test_chat_stream.py
+++ b/apps/agent/agent/tests/unit/test_chat_stream.py
@@ -61,9 +61,9 @@ async def _plain_handler(_on_step: OnStep) -> PublicAPIResponse:
 def _tool_handler(response: PublicAPIResponse) -> ChatHandler:
     async def handler(on_step: OnStep) -> PublicAPIResponse:
         await on_step(
-            StepEvent(tool="resolve_anime", status="running", data={"t": "x"})
+            StepEvent("resolve_anime", "provider-call-1", "running", {"t": "x"})
         )
-        await on_step(StepEvent(tool="resolve_anime", status="done", data={"id": 1}))
+        await on_step(StepEvent("resolve_anime", "provider-call-1", "done", {"id": 1}))
         return response
 
     return handler
@@ -71,6 +71,22 @@ def _tool_handler(response: PublicAPIResponse) -> ChatHandler:
 
 async def _failing_handler(_on_step: OnStep) -> PublicAPIResponse:
     raise RuntimeError("boom")
+
+
+async def _running_then_failing_handler(on_step: OnStep) -> PublicAPIResponse:
+    await on_step(StepEvent("search_nearby", "provider-call-error", "running", {}))
+    raise RuntimeError("normalization failed")
+
+
+def _concurrent_tool_handler(response: PublicAPIResponse) -> ChatHandler:
+    async def handler(on_step: OnStep) -> PublicAPIResponse:
+        await on_step(StepEvent("resolve_anime", "call-a", "running", {"q": "a"}))
+        await on_step(StepEvent("resolve_anime", "call-b", "running", {"q": "b"}))
+        await on_step(StepEvent("resolve_anime", "call-a", "done", {"id": "a"}))
+        await on_step(StepEvent("resolve_anime", "call-b", "done", {"id": "b"}))
+        return response
+
+    return handler
 
 
 async def test_stream_emits_ordered_envelope_for_plain_response() -> None:
@@ -123,6 +139,20 @@ async def test_tool_parts_precede_data_parts() -> None:
     assert order.index("tool-output-available") < order.index("data-response")
 
 
+async def test_same_named_concurrent_calls_resolve_by_call_id() -> None:
+    chunks = _parse(await _collect(_concurrent_tool_handler(_response())))
+    inputs = _of_type(chunks, "tool-input-available")
+    outputs = _of_type(chunks, "tool-output-available")
+    assert [(part["toolCallId"], part["input"]) for part in inputs] == [
+        ("call-a", {"q": "a"}),
+        ("call-b", {"q": "b"}),
+    ]
+    assert [(part["toolCallId"], part["output"]) for part in outputs] == [
+        ("call-a", {"id": "a"}),
+        ("call-b", {"id": "b"}),
+    ]
+
+
 async def test_handler_failure_emits_error_part_not_data() -> None:
     chunks = _parse(await _collect(_failing_handler))
     assert _types(chunks) == [
@@ -140,3 +170,10 @@ async def test_handler_failure_emits_error_part_not_data() -> None:
 async def test_error_text_does_not_leak_exception_detail() -> None:
     error = _of_type(_parse(await _collect(_failing_handler)), "error")[0]
     assert "boom" not in str(error["errorText"])
+
+
+async def test_running_call_is_closed_when_handler_raises() -> None:
+    chunks = _parse(await _collect(_running_then_failing_handler))
+    tool_error = _of_type(chunks, "tool-output-error")
+    assert [part["toolCallId"] for part in tool_error] == ["provider-call-error"]
+    assert _types(chunks).index("tool-output-error") < _types(chunks).index("error")

--- a/apps/agent/tests/fixtures/chat_stream/record_fixtures.py
+++ b/apps/agent/tests/fixtures/chat_stream/record_fixtures.py
@@ -25,7 +25,7 @@ os.environ.setdefault("MIMO_API_KEY", "recording-stub")
 os.environ.setdefault("SUPABASE_DB_URL", "postgresql://test:test@localhost:5432/test")
 
 if TYPE_CHECKING:
-    from agent.agents.runtime_deps import OnStep, StepEvent
+    from agent.agents.runtime_deps import OnStep, StepEvent, StepStatus
     from agent.interfaces.routes.chat_stream import ChatHandler
     from agent.interfaces.schemas import PublicAPIResponse
 
@@ -84,10 +84,10 @@ def _clarify_response() -> PublicAPIResponse:
     )
 
 
-def _step(tool: str, status: str, data: dict[str, object]) -> StepEvent:
+def _step(tool: str, status: StepStatus, data: dict[str, object]) -> StepEvent:
     from agent.agents.runtime_deps import StepEvent
 
-    return StepEvent(tool=tool, status=status, data=data)
+    return StepEvent(tool, f"{tool}-fixture", status, data)
 
 
 def _replaying_handler(


### PR DESCRIPTION
Campaign review P1-1/P1-2 (Codex-authored, lead-committed).

- StepEvent now carries `call_id`; `chat_stream` keys tool-part lifecycle by call_id (not tool name) → concurrent same-tool calls no longer clobber each other's mapping
- `_active` set tracks open tool parts; `_handle_error` emits `terminal_errors()` for every orphaned part before the stream-level error → no dangling running parts when a tool raises after emitting running
- regressions: same-named concurrent calls resolve by call_id; running-then-raise finalizes cleanly

Gates (lead-run): make lint + typecheck ✓ · 1180 tests / 87.38% cov ✓ · suppressions 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)