### PR TITLE
fix(catalog): review-2 P1/P2 — query cache-bust guard, spatial-grid clustering, OpenAPI https pattern

### DIFF
--- a/packages/contract/scripts/emit-openapi.ts
+++ b/packages/contract/scripts/emit-openapi.ts
@@ -11,11 +11,13 @@ import { dirname, join } from "node:path";
 import { writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { OpenAPIGenerator } from "@orpc/openapi";
-import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
+import { JSON_SCHEMA_REGISTRY, ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { checkinContract } from "../src/checkin-contract.js";
 import { catalogContract } from "../src/contract.js";
-import { shareContract } from "../src/share-contract.js";
+import { HttpsUrl, shareContract } from "../src/share-contract.js";
 import { usersContract } from "../src/users-contract.js";
+
+JSON_SCHEMA_REGISTRY.add(HttpsUrl, { pattern: "^[Hh][Tt][Tt][Pp][Ss]://" });
 
 const generator = new OpenAPIGenerator({
   schemaConverters: [new ZodToJsonSchemaConverter()],

--- a/packages/contract/test/users-openapi.test.ts
+++ b/packages/contract/test/users-openapi.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import usersOpenApi from "../users-openapi.json";
 
 const BEARER_SECURITY = [{ bearerAuth: [] }];
+const HTTPS_PATTERN = "^[Hh][Tt][Tt][Pp][Ss]://";
+const resolveSchema = usersOpenApi.paths["/v1/users/shares/resolve/{token}"]
+  .get.responses["200"].content["application/json"].schema;
+const itinerary = resolveSchema.properties.itinerary.properties;
 
 describe("users OpenAPI security", () => {
   it("defines HTTP bearer JWT authentication", () => {
@@ -24,5 +28,15 @@ describe("users OpenAPI security", () => {
   it("marks public share resolution as explicitly anonymous", () => {
     const resolve = usersOpenApi.paths["/v1/users/shares/resolve/{token}"].get;
     expect(resolve.security).toEqual([]);
+  });
+
+  it("emits the HTTPS constraint for every public URL field", () => {
+    const urls = [itinerary.stops.items.properties.frame_image_url,
+      itinerary.comparisons.items.properties.image_url,
+      itinerary.hero_image_url, itinerary.attributions.items.properties.url];
+    expect(urls).toHaveLength(4);
+    for (const schema of urls) {
+      expect(schema).toMatchObject({ format: "uri", pattern: HTTPS_PATTERN });
+    }
   });
 });

--- a/packages/contract/users-openapi.json
+++ b/packages/contract/users-openapi.json
@@ -1535,7 +1535,8 @@
                               },
                               "frame_image_url": {
                                 "type": "string",
-                                "format": "uri"
+                                "format": "uri",
+                                "pattern": "^[Hh][Tt][Tt][Pp][Ss]://"
                               },
                               "frame_label": {
                                 "type": "string",
@@ -1565,7 +1566,8 @@
                               },
                               "image_url": {
                                 "type": "string",
-                                "format": "uri"
+                                "format": "uri",
+                                "pattern": "^[Hh][Tt][Tt][Pp][Ss]://"
                               },
                               "caption": {
                                 "type": "string",
@@ -1583,7 +1585,8 @@
                         },
                         "hero_image_url": {
                           "type": "string",
-                          "format": "uri"
+                          "format": "uri",
+                          "pattern": "^[Hh][Tt][Tt][Pp][Ss]://"
                         },
                         "attributions": {
                           "type": "array",
@@ -1598,7 +1601,8 @@
                               },
                               "url": {
                                 "type": "string",
-                                "format": "uri"
+                                "format": "uri",
+                                "pattern": "^[Hh][Tt][Tt][Pp][Ss]://"
                               }
                             },
                             "required": [

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -100,9 +100,10 @@ export function createWorkerApp(deps: {
     c.env.CONTAINER.get(c.env.CONTAINER.idFromName("default")).fetch(c.req.raw),
   );
   app.all("/img/*", (c) => handleImageProxy(c.req.raw, c.executionCtx));
-  app.get("/catalog/public/anime-overview/:bangumiId{[0-9]+}", (c) =>
-    forwardPublicCatalog(c.env, c.req.raw),
-  );
+  app.get("/catalog/public/anime-overview/:bangumiId{[0-9]+}", (c) => {
+    if (new URL(c.req.url).search) return c.text("Unexpected query parameters", 400);
+    return forwardPublicCatalog(c.env, c.req.raw);
+  });
   app.all("/catalog/public/*", (c) => c.notFound());
   // Hono runs the first matching handler in registration order.
   // /v1/users/* bypasses the container entirely: the users service verifies the

--- a/worker/entry.test.ts
+++ b/worker/entry.test.ts
@@ -63,6 +63,14 @@ void test("public catalog forwarding keeps only the minimal safe header allowlis
   assert.deepEqual([...cap.req.headers], [["accept", "application/json"]]);
 });
 
+void test("public anime overview rejects unexpected query parameters", async () => {
+  const app = createWorkerApp({ nextHandler: stubNext });
+  const cap: { req?: Request } = {};
+  const res = await app.request("/catalog/public/anime-overview/3302?nonce=fixed", {}, envWithCatalog(cap), stubCtx);
+  assert.equal(res.status, 400);
+  assert.equal(cap.req, undefined);
+});
+
 async function assertPublicCatalogRejected(path: string, method = "GET"): Promise<void> {
   const app = createWorkerApp({ nextHandler: stubNext });
   const cap: { req?: Request } = {};

--- a/workers/catalog/src/api/anime-overview.ts
+++ b/workers/catalog/src/api/anime-overview.ts
@@ -25,7 +25,6 @@ const SCENE_LIMIT = 20;
 const SAMPLE_ROUTE_REGION_LIMIT = 3;
 const SAMPLE_ROUTE_POINT_CAP = 12;
 const CLUSTER_RADIUS_M = 50;
-const SCENE_CLUSTER_INPUT_CAP = 500;
 
 /** The one DB capability this handler needs: run a query, get back `{ rows }`. */
 export interface OverviewDb {
@@ -121,7 +120,7 @@ function centroid(members: OverviewRow[]): { lat: number; lng: number } {
 
 /** 名場面 ranking: co-located clusters ranked by shot count, capped. */
 function buildScenes(rows: OverviewRow[]): AnimeScene[] {
-  const scenes = clusterByLocation(rows.slice(0, SCENE_CLUSTER_INPUT_CAP), CLUSTER_RADIUS_M).map(toScene);
+  const scenes = clusterByLocation(rows, CLUSTER_RADIUS_M).map(toScene);
   scenes.sort((a, b) => b.shot_count - a.shot_count || a.id.localeCompare(b.id));
   return scenes.slice(0, SCENE_LIMIT);
 }

--- a/workers/catalog/src/index.ts
+++ b/workers/catalog/src/index.ts
@@ -25,6 +25,7 @@ app.get("/healthz", (c) =>
 // tagging its response on the way back out.
 const PUBLIC_CACHE_CONTROL = "public, max-age=300, s-maxage=3600";
 app.use("/catalog/public/*", async (c, next) => {
+  if (new URL(c.req.url).search) return c.json({ error: "unexpected query parameters" }, 400);
   await next();
   if (c.res.ok) c.res.headers.set("Cache-Control", PUBLIC_CACHE_CONTROL);
 });

--- a/workers/catalog/src/lib/clustering.ts
+++ b/workers/catalog/src/lib/clustering.ts
@@ -1,5 +1,5 @@
 /**
- * Deterministic location clustering via union-find.
+ * Deterministic location clustering via a spatial grid and union-find.
  *
  * Faithful TS port of
  * `backend/agents/route_optimizer.py::cluster_by_location` (lines ~34-114),
@@ -30,6 +30,13 @@ export interface LocationCluster<P extends ClusterablePoint = ClusterablePoint> 
 }
 
 type NonEmpty<T> = [T, ...T[]];
+type SpatialGrid<P extends ClusterablePoint> = Map<string, PointNode<P>[]>;
+
+const EARTH_RADIUS_M = 6_371_000;
+const OFFSETS = [-1, 0, 1] as const;
+const NEIGHBOR_OFFSETS = OFFSETS.flatMap((x) =>
+  OFFSETS.flatMap((y) => OFFSETS.map((z) => [x, y, z] as const)),
+);
 
 /** Mutable union-find node; parent links replace unchecked numeric indexing. */
 class UnionNode {
@@ -40,6 +47,12 @@ class UnionNode {
 interface PointNode<P extends ClusterablePoint> {
   point: P;
   node: UnionNode;
+}
+
+interface SpatialCell {
+  x: number;
+  y: number;
+  z: number;
 }
 
 /** Path-compressing find — mirrors Python `_find`. */
@@ -84,20 +97,54 @@ export function clusterByLocation<P extends ClusterablePoint>(
   radiusM = 50,
 ): LocationCluster<P>[] {
   const entries = points.map((point) => ({ point, node: new UnionNode() }));
-  pairUnion(entries, radiusM);
+  if (radiusM > 0) spatialUnion(entries, radiusM);
   return buildClusters(entries);
 }
 
-function pairUnion<P extends ClusterablePoint>(
-  entries: PointNode<P>[],
-  radiusM: number,
+function spatialUnion<P extends ClusterablePoint>(entries: PointNode<P>[], radiusM: number): void {
+  const grid: SpatialGrid<P> = new Map();
+  const cellSize = chordLength(radiusM);
+  for (const entry of entries) addSpatialEntry(grid, entry, cellSize, radiusM);
+}
+
+function addSpatialEntry<P extends ClusterablePoint>(
+  grid: SpatialGrid<P>, entry: PointNode<P>, cellSize: number, radiusM: number,
 ): void {
-  // O(n^2) pairwise comparison, same iteration order as Python (i, then j>i).
-  for (const [index, left] of entries.entries()) {
-    for (const right of entries.slice(index + 1)) {
-      unionIfClose(left, right, radiusM);
-    }
-  }
+  const cell = spatialCell(entry.point, cellSize);
+  for (const neighbor of neighborEntries(grid, cell)) unionIfClose(neighbor, entry, radiusM);
+  insertEntry(grid, cellKey(cell), entry);
+}
+
+function chordLength(radiusM: number): number {
+  const angle = Math.min(radiusM / EARTH_RADIUS_M, Math.PI);
+  return 2 * Math.sin(angle / 2);
+}
+
+function spatialCell(point: ClusterablePoint, cellSize: number): SpatialCell {
+  const lat = radians(point.latitude);
+  const lng = radians(point.longitude);
+  const cosLat = Math.cos(lat);
+  return { x: Math.floor(cosLat * Math.cos(lng) / cellSize),
+    y: Math.floor(cosLat * Math.sin(lng) / cellSize), z: Math.floor(Math.sin(lat) / cellSize) };
+}
+
+function radians(degrees: number): number {
+  return degrees * Math.PI / 180;
+}
+
+function neighborEntries<P extends ClusterablePoint>(grid: SpatialGrid<P>, cell: SpatialCell): PointNode<P>[] {
+  return NEIGHBOR_OFFSETS.flatMap(([x, y, z]) =>
+    grid.get(cellKey({ x: cell.x + x, y: cell.y + y, z: cell.z + z })) ?? []);
+}
+
+function cellKey(cell: SpatialCell): string {
+  return [cell.x, cell.y, cell.z].join(":");
+}
+
+function insertEntry<P extends ClusterablePoint>(grid: SpatialGrid<P>, key: string, entry: PointNode<P>): void {
+  const bucket = grid.get(key);
+  if (bucket) bucket.push(entry);
+  else grid.set(key, [entry]);
 }
 
 function unionIfClose<P extends ClusterablePoint>(left: PointNode<P>, right: PointNode<P>, radiusM: number): void {

--- a/workers/catalog/test/anime-overview.worker.test.ts
+++ b/workers/catalog/test/anime-overview.worker.test.ts
@@ -125,12 +125,15 @@ describe("animeOverview scene edge cases", () => {
     });
   });
 
-  it("caps the quadratic clustering input while preserving the total count", async () => {
-    const rows = Array.from({ length: 501 }, (_, index) =>
-      row(`p-${String(index).padStart(3, "0")}`, 35.0, 139.0, "Tokyo"));
+  it("includes a large co-located cluster at the tail of the ID range", async () => {
+    const prefix = Array.from({ length: 520 }, (_, index) =>
+      row(`p-${String(index).padStart(3, "0")}`, 30 + index * 0.001, 138.0, "Tokyo"));
+    const tail = Array.from({ length: 100 }, (_, index) =>
+      row(`z-${String(index).padStart(3, "0")}`, 35.0, 139.0, "Tokyo"));
+    const rows = [...prefix, ...tail];
     const result = await animeOverview(fakeDb(rows), { bangumi_id: "302" });
-    expect(result.points_length).toBe(501);
-    expect(result.scenes[0]?.shot_count).toBe(500);
+    expect(result.points_length).toBe(620);
+    expect(result.scenes[0]).toMatchObject({ id: "z-000", shot_count: 100 });
   });
 });
 

--- a/workers/catalog/test/worker.worker.test.ts
+++ b/workers/catalog/test/worker.worker.test.ts
@@ -42,4 +42,11 @@ describe("catalog Worker (vitest-pool-workers)", () => {
     const body = json as { error: string };
     expect(body.error).toBe("catalog database not configured");
   });
+
+  it("rejects unexpected public query parameters before database access", async () => {
+    const path = "/catalog/public/anime-overview/3302?nonce=fixed";
+    const res = await app.request(path, {}, {} satisfies Env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "unexpected query parameters" });
+  });
 });


### PR DESCRIPTION
Second-review catalog fixes (Codex-authored, lead-committed).

- **query-string cache-busting (P1)**: edge (worker/app.ts) + catalog (index.ts) reject any query params on `/catalog/public/*` with 400 → canonical cache key, no anonymous DB-read amplification
- **clustering truncation (P1)**: O(n²) pairwise → spatial-grid union-find (3D ECEF cells, neighbor-only comparison); clusters ALL rows, removing the 500-input ID-prefix truncation that dropped a late largest cluster's top scene
- **OpenAPI https (P2)**: `HttpsUrl` emits JSON-Schema `pattern: ^[Hh][Tt][Tt][Pp][Ss]://` on all 4 public URL fields (generated validators/docs now match the runtime schema); artifact test asserts it
- city empty-pipeline: documented as known limitation, separate backfill card recommended

Gates (lead-run): **full workspace typecheck OK (all 4 packages)** · catalog 244 + root worker 42 + contract 49 tests · OpenAPI idempotent · suppressions 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)