### PR TITLE
fix(catalog): unlock #363 spike fixtures + repair invalid array-cast SQL in resolve (3rd latent prod bug)

### DIFF
--- a/workers/catalog/src/api/resolve.ts
+++ b/workers/catalog/src/api/resolve.ts
@@ -221,7 +221,7 @@ async function selectCandidates(db: CatalogDb, workIds: string[]): Promise<Anime
     SELECT b.id, b.title, b.title_cn, b.cover_url, b.air_date,
            COUNT(p.id) AS points_count
     FROM bangumi b LEFT JOIN points p ON p.bangumi_id = b.id
-    WHERE b.id = ANY(${workIds}::text[])
+    WHERE b.id IN (${sql.join(workIds, sql`, `)})
     GROUP BY b.id, b.title, b.title_cn, b.cover_url, b.air_date
   `);
   return result.rows.map(readStoredCandidate);

--- a/workers/catalog/test/geo-query.spike.test.ts
+++ b/workers/catalog/test/geo-query.spike.test.ts
@@ -23,13 +23,13 @@ let neonSql: ReturnType<typeof makeNeonSql>;
 async function seedPoints(): Promise<void> {
   // Trigger derives GEOGRAPHY `location` from lat/lon, so insert coordinates only.
   await db.execute(sql`
-    INSERT INTO bangumi (id, title) VALUES ('lucky-star', 'らき☆すた'), ('gup', 'ガールズ&パンツァー')
+    INSERT INTO bangumi (id, title) VALUES ('lucky-star', 'らき☆すた')
   `);
   await db.execute(sql`
     INSERT INTO points (id, bangumi_id, name, latitude, longitude) VALUES
       ('washinomiya', 'lucky-star', '鷲宮神社', 36.1019, 139.6586),
       ('satte', 'lucky-star', '幸手権現堂', 36.0833, 139.7250),
-      ('oarai', 'gup', '大洗磯前神社', 36.3142, 140.5876)
+      ('kawagoe', 'lucky-star', '川越駅', 35.9077, 139.4828)
   `);
 }
 
@@ -54,21 +54,20 @@ databaseDescribe("findPointsWithinRadius — PostGIS ST_DWithin read primitive",
     expect(rows[0]?.latitude).toBeCloseTo(36.1019, 4);
   });
 
-  // known-failing: #363 (oarai seed row never lands — suspected FK/seed gap)
-  it.skip("excludes far Oarai at 10km but includes it (nearest-first) at 200km", async () => {
+  it("excludes Kawagoe at 10km but includes it (nearest-first) at 50km", async () => {
     const near = await findPointsWithinRadius(neonSql, {
       lat: 36.1019,
       lng: 139.6586,
       radiusM: 10_000,
     });
-    expect(near.map((r) => r.id)).not.toContain("oarai");
+    expect(near.map((r) => r.id)).not.toContain("kawagoe");
 
     const wide = await findPointsWithinRadius(neonSql, {
       lat: 36.1019,
       lng: 139.6586,
-      radiusM: 200_000,
+      radiusM: 50_000,
     });
-    expect(wide.map((r) => r.id)).toEqual(["washinomiya", "satte", "oarai"]);
+    expect(wide.map((r) => r.id)).toEqual(["washinomiya", "satte", "kawagoe"]);
     const distances = wide.map((r) => r.distanceM);
     expect(distances[0]).toBeLessThan(distances[1] ?? 0);
     expect(distances[1]).toBeLessThan(distances[2] ?? 0);

--- a/workers/catalog/test/resolve-api.spike.test.ts
+++ b/workers/catalog/test/resolve-api.spike.test.ts
@@ -3,11 +3,14 @@ import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import { afterAll, beforeAll, expect, it } from "vitest";
-import type { CatalogDb, NeonSql } from "../src/db/client";
+import { makeNeonSql, type CatalogDb, type NeonSql } from "../src/db/client";
 import { catalogRouter, type CatalogContext } from "../src/router";
 import {
-  databaseDescribeKnownFailing,
+  databaseDescribe,
+  localDatabaseUrl,
   openDirectPool,
+  openServerlessDb,
+  restoreNeonConfig,
   truncateCatalogPool,
 } from "./spike-db";
 
@@ -16,29 +19,29 @@ const handler = new OpenAPIHandler(catalogRouter);
 
 let pool: pg.Pool;
 let db: CatalogDb;
+let neonSql: NeonSql;
 
 async function seedWorks(): Promise<void> {
   await pool.query(`INSERT INTO bangumi (id, title) VALUES
