### PR TITLE
fix(web): round-2 review fixes — typecheck red base, chat/shiori epoch races, SSR origin, soft-404, theme, a11y

### DIFF
--- a/apps/web/src/api/orpc.ts
+++ b/apps/web/src/api/orpc.ts
@@ -23,14 +23,30 @@ export type UsersUtils = ReturnType<typeof createUsersUtils>;
 let cachedCatalog: CatalogUtils | undefined;
 let cachedUsers: UsersUtils | undefined;
 
-/** Lazy app-wide catalog utils; the stateless transport is safe to memoize. */
+/** Memoization is browser-only: SSR resolves the origin per request, and a
+ * module-global would freeze whichever accepted host served the first one. */
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+function buildCatalogUtils(): CatalogUtils {
+  return createCatalogUtils(createCatalogClient({ url: currentApiConfig().catalogUrl }));
+}
+
+function buildUsersUtils(): UsersUtils {
+  return createUsersUtils(createUsersClient({ url: currentApiConfig().usersUrl }));
+}
+
+/** Catalog utils: fresh per SSR request, lazily memoized in the browser. */
 export function catalog(): CatalogUtils {
-  cachedCatalog ??= createCatalogUtils(createCatalogClient({ url: currentApiConfig().catalogUrl }));
+  if (!isBrowser()) return buildCatalogUtils();
+  cachedCatalog ??= buildCatalogUtils();
   return cachedCatalog;
 }
 
-/** Lazy app-wide users utils; the stateless transport is safe to memoize. */
+/** Users utils: fresh per SSR request, lazily memoized in the browser. */
 export function users(): UsersUtils {
-  cachedUsers ??= createUsersUtils(createUsersClient({ url: currentApiConfig().usersUrl }));
+  if (!isBrowser()) return buildUsersUtils();
+  cachedUsers ??= buildUsersUtils();
   return cachedUsers;
 }

--- a/apps/web/src/components/landing/useTheme.ts
+++ b/apps/web/src/components/landing/useTheme.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
+import { THEME_STORAGE_KEY } from "../theme-bootstrap";
 
 export type Theme = "day" | "night";
 
-const STORAGE_KEY = "animichi-theme";
+const STORAGE_KEY = THEME_STORAGE_KEY;
 
 function readStored(): Theme | null {
   const value = window.localStorage.getItem(STORAGE_KEY);

--- a/apps/web/src/components/theme-bootstrap.ts
+++ b/apps/web/src/components/theme-bootstrap.ts
@@ -1,0 +1,11 @@
+/**
+ * Pre-hydration theme init, shipped as an inline <head> script from the root
+ * route so EVERY page (not just the landing tree) honors the stored day/night
+ * preference — and the landing page stops flashing the day default.
+ */
+
+export const THEME_STORAGE_KEY = "animichi-theme";
+
+export const THEME_BOOTSTRAP_SCRIPT =
+  `(function(){try{var t=localStorage.getItem("${THEME_STORAGE_KEY}");` +
+  `if(t==="day"||t==="night"){document.documentElement.dataset.theme=t;}}catch(e){}})();`;

--- a/apps/web/src/features/anime/ScenesSection.tsx
+++ b/apps/web/src/features/anime/ScenesSection.tsx
@@ -6,8 +6,8 @@ type Props = Readonly<{ scenes: readonly AnimeScene[]; copy: AnimeCopy }>;
 type ItemProps = Readonly<{ scene: AnimeScene; copy: AnimeCopy }>;
 
 /** Only real http(s) URLs may hit `<img src>`: `src=""` requests the page itself. */
-function hasRenderableShot(url: string): boolean {
-  if (!URL.canParse(url)) return false;
+function hasRenderableShot(url: string | null): url is string {
+  if (url === null || !URL.canParse(url)) return false;
   const protocol = new URL(url).protocol;
   return protocol === "https:" || protocol === "http:";
 }
@@ -22,11 +22,11 @@ function SceneShotPlaceholder({ scene }: Readonly<{ scene: AnimeScene }>) {
   );
 }
 
-function SceneImage({ scene }: Readonly<{ scene: AnimeScene }>) {
+function SceneImage({ url, name }: Readonly<{ url: string; name: string }>) {
   return (
     <img
-      src={scene.screenshot_url}
-      alt={scene.name}
+      src={url}
+      alt={name}
       loading="lazy"
       className="aspect-video w-full rounded-lg object-cover"
     />
@@ -34,8 +34,9 @@ function SceneImage({ scene }: Readonly<{ scene: AnimeScene }>) {
 }
 
 function SceneShot({ scene }: Readonly<{ scene: AnimeScene }>) {
-  if (!hasRenderableShot(scene.screenshot_url)) return <SceneShotPlaceholder scene={scene} />;
-  return <SceneImage scene={scene} />;
+  const url = scene.screenshot_url;
+  if (!hasRenderableShot(url)) return <SceneShotPlaceholder scene={scene} />;
+  return <SceneImage url={url} name={scene.name} />;
 }
 
 function sceneMeta({ scene, copy }: ItemProps): string {

--- a/apps/web/src/features/anime/copy.ts
+++ b/apps/web/src/features/anime/copy.ts
@@ -24,6 +24,10 @@ export interface AnimeCopy {
   readonly attribution: string;
   readonly shotCountFact: (n: number) => string;
   readonly spotUnit: (n: number) => string;
+  readonly errorTitle: string;
+  readonly errorBody: string;
+  readonly errorRetry: string;
+  readonly errorHome: string;
 }
 
 function hoursOf(minutes: number): number {
@@ -49,6 +53,10 @@ const ja: AnimeCopy = {
   attribution: "この作品の聖地データの出典はAnitabi（CC BY-NC-SA）です。",
   shotCountFact: (n) => `カット数 ${String(n)}`,
   spotUnit: (n) => `${String(n)}件`,
+  errorTitle: "エラーが発生しました",
+  errorBody: "作品情報を読み込めませんでした。もう一度お試しください。",
+  errorRetry: "もう一度試す",
+  errorHome: "ホームに戻る",
 };
 
 const zh: AnimeCopy = {
@@ -70,6 +78,10 @@ const zh: AnimeCopy = {
   attribution: "该作品的圣地数据来源为Anitabi（CC BY-NC-SA）。",
   shotCountFact: (n) => `镜头数 ${String(n)}`,
   spotUnit: (n) => `${String(n)}处`,
+  errorTitle: "出错了",
+  errorBody: "暂时无法加载该作品，请重试。",
+  errorRetry: "重试",
+  errorHome: "返回首页",
 };
 
 const en: AnimeCopy = {
@@ -91,6 +103,10 @@ const en: AnimeCopy = {
   attribution: "Spot data for this title is sourced from Anitabi (CC BY-NC-SA).",
   shotCountFact: (n) => `${String(n)} shots`,
   spotUnit: (n) => `${String(n)} spots`,
+  errorTitle: "Something went wrong",
+  errorBody: "We could not load this title right now. Please try again.",
+  errorRetry: "Try again",
+  errorHome: "Return home",
 };
 
 const COPY: Record<Locale, AnimeCopy> = { ja, zh, en };

--- a/apps/web/src/features/anime/route-states.tsx
+++ b/apps/web/src/features/anime/route-states.tsx
@@ -1,6 +1,8 @@
 import { useQueryErrorResetBoundary } from "@tanstack/react-query";
-import { useRouter } from "@tanstack/react-router";
+import { useRouter, useSearch } from "@tanstack/react-router";
 import { useEffect } from "react";
+import { DEFAULT_LOCALE, isLocale, type Locale } from "../../i18n/locales";
+import { animeCopyFor, type AnimeCopy } from "./copy";
 
 /**
  * Branded error + pending states for `/anime/:id` (NotFound style). The
@@ -19,31 +21,41 @@ function useRetry(): () => void {
   return () => void router.invalidate();
 }
 
-function AnimeErrorActions({ onRetry }: Readonly<{ onRetry: () => void }>) {
+/** The loader failed, so no loaderData: the `hl` search param is the source. */
+function useErrorLocale(): Locale {
+  const search: Readonly<Record<string, unknown>> = useSearch({ strict: false });
+  const hl = search.hl;
+  return typeof hl === "string" && isLocale(hl) ? hl : DEFAULT_LOCALE;
+}
+
+type ErrorCopyProps = Readonly<{ copy: AnimeCopy }>;
+
+function AnimeErrorActions({ copy, onRetry }: ErrorCopyProps & Readonly<{ onRetry: () => void }>) {
   return (
     <p className="m-0 flex items-center justify-center gap-4">
-      <button type="button" className="home-link" onClick={onRetry}>Try again</button>
-      <a className="home-link" href="/">Return home</a>
+      <button type="button" className="home-link" onClick={onRetry}>{copy.errorRetry}</button>
+      <a className="home-link" href="/">{copy.errorHome}</a>
     </p>
   );
 }
 
-function AnimeErrorHeading() {
+function AnimeErrorHeading({ copy }: ErrorCopyProps) {
   return (
     <>
       <p className="eyebrow">Animichi</p>
-      <h1 id="anime-error-title">Something went wrong</h1>
-      <p className="tagline">We could not load this title right now. Please try again.</p>
+      <h1 id="anime-error-title">{copy.errorTitle}</h1>
+      <p className="tagline">{copy.errorBody}</p>
     </>
   );
 }
 
 export function AnimeErrorState() {
   const handleRetry = useRetry();
+  const copy = animeCopyFor(useErrorLocale());
   return (
     <main className="app-shell hero compact" aria-labelledby="anime-error-title">
-      <AnimeErrorHeading />
-      <AnimeErrorActions onRetry={handleRetry} />
+      <AnimeErrorHeading copy={copy} />
+      <AnimeErrorActions copy={copy} onRetry={handleRetry} />
     </main>
   );
 }

--- a/apps/web/src/features/chat/use-chat-session.ts
+++ b/apps/web/src/features/chat/use-chat-session.ts
@@ -1,9 +1,9 @@
-import { useChat } from "@ai-sdk/react";
+import { Chat, useChat } from "@ai-sdk/react";
 import { ChatResponseDataPart } from "@seichijunrei/contract";
 import type { ChatDataPart } from "@seichijunrei/contract";
 import { DefaultChatTransport } from "ai";
 import type { UIMessage } from "ai";
-import { useCallback, useMemo, useRef } from "react";
+import { useRef } from "react";
 import type { RefObject } from "react";
 
 /**
@@ -49,41 +49,70 @@ function captureSessionId(ref: SessionRef, part: Readonly<{ data: ChatDataPart }
   if (typeof id === "string" && id !== "") ref.current.id = id;
 }
 
-function useCaptureSessionId(ref: SessionRef) {
-  return useCallback(
-    (part: Readonly<{ data: ChatDataPart }>) => {
-      captureSessionId(ref, part);
+/**
+ * A Chat whose transport and onData are fixed at construction: `scope` is the
+ * immutable epoch. `useChat`'s own onData delegates through a latest-render
+ * ref, so a late frame from a previous scope's stream would invoke the new
+ * scope's callback; constructing the Chat ourselves pins the callback to its
+ * epoch, and the guard drops frames once the tracker moved to another scope.
+ */
+function createScopedChat(chatUrl: string, scope: string, ref: SessionRef): Chat<ChatUIMessage> {
+  return new Chat<ChatUIMessage>({
+    id: scope,
+    transport: createSessionTransport(chatUrl, ref),
+    dataPartSchemas,
+    onData: (part) => {
+      if (ref.current.scope === scope) captureSessionId(ref, part);
     },
-    [ref],
-  );
+  });
 }
 
-function useSessionTransport(chatUrl: string, ref: SessionRef) {
-  return useMemo(
-    () =>
-      new DefaultChatTransport<ChatUIMessage>({
-        api: chatUrl,
-        headers: () => sessionHeaders(ref.current.id),
-      }),
-    [chatUrl, ref],
-  );
+function createSessionTransport(chatUrl: string, ref: SessionRef): DefaultChatTransport<ChatUIMessage> {
+  return new DefaultChatTransport({
+    api: chatUrl,
+    headers: () => sessionHeaders(ref.current.id),
+  });
+}
+
+interface ScopedChat {
+  scope: string;
+  chat: Chat<ChatUIMessage>;
+}
+
+/** Stop the outgoing scope's stream before the next scope's chat takes over. */
+function switchScopedChat(
+  previous: ScopedChat | null,
+  chatUrl: string,
+  scope: string,
+  ref: SessionRef,
+): ScopedChat {
+  void previous?.chat.stop();
+  return { scope, chat: createScopedChat(chatUrl, scope, ref) };
+}
+
+function useScopedChat(chatUrl: string, scope: string, ref: SessionRef): Chat<ChatUIMessage> {
+  const holder = useRef<ScopedChat | null>(null);
+  if (holder.current === null || holder.current.scope !== scope) {
+    holder.current = switchScopedChat(holder.current, chatUrl, scope, ref);
+  }
+  return holder.current.chat;
 }
 
 /**
  * `useChat` over `/v1/chat` (AI SDK UI message stream, spec S1.1 SD-9).
  *
  * The chat instance is scoped to the `?session=` identity: switching sessions
- * recreates it (official `id`-keyed reset), so an in-flight stream from the
- * previous session can never mix into the next one. The backend-assigned
- * `session_id` from `data-response` frames is fed back into follow-up requests
- * through the transport's dynamic `headers` function.
+ * stops the previous stream, recreates the Chat, and the construction-time
+ * epoch guard drops any frame that still arrives late — an in-flight stream
+ * from the previous session can never mix into the next one. The
+ * backend-assigned `session_id` from `data-response` frames is fed back into
+ * follow-up requests through the transport's dynamic `headers` function.
  */
 export function useChatSession(chatUrl: string, sessionId?: string) {
   const scope = scopeOf(sessionId);
   const ref = useSessionTracker(sessionId, scope);
-  const transport = useSessionTransport(chatUrl, ref);
-  const onData = useCaptureSessionId(ref);
-  return useChat<ChatUIMessage>({ id: scope, transport, dataPartSchemas, onData });
+  const chat = useScopedChat(chatUrl, scope, ref);
+  return useChat<ChatUIMessage>({ chat });
 }
 
 export type ChatSession = ReturnType<typeof useChatSession>;

--- a/apps/web/src/features/shiori/ShioriGenerator.tsx
+++ b/apps/web/src/features/shiori/ShioriGenerator.tsx
@@ -67,24 +67,25 @@ function useDeliveredPhotos(onPhotosSanitized?: PhotosSanitizedHandler) {
   return { photos, deliver };
 }
 
+/** A new (inputs, policy) epoch immediately retires the previous batch: the
+ * empty delivery revokes stale URLs and blanks preview/export payloads until
+ * re-sanitization under the new policy completes. */
 function runIngestion(
   inputs: readonly ShioriPhotoInput[],
   retainExif: boolean,
   deliver: PhotosSanitizedHandler,
 ): () => void {
-  if (inputs.length === 0) return deliverEmpty(deliver);
+  deliver([]);
+  if (inputs.length === 0) return () => undefined;
   return trackIngestion(ingestShioriPhotos(inputs, { retainExif }), deliver);
 }
 
-function deliverEmpty(deliver: PhotosSanitizedHandler): () => void {
-  deliver([]);
-  return () => undefined;
-}
-
+/** A cancelled epoch still revokes whatever URLs its late resolution minted. */
 function trackIngestion(pending: PendingPhotos, deliver: PhotosSanitizedHandler): () => void {
   let alive = true;
   void pending.then((next) => {
     if (alive) deliver(next);
+    else revokeShioriPhotoUrls(next);
   });
   return () => { alive = false; };
 }

--- a/apps/web/src/features/shiori/exifStrip.ts
+++ b/apps/web/src/features/shiori/exifStrip.ts
@@ -46,9 +46,17 @@ interface JpegWalk {
 /** Removes APPn (except APP0/JFIF) + COM segments everywhere, incl. between scans. */
 export function stripJpegMetadata(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
   const walk = startWalk(bytes);
-  while (readMarker(walk) !== EOI) stripNextSegment(walk);
+  while (nextMarker(walk) !== EOI) stripNextSegment(walk);
   finishAtEoi(walk);
   return concatBytes(walk.kept);
+}
+
+/** Markers may be padded with extra 0xFF fill bytes (ITU T.81 B.1.1.2). */
+function nextMarker(walk: JpegWalk): number {
+  while (walk.bytes[walk.offset] === 0xff && walk.bytes[walk.offset + 1] === 0xff) {
+    walk.offset += 1;
+  }
+  return readMarker(walk);
 }
 
 function startWalk(bytes: Uint8Array): JpegWalk {
@@ -138,9 +146,17 @@ async function stripJpegBlob(photo: Blob): Promise<Blob> {
 
 async function redrawWithoutMetadata(photo: Blob): Promise<Blob> {
   const bitmap = await createImageBitmap(photo);
+  try {
+    return await redrawBitmap(bitmap, photo.type);
+  } finally {
+    bitmap.close();
+  }
+}
+
+function redrawBitmap(bitmap: ImageBitmap, type: string): Promise<Blob> {
   const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
   const context = canvas.getContext("2d");
   if (!context) throw new Error("2d canvas context unavailable");
   context.drawImage(bitmap, 0, 0);
-  return canvas.convertToBlob({ type: photo.type });
+  return canvas.convertToBlob({ type });
 }

--- a/apps/web/src/i18n/locales.ts
+++ b/apps/web/src/i18n/locales.ts
@@ -11,7 +11,7 @@ export const LOCALE_LABELS: Record<Locale, string> = {
   en: "EN",
 };
 
-function isLocale(value: string): value is Locale {
+export function isLocale(value: string): value is Locale {
   return (LOCALES as readonly string[]).includes(value);
 }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import {
   useMatches,
 } from "@tanstack/react-router";
 import { NotFound } from "../components/NotFound";
+import { THEME_BOOTSTRAP_SCRIPT } from "../components/theme-bootstrap";
 import { DEFAULT_LOCALE, LOCALES, type Locale } from "../i18n/locales";
 import globalsUrl from "../styles/globals.css?url";
 
@@ -21,6 +22,9 @@ type RootDocumentProps = Readonly<{
 
 const rootHead = {
   links: [{ rel: "stylesheet", href: globalsUrl }],
+  // Pre-hydration theme init: every route honors the stored preference,
+  // and the landing page cannot flash the day default.
+  scripts: [{ children: THEME_BOOTSTRAP_SCRIPT }],
   meta: [
     { charSet: "utf-8" },
     { name: "viewport", content: "width=device-width, initial-scale=1" },

--- a/apps/web/src/routes/anime/$bangumiId.tsx
+++ b/apps/web/src/routes/anime/$bangumiId.tsx
@@ -39,9 +39,13 @@ function siteOrigin(): string {
   }
 }
 
-/** The catalog 404s unknown works (WORK_NOT_FOUND); echo it as a router 404. */
+/**
+ * Only the catalog's typed WORK_NOT_FOUND becomes a router 404. Any other
+ * 404 (a gateway HTML page when the backend is down, a routing mishap) is an
+ * outage and must reach the errorComponent, never a soft-404.
+ */
 function isWorkNotFound(error: unknown): boolean {
-  return error instanceof ORPCError && error.status === 404;
+  return error instanceof ORPCError && error.defined && error.code === "WORK_NOT_FOUND";
 }
 
 async function loadOverview(queryClient: QueryClient, bangumiId: string): Promise<AnimeOverview> {

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -84,7 +84,7 @@
 }
 
 .chat-step[data-status="error"] {
-  color: var(--color-error-fg);
+  color: var(--color-error-strong);
 }
 
 .chat-card {
@@ -117,8 +117,8 @@
   justify-content: space-between;
   gap: 1rem;
   padding: 0.625rem 1rem;
-  background: var(--color-error-fg);
-  color: var(--color-primary-fg);
+  background: var(--color-error-bg);
+  color: var(--color-error-strong);
 }
 
 .chat-error-banner__retry {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -24,6 +24,9 @@
   --color-success-fg: #6fba2c;
   --color-warning-fg: #f5c31c;
   --color-error-fg: #e05a5a;
+  /* AA pair for error surfaces: strong red text on a light red tint. */
+  --color-error-strong: #b03030;
+  --color-error-bg: #fdecec;
   --color-walk-bg: #e8f5e9;
   --color-walk-fg: #2e7d32;
   --color-explore-bg: #e0f7f5;

--- a/apps/web/tests/msw/anime-overview.ts
+++ b/apps/web/tests/msw/anime-overview.ts
@@ -88,6 +88,16 @@ export const animeOverviewNotFoundHandler: HttpHandler = http.get(ANIME_OVERVIEW
   }),
 );
 
+/** A generic gateway 404 (HTML, no typed envelope): NOT an unknown work. */
+export const animeOverviewGatewayNotFoundHandler: HttpHandler = http.get(
+  ANIME_OVERVIEW_PATH,
+  () =>
+    new HttpResponse("<html><body>404 Not Found</body></html>", {
+      status: 404,
+      headers: { "content-type": "text/html" },
+    }),
+);
+
 /** An always-failing handler for loader error-path tests. */
 export const animeOverviewOutageHandler: HttpHandler = http.get(ANIME_OVERVIEW_PATH, () =>
   orpcErrorResponse({ code: "INTERNAL_SERVER_ERROR", status: 500, message: "catalog unavailable" }),

--- a/apps/web/tests/msw/chat-handlers.ts
+++ b/apps/web/tests/msw/chat-handlers.ts
@@ -75,16 +75,58 @@ export function chatStreamHeldOpenHandler(name: ChatStreamFixture): HttpHandler 
   });
 }
 
+export interface ControlledChatStream {
+  readonly handler: HttpHandler;
+  /** Flush the recorded final data-response frame (and close), if still open. */
+  readonly releaseFinal: () => void;
+}
+
+/** Streams the recording head, then lets the test release the final frame late. */
+export function chatStreamControlledHandler(
+  name: ChatStreamFixture,
+  sessionId: string,
+): ControlledChatStream {
+  const recorded = patchSessionId(chatStreamFixture(name), sessionId);
+  const splitAt = recorded.indexOf('data: {"type":"data-response"');
+  let release: () => void = () => undefined;
+  const handler = http.post(CHAT_URL, () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(recorded.slice(0, splitAt)));
+        release = () => {
+          flushTail(controller, recorded.slice(splitAt));
+        };
+      },
+    });
+    return new HttpResponse(body, { headers: SSE_HEADERS });
+  });
+  return {
+    handler,
+    releaseFinal: () => {
+      release();
+    },
+  };
+}
+
+function flushTail(controller: ReadableStreamDefaultController<Uint8Array>, tail: string): void {
+  try {
+    controller.enqueue(new TextEncoder().encode(tail));
+    controller.close();
+  } catch {
+    // The consumer aborted the stream first: the late frame has nowhere to go.
+  }
+}
+
+const SSE_HEADERS = {
+  "content-type": "text/event-stream",
+  "x-vercel-ai-ui-message-stream": "v1",
+};
+
 function sseResponse(
   text: string,
   { close = true }: Readonly<{ close?: boolean }> = {},
 ): HttpResponse<ReadableStream<Uint8Array>> {
-  return new HttpResponse(sseBody(text, close), {
-    headers: {
-      "content-type": "text/event-stream",
-      "x-vercel-ai-ui-message-stream": "v1",
-    },
-  });
+  return new HttpResponse(sseBody(text, close), { headers: SSE_HEADERS });
 }
 
 export const healthzOkHandler = http.get(HEALTHZ_URL, () =>

--- a/apps/web/tests/unit/anime/anime-route-defense.test.tsx
+++ b/apps/web/tests/unit/anime/anime-route-defense.test.tsx
@@ -5,7 +5,11 @@ import { RouterProvider } from "@tanstack/react-router";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getRouter } from "../../../src/router";
-import { animeOverviewHandler, animeOverviewNotFoundHandler } from "../../msw/anime-overview";
+import {
+  animeOverviewGatewayNotFoundHandler,
+  animeOverviewHandler,
+  animeOverviewNotFoundHandler,
+} from "../../msw/anime-overview";
 import { server } from "../../msw/node";
 
 afterEach(cleanup);
@@ -32,6 +36,13 @@ describe("/anime/$bangumiId soft-404 defense", () => {
     await openAnime("654321");
     expect(await screen.findByRole("heading", { name: "404" })).toBeTruthy();
     expect(screen.queryByText(/WORK_NOT_FOUND/)).toBeNull();
+  });
+
+  it("treats an untyped gateway 404 as an outage, not an unknown work", async () => {
+    server.use(animeOverviewGatewayNotFoundHandler);
+    await openAnime("123");
+    expect(await screen.findByText("Something went wrong")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "404" })).toBeNull();
   });
 
   it("marks the empty-overview page as noindex for crawlers", async () => {

--- a/apps/web/tests/unit/anime/anime-route-defense.test.tsx
+++ b/apps/web/tests/unit/anime/anime-route-defense.test.tsx
@@ -41,7 +41,7 @@ describe("/anime/$bangumiId soft-404 defense", () => {
   it("treats an untyped gateway 404 as an outage, not an unknown work", async () => {
     server.use(animeOverviewGatewayNotFoundHandler);
     await openAnime("123");
-    expect(await screen.findByText("Something went wrong")).toBeTruthy();
+    expect(await screen.findByText("エラーが発生しました")).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "404" })).toBeNull();
   });
 

--- a/apps/web/tests/unit/anime/route-states.test.tsx
+++ b/apps/web/tests/unit/anime/route-states.test.tsx
@@ -11,10 +11,10 @@ import { server } from "../../msw/node";
 
 afterEach(cleanup);
 
-async function openAnime(bangumiId: string) {
+async function openAnime(bangumiId: string, search: Readonly<{ hl?: "ja" | "zh" | "en" }> = {}) {
   const router = getRouter();
   router.options.context.queryClient.setDefaultOptions({ queries: { retry: false } });
-  await router.navigate({ to: "/anime/$bangumiId", params: { bangumiId }, search: {} });
+  await router.navigate({ to: "/anime/$bangumiId", params: { bangumiId }, search });
   render(<RouterProvider router={router} />);
   return router;
 }
@@ -31,14 +31,22 @@ describe("/anime/$bangumiId error state", () => {
     server.use(animeOverviewOutageHandler);
     await openAnime("123");
     expect(await screen.findByText("Animichi")).toBeTruthy();
-    expect(screen.getByText("Something went wrong")).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Return home" }).getAttribute("href")).toBe("/");
+    expect(screen.getByText("エラーが発生しました")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "ホームに戻る" }).getAttribute("href")).toBe("/");
+  });
+
+  it("localizes the error screen when hl=zh is in the search", async () => {
+    server.use(animeOverviewOutageHandler);
+    await openAnime("123", { hl: "zh" });
+    expect(await screen.findByText("出错了")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "重试" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "返回首页" })).toBeTruthy();
   });
 
   it("never leaks the technical error text to the user", async () => {
     server.use(animeOverviewOutageHandler);
     await openAnime("123");
-    await screen.findByText("Something went wrong");
+    await screen.findByText("エラーが発生しました");
     expect(screen.queryByText(/catalog unavailable/)).toBeNull();
     expect(screen.queryByText(/INTERNAL_SERVER_ERROR/)).toBeNull();
   });
@@ -46,10 +54,10 @@ describe("/anime/$bangumiId error state", () => {
   it("recovers via the try-again button once the catalog is back", async () => {
     server.use(animeOverviewOutageHandler);
     await openAnime("123");
-    await screen.findByRole("button", { name: "Try again" });
+    await screen.findByRole("button", { name: "もう一度試す" });
     server.use(animeOverviewHandler);
     // Re-query at click time: the boundary recreates the subtree after the catch.
-    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    fireEvent.click(screen.getByRole("button", { name: "もう一度試す" }));
     expect(await screen.findByText(/Suga Shrine Stairs/)).toBeTruthy();
   });
 });

--- a/apps/web/tests/unit/anime/scenes-section.test.tsx
+++ b/apps/web/tests/unit/anime/scenes-section.test.tsx
@@ -34,6 +34,13 @@ describe("ScenesSection screenshots", () => {
     expect(img.getAttribute("src")).toBe("https://cdn.test/scene-1.jpg");
   });
 
+  it("renders the placeholder when the contract delivers a null screenshot_url", () => {
+    renderScenes(makeScene({ screenshot_url: null }));
+    const shot = screen.getByRole("img", { name: "Suga Shrine Stairs" });
+    expect(shot.tagName).not.toBe("IMG");
+    expect(document.querySelector("img")).toBeNull();
+  });
+
   it("renders an accessible placeholder instead of an img when the url is empty", () => {
     renderScenes(makeScene({ screenshot_url: "" }));
     const shot = screen.getByRole("img", { name: "Suga Shrine Stairs" });

--- a/apps/web/tests/unit/api/orpc-browser-memo.test.tsx
+++ b/apps/web/tests/unit/api/orpc-browser-memo.test.tsx
@@ -1,0 +1,16 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from "vitest";
+import { catalog, users } from "../../../src/api/orpc";
+
+/** Browser environment: one origin for the whole page, memoization is safe. */
+describe("orpc utils in the browser", () => {
+  it("memoizes the catalog utils across calls", () => {
+    expect(catalog()).toBe(catalog());
+  });
+
+  it("memoizes the users utils across calls", () => {
+    expect(users()).toBe(users());
+  });
+});

--- a/apps/web/tests/unit/api/orpc-ssr-isolation.test.ts
+++ b/apps/web/tests/unit/api/orpc-ssr-isolation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { catalog, users } from "../../../src/api/orpc";
+
+/**
+ * Node environment (no `window`): the SSR path. Utils must be rebuilt per
+ * call so the base URL follows each request's origin instead of whichever
+ * accepted host happened to serve the first SSR request.
+ */
+describe("orpc utils on the server", () => {
+  it("builds fresh catalog utils per call instead of caching the first origin", () => {
+    expect(catalog()).not.toBe(catalog());
+  });
+
+  it("builds fresh users utils per call instead of caching the first origin", () => {
+    expect(users()).not.toBe(users());
+  });
+});

--- a/apps/web/tests/unit/chat-error-contrast.test.ts
+++ b/apps/web/tests/unit/chat-error-contrast.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import chatCss from "../../src/styles/chat.css?raw";
+import globalsCss from "../../src/styles/globals.css?raw";
+import { normalizeHex, parseTokens, ruleDeclaration, tokenValue } from "./_token-helpers";
+
+const tokens = parseTokens(globalsCss);
+
+function resolve(declaration: string | null): string {
+  if (declaration === null) throw new Error("missing declaration");
+  const name = /var\((--[\w-]+)\)/u.exec(declaration)?.[1];
+  return normalizeHex(name === undefined ? declaration : tokenValue(tokens, name));
+}
+
+function channel(hex: string, at: number): number {
+  const linear = Number.parseInt(hex.slice(at, at + 2), 16) / 255;
+  return linear <= 0.04045 ? linear / 12.92 : ((linear + 0.055) / 1.055) ** 2.4;
+}
+
+function luminance(hex: string): number {
+  return 0.2126 * channel(hex, 1) + 0.7152 * channel(hex, 3) + 0.0722 * channel(hex, 5);
+}
+
+function contrast(foreground: string, background: string): number {
+  const first = luminance(foreground);
+  const second = luminance(background);
+  return (Math.max(first, second) + 0.05) / (Math.min(first, second) + 0.05);
+}
+
+describe("chat error colors meet WCAG AA (>= 4.5:1)", () => {
+  it("keeps the error banner text readable on the banner background", () => {
+    const background = resolve(ruleDeclaration(chatCss, ".chat-error-banner", "background"));
+    const foreground = resolve(ruleDeclaration(chatCss, ".chat-error-banner", "color"));
+    expect(contrast(foreground, background)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("keeps the errored tool-step text readable on the card background", () => {
+    const selector = '.chat-step[data-status="error"]';
+    const foreground = resolve(ruleDeclaration(chatCss, selector, "color"));
+    const card = normalizeHex(tokenValue(tokens, "--color-card"));
+    expect(contrast(foreground, card)).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/apps/web/tests/unit/chat/use-chat-session.test.tsx
+++ b/apps/web/tests/unit/chat/use-chat-session.test.tsx
@@ -5,7 +5,12 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { useChatSession } from "../../../src/features/chat/use-chat-session";
 import { server } from "../../msw/node";
-import { CHAT_URL, chatStreamHandler, chatStreamHeldOpenHandler } from "../../msw/chat-handlers";
+import {
+  CHAT_URL,
+  chatStreamControlledHandler,
+  chatStreamHandler,
+  chatStreamHeldOpenHandler,
+} from "../../msw/chat-handlers";
 
 type Props = Readonly<{ sessionId?: string }>;
 
@@ -19,6 +24,13 @@ function spyingHandler(seen: (string | null)[], sessionId?: string) {
   return chatStreamHandler("search", {
     sessionId,
     spy: (request) => seen.push(request.headers.get("x-session-id")),
+  });
+}
+
+/** Let a released stream tail cross the fetch boundary and be processed. */
+async function drainLateFrames() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 25));
   });
 }
 
@@ -70,6 +82,25 @@ describe("session switch resets the chat instance", () => {
     view.rerender({ sessionId: "B" });
     expect(view.result.current.messages).toEqual([]);
     expect(view.result.current.status).toBe("ready");
+  });
+
+  it("never lets a late frame from the old stream leak its session id into B", async () => {
+    const controlled = chatStreamControlledHandler("search", "stale-A");
+    server.use(controlled.handler);
+    const view = renderSession();
+    act(() => {
+      void view.result.current.sendMessage({ text: "ユーフォ" });
+    });
+    await waitFor(() => {
+      expect(view.result.current.messages.length).toBeGreaterThan(0);
+    });
+    view.rerender({ sessionId: "B" });
+    controlled.releaseFinal();
+    await drainLateFrames();
+    const seen: (string | null)[] = [];
+    server.use(spyingHandler(seen));
+    await sendAndSettle(view, "続き");
+    expect(seen).toEqual(["B"]);
   });
 
   it("does not reset when the same session identity re-renders", async () => {

--- a/apps/web/tests/unit/shiori/exif-strip.test.ts
+++ b/apps/web/tests/unit/shiori/exif-strip.test.ts
@@ -70,7 +70,8 @@ describe("sanitizePhoto", () => {
     const redrawn = new Blob(["clean"], { type: "image/png" });
     const convertToBlob = vi.fn().mockResolvedValue(redrawn);
     const drawImage = vi.fn();
-    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue({ width: 4, height: 3 }));
+    const bitmap = { width: 4, height: 3, close: vi.fn() };
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue(bitmap));
     vi.stubGlobal(
       "OffscreenCanvas",
       class {
@@ -82,12 +83,14 @@ describe("sanitizePhoto", () => {
     const sanitized = await sanitizePhoto(new Blob(["png-with-eXIf"], { type: "image/png" }));
 
     expect(sanitized).toBe(redrawn);
-    expect(drawImage).toHaveBeenCalledWith({ width: 4, height: 3 }, 0, 0);
+    expect(drawImage).toHaveBeenCalledWith(bitmap, 0, 0);
     expect(convertToBlob).toHaveBeenCalledWith({ type: "image/png" });
+    expect(bitmap.close).toHaveBeenCalledTimes(1);
   });
 
-  it("fails loudly when the canvas context is unavailable", async () => {
-    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue({ width: 4, height: 3 }));
+  it("closes the bitmap even when the canvas context is unavailable", async () => {
+    const bitmap = { width: 4, height: 3, close: vi.fn() };
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue(bitmap));
     vi.stubGlobal(
       "OffscreenCanvas",
       class {
@@ -98,5 +101,6 @@ describe("sanitizePhoto", () => {
     await expect(sanitizePhoto(new Blob(["x"], { type: "image/webp" }))).rejects.toThrow(
       "2d canvas context unavailable",
     );
+    expect(bitmap.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/unit/shiori/jpeg-strip-hardening.test.ts
+++ b/apps/web/tests/unit/shiori/jpeg-strip-hardening.test.ts
@@ -80,3 +80,17 @@ describe("stripJpegMetadata fail-closed hardening", () => {
     expect([...stripJpegMetadata(input)]).toEqual([...clean]);
   });
 });
+
+describe("stripJpegMetadata fill-byte tolerance", () => {
+  it("accepts legal 0xFF fill bytes padding a marker between segments", () => {
+    const input = jpeg(DQT, [0xff], SCAN_WITH_STUFFING, EOI);
+
+    expect([...stripJpegMetadata(input)]).toEqual([...jpeg(DQT, SCAN_WITH_STUFFING, EOI)]);
+  });
+
+  it("still strips a metadata segment padded with fill bytes", () => {
+    const input = jpeg(DQT, [0xff, 0xff], APP1_EXIF_GPS, SCAN_WITH_STUFFING, EOI);
+
+    expect(bytesToText(stripJpegMetadata(input))).not.toContain("GPSLAT");
+  });
+});

--- a/apps/web/tests/unit/shiori/shiori-generator-epoch.test.tsx
+++ b/apps/web/tests/unit/shiori/shiori-generator-epoch.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SanitizedShioriPhoto } from "../../../src/features/shiori/types";
+import { ShioriGenerator, type ShioriGeneratorSource } from "../../../src/features/shiori/ShioriGenerator";
+import { makeItinerary, makeMeta, makePhotoInput } from "./_factories";
+import { blobText } from "./_jpegFixtures";
+
+const createObjectURL = vi.fn((_blob: Blob) => `blob:mock-${String(createObjectURL.mock.calls.length)}`);
+const revokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function makeSource(): ShioriGeneratorSource {
+  return {
+    meta: makeMeta(),
+    itinerary: makeItinerary(),
+    photos: [makePhotoInput()],
+    checkedStopIds: ["stop-station", "stop-shrine"],
+    isRouteDayOver: false,
+  };
+}
+
+const lastPayload = (spy: ReturnType<typeof vi.fn>): readonly SanitizedShioriPhoto[] =>
+  spy.mock.calls.at(-1)?.[0] as readonly SanitizedShioriPhoto[];
+
+describe("ShioriGenerator EXIF policy epoch", () => {
+  it("retires the old preview and export payload the moment the policy flips", async () => {
+    const onPhotosSanitized = vi.fn();
+    render(
+      <ShioriGenerator source={makeSource()} locale="ja" onPhotosSanitized={onPhotosSanitized} />,
+    );
+    await screen.findByRole("img", { name: "気多若宮神社 の対比図" });
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "写真の位置情報（EXIF）を残す" }));
+
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(lastPayload(onPhotosSanitized)).toEqual([]);
+    await waitFor(async () => {
+      expect(await blobText(lastPayload(onPhotosSanitized)[0]?.blob)).toContain("GPSLAT");
+    });
+  });
+
+  it("revokes the previous epoch's object URL when the policy flips", async () => {
+    render(<ShioriGenerator source={makeSource()} locale="ja" />);
+    await screen.findByRole("img", { name: "気多若宮神社 の対比図" });
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "写真の位置情報（EXIF）を残す" }));
+
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-1");
+  });
+
+  it("revokes URLs minted by an ingestion abandoned on unmount", async () => {
+    const view = render(<ShioriGenerator source={makeSource()} locale="ja" />);
+
+    view.unmount();
+
+    await waitFor(() => {
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-1");
+    });
+  });
+});

--- a/apps/web/tests/unit/theme-bootstrap.test.ts
+++ b/apps/web/tests/unit/theme-bootstrap.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { THEME_BOOTSTRAP_SCRIPT, THEME_STORAGE_KEY } from "../../src/components/theme-bootstrap";
+import { Route } from "../../src/routes/__root";
+
+/** Execute exactly what the served <head> executes: an inline script tag. */
+function runBootstrap(): void {
+  const script = document.createElement("script");
+  script.textContent = THEME_BOOTSTRAP_SCRIPT;
+  document.head.append(script);
+  script.remove();
+}
+
+afterEach(() => {
+  window.localStorage.clear();
+  delete document.documentElement.dataset.theme;
+});
+
+describe("theme bootstrap script", () => {
+  it("applies the stored night preference before hydration", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "night");
+    runBootstrap();
+    expect(document.documentElement.dataset.theme).toBe("night");
+  });
+
+  it("applies the stored day preference before hydration", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "day");
+    runBootstrap();
+    expect(document.documentElement.dataset.theme).toBe("day");
+  });
+
+  it("leaves the default theme untouched for a garbage stored value", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "neon");
+    runBootstrap();
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+
+  it("leaves the default theme untouched when nothing is stored", () => {
+    runBootstrap();
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+});
+
+describe("root route head", () => {
+  it("ships the theme bootstrap as an inline script for every route", () => {
+    const head = Route.options.head?.({} as never);
+    const scripts = (head as { scripts?: readonly { children?: string }[] }).scripts ?? [];
+    const inline = scripts.map((script) => script.children ?? "").join("\n");
+    expect(inline).toContain(THEME_STORAGE_KEY);
+  });
+});


### PR DESCRIPTION
## Summary

Second-round review fix card **FIX2-frontend** (Codex + Fable findings). Scope: `apps/web/**` only. Every fix landed test-first.

| # | Sev | Finding | Fix | Test |
|---|-----|---------|-----|------|
| 1 | P0 | `ScenesSection` consumed `screenshot_url` as `string\|undefined` while the contract says `string\|null` → tsc red base | `hasRenderableShot` is a `url is string` predicate over the nullable field; `SceneImage` takes the narrowed url; null renders the placeholder | unit: `scenes-section.test.tsx` (null case) |
| 2 | P1 | Session epoch race: `useChat`'s managed `onData` delegates through a latest-render ref, so A's late final frame wrote its `session_id` into B's tracker → next B turn sent `X-Session-Id: A` | Chat constructed per scope with transport+`onData` fixed at construction (immutable epoch); scope switch stops the old stream; guard drops frames from retired epochs | unit: controllable MSW stream releases A's late frame after switching to B, asserts B's header |
| 3 | P1 | `cachedCatalog`/`cachedUsers` module globals froze the first SSR request's origin | Utils rebuilt per call on the server; memoization browser-only | unit: node-env fresh-instance + jsdom memoization tests |
| 4 | P1 | Shiori EXIF policy flip kept the old raw preview/export payload alive; cancelled ingestion leaked minted objectURLs | New (inputs, policy) epoch delivers `[]` synchronously (revokes old URLs, blanks preview/export until re-sanitize done); cancelled epoch revokes late-minted URLs | unit: `shiori-generator-epoch.test.tsx` (3 tests) |
| 5 | P1 | `isWorkNotFound` matched any 404 → gateway HTML 404 rendered the branded soft-404 | Router 404 requires the typed defined error `code === "WORK_NOT_FOUND"`; other 404s reach the errorComponent | unit: gateway-HTML-404 handler → error state, not 404 |
| 6 | P1 | Night theme only applied inside the landing tree; /chat and /anime ignored the stored preference | Pre-hydration inline script in `__root.tsx` head applies the stored theme before first paint on every route (also kills the landing day-flash) | unit: script-execution + root-head registration tests |
| 7 | P2 | Picked: (a) chat error banner/step contrast 3.3–3.6:1 → new `--color-error-strong`/`--color-error-bg` AA pair with a computed-WCAG-ratio test; (b) `AnimeErrorState` hardcoded English → trilingual `AnimeCopy`, locale from `?hl=`; (c) exifStrip rejected legal JPEG 0xFF fill bytes → tolerated per ITU T.81 B.1.1.2; (d) `ImageBitmap.close()` in `finally` | | unit tests for each |

Not picked from the P2 menu: the SSR→hydrate router integration test (lowest value/cost ratio; per-request QueryClient isolation is already pinned by `router.test.tsx`, and the SSR swimlane is deliberately validated against a real Worker at the G1 gate).

## Gates (all green)

- `pnpm run build` — Nitro Cloudflare build OK
- `pnpm run typecheck` (run separately, not via build) — **0 errors**
- `pnpm run lint:oxlint` — clean, `--deny-warnings`
- `pnpm test` — 72 files, **394 passed**, coverage 99.01 / 95.78 / 99.50 / 99.74 (floor 90)
- `pnpm run test:integration` — 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)