### PR TITLE
fix(agent+web): review-2 P0/P1 — Zod-aligned wire, atomic ownership, error lifecycle + frontend error consumer

### DIFF
--- a/apps/agent/agent/agents/animichi_runner.py
+++ b/apps/agent/agent/agents/animichi_runner.py
@@ -275,18 +275,22 @@ def _blocked_message(locale: str) -> str:
 async def _record_terminal_clarify(
     deps: RuntimeDeps, output: ClarifyResponseModel
 ) -> None:
-    data: dict[str, object] = {
-        "reason": output.reason,
-        "candidate_ids": output.candidate_ids,
-    }
-    deps.steps.append(
-        StepRecord(
-            tool="clarify",
-            success=True,
-            data=data,
-            model_initiated=False,
-        )
-    )
-    if deps.on_step is not None:
-        call_id = new_step_call_id("clarify")
-        await deps.on_step(StepEvent("clarify", call_id, "done", data))
+    data = _clarify_step_data(output)
+    deps.steps.append(_clarify_step_record(data))
+    if deps.on_step is None:
+        return
+    await _emit_clarify_lifecycle(deps.on_step, data)
+
+
+def _clarify_step_data(output: ClarifyResponseModel) -> dict[str, object]:
+    return {"reason": output.reason, "candidate_ids": output.candidate_ids}
+
+
+def _clarify_step_record(data: dict[str, object]) -> StepRecord:
+    return StepRecord(tool="clarify", success=True, data=data, model_initiated=False)
+
+
+async def _emit_clarify_lifecycle(on_step: OnStep, data: dict[str, object]) -> None:
+    call_id = new_step_call_id("clarify")
+    await on_step(StepEvent("clarify", call_id, "running", data))
+    await on_step(StepEvent("clarify", call_id, "done", data))

--- a/apps/agent/agent/domain/ports.py
+++ b/apps/agent/agent/domain/ports.py
@@ -79,6 +79,14 @@ class DatabasePort(Protocol):
 class SessionRepo(Protocol):
     """Session-related DB operations used by persistence helpers."""
 