-    ('alpha', 'Alpha'), ('beta', 'Beta'), ('zero', 'Zero Point')`);
+    ('1001', 'Alpha'), ('1002', 'Beta'), ('1003', 'Zero Point')`);
 }
 
 async function seedPoints(): Promise<void> {
   await pool.query(`INSERT INTO points (id, bangumi_id, name, latitude, longitude) VALUES
-    ('a-1', 'alpha', 'Alpha Point', 35, 135),
-    ('b-1', 'beta', 'Beta Point 1', 36, 136),
-    ('b-2', 'beta', 'Beta Point 2', 37, 137)`);
+    ('a-1', '1001', 'Alpha Point', 35, 135),
+    ('b-1', '1002', 'Beta Point 1', 36, 136),
+    ('b-2', '1002', 'Beta Point 2', 37, 137)`);
 }
 
 async function seedAliases(): Promise<void> {
   await pool.query(`INSERT INTO aliases (work_id, alias, alias_normalized, source, priority) VALUES
-    ('alpha', 'Shared', 'shared', 'bangumi', 40),
-    ('alpha', 'Shared', 'shared', 'manual', 40),
-    ('beta', 'Shared', 'shared', 'bangumi', 40),
-    ('zero', 'Zero', 'zero', 'bangumi', 40)`);
+    ('1001', 'Shared', 'shared', 'bangumi', 40),
+    ('1001', 'Shared', 'shared', 'manual', 40),
+    ('1002', 'Shared', 'shared', 'bangumi', 40),
+    ('1003', 'Zero', 'zero', 'bangumi', 40)`);
 }
 
 function context(): CatalogContext {
-  const neonSql = (() => Promise.resolve([])) as unknown as NeonSql;
   return { db, neonSql };
 }
 
@@ -71,6 +74,8 @@ function pointKeys(value: unknown): string[] {
 }
 
 beforeAll(async () => {
+  await openServerlessDb();
+  neonSql = makeNeonSql(localDatabaseUrl());
   pool = await openDirectPool();
   db = drizzle(pool) as unknown as CatalogDb;
   await truncateCatalogPool(pool);
@@ -80,16 +85,17 @@ beforeAll(async () => {
 }, 120_000);
 
 afterAll(async () => {
+  restoreNeonConfig();
   await pool.end();
 });
 
-databaseDescribeKnownFailing("#363", "Phase 1a resolver SQL against Postgres", () => {
+databaseDescribe("Phase 1a resolver SQL against Postgres", () => {
   it("deduplicates work ids and orders tied candidates by derived point count", async () => {
     await expect(call("resolve", { query: "Shared" })).resolves.toEqual({
       outcome: "needs_disambiguation", reason: "anime_ambiguity",
       candidates: [
-        { bangumi_id: "beta", title: "Beta", points_count: 2 },
-        { bangumi_id: "alpha", title: "Alpha", points_count: 1 },
+        { bangumi_id: "1002", title: "Beta", points_count: 2 },
+        { bangumi_id: "1001", title: "Alpha", points_count: 1 },
       ],
     });
   });
@@ -97,12 +103,12 @@ databaseDescribeKnownFailing("#363", "Phase 1a resolver SQL against Postgres", (
   it("resolves a work with zero points instead of returning not_found", async () => {
     await expect(call("resolve", { query: "Zero" })).resolves.toEqual({
       outcome: "resolved",
-      match: { bangumi_id: "zero", title: "Zero Point", points_count: 0 },
+      match: { bangumi_id: "1003", title: "Zero Point", points_count: 0 },
     });
   });
 
   it("returns published rows through pointsByWorkId", async () => {
-    const result = await call("points-by-work-id", { work_id: "beta" });
-    expect(pointKeys(result)).toEqual(["beta:b-1", "beta:b-2"]);
+    const result = await call("points-by-work-id", { work_id: "1002" });
+    expect(pointKeys(result)).toEqual(["1002:b-1", "1002:b-2"]);
   });
 });


### PR DESCRIPTION
Closes #363 — the last parked spike tests are live, and acceptance surfaced a **third latent production bug**.

## Fixture fixes (Codex)

- `resolve-api.spike`: real `makeNeonSql` in the context (stale stub replaced); work ids numeric per `BANGUMI_ID_RE`; parameter shapes updated to the live contract.
- `geo-query.spike`: the FK hypothesis was DISPROVED — the real cause is the production **50 km radius clamp** (Oarai at 80+ km was legitimately clamped away; the fixture had never run live). Re-fixtured with Kawagoe (~26.8 km): exclusion at 10 km, inclusion at 50 km, nearest-first.

## Production bug (lead acceptance)

`selectCandidates` (src/api/resolve.ts) built `WHERE b.id = ANY(($1,$2)::text[])` — drizzle's sql template expands a JS array into a ROW tuple, and casting a ROW to `text[]` is invalid SQL. The **multi-candidate alias path had never executed on a real driver** (worker unit tests mock the db; single-hit/miss paths dominate). Any ambiguous-title resolve (the disambiguation feature!) would 500 in production. Rewritten as `IN (${sql.join(workIds, sql`, `)})` — the exact idiom `route.ts`/`nearby.ts` already use.

## Verification (lead, live)

- oxlint / tsc clean; worker suite **243 passed**
- Full live spike suite (neon_local + ephemeral cloud branch): **76 passed / 0 skipped / 0 failed** — the catalog spike surface is now 100% live, zero parked tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)