### PR TITLE
feat(web): restore locale switcher in mobile fox home top bar

### DIFF
--- a/apps/web/src/components/landing/MobileFoxHome.tsx
+++ b/apps/web/src/components/landing/MobileFoxHome.tsx
@@ -1,4 +1,5 @@
 import { useDict } from "../../i18n/context";
+import { LocaleSwitcher } from "../../i18n/LocaleSwitcher";
 import { ToriiMark } from "./ToriiMark";
 
 const BG_SRC = "/images/landing/shrine-approach.webp";
@@ -13,7 +14,10 @@ function MobileFoxBar({ onLogin }: { onLogin: () => void }) {
   const landing = useDict().landing;
   return (<header className="mobile-fox__bar">
     <span className="mobile-fox__badge"><ToriiMark size={22} /></span>
-    <button className="landing__login" type="button" onClick={onLogin}>{landing.login}</button>
+    <div className="mobile-fox__bar-actions">
+      <LocaleSwitcher />
+      <button className="landing__login" type="button" onClick={onLogin}>{landing.login}</button>
+    </div>
   </header>);
 }
 

--- a/apps/web/src/styles/landing.css
+++ b/apps/web/src/styles/landing.css
@@ -483,6 +483,16 @@
   background: var(--color-card);
 }
 
+.mobile-fox__bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mobile-fox__bar-actions .locale-switcher__option {
+  padding: 4px 8px;
+}
+
 .mobile-fox__scene {
   position: relative;
   z-index: 1;

--- a/apps/web/tests/unit/landing-page.test.tsx
+++ b/apps/web/tests/unit/landing-page.test.tsx
@@ -61,7 +61,7 @@ describe("LandingPage", () => {
 describe("LandingPage i18n", () => {
   it("re-renders all copy in English with no ja fallback leaking", () => {
     renderWithLocale(<LandingPage />);
-    act(() => { screen.getByRole("button", { name: "EN" }).click(); });
+    act(() => { screen.getAllByRole("button", { name: "EN" })[0]?.click(); });
     expect(screen.getAllByRole("button", { name: "Start Exploring" }).length).toBe(2);
     expect(screen.getByText("Anime Travel Journal")).toBeTruthy();
     expect(screen.queryByText("巡礼をはじめる")).toBeNull();

--- a/apps/web/tests/unit/mobile-fox-home.test.tsx
+++ b/apps/web/tests/unit/mobile-fox-home.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { cleanup, screen } from "@testing-library/react";
+import { act, cleanup, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MobileFoxHome } from "../../src/components/landing/MobileFoxHome";
 import { renderWithLocale, setLanguages } from "./_i18n";
@@ -50,6 +50,18 @@ describe("MobileFoxHome", () => {
     renderWithLocale(<MobileFoxHome onLogin={onLogin} onStart={noop} />);
     screen.getByRole("button", { name: "ログイン" }).click();
     expect(onLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes a language switcher in the top bar", () => {
+    renderWithLocale(<MobileFoxHome onLogin={noop} onStart={noop} />);
+    expect(screen.getByRole("group", { name: "Language" })).toBeTruthy();
+  });
+
+  it("switches the title to Animichi when the English locale is picked", () => {
+    renderWithLocale(<MobileFoxHome onLogin={noop} onStart={noop} />);
+    expect(screen.getByRole("heading", { name: "聖地巡礼" })).toBeTruthy();
+    act(() => { screen.getByRole("button", { name: "EN" }).click(); });
+    expect(screen.getByRole("heading", { name: "Animichi" })).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## What

The mobile fox welcome home (≤640px, PR #402) top bar only had the torii badge and a Log in pill. The language switcher was hidden along with the desktop bar via CSS. Owner asked to keep a language entry point on mobile.

This adds the existing `LocaleSwitcher` (reused, not rewritten) to the mobile top bar, grouped with Log in on the right so the torii + login layout rhythm from the mockup stays intact. No day/night toggle (mockup has none — language only).

## Changes
- `MobileFoxHome.tsx` — render `LocaleSwitcher` inside a new `.mobile-fox__bar-actions` group next to the Log in pill.
- `landing.css` — scoped `.mobile-fox__bar-actions` flex group + tighter switcher option padding (semantic tokens only).
- `mobile-fox-home.test.tsx` — new tests: top bar exposes the Language switcher group; picking EN flips the title 聖地巡礼 → Animichi (also covers the "Japanese title is correct" concern).
- `landing-page.test.tsx` — updated the i18n test to pick the first of the now-two EN switchers (desktop + mobile both drive the same context).

## Gate
- `pnpm run typecheck` — pass
- `pnpm run build` — pass (routeTree regenerated)
- `pnpm run lint:oxlint` — pass (`--deny-warnings`)
- `pnpm run test` — 433 passed (78 files); coverage stmts 99.08% / branches 95.49% / fns 99.54% / lines 99.76%

🤖 Generated with [Claude Code](https://claude.com/claude-code)