+    async def create_owned_session(
+        self,
+        session_id: str,
+        user_id: str,
+        first_query: str,
+        session_state: dict[str, object],
+    ) -> None: ...
+
     async def upsert_session(
         self,
         session_id: str,

--- a/apps/agent/agent/infrastructure/supabase/repositories/session.py
+++ b/apps/agent/agent/infrastructure/supabase/repositories/session.py
@@ -7,12 +7,32 @@ from collections.abc import Mapping
 
 from agent.infrastructure.supabase.client_types import AsyncPGPool, Row
 
+_CREATE_SESSION_SQL = """
+    INSERT INTO sessions (id, state, metadata) VALUES ($1, $2::jsonb, '{}'::jsonb)
+"""
+_CREATE_CONVERSATION_SQL = """
+    INSERT INTO conversations (session_id, user_id, first_query) VALUES ($1, $2, $3)
+"""
+
 
 class SessionRepository:
     """Session and conversation data access."""
 
     def __init__(self, pool: AsyncPGPool) -> None:
         self._pool = pool
+
+    async def create_owned_session(
+        self, session_id: str, user_id: str, first_query: str, state: dict[str, object]
+    ) -> None:
+        """Atomically create server session state and its ownership row."""
+        async with self._pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute(
+                    _CREATE_SESSION_SQL, session_id, json.dumps(state)
+                )
+                await connection.execute(
+                    _CREATE_CONVERSATION_SQL, session_id, user_id, first_query
+                )
 
     async def get_session(self, session_id: str) -> Row | None:
         """Fetch a session by ID."""

--- a/apps/agent/agent/interfaces/chat_wire.py
+++ b/apps/agent/agent/interfaces/chat_wire.py
@@ -1,0 +1,204 @@
+"""Strict Python projection for the public chat data-part contract."""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from agent.interfaces.schemas import JsonObject, PublicAPIResponse
+
+ChatIntent = Literal[
+    "search_bangumi",
+    "search_nearby",
+    "plan_route",
+    "plan_selected",
+    "plan_multi",
+    "general_qa",
+    "greet_user",
+    "clarify",
+    "partial",
+    "blocked",
+    "unknown",
+    "error",
+]
+
+
+class _WireModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class StreamPoint(_WireModel):
+    id: str | None = None
+    name: str | None = None
+    name_cn: str | None = None
+    bangumi_id: str | None = None
+    episode: int | None = None
+    time_seconds: int | None = None
+    screenshot_url: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    title: str | None = None
+    title_cn: str | None = None
+    distance_m: float | None = None
+    origin: str | None = None
+    cover_url: str | None = None
+    city: str | None = None
+    lat: float | None = None
+    lng: float | None = None
+    ep: int | None = None
+
+
+class SearchResults(_WireModel):
+    kind: Literal["bangumi", "nearby", "multi"] | None = None
+    bangumi_id: str | int | None = None
+    title: str | None = None
+    row_count: int | None = None
+    status: str | None = None
+    strategy: str | None = None
+    summary: JsonObject | None = None
+    rows: list[StreamPoint] | None = None
+
+
+class TimedStop(_WireModel):
+    cluster_id: str
+    name: str
+    arrive: str
+    depart: str
+    dwell_minutes: int
+    lat: float
+    lng: float
+    photo_count: int
+
+
+class TransitLeg(_WireModel):
+    from_id: str
+    to_id: str
+    mode: Literal["walk", "transit"]
+    duration_minutes: int
+    distance_m: float
+
+
+class TimedItinerary(_WireModel):
+    stops: list[TimedStop]
+    legs: list[TransitLeg]
+    total_minutes: int
+    total_distance_m: float
+    spot_count: int | None = None
+    pacing: Literal["chill", "normal", "packed"] | None = None
+    start_time: str | None = None
+    export_google_maps_url: list[str] | None = None
+    export_ics: str | None = None
+
+
+class StreamRoute(_WireModel):
+    id: str | None = None
+    version: str | None = None
+    ordered_points: list[str] | list[StreamPoint] | None = None
+    point_count: int | None = None
+    cover_url: str | None = None
+    anime_title: str | None = None
+    anime_title_cn: str | None = None
+    truncated: bool | None = None
+    shown_cluster_count: int | None = None
+    total_cluster_count: int | None = None
+    timed_itinerary: TimedItinerary | None = None
+    status: str | None = None
+    total_walk_minutes: float | None = None
+
+
+class ClarificationCandidate(_WireModel):
+    bangumi_id: str | None = None
+    title: str | None = None
+    title_cn: str | None = None
+    cover_url: str | None = None
+    year: int | None = None
+    points_count: int | None = None
+    id: str | None = None
+    lat: float | None = None
+    lng: float | None = None
+
+
+class SearchData(_WireModel):
+    results: SearchResults | None = None
+
+
+class RouteData(_WireModel):
+    results: SearchResults | None = None
+    route: StreamRoute | None = None
+
+
+class ClarificationData(_WireModel):
+    reason: str | None = None
+    clarification_id: int | None = None
+    candidates: list[ClarificationCandidate] | None = None
+    outcome: JsonObject | None = None
+
+
+class PublicAPIErrorWire(_WireModel):
+    code: str
+    message: str
+    details: JsonObject | None = None
+
+
+class UIWire(_WireModel):
+    component: str
+
+
+class ChatResponseWire(_WireModel):
+    intent: ChatIntent
+    success: bool | None = None
+    status: str | None = None
+    session_id: str | None = None
+    message: str | None = None
+    data: SearchData | RouteData | ClarificationData | JsonObject | None = None
+    session: JsonObject | None = None
+    route_history: list[JsonObject] | None = None
+    errors: list[PublicAPIErrorWire] | None = None
+    ui: UIWire | None = None
+    generated_title: str | None = None
+    debug: JsonObject | None = None
+
+
+def _search_results(data: JsonObject) -> SearchResults | None:
+    raw = data.get("results")
+    if not isinstance(raw, dict):
+        return None
+    values = dict(raw)
+    values["bangumi_id"] = raw.get("bangumi_id", raw.get("anime_id"))
+    metadata = raw.get("metadata")
+    if isinstance(metadata, dict):
+        values["title"] = raw.get("title", metadata.get("anime_title"))
+    return SearchResults.model_validate(values, extra="ignore")
+
+
+def _route(data: JsonObject) -> StreamRoute | None:
+    raw = data.get("route")
+    return (
+        StreamRoute.model_validate(raw, extra="ignore")
+        if isinstance(raw, dict)
+        else None
+    )
+
+
+def _wire_data(
+    response: PublicAPIResponse,
+) -> SearchData | RouteData | ClarificationData | JsonObject:
+    if response.intent in {"search_bangumi", "search_nearby"}:
+        return SearchData(results=_search_results(response.data))
+    if response.intent in {"plan_route", "plan_selected", "plan_multi", "partial"}:
+        return RouteData(
+            results=_search_results(response.data), route=_route(response.data)
+        )
+    if response.intent == "clarify":
+        return ClarificationData.model_validate(response.data, extra="ignore")
+    return {}
+
+
+def chat_response_wire(response: PublicAPIResponse) -> JsonObject:
+    """Project an internal response into the exact strict Zod wire shape."""
+    wire = ChatResponseWire.model_validate(
+        response, from_attributes=True, extra="ignore"
+    )
+    wire.data = _wire_data(response)
+    return cast(JsonObject, wire.model_dump(mode="json", exclude_none=True))

--- a/apps/agent/agent/interfaces/persistence.py
+++ b/apps/agent/agent/interfaces/persistence.py
@@ -110,8 +110,6 @@ async def persist_result(
         session_id=session_id,
         user_id=user_id,
         request=request,
-        response=response,
-        result=result,
     )
     await persist_messages(
         db=db,
@@ -209,22 +207,33 @@ async def persist_conversation(
     session_id: str,
     user_id: str | None,
     request: PublicAPIRequest,
-    response: PublicAPIResponse,
-    result: AgentResult | None,
 ) -> None:
     """Persist the authenticated user's conversation index entry."""
-    if not user_id or result is None or not response.success:
+    if not user_id:
         return
 
     session_repo = get_session_repo(db)
     if session_repo is not None:
-        try:
-            await session_repo.upsert_conversation(session_id, user_id, request.text)
-        except _PERSIST_ERRORS:
-            logger.warning("upsert_conversation_failed", session_id=session_id)
+        await session_repo.upsert_conversation(session_id, user_id, request.text)
         # DECISION(2026-07-07): auto-generated conversation titles stay
         # disabled pending the conversation-history feature landing —
         # tracked in docs/superpowers/plans/2026-07-07-refactor-backlog.md.
+
+
+async def create_owned_session(
+    db: object,
+    session_id: str,
+    user_id: str,
+    first_query: str,
+    session_state: dict[str, object],
+) -> None:
+    """Create one authenticated session and ownership row atomically."""
+    session_repo = get_session_repo(db)
+    if session_repo is None:
+        raise RuntimeError("authenticated sessions require a session repository")
+    await session_repo.create_owned_session(
+        session_id, user_id, first_query, session_state
+    )
 
 
 async def load_session_state(

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -54,6 +54,7 @@ from agent.infrastructure.observability import (
 from agent.infrastructure.session import SessionStore, create_session_store
 from agent.interfaces.persistence import (
     build_response_session,
+    create_owned_session,
     extract_plan_steps,
     load_session_state,
     persist_messages,
@@ -67,6 +68,7 @@ from agent.interfaces.schemas import (
     PublicAPIError,
     PublicAPIRequest,
     PublicAPIResponse,
+    as_json_object,
 )
 from agent.interfaces.session_facade import (
     build_context_block,
@@ -173,12 +175,10 @@ class RuntimeAPI:
         on_step: OnStep | None = None,
     ) -> PublicAPIResponse:
         """Execute the runtime pipeline and normalize its output."""
-        session_id = request.session_id or None
+        session_id, is_new_session = await self._prepare_session(request, user_id)
         started_at = perf_counter()
         response: PublicAPIResponse | None = None
         effective_model = model if model is not None else request.model
-        await self.validate_session_owner(session_id, user_id)
-
         with runtime_span("runtime.handle") as span:
             _set_span_request_attrs(span, session_id, request, effective_model, user_id)
 
@@ -186,7 +186,7 @@ class RuntimeAPI:
             user_message_persisted = False
             try:
                 previous_state, context, message_history = await self._load_session(
-                    session_id, request
+                    None if is_new_session else session_id, request
                 )
                 result, response, context_delta = await self._execute_pipeline(
                     request,
@@ -221,9 +221,9 @@ class RuntimeAPI:
                 )
 
                 session_summary, route_history = build_response_session(session_state)
-                response.session = session_summary
+                response.session = as_json_object(session_summary)
                 response.route_history = [
-                    r for r in route_history if isinstance(r, dict)
+                    as_json_object(r) for r in route_history if isinstance(r, dict)
                 ]
                 response.generated_title = generated_title
                 return response
@@ -259,6 +259,18 @@ class RuntimeAPI:
                     status=status,
                     user_message_persisted=user_message_persisted,
                 )
+
+    async def _prepare_session(
+        self, request: PublicAPIRequest, user_id: str | None
+    ) -> tuple[str | None, bool]:
+        session_id = request.session_id or None
+        await self.validate_session_owner(session_id, user_id)
+        if session_id is not None or user_id is None:
+            return session_id, False
+        session_id = uuid4().hex
+        state = normalize_session_state(None)
+        await create_owned_session(self._db, session_id, user_id, request.text, state)
+        return session_id, True
 
     async def _load_session(
         self,

--- a/apps/agent/agent/interfaces/response_builder.py
+++ b/apps/agent/agent/interfaces/response_builder.py
@@ -11,7 +11,12 @@ from agent.agents.session_state import (
     SearchPayloadState,
 )
 from agent.application.errors import ApplicationError
-from agent.interfaces.schemas import PublicAPIError, PublicAPIResponse
+from agent.interfaces.schemas import (
+    JsonObject,
+    PublicAPIError,
+    PublicAPIResponse,
+    as_json_object,
+)
 
 _UI_MAP: dict[str, str] = {
     "search_bangumi": "PilgrimageGrid",
@@ -170,7 +175,7 @@ def application_error_response(exc: ApplicationError) -> PublicAPIResponse:
     )
 
 
-def serialize_step_record(step: StepRecord) -> dict[str, object]:
+def serialize_step_record(step: StepRecord) -> JsonObject:
     """Serialize one step for opt-in debug output."""
     serialized: dict[str, object] = {
         "tool": step.tool,
@@ -181,4 +186,4 @@ def serialize_step_record(step: StepRecord) -> dict[str, object]:
     }
     if step.provenance is not None:
         serialized["provenance"] = asdict(step.provenance)
-    return serialized
+    return as_json_object(serialized)

--- a/apps/agent/agent/interfaces/routes/chat_stream.py
+++ b/apps/agent/agent/interfaces/routes/chat_stream.py
@@ -28,7 +28,8 @@ from pydantic_ai.ui.vercel_ai.response_types import (
 )
 
 from agent.agents.runtime_deps import OnStep, StepEvent
-from agent.interfaces.schemas import PublicAPIResponse
+from agent.interfaces.chat_wire import chat_response_wire
+from agent.interfaces.schemas import GRACEFUL_TERMINAL_STATUSES, PublicAPIResponse
 
 logger = structlog.get_logger(__name__)
 
@@ -37,7 +38,7 @@ _SDK_VERSION = 6
 _ERROR_TEXT = "Something went wrong. Please try again."
 
 ChatHandler = Callable[[OnStep], Awaitable[PublicAPIResponse]]
-_Queue = asyncio.Queue["BaseChunk | None"]
+_Queue = asyncio.Queue["str | None"]
 
 
 class _ToolPartTranslator:
@@ -85,18 +86,23 @@ def _data_parts(response: PublicAPIResponse) -> list[BaseChunk]:
         DataChunk(
             type="data-response",
             id=RESPONSE_DATA_ID,
-            data=response.model_dump(mode="json"),
+            data=chat_response_wire(response),
         ),
     ]
 
 
 def _response_chunks(response: PublicAPIResponse) -> list[BaseChunk]:
+    finish_reason = "error" if _is_failure(response) else "stop"
     return [
         *_data_parts(response),
         FinishStepChunk(),
-        FinishChunk(finish_reason="stop"),
+        FinishChunk(finish_reason=finish_reason),
         DoneChunk(),
     ]
+
+
+def _is_failure(response: PublicAPIResponse) -> bool:
+    return not response.success and response.status not in GRACEFUL_TERMINAL_STATUSES
 
 
 def _error_chunks() -> list[BaseChunk]:
@@ -110,7 +116,7 @@ def _error_chunks() -> list[BaseChunk]:
 
 async def _put_all(queue: _Queue, chunks: Sequence[BaseChunk]) -> None:
     for chunk in chunks:
-        await queue.put(chunk)
+        await queue.put(_frame(chunk))
 
 
 def _make_on_step(queue: _Queue, translator: _ToolPartTranslator) -> OnStep:
@@ -132,14 +138,20 @@ async def _produce(handler: ChatHandler, queue: _Queue) -> None:
     await _put_all(queue, [StartChunk(), StartStepChunk()])
     try:
         response = await handler(_make_on_step(queue, translator))
+        await _put_all(queue, _terminal_chunks(translator, response))
     except Exception as exc:
         await _handle_error(queue, translator, exc)
-    else:
-        await _put_all(queue, _response_chunks(response))
-    await queue.put(None)
+    finally:
+        await queue.put(None)
 
 
-async def _drain(queue: _Queue) -> AsyncIterator[BaseChunk]:
+def _terminal_chunks(
+    translator: _ToolPartTranslator, response: PublicAPIResponse
+) -> list[BaseChunk]:
+    return [*translator.terminal_errors(), *_response_chunks(response)]
+
+
+async def _drain(queue: _Queue) -> AsyncIterator[str]:
     while True:
         chunk = await queue.get()
         if chunk is None:
@@ -165,7 +177,7 @@ async def stream_chat(handler: ChatHandler) -> AsyncIterator[str]:
     queue: _Queue = asyncio.Queue()
     task = asyncio.create_task(_produce(handler, queue))
     try:
-        async for chunk in _drain(queue):
-            yield _frame(chunk)
+        async for frame in _drain(queue):
+            yield frame
     finally:
         await _settle(task)

--- a/apps/agent/agent/interfaces/schemas.py
+++ b/apps/agent/agent/interfaces/schemas.py
@@ -8,7 +8,16 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, JsonValue, TypeAdapter, model_validator
+
+JsonObject = dict[str, JsonValue]
+_JSON_OBJECT_ADAPTER = TypeAdapter(JsonObject)
+
+
+def as_json_object(value: object) -> JsonObject:
+    """Validate an arbitrary boundary value as a recursive JSON object."""
+    return _JSON_OBJECT_ADAPTER.validate_python(value)
+
 
 GRACEFUL_TERMINAL_STATUSES: frozenset[str] = frozenset(
     {"needs_clarification", "partial", "blocked", "empty", "too_large"}
@@ -110,7 +119,7 @@ class PublicAPIError(BaseModel):
 
     code: str
     message: str
-    details: dict[str, object] = Field(default_factory=dict)
+    details: JsonObject = Field(default_factory=dict)
 
 
 class PublicAPIResponse(BaseModel):
@@ -121,9 +130,9 @@ class PublicAPIResponse(BaseModel):
     intent: str
     session_id: str | None = None
     message: str = ""
-    data: dict[str, object] = Field(default_factory=dict)
-    session: dict[str, object] = Field(default_factory=dict)
-    route_history: list[dict[str, object]] = Field(default_factory=list)
+    data: JsonObject = Field(default_factory=dict)
+    session: JsonObject = Field(default_factory=dict)
+    route_history: list[JsonObject] = Field(default_factory=list)
     errors: list[PublicAPIError] = Field(default_factory=list)
     ui: dict[str, str] | None = Field(
         default=None,
@@ -133,4 +142,4 @@ class PublicAPIResponse(BaseModel):
         default=None,
         description="LLM-generated conversation title (first interaction only)",
     )
-    debug: dict[str, object] | None = None
+    debug: JsonObject | None = None

--- a/apps/agent/agent/tests/db_doubles.py
+++ b/apps/agent/agent/tests/db_doubles.py
@@ -13,6 +13,7 @@ def build_persistence_supabase_double() -> MagicMock:
     Wires only the shared persistence writes; callers set their own read doubles.
     """
     db = MagicMock(spec=SupabaseClient)
+    db.session.create_owned_session = AsyncMock()
     db.session.upsert_session = AsyncMock()
     db.session.upsert_conversation = AsyncMock()
     db.session.update_conversation_title = AsyncMock()

--- a/apps/agent/agent/tests/unit/chat_wire_parser.ts
+++ b/apps/agent/agent/tests/unit/chat_wire_parser.ts
@@ -1,0 +1,5 @@
+import { readFileSync } from "node:fs";
+import { ChatResponseDataPart } from "../../../../../packages/contract/src/chat-data-parts.ts";
+
+const parsed: unknown = JSON.parse(readFileSync(0, "utf8"));
+process.stdout.write(ChatResponseDataPart.parse(parsed).intent);

--- a/apps/agent/agent/tests/unit/conftest_public_api.py
+++ b/apps/agent/agent/tests/unit/conftest_public_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Literal
 
 import pytest
@@ -140,13 +140,15 @@ def make_result(
     intent: str = "search_bangumi",
     locale: str = "ja",
     message: str = "該当する巡礼地が見つかりませんでした。",
-    data: dict[str, object] | None = None,
+    data: Mapping[str, object] | None = None,
     steps: list[StepRecord] | None = None,
     tool_state: dict[str, object] | None = None,
 ) -> AgentResult:
     """Build a compact output plus its authoritative typed registry."""
     del locale, tool_state
-    payload = data or {"results": {"rows": [], "row_count": 0}}
+    payload = (
+        dict(data) if data is not None else {"results": {"rows": [], "row_count": 0}}
+    )
     records = steps or []
     state = _state(intent, payload, records)
     return AgentResult(

--- a/apps/agent/agent/tests/unit/repositories/test_session_repo.py
+++ b/apps/agent/agent/tests/unit/repositories/test_session_repo.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -18,6 +18,20 @@ def pool() -> AsyncMock:
 @pytest.fixture
 def repo(pool: AsyncMock) -> SessionRepository:
     return SessionRepository(pool)
+
+
+async def test_create_owned_session_uses_one_transaction(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    connection = AsyncMock()
+    transaction = MagicMock()
+    connection.transaction = MagicMock(return_value=transaction)
+    acquire = MagicMock()
+    acquire.__aenter__ = AsyncMock(return_value=connection)
+    pool.acquire = MagicMock(return_value=acquire)
+    await repo.create_owned_session("session-zero", "user-zero", "hello", {})
+    assert connection.execute.await_count == 2
+    transaction.__aenter__.assert_awaited_once()
 
 
 async def test_upsert_session_calls_execute_with_correct_params(

--- a/apps/agent/agent/tests/unit/test_chat_ownership.py
+++ b/apps/agent/agent/tests/unit/test_chat_ownership.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 
 from agent.agents.agent_result import AgentResult
-from agent.agents.runtime_models import GreetingResponseModel
+from agent.agents.runtime_models import BlockedResponseModel, GreetingResponseModel
 from agent.agents.session_state import SessionState
 from agent.infrastructure.session.memory import InMemorySessionStore
 from agent.interfaces.public_api import RuntimeAPI
@@ -42,6 +42,7 @@ class _ChatOwnershipHarness:
         self.store = InMemorySessionStore()
         self.db = build_persistence_supabase_double()
         self.db.session.check_session_owner = AsyncMock(side_effect=self._owns)
+        self.db.session.create_owned_session.side_effect = self._create_owned
         self.db.session.upsert_conversation.side_effect = self._claim
         self.db.insert_message = AsyncMock()
         self.db.insert_request_log = AsyncMock()
@@ -51,6 +52,11 @@ class _ChatOwnershipHarness:
         return self.owners.get(session_id) == user_id
 
     async def _claim(self, session_id: str, user_id: str, _query: str) -> None:
+        self.owners[session_id] = user_id
+
+    async def _create_owned(
+        self, session_id: str, user_id: str, _query: str, _state: object
+    ) -> None:
         self.owners[session_id] = user_id
 
     async def post(self, user_id: str, session_id: str | None = None) -> httpx.Response:
@@ -88,3 +94,22 @@ async def test_chat_rejects_cross_user_session_without_mutation(
     before = await harness.snapshot(session_id)
     response = await harness.post("user-b", session_id)
     assert (response.status_code, await harness.snapshot(session_id)) == (404, before)
+
+
+async def test_first_failed_turn_still_creates_owner_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = AgentResult(
+        output=BlockedResponseModel(message="blocked"),
+        intent="blocked",
+        session_state=SessionState(),
+        status="blocked",
+        success_override=False,
+    )
+    monkeypatch.setattr(
+        "agent.interfaces.public_api.run_animichi_agent", AsyncMock(return_value=result)
+    )
+    harness = _ChatOwnershipHarness()
+    session_id = await harness.create()
+    assert harness.owners[session_id] == "user-a"
+    assert (await harness.post("user-a", session_id)).status_code == 200

--- a/apps/agent/agent/tests/unit/test_chat_stream_terminals.py
+++ b/apps/agent/agent/tests/unit/test_chat_stream_terminals.py
@@ -1,0 +1,94 @@
+"""Terminal-state regressions for the progressive chat stream."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import cast
+from unittest.mock import MagicMock
+
+from agent.agents.animichi_runner import _record_terminal_clarify
+from agent.agents.runtime_deps import OnStep, RuntimeDeps, StepEvent
+from agent.agents.runtime_models import ClarifyResponseModel
+from agent.interfaces.routes.chat_stream import ChatHandler, stream_chat
+from agent.interfaces.schemas import JsonObject, PublicAPIResponse
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+
+async def _collect(handler: ChatHandler) -> list[str]:
+    return [frame async for frame in stream_chat(handler)]
+
+
+def _parse(frames: list[str]) -> list[dict[str, object] | str]:
+    values = [frame.removeprefix("data: ").removesuffix("\n\n") for frame in frames]
+    return [value if value == "[DONE]" else json.loads(value) for value in values]
+
+
+def _parts(chunks: list[dict[str, object] | str], kind: str) -> list[dict[str, object]]:
+    return [
+        chunk
+        for chunk in chunks
+        if isinstance(chunk, dict) and chunk.get("type") == kind
+    ]
+
+
+def _types(chunks: list[dict[str, object] | str]) -> list[str]:
+    return [chunk if isinstance(chunk, str) else str(chunk["type"]) for chunk in chunks]
+
+
+async def _normalized_failure(on_step: OnStep) -> PublicAPIResponse:
+    await on_step(StepEvent("search_nearby", "normalized-call", "running", {}))
+    return PublicAPIResponse(success=False, status="timeout", intent="error")
+
+
+async def _clarification(on_step: OnStep) -> PublicAPIResponse:
+    deps = _clarification_deps(on_step)
+    output = ClarifyResponseModel(
+        reason="anime_not_found", message="Which?", candidate_ids=[]
+    )
+    await _record_terminal_clarify(deps, output)
+    return PublicAPIResponse(
+        success=True, status="needs_clarification", intent="clarify"
+    )
+
+
+def _clarification_deps(on_step: OnStep) -> RuntimeDeps:
+    return RuntimeDeps(
+        db=MagicMock(),
+        locale="en",
+        query="x",
+        catalog=MockCatalogClient(),
+        on_step=on_step,
+    )
+
+
+async def _non_serializable(_on_step: OnStep) -> PublicAPIResponse:
+    return PublicAPIResponse.model_construct(
+        success=True,
+        status="ok",
+        intent="greet_user",
+        session=cast(JsonObject, {"bad": object()}),
+    )
+
+
+async def test_normalized_failure_closes_tools_and_finishes_as_error() -> None:
+    chunks = _parse(await _collect(_normalized_failure))
+    types = _types(chunks)
+    assert types.index("tool-output-error") < types.index("data-response")
+    assert _parts(chunks, "finish")[0]["finishReason"] == "error"
+    data = _parts(chunks, "data-response")[-1]["data"]
+    assert isinstance(data, dict)
+    assert data["intent"] == "error"
+
+
+async def test_clarification_emits_complete_tool_lifecycle() -> None:
+    chunks = _parse(await _collect(_clarification))
+    kinds = ("tool-input-start", "tool-input-available", "tool-output-available")
+    parts = [_parts(chunks, kind)[0] for kind in kinds]
+    assert {part["toolCallId"] for part in parts} == {parts[0]["toolCallId"]}
+
+
+async def test_non_serializable_response_does_not_hang_stream() -> None:
+    chunks = _parse(await asyncio.wait_for(_collect(_non_serializable), timeout=1))
+    assert _types(chunks)[-1] == "[DONE]"
+    assert _parts(chunks, "finish")[0]["finishReason"] == "error"

--- a/apps/agent/agent/tests/unit/test_chat_wire_contract.py
+++ b/apps/agent/agent/tests/unit/test_chat_wire_contract.py
@@ -1,0 +1,152 @@
+"""Cross-language tests for the Python response builder -> strict Zod seam."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent.agents.agent_result import AgentResult
+from agent.agents.runtime_models import BlockedResponseModel, PartialResponseModel
+from agent.agents.session_state import (
+    NearbyGroupState,
+    OrderedCandidate,
+    RouteSummaryState,
+    SearchMetadataState,
+    SessionState,
+)
+from agent.interfaces.chat_wire import chat_response_wire
+from agent.interfaces.response_builder import agent_result_to_response
+from agent.interfaces.schemas import JsonObject, PublicAPIResponse
+from agent.tests.unit.conftest_public_api import make_result
+
+_UNIT_DIR = Path(__file__).parent
+_INTENTS = (
+    "search_bangumi",
+    "search_nearby",
+    "plan_route",
+    "plan_selected",
+    "plan_multi",
+    "general_qa",
+    "greet_user",
+    "clarify",
+    "partial",
+    "blocked",
+    "unknown",
+    "error",
+)
+
+
+def _terminal_result(intent: str) -> AgentResult:
+    return AgentResult(
+        output=_terminal_output(intent),
+        intent=intent,
+        session_state=SessionState(),
+        status=intent,
+        success_override=False,
+    )
+
+
+def _terminal_output(intent: str) -> PartialResponseModel | BlockedResponseModel:
+    output = (
+        PartialResponseModel(message="partial")
+        if intent == "partial"
+        else BlockedResponseModel(message="blocked")
+    )
+    return output
+
+
+def _response(intent: str) -> PublicAPIResponse:
+    if intent in {"partial", "blocked"}:
+        return agent_result_to_response(_terminal_result(intent), include_debug=False)
+    if intent == "error":
+        return PublicAPIResponse(success=False, status="timeout", intent="error")
+    result = _rich_result("general_qa" if intent == "unknown" else intent)
+    response = agent_result_to_response(result, include_debug=False)
+    response.intent = intent
+    return response
+
+
+def _rich_result(intent: str) -> AgentResult:
+    result = make_result(intent, data=_payload(intent))
+    _enrich_search(result)
+    _enrich_route(result)
+    _enrich_clarification(result)
+    return result
+
+
+def _payload(intent: str) -> JsonObject:
+    point: JsonObject = {"id": "p1", "name": "Bridge", "bangumi_id": "1"}
+    if intent in {"search_bangumi", "search_nearby"}:
+        return {"results": {"rows": [point], "row_count": 1}}
+    if intent.startswith("plan_"):
+        return {"route": {"ordered_points": [point]}}
+    return {}
+
+
+def _enrich_search(result: AgentResult) -> None:
+    ref = result.session_state.last_result_ref
+    if ref is None:
+        return
+    payload = result.session_state.search_results[ref]
+    payload.metadata = SearchMetadataState(anime_title="Work", source="catalog")
+    payload.nearby_groups = [NearbyGroupState(bangumi_id="1", title="Work")]
+    payload.omitted_work_ids = ["2"]
+    payload.partial = True
+
+
+def _enrich_route(result: AgentResult) -> None:
+    if not result.session_state.route_lru:
+        return
+    route = result.session_state.routes[result.session_state.route_lru[-1]]
+    route.summary = _route_summary()
+
+
+def _route_summary() -> RouteSummaryState:
+    return RouteSummaryState(
+        point_count=1,
+        total_minutes=1,
+        total_distance_m=1.0,
+        clusters=1,
+        with_coordinates=0,
+        without_coordinates=1,
+    )
+
+
+def _enrich_clarification(result: AgentResult) -> None:
+    pending = result.session_state.pending_clarification
+    if pending is None:
+        return
+    pending.ordered_candidates = [_candidate()]
+
+
+def _candidate() -> OrderedCandidate:
+    return OrderedCandidate(
+        id="1",
+        title="Work",
+        city="Kyoto",
+        points_count=3,
+        lat=35.0,
+        lng=135.0,
+        effective_radius_m=500,
+    )
+
+
+def _parse_with_zod(value: object) -> str:
+    result = subprocess.run(
+        ["node", "--import", "tsx", "chat_wire_parser.ts"],
+        cwd=_UNIT_DIR,
+        input=json.dumps(value),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout
+
+
+@pytest.mark.parametrize("intent", _INTENTS)
+def test_real_response_builder_wire_parses_in_zod(intent: str) -> None:
+    wire = chat_response_wire(_response(intent))
+    assert _parse_with_zod(wire) == intent

--- a/apps/agent/agent/tests/unit/test_generated_title.py
+++ b/apps/agent/agent/tests/unit/test_generated_title.py
@@ -30,6 +30,7 @@ def _mock_pipeline(monkeypatch):
 @pytest.fixture
 def mock_db():
     db = MagicMock(spec=SupabaseClient)
+    db.session.create_owned_session = AsyncMock()
     db.session.upsert_session = AsyncMock()
     db.session.upsert_conversation = AsyncMock()
     db.session.update_conversation_title = AsyncMock()

--- a/apps/agent/agent/tests/unit/test_phase1d_persistence.py
+++ b/apps/agent/agent/tests/unit/test_phase1d_persistence.py
@@ -77,6 +77,7 @@ def _blocked_result() -> AgentResult:
 
 def _db() -> MagicMock:
     db = MagicMock(spec=SupabaseClient)
+    db.session.create_owned_session = AsyncMock()
     db.session.upsert_session = AsyncMock()
     db.insert_message = AsyncMock()
     db.insert_request_log = AsyncMock()

--- a/apps/agent/agent/tests/unit/test_public_api_errors.py
+++ b/apps/agent/agent/tests/unit/test_public_api_errors.py
@@ -38,6 +38,7 @@ def mock_db():
     pool.fetch = AsyncMock(return_value=[])
     db.pool = pool
     db.points.search_points_by_location = AsyncMock(return_value=[])
+    db.session.create_owned_session = AsyncMock()
     db.session.upsert_session = AsyncMock()
     db.session.upsert_conversation = AsyncMock()
     db.session.update_conversation_title = AsyncMock()

--- a/apps/agent/agent/tests/unit/test_public_api_facade.py
+++ b/apps/agent/agent/tests/unit/test_public_api_facade.py
@@ -34,6 +34,7 @@ def mock_db():
     pool.fetch = AsyncMock(return_value=[])
     db.pool = pool
     db.points.search_points_by_location = AsyncMock(return_value=[])
+    db.session.create_owned_session = AsyncMock()
     db.session.upsert_session = AsyncMock()
     db.session.upsert_conversation = AsyncMock()
     db.session.update_conversation_title = AsyncMock()

--- a/apps/agent/agent/tests/unit/test_public_api_persistence.py
+++ b/apps/agent/agent/tests/unit/test_public_api_persistence.py
@@ -30,6 +30,7 @@ def mock_db() -> MagicMock:
     pool.fetch = AsyncMock(return_value=[])
     db.pool = pool
     db.points.search_points_by_location = AsyncMock(return_value=[])
+    db.session.create_owned_session = AsyncMock()
     db.session.upsert_session = AsyncMock()
     db.session.upsert_conversation = AsyncMock()
     db.session.check_session_owner = AsyncMock(return_value=True)
@@ -52,6 +53,7 @@ class TestGreetingPersistence:
         _fake = make_run_agent_stub(result)
 
         db = MagicMock()
+        db.session.create_owned_session = AsyncMock()
         db.session.upsert_session = AsyncMock()
         db.session.upsert_conversation = AsyncMock()
         db.insert_request_log = AsyncMock()

--- a/apps/agent/tests/fixtures/chat_stream/clarify.sse
+++ b/apps/agent/tests/fixtures/chat_stream/clarify.sse
@@ -2,15 +2,15 @@ data: {"type":"start"}
 
 data: {"type":"start-step"}
 
-data: {"type":"tool-input-start","toolCallId":"resolve_anime-1","toolName":"resolve_anime"}
+data: {"type":"tool-input-start","toolCallId":"resolve_anime-fixture","toolName":"resolve_anime"}
 
-data: {"type":"tool-input-available","toolCallId":"resolve_anime-1","toolName":"resolve_anime","input":{"title":"ハルヒ"}}
+data: {"type":"tool-input-available","toolCallId":"resolve_anime-fixture","toolName":"resolve_anime","input":{"title":"ハルヒ"}}
 
-data: {"type":"tool-output-available","toolCallId":"resolve_anime-1","output":{"ambiguous":true}}
+data: {"type":"tool-output-available","toolCallId":"resolve_anime-fixture","output":{"ambiguous":true}}
 
 data: {"type":"data-response","id":"response","data":{"intent":"clarify"}}
 
-data: {"type":"data-response","id":"response","data":{"success":true,"status":"needs_clarification","intent":"clarify","session_id":null,"message":"どの作品でしょうか？","data":{"reason":"title_ambiguous","clarification_id":1,"candidates":[{"id":"115908","title":"涼宮ハルヒの憂鬱","cover_url":null},{"id":"117696","title":"涼宮ハルヒの消失","cover_url":null}]},"session":{},"route_history":[],"errors":[],"ui":{"component":"Clarification"},"generated_title":null,"debug":null}}
+data: {"type":"data-response","id":"response","data":{"intent":"clarify","success":true,"status":"needs_clarification","message":"どの作品でしょうか？","data":{"reason":"anime_ambiguity","clarification_id":1,"candidates":[{"title":"115908","id":"115908"},{"title":"117696","id":"117696"}]},"session":{},"route_history":[],"errors":[],"ui":{"component":"Clarification"}}}
 
 data: {"type":"finish-step"}
 

--- a/apps/agent/tests/fixtures/chat_stream/record_fixtures.py
+++ b/apps/agent/tests/fixtures/chat_stream/record_fixtures.py
@@ -33,55 +33,75 @@ _FIXTURE_DIR = Path(__file__).parent
 
 
 def _search_response() -> PublicAPIResponse:
-    from agent.interfaces.schemas import PublicAPIResponse
+    from agent.interfaces.response_builder import agent_result_to_response
+    from agent.tests.unit.conftest_public_api import make_result
 
-    results = {
-        "kind": "bangumi",
-        "bangumi_id": 12345,
-        "title": "響け！ユーフォニアム",
-        "row_count": 2,
-        "status": "ok",
-        "strategy": "bangumi",
-        "summary": {"count": 2, "source": "catalog", "cache": "miss"},
-        "rows": [
-            {"id": "p1", "name": "宇治橋", "lat": 34.891, "lng": 135.807, "ep": 1},
-            {"id": "p2", "name": "京阪宇治駅", "lat": 34.911, "lng": 135.806, "ep": 3},
-        ],
+    data = {
+        "results": {
+            "kind": "bangumi",
+            "bangumi_id": 12345,
+            "title": "響け！ユーフォニアム",
+            "row_count": 2,
+            "status": "ok",
+            "strategy": "bangumi",
+            "summary": {"count": 2, "source": "catalog", "cache": "miss"},
+            "rows": [
+                {
+                    "id": "p1",
+                    "name": "宇治橋",
+                    "latitude": 34.891,
+                    "longitude": 135.807,
+                    "episode": 1,
+                },
+                {
+                    "id": "p2",
+                    "name": "京阪宇治駅",
+                    "latitude": 34.911,
+                    "longitude": 135.806,
+                    "episode": 3,
+                },
+            ],
+        },
+        "route": {
+            "ordered_points": [
+                {
+                    "id": "p1",
+                    "name": "宇治橋",
+                    "bangumi_id": "12345",
+                    "latitude": 34.891,
+                    "longitude": 135.807,
+                    "episode": 1,
+                },
+                {
+                    "id": "p2",
+                    "name": "京阪宇治駅",
+                    "bangumi_id": "12345",
+                    "latitude": 34.911,
+                    "longitude": 135.806,
+                    "episode": 3,
+                },
+            ],
+            "point_count": 2,
+            "status": "ok",
+            "total_walk_minutes": 12,
+        },
     }
-    route = {
-        "ordered_points": ["p1", "p2"],
-        "point_count": 2,
-        "status": "ok",
-        "total_walk_minutes": 12,
-    }
-    return PublicAPIResponse(
-        success=True,
-        status="ok",
-        intent="plan_route",
-        message="宇治の聖地を2件、徒歩ルートにまとめました。",
-        data={"results": results, "route": route},
-        ui={"component": "RoutePlannerWizard"},
+    result = make_result(
+        "plan_route", message="宇治の聖地を2件、徒歩ルートにまとめました。", data=data
     )
+    return agent_result_to_response(result, include_debug=False)
 
 
 def _clarify_response() -> PublicAPIResponse:
-    from agent.interfaces.schemas import PublicAPIResponse
+    from agent.interfaces.response_builder import agent_result_to_response
+    from agent.tests.unit.conftest_public_api import make_result
 
-    return PublicAPIResponse(
-        success=True,
-        status="needs_clarification",
-        intent="clarify",
+    result = make_result(
+        "clarify",
         message="どの作品でしょうか？",
-        data={
-            "reason": "title_ambiguous",
-            "clarification_id": 1,
-            "candidates": [
-                {"id": "115908", "title": "涼宮ハルヒの憂鬱", "cover_url": None},
-                {"id": "117696", "title": "涼宮ハルヒの消失", "cover_url": None},
-            ],
-        },
-        ui={"component": "Clarification"},
+        data={"reason": "anime_ambiguity", "candidate_ids": ["115908", "117696"]},
     )
+    return agent_result_to_response(result, include_debug=False)
 
 
 def _step(tool: str, status: StepStatus, data: dict[str, object]) -> StepEvent:

--- a/apps/agent/tests/fixtures/chat_stream/search.sse
+++ b/apps/agent/tests/fixtures/chat_stream/search.sse
@@ -2,27 +2,27 @@ data: {"type":"start"}
 
 data: {"type":"start-step"}
 
-data: {"type":"tool-input-start","toolCallId":"resolve_anime-1","toolName":"resolve_anime"}
+data: {"type":"tool-input-start","toolCallId":"resolve_anime-fixture","toolName":"resolve_anime"}
 
-data: {"type":"tool-input-available","toolCallId":"resolve_anime-1","toolName":"resolve_anime","input":{"title":"ユーフォ"}}
+data: {"type":"tool-input-available","toolCallId":"resolve_anime-fixture","toolName":"resolve_anime","input":{"title":"ユーフォ"}}
 
-data: {"type":"tool-output-available","toolCallId":"resolve_anime-1","output":{"bangumi_id":12345}}
+data: {"type":"tool-output-available","toolCallId":"resolve_anime-fixture","output":{"bangumi_id":12345}}
 
-data: {"type":"tool-input-start","toolCallId":"search_bangumi-2","toolName":"search_bangumi"}
+data: {"type":"tool-input-start","toolCallId":"search_bangumi-fixture","toolName":"search_bangumi"}
 
-data: {"type":"tool-input-available","toolCallId":"search_bangumi-2","toolName":"search_bangumi","input":{"bangumi_id":12345}}
+data: {"type":"tool-input-available","toolCallId":"search_bangumi-fixture","toolName":"search_bangumi","input":{"bangumi_id":12345}}
 
-data: {"type":"tool-output-available","toolCallId":"search_bangumi-2","output":{"row_count":2}}
+data: {"type":"tool-output-available","toolCallId":"search_bangumi-fixture","output":{"row_count":2}}
 
-data: {"type":"tool-input-start","toolCallId":"plan_route-3","toolName":"plan_route"}
+data: {"type":"tool-input-start","toolCallId":"plan_route-fixture","toolName":"plan_route"}
 
-data: {"type":"tool-input-available","toolCallId":"plan_route-3","toolName":"plan_route","input":{}}
+data: {"type":"tool-input-available","toolCallId":"plan_route-fixture","toolName":"plan_route","input":{}}
 
-data: {"type":"tool-output-available","toolCallId":"plan_route-3","output":{"point_count":2}}
+data: {"type":"tool-output-available","toolCallId":"plan_route-fixture","output":{"point_count":2}}
 
 data: {"type":"data-response","id":"response","data":{"intent":"plan_route"}}
 
-data: {"type":"data-response","id":"response","data":{"success":true,"status":"ok","intent":"plan_route","session_id":null,"message":"宇治の聖地を2件、徒歩ルートにまとめました。","data":{"results":{"kind":"bangumi","bangumi_id":12345,"title":"響け！ユーフォニアム","row_count":2,"status":"ok","strategy":"bangumi","summary":{"count":2,"source":"catalog","cache":"miss"},"rows":[{"id":"p1","name":"宇治橋","lat":34.891,"lng":135.807,"ep":1},{"id":"p2","name":"京阪宇治駅","lat":34.911,"lng":135.806,"ep":3}]},"route":{"ordered_points":["p1","p2"],"point_count":2,"status":"ok","total_walk_minutes":12}},"session":{},"route_history":[],"errors":[],"ui":{"component":"RoutePlannerWizard"},"generated_title":null,"debug":null}}
+data: {"type":"data-response","id":"response","data":{"intent":"plan_route","success":true,"status":"ok","message":"宇治の聖地を2件、徒歩ルートにまとめました。","data":{"route":{"ordered_points":[{"id":"p1","name":"宇治橋","bangumi_id":"12345","episode":1,"latitude":34.891,"longitude":135.807},{"id":"p2","name":"京阪宇治駅","bangumi_id":"12345","episode":3,"latitude":34.911,"longitude":135.806}],"point_count":2,"status":"ok"}},"session":{},"route_history":[],"errors":[],"ui":{"component":"RoutePlannerWizard"}}}
 
 data: {"type":"finish-step"}
 

--- a/apps/web/src/features/chat/components/DataPartCard.tsx
+++ b/apps/web/src/features/chat/components/DataPartCard.tsx
@@ -17,12 +17,12 @@ function SkeletonCard({ part, dict }: Readonly<{ part: ChatDataPart; dict: ChatD
   );
 }
 
-function IntentCard({ part }: Readonly<{ part: ChatDataPart }>) {
+function IntentCard({ part, dict }: Readonly<{ part: ChatDataPart; dict: ChatDict }>) {
   const Body = intentRegistry[part.intent];
   return (
     <article className="chat-card" data-intent={part.intent}>
       {part.message ? <p className="chat-card__message">{part.message}</p> : null}
-      <Body part={part} />
+      <Body part={part} dict={dict} />
     </article>
   );
 }
@@ -36,5 +36,5 @@ export function DataPartCard({ data, dict }: CardProps) {
   const part = parseChatDataPart(data);
   if (!part) return <FallbackCard dict={dict} />;
   if (isIntentOnly(part)) return <SkeletonCard part={part} dict={dict} />;
-  return <IntentCard part={part} />;
+  return <IntentCard part={part} dict={dict} />;
 }

--- a/apps/web/src/features/chat/components/cards.tsx
+++ b/apps/web/src/features/chat/components/cards.tsx
@@ -1,6 +1,7 @@
 import type { ChatDataPart } from "@seichijunrei/contract";
+import type { ChatDict } from "../i18n";
 
-export type IntentCardProps = Readonly<{ part: ChatDataPart }>;
+export type IntentCardProps = Readonly<{ part: ChatDataPart; dict: ChatDict }>;
 
 type PartData = NonNullable<ChatDataPart["data"]>;
 
@@ -23,8 +24,27 @@ function candidatesOf(part: ChatDataPart) {
   return data && "candidates" in data ? (data.candidates ?? []) : [];
 }
 
-function SpotList({ part }: IntentCardProps) {
+type PartOnlyProps = Readonly<{ part: ChatDataPart }>;
+
+type SpotRow = Readonly<{ id?: string; name?: string }>;
+
+/** Streamed routes may carry spots only as `route.ordered_points` objects. */
+function routeSpotsOf(part: ChatDataPart): SpotRow[] {
+  const points = routeOf(part)?.ordered_points ?? [];
+  const spots: SpotRow[] = [];
+  for (const point of points) {
+    if (typeof point !== "string") spots.push(point);
+  }
+  return spots;
+}
+
+function spotsOf(part: ChatDataPart): SpotRow[] {
   const rows = resultsOf(part)?.rows ?? [];
+  return rows.length > 0 ? rows : routeSpotsOf(part);
+}
+
+function SpotList({ part }: PartOnlyProps) {
+  const rows = spotsOf(part);
   if (rows.length === 0) return null;
   const items = rows.map((row) => <li key={row.id ?? row.name}>{row.name}</li>);
   return <ul className="chat-card__spots">{items}</ul>;
@@ -40,7 +60,7 @@ export function SearchCard({ part }: IntentCardProps) {
   );
 }
 
-function RouteStats({ part }: IntentCardProps) {
+function RouteStats({ part }: PartOnlyProps) {
   const route = routeOf(part);
   if (!route) return null;
   return (
@@ -71,4 +91,22 @@ export function ClarifyCard({ part }: IntentCardProps) {
 
 export function ProseCard(_props: IntentCardProps) {
   return null;
+}
+
+function ErrorList({ part }: PartOnlyProps) {
+  const errors = part.errors ?? [];
+  if (errors.length === 0) return null;
+  const items = errors.map((error) => (
+    <li key={`${error.code}:${error.message}`}>{error.message}</li>
+  ));
+  return <ul className="chat-card__errors">{items}</ul>;
+}
+
+export function ErrorCard({ part, dict }: IntentCardProps) {
+  return (
+    <div className="chat-card__body" role="alert">
+      {part.message ? null : <p className="chat-card__message">{dict.errorCard}</p>}
+      <ErrorList part={part} />
+    </div>
+  );
 }

--- a/apps/web/src/features/chat/i18n.ts
+++ b/apps/web/src/features/chat/i18n.ts
@@ -10,6 +10,7 @@ export interface ChatDict {
   readonly retry: string;
   readonly historyFootprint: string;
   readonly fallbackCard: string;
+  readonly errorCard: string;
   readonly historyError: string;
   readonly preparing: string;
 }
@@ -27,6 +28,7 @@ const ja: ChatDict = {
   retry: "再試行",
   historyFootprint: "これまでのやり取り",
   fallbackCard: "この内容はうまく表示できませんでした",
+  errorCard: "ごめんね、エラーが起きちゃった。もう一度ためしてみてね",
   historyError: "過去の会話を読み込めませんでした",
   preparing: "じゅんびちゅう…",
 };
@@ -40,6 +42,7 @@ const zh: ChatDict = {
   retry: "重试",
   historyFootprint: "之前的对话",
   fallbackCard: "这段内容暂时无法显示",
+  errorCard: "抱歉,出错了。请再试一次",
   historyError: "无法加载之前的对话",
   preparing: "准备中…",
 };
@@ -57,6 +60,7 @@ const en: ChatDict = {
   retry: "Retry",
   historyFootprint: "Earlier conversation",
   fallbackCard: "This part could not be displayed",
+  errorCard: "Sorry, something went wrong. Please try again",
   historyError: "Couldn't load this conversation",
   preparing: "Getting ready…",
 };

--- a/apps/web/src/features/chat/registry.ts
+++ b/apps/web/src/features/chat/registry.ts
@@ -1,6 +1,6 @@
 import type { ChatDataPart } from "@seichijunrei/contract";
 import type { ComponentType } from "react";
-import { ClarifyCard, ProseCard, RouteCard, SearchCard } from "./components/cards";
+import { ClarifyCard, ErrorCard, ProseCard, RouteCard, SearchCard } from "./components/cards";
 import type { IntentCardProps } from "./components/cards";
 
 /** intent → card body. Later chat cards extend this map, not the renderer. */
@@ -15,5 +15,6 @@ export const intentRegistry: Record<ChatDataPart["intent"], ComponentType<Intent
   general_qa: ProseCard,
   greet_user: ProseCard,
   blocked: ProseCard,
+  error: ErrorCard,
   unknown: ProseCard,
 };

--- a/apps/web/tests/msw/chat-handlers.ts
+++ b/apps/web/tests/msw/chat-handlers.ts
@@ -41,7 +41,19 @@ export interface ChatStreamOptions {
 
 function patchSessionId(text: string, sessionId?: string): string {
   if (!sessionId) return text;
-  return text.replaceAll('"session_id":null', `"session_id":"${sessionId}"`);
+  return text
+    .split("\n")
+    .map((line) => patchSessionIdLine(line, sessionId))
+    .join("\n");
+}
+
+/** The recordings omit the null `session_id`; inject it into full final frames. */
+function patchSessionIdLine(line: string, sessionId: string): string {
+  if (!line.startsWith('data: {"type":"data-response"')) return line;
+  const frame = JSON.parse(line.slice("data: ".length)) as { data: Record<string, unknown> };
+  if (!("success" in frame.data)) return line;
+  frame.data.session_id = sessionId;
+  return `data: ${JSON.stringify(frame)}`;
 }
 
 function corruptFinalFrame(text: string, malformed?: boolean): string {

--- a/apps/web/tests/unit/chat/chat-page-stream.test.tsx
+++ b/apps/web/tests/unit/chat/chat-page-stream.test.tsx
@@ -61,7 +61,7 @@ describe("A2 query entry", () => {
     renderChatPage(chatSearch({ q: "ハルヒ" }));
     expect(await screen.findByText("ハルヒ")).toBeTruthy();
     await screen.findByText("どの作品でしょうか？");
-    expect(screen.getByText("涼宮ハルヒの憂鬱")).toBeTruthy();
+    expect(screen.getByText("115908")).toBeTruthy();
   });
 });
 

--- a/apps/web/tests/unit/chat/data-part-card.test.tsx
+++ b/apps/web/tests/unit/chat/data-part-card.test.tsx
@@ -79,3 +79,34 @@ describe("DataPartCard intent bodies", () => {
     expect(screen.getByText("どれ?")).toBeTruthy();
   });
 });
+
+describe("DataPartCard error intent", () => {
+  it("renders the envelope message and each error detail as an alert", () => {
+    renderPart({
+      intent: "error",
+      message: "モデルに接続できませんでした",
+      errors: [
+        { code: "provider_unavailable", message: "provider timed out" },
+        { code: "retry_exhausted", message: "all retries failed" },
+      ],
+      data: {},
+    });
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeTruthy();
+    expect(screen.getByText("モデルに接続できませんでした")).toBeTruthy();
+    expect(screen.getByText("provider timed out")).toBeTruthy();
+    expect(screen.getByText("all retries failed")).toBeTruthy();
+  });
+
+  it("falls back to localized copy when the envelope has no message", () => {
+    renderPart({ intent: "error", data: {} });
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByText(dict.errorCard)).toBeTruthy();
+  });
+
+  it("keeps the localized fallback out of the card when a message exists", () => {
+    renderPart({ intent: "error", message: "接続エラー", data: {} });
+    expect(screen.getByText("接続エラー")).toBeTruthy();
+    expect(screen.queryByText(dict.errorCard)).toBeNull();
+  });
+});

--- a/packages/contract/src/chat-data-parts.ts
+++ b/packages/contract/src/chat-data-parts.ts
@@ -92,6 +92,7 @@ export const ChatResponseDataPart = z.discriminatedUnion("intent", [
   ResponseEnvelope.extend({ intent: z.literal("clarify"), data: ClarificationData.optional() }),
   ResponseEnvelope.extend({ intent: z.literal("partial"), data: RouteData.optional() }),
   prosePart("blocked"),
+  ResponseEnvelope.extend({ intent: z.literal("error"), data: EmptyData.optional() }),
   ResponseEnvelope.extend({ intent: z.literal("unknown"), data: EmptyData.optional() }),
 ]);
 


### PR DESCRIPTION
Second-review P0/P1 fixes (Codex agent + Fable frontend-consumer completion, lead-committed). Atomic contract+consumer unit.

**agent/contract:**
- P0-1: real per-intent response builder wire now parses in the Zod schema (cross-language `chat_wire_parser.ts` test, all intents); fixtures regenerated from the real builder (not hand-reduced)
- chat-data-parts: `error` discriminator variant
- ownership claim atomic + required for every authenticated server-created session (P1-3)
- normalized failures close active tools + termination driven off response.success/status (P1-4/5)
- clarification full input→output lifecycle under one call id (P1-6)
- serialization inside protected block + queue completion in `finally` (P1-7)

**frontend consumer (composition-completion):**
- `error` intent card + registry entry (closes TS2741 the contract change would otherwise cause)
- adapted SpotList to route.ordered_points, structural session-id patch, fixture-truth assertions

Gates (lead-run, full workspace): typecheck ✓ all 4 packages · web 397 + agent 1205 + catalog 243 tests ✓ · OpenAPI stable · cross-lang wire test green · suppressions 0

Flagged upstream (non-blocking): re-recorded clarify candidates emit bangumi ids as titles — agent data-quality item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)