### PR TITLE
feat(web): S5.5 App Home — Continue From + Popular Ranking

### DIFF
--- a/apps/web/src/api/hooks/use-continue-from.ts
+++ b/apps/web/src/api/hooks/use-continue-from.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import type { UserRoute } from "@seichijunrei/contract";
+import { users } from "../orpc";
+
+/**
+ * Pick the "続きから" route: the most recently updated in-progress (`draft`)
+ * route (SD-8 — depends only on sessions/routes, never `user_memory`).
+ */
+export function pickContinueFrom(routes: readonly UserRoute[]): UserRoute | undefined {
+  const drafts = routes.filter((route) => route.status === "draft");
+  return [...drafts].sort((a, b) => b.updated_at.localeCompare(a.updated_at))[0];
+}
+
+export interface ContinueFromState {
+  readonly route: UserRoute | undefined;
+  readonly isPending: boolean;
+}
+
+export function useContinueFrom(): ContinueFromState {
+  const query = useQuery({ ...users().listRoutes.queryOptions(), retry: false });
+  return { route: query.data ? pickContinueFrom(query.data.routes) : undefined, isPending: query.isPending };
+}

--- a/apps/web/src/api/hooks/use-popular.ts
+++ b/apps/web/src/api/hooks/use-popular.ts
@@ -1,0 +1,11 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { fetchPopular } from "../popular";
+
+/** Query options for the popular ranking, keyed under `["popular", limit]`. */
+export function popularRankingOptions(limit = 8) {
+  return queryOptions({ queryKey: ["popular", limit], queryFn: () => fetchPopular(limit) });
+}
+
+export function usePopularRanking(limit = 8) {
+  return useQuery(popularRankingOptions(limit));
+}

--- a/apps/web/src/api/popular.ts
+++ b/apps/web/src/api/popular.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { resolveOrigin } from "./config";
+
+/**
+ * Popular-ranking payload for `GET /v1/bangumi/popular`.
+ *
+ * This agent-side endpoint predates the oRPC contract (spec S5.5 keeps it as
+ * an existing public route), so the shape is mirrored here rather than in
+ * `packages/contract`. Numeric ids/counts are coerced from the raw DB rows.
+ */
+export const PopularBangumi = z.object({
+  id: z.coerce.string(),
+  title: z.string(),
+  title_cn: z.string().nullish(),
+  cover_url: z.string().nullish(),
+  city: z.string().nullish(),
+  points_count: z.coerce.number().default(0),
+  rating: z.coerce.number().nullish(),
+});
+export type PopularBangumi = z.infer<typeof PopularBangumi>;
+
+export const PopularResult = z.object({ bangumi: z.array(PopularBangumi) });
+export type PopularResult = z.infer<typeof PopularResult>;
+
+function browserLocation(): { readonly origin: string } | undefined {
+  return typeof window === "undefined" ? undefined : window.location;
+}
+
+export function popularUrl(limit: number): string {
+  const origin = resolveOrigin(import.meta.env, browserLocation());
+  return `${origin}/v1/bangumi/popular?limit=${String(limit)}`;
+}
+
+export async function fetchPopular(limit = 8): Promise<PopularResult> {
+  const response = await fetch(popularUrl(limit), { headers: { accept: "application/json" } });
+  if (!response.ok) throw new Error(`popular request failed: ${String(response.status)}`);
+  return PopularResult.parse(await response.json());
+}

--- a/apps/web/src/components/home/AppHome.tsx
+++ b/apps/web/src/components/home/AppHome.tsx
@@ -1,0 +1,18 @@
+import { ContinueFromCard } from "./ContinueFromCard";
+import { PopularRanking } from "./PopularRanking";
+import { SearchBox } from "./SearchBox";
+
+interface AppHomeProps {
+  readonly onSearch: (query: string) => void;
+}
+
+/** Authenticated App Home: search + 続きから + 人気ランキング (spec S5.5). */
+export function AppHome({ onSearch }: AppHomeProps) {
+  return (
+    <main className="mx-auto grid max-w-2xl gap-6 px-4 py-8">
+      <SearchBox onSubmit={onSearch} />
+      <ContinueFromCard />
+      <PopularRanking />
+    </main>
+  );
+}

--- a/apps/web/src/components/home/ContinueFromCard.tsx
+++ b/apps/web/src/components/home/ContinueFromCard.tsx
@@ -1,0 +1,23 @@
+import type { UserRoute } from "@seichijunrei/contract";
+import { useContinueFrom } from "../../api/hooks/use-continue-from";
+import type { Dict } from "../../i18n/dictionaries";
+import { useDict } from "../../i18n/context";
+
+function ContinueCard({ route, home }: { readonly route: UserRoute; readonly home: Dict["home"] }) {
+  return (
+    <section aria-labelledby="continue-from-title" className="rounded-2xl bg-[var(--color-card)] p-4">
+      <h2 id="continue-from-title" className="m-0 text-sm text-[var(--color-muted-fg)]">{home.continue_title}</h2>
+      <p className="mt-1 mb-3 font-bold text-[var(--color-fg)]">{route.title}</p>
+      <a className="inline-block rounded-xl bg-[var(--color-primary)] px-4 py-2 font-bold text-[var(--color-primary-fg)]" href={`/chat?route=${route.id}`}>{home.continue_resume}</a>
+    </section>
+  );
+}
+
+/** "続きから": an in-progress route resume card; renders nothing when absent
+ * (logged-out, unauthorized, or no draft — spec S5.5 empty state). */
+export function ContinueFromCard() {
+  const home = useDict().home;
+  const { route } = useContinueFrom();
+  if (!route) return null;
+  return <ContinueCard route={route} home={home} />;
+}

--- a/apps/web/src/components/home/PopularRanking.tsx
+++ b/apps/web/src/components/home/PopularRanking.tsx
@@ -1,0 +1,52 @@
+import type { PopularBangumi } from "../../api/popular";
+import { usePopularRanking } from "../../api/hooks/use-popular";
+import type { Dict } from "../../i18n/dictionaries";
+import { useDict, useLocale } from "../../i18n/context";
+import type { Locale } from "../../i18n/locales";
+
+function rowTitle(row: PopularBangumi, locale: Locale): string {
+  return locale === "zh" ? (row.title_cn ?? row.title) : row.title;
+}
+
+function RankItem({ row, locale, home }: { readonly row: PopularBangumi; readonly locale: Locale; readonly home: Dict["home"] }) {
+  return (
+    <li>
+      <a className="flex items-baseline gap-3 rounded-xl px-3 py-2 hover:bg-[var(--color-muted)]" href={`/anime/${row.id}`}>
+        <span className="font-bold text-[var(--color-fg)]">{rowTitle(row, locale)}</span>
+        <span className="ml-auto text-sm text-[var(--color-muted-fg)]">{row.points_count} {home.popular_spots}</span>
+      </a>
+    </li>
+  );
+}
+
+function RankList({ rows, home }: { readonly rows: readonly PopularBangumi[]; readonly home: Dict["home"] }) {
+  const locale = useLocale();
+  return (
+    <ol className="m-0 list-none p-0">
+      {rows.map((row) => <RankItem key={row.id} row={row} locale={locale} home={home} />)}
+    </ol>
+  );
+}
+
+function RankingBody({ rows, home }: { readonly rows: readonly PopularBangumi[]; readonly home: Dict["home"] }) {
+  if (rows.length === 0) return <p className="m-0 text-[var(--color-muted-fg)]">{home.popular_empty}</p>;
+  return <RankList rows={rows} home={home} />;
+}
+
+function RankingSection({ rows, home }: { readonly rows: readonly PopularBangumi[]; readonly home: Dict["home"] }) {
+  return (
+    <section aria-labelledby="popular-title" className="rounded-2xl bg-[var(--color-card)] p-4">
+      <h2 id="popular-title" className="mt-0 mb-2 text-[var(--color-fg)]">{home.popular_title}</h2>
+      <RankingBody rows={rows} home={home} />
+    </section>
+  );
+}
+
+/** "人気ランキング": popular titles from the existing agent endpoint; an empty
+ * or failed query degrades to a graceful empty state (spec S5.5). */
+export function PopularRanking() {
+  const home = useDict().home;
+  const query = usePopularRanking();
+  if (query.isPending) return <p role="status">{home.popular_title}…</p>;
+  return <RankingSection rows={query.isSuccess ? query.data.bangumi : []} home={home} />;
+}

--- a/apps/web/src/components/home/SearchBox.tsx
+++ b/apps/web/src/components/home/SearchBox.tsx
@@ -1,0 +1,27 @@
+import type { ChangeEvent, KeyboardEvent } from "react";
+import { useState } from "react";
+import { useDict } from "../../i18n/context";
+
+interface SearchBoxProps {
+  readonly onSubmit: (query: string) => void;
+}
+
+function useSearchBox(onSubmit: (query: string) => void) {
+  const [query, setQuery] = useState("");
+  const submit = () => { onSubmit(query.trim()); };
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => { setQuery(event.target.value); };
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => { if (event.key === "Enter") submit(); };
+  return { query, submit, onChange, onKeyDown };
+}
+
+/** App Home search box: submits the query into `/chat` (spec S5.5, reuses S1.1 A2). */
+export function SearchBox({ onSubmit }: SearchBoxProps) {
+  const home = useDict().home;
+  const box = useSearchBox(onSubmit);
+  return (
+    <div className="flex gap-2 rounded-2xl bg-[var(--color-card)] p-2 shadow-sm">
+      <input type="search" className="flex-1 rounded-xl bg-transparent px-3 py-2 text-[var(--color-fg)] outline-none" value={box.query} placeholder={home.search_placeholder} aria-label={home.search_placeholder} onChange={box.onChange} onKeyDown={box.onKeyDown} />
+      <button type="button" className="rounded-xl bg-[var(--color-primary)] px-4 py-2 font-bold text-[var(--color-primary-fg)]" onClick={box.submit}>{home.search_cta}</button>
+    </div>
+  );
+}

--- a/apps/web/src/components/home/search-target.ts
+++ b/apps/web/src/components/home/search-target.ts
@@ -1,0 +1,19 @@
+/** `/chat` A2 navigation target: reuses S1.1's `?q=` entry-point (spec S5.5). */
+export interface ChatSearchTarget {
+  readonly to: "/chat";
+  readonly search: { readonly q: string };
+}
+
+export function chatSearchTarget(query: string): ChatSearchTarget | null {
+  const q = query.trim();
+  return q ? { to: "/chat", search: { q } } : null;
+}
+
+export type NavigateFn = (target: ChatSearchTarget) => void;
+
+export function makeSearchHandler(navigate: NavigateFn): (query: string) => void {
+  return (query) => {
+    const target = chatSearchTarget(query);
+    if (target) navigate(target);
+  };
+}

--- a/apps/web/src/i18n/dictionaries/en.json
+++ b/apps/web/src/i18n/dictionaries/en.json
@@ -31,6 +31,15 @@
     "mobile_bg_alt": "Hand-drawn illustration of a torii gate and shrine approach",
     "fox_alt": "Fox guide welcoming you with a travel journal card"
   },
+  "home": {
+    "search_placeholder": "Enter an anime, station, or city",
+    "search_cta": "Build a route",
+    "continue_title": "Continue from",
+    "continue_resume": "Resume",
+    "popular_title": "Popular ranking",
+    "popular_empty": "No popular titles yet",
+    "popular_spots": "spots"
+  },
   "auth": {
     "title": "Log in",
     "subtitle": "Enter your email and we'll send you a sign-in link.",

--- a/apps/web/src/i18n/dictionaries/ja.json
+++ b/apps/web/src/i18n/dictionaries/ja.json
@@ -31,6 +31,15 @@
     "mobile_bg_alt": "手描き風の鳥居と参道のイラスト",
     "fox_alt": "しおりカードを持って案内するキツネ"
   },
+  "home": {
+    "search_placeholder": "アニメ・駅・都市を入力",
+    "search_cta": "ルートを作る",
+    "continue_title": "続きから",
+    "continue_resume": "再開する",
+    "popular_title": "人気ランキング",
+    "popular_empty": "まだ人気の作品がありません",
+    "popular_spots": "スポット"
+  },
   "auth": {
     "title": "ログイン",
     "subtitle": "メールアドレスを入力すると、ログインリンクをお送りします。",

--- a/apps/web/src/i18n/dictionaries/zh.json
+++ b/apps/web/src/i18n/dictionaries/zh.json
@@ -31,6 +31,15 @@
     "mobile_bg_alt": "手绘风格的鸟居与参道插画",
     "fox_alt": "举着巡礼手帐卡片迎接你的狐狸向导"
   },
+  "home": {
+    "search_placeholder": "输入作品名、车站或城市",
+    "search_cta": "生成路线",
+    "continue_title": "继续上次",
+    "continue_resume": "继续",
+    "popular_title": "人气排行",
+    "popular_empty": "暂时还没有人气作品",
+    "popular_spots": "个取景地"
+  },
   "auth": {
     "title": "登录",
     "subtitle": "输入邮箱，我们会给你发送一个登录链接。",

--- a/apps/web/src/lib/auth/session.ts
+++ b/apps/web/src/lib/auth/session.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { createAuthClient } from "better-auth/client";
+
+/** Root-route auth gate state; `pending` renders the anonymous Landing (S5.5). */
+export type AuthStatus = "pending" | "authenticated" | "anonymous";
+
+function authBaseUrl(): string | undefined {
+  const value = import.meta.env.VITE_NEON_AUTH_BASE_URL;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/** Resolve the caller's auth status; unconfigured or failing auth is anonymous. */
+export async function fetchAuthStatus(): Promise<AuthStatus> {
+  const base = authBaseUrl();
+  if (!base) return "anonymous";
+  try {
+    const { data } = await createAuthClient({ baseURL: base }).getSession();
+    return data ? "authenticated" : "anonymous";
+  } catch {
+    return "anonymous";
+  }
+}
+
+export function useAuthStatus(fetcher: () => Promise<AuthStatus> = fetchAuthStatus): AuthStatus {
+  const [status, setStatus] = useState<AuthStatus>("pending");
+  useEffect(() => {
+    let active = true;
+    void fetcher().then((next) => { if (active) setStatus(next); });
+    return () => { active = false; };
+  }, [fetcher]);
+  return status;
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,6 +1,29 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { Landing } from "../components/Landing";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { AppHome } from "../components/home/AppHome";
+import { makeSearchHandler } from "../components/home/search-target";
+import { LandingPage } from "../components/landing/LandingPage";
+import { LocaleProvider } from "../i18n/context";
+import { useAuthStatus } from "../lib/auth/session";
 
 export const Route = createFileRoute("/")({
-  component: Landing,
+  component: HomeRoute,
 });
+
+function AuthedHome() {
+  const navigate = useNavigate();
+  return <AppHome onSearch={makeSearchHandler((target) => { void navigate(target); })} />;
+}
+
+/** Single root route, dual state: App Home for authenticated users (spec S5.5),
+ * the S0.6 marketing Landing for everyone else (pending resolves to Landing). */
+export function HomeView() {
+  return useAuthStatus() === "authenticated" ? <AuthedHome /> : <LandingPage />;
+}
+
+export function HomeRoute() {
+  return (
+    <LocaleProvider>
+      <HomeView />
+    </LocaleProvider>
+  );
+}

--- a/apps/web/tests/msw/popular.ts
+++ b/apps/web/tests/msw/popular.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from "msw";
+import type { HttpHandler } from "msw";
+import { TEST_ORIGIN } from "./fixtures";
+
+/**
+ * MSW swimlane for the existing agent-side `GET /v1/bangumi/popular` endpoint
+ * (spec S5.5: an existing public endpoint this train does not migrate, so it
+ * has no oRPC contract — the fixtures mirror its `{ bangumi: [...] }` shape).
+ */
+export const POPULAR_URL = `${TEST_ORIGIN}/v1/bangumi/popular`;
+
+export const popularFixture = {
+  bangumi: [
+    { id: "1", title: "Your Name", title_cn: "你的名字", cover_url: "https://cdn.test/1.jpg", city: "Tokyo", points_count: 12, rating: 9.1 },
+    { id: "2", title: "Euphonium", title_cn: "吹响吧！上低音号", cover_url: null, city: "Uji", points_count: 8, rating: 8.4 },
+  ],
+} as const;
+
+export const popularHandler: HttpHandler = http.get(POPULAR_URL, () =>
+  HttpResponse.json(popularFixture),
+);
+
+export const popularEmptyHandler: HttpHandler = http.get(POPULAR_URL, () =>
+  HttpResponse.json({ bangumi: [] }),
+);
+
+export const popularErrorHandler: HttpHandler = http.get(POPULAR_URL, () =>
+  HttpResponse.json({ detail: "boom" }, { status: 500 }),
+);

--- a/apps/web/tests/msw/users.ts
+++ b/apps/web/tests/msw/users.ts
@@ -1,0 +1,38 @@
+import { http, HttpResponse } from "msw";
+import type { HttpHandler, JsonBodyType } from "msw";
+import { ListRoutesResult } from "@seichijunrei/contract";
+import type { UserRoute } from "@seichijunrei/contract";
+import { orpcErrorResponse } from "./contract-handler";
+import { TEST_ORIGIN } from "./fixtures";
+
+/**
+ * Contract-typed MSW swimlane for the authenticated `users.listRoutes` GET
+ * route. The body is `parse()`d with the contract's `ListRoutesResult` — no
+ * hand-written JSON — and the 401 handler models a logged-out caller.
+ */
+export const USERS_ROUTES_URL = `${TEST_ORIGIN}/v1/users/routes`;
+
+export const draftRoute: UserRoute = {
+  id: "11111111-1111-4111-8111-111111111111",
+  title: "Uji × Euphonium",
+  point_ids: ["p1", "p2"],
+  status: "draft",
+  saved_at: null,
+  updated_at: "2026-07-15T00:00:00.000Z",
+};
+
+function routesResponse(routes: readonly UserRoute[]): HttpResponse<JsonBodyType> {
+  return HttpResponse.json(ListRoutesResult.parse({ routes }) as JsonBodyType);
+}
+
+export const usersRoutesWithDraftHandler: HttpHandler = http.get(USERS_ROUTES_URL, () =>
+  routesResponse([draftRoute]),
+);
+
+export const usersRoutesEmptyHandler: HttpHandler = http.get(USERS_ROUTES_URL, () =>
+  routesResponse([]),
+);
+
+export const usersRoutesUnauthorizedHandler: HttpHandler = http.get(USERS_ROUTES_URL, () =>
+  orpcErrorResponse({ code: "UNAUTHORIZED", status: 401, message: "Sign in required" }),
+);

--- a/apps/web/tests/unit/home/_render.tsx
+++ b/apps/web/tests/unit/home/_render.tsx
@@ -1,0 +1,16 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { makeQueryClient } from "../../../src/api/query-client";
+import { LocaleProvider } from "../../../src/i18n/context";
+
+/** Render a home block inside a fresh QueryClient + i18n provider (retries off). */
+export function renderHome(ui: ReactElement) {
+  const client = makeQueryClient();
+  client.setDefaultOptions({ queries: { retry: false } });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider>{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}

--- a/apps/web/tests/unit/home/app-home.test.tsx
+++ b/apps/web/tests/unit/home/app-home.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppHome } from "../../../src/components/home/AppHome";
+import { server } from "../../msw/node";
+import { popularEmptyHandler } from "../../msw/popular";
+import { usersRoutesWithDraftHandler } from "../../msw/users";
+import { setLanguages } from "../_i18n";
+import { renderHome } from "./_render";
+
+beforeEach(() => {
+  setLanguages(["ja-JP"]);
+  server.use(popularEmptyHandler, usersRoutesWithDraftHandler);
+});
+afterEach(cleanup);
+
+describe("AppHome composition", () => {
+  it("wires the search box submit to the onSearch handler", () => {
+    const onSearch = vi.fn();
+    renderHome(<AppHome onSearch={onSearch} />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "Suzume" } });
+    fireEvent.click(screen.getByRole("button", { name: "ルートを作る" }));
+    expect(onSearch).toHaveBeenCalledWith("Suzume");
+  });
+});
+
+const LOCALE_COPY = [
+  { tag: "ja-JP", cta: "ルートを作る", continueTitle: "続きから", popularEmpty: "まだ人気の作品がありません" },
+  { tag: "zh-CN", cta: "生成路线", continueTitle: "继续上次", popularEmpty: "暂时还没有人气作品" },
+  { tag: "en-US", cta: "Build a route", continueTitle: "Continue from", popularEmpty: "No popular titles yet" },
+] as const;
+
+describe("AppHome i18n", () => {
+  it.each(LOCALE_COPY)("renders all three blocks' copy for $tag", async ({ tag, cta, continueTitle, popularEmpty }) => {
+    setLanguages([tag]);
+    renderHome(<AppHome onSearch={vi.fn()} />);
+    expect(await screen.findByText(continueTitle)).toBeTruthy();
+    expect(screen.getByRole("button", { name: cta })).toBeTruthy();
+    expect(await screen.findByText(popularEmpty)).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/home/continue-from-card.test.tsx
+++ b/apps/web/tests/unit/home/continue-from-card.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ContinueFromCard } from "../../../src/components/home/ContinueFromCard";
+import { server } from "../../msw/node";
+import {
+  draftRoute,
+  usersRoutesEmptyHandler,
+  usersRoutesUnauthorizedHandler,
+  usersRoutesWithDraftHandler,
+} from "../../msw/users";
+import { setLanguages } from "../_i18n";
+import { renderHome } from "./_render";
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(cleanup);
+
+describe("ContinueFromCard", () => {
+  it("shows the in-progress route with a resume link when one exists", async () => {
+    server.use(usersRoutesWithDraftHandler);
+    renderHome(<ContinueFromCard />);
+    expect(await screen.findByText(draftRoute.title)).toBeTruthy();
+    expect(screen.getByRole("link", { name: "再開する" }).getAttribute("href")).toBe(`/chat?route=${draftRoute.id}`);
+  });
+
+  it("renders nothing for a logged-out (unauthorized) caller", async () => {
+    server.use(usersRoutesUnauthorizedHandler);
+    renderHome(<ContinueFromCard />);
+    await waitFor(() => { expect(screen.queryByText("続きから")).toBeNull(); });
+  });
+
+  it("renders nothing for a signed-in user with no in-progress route", async () => {
+    server.use(usersRoutesEmptyHandler);
+    renderHome(<ContinueFromCard />);
+    await waitFor(() => { expect(screen.queryByText("続きから")).toBeNull(); });
+  });
+});

--- a/apps/web/tests/unit/home/continue-from.test.ts
+++ b/apps/web/tests/unit/home/continue-from.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { UserRoute } from "@seichijunrei/contract";
+import { pickContinueFrom } from "../../../src/api/hooks/use-continue-from";
+
+function makeRoute(overrides: Partial<UserRoute>): UserRoute {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    title: "Draft route",
+    point_ids: ["p1"],
+    status: "draft",
+    saved_at: null,
+    updated_at: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("pickContinueFrom", () => {
+  it("selects the most recently updated in-progress (draft) route", () => {
+    const older = makeRoute({ id: "00000000-0000-0000-0000-00000000000a", updated_at: "2026-07-01T00:00:00.000Z" });
+    const newer = makeRoute({ id: "00000000-0000-0000-0000-00000000000b", updated_at: "2026-07-10T00:00:00.000Z" });
+    expect(pickContinueFrom([older, newer])?.id).toBe(newer.id);
+  });
+
+  it("ignores saved and completed routes (SD-8: in-progress only)", () => {
+    const saved = makeRoute({ status: "saved" });
+    const completed = makeRoute({ status: "completed" });
+    expect(pickContinueFrom([saved, completed])).toBeUndefined();
+  });
+
+  it("returns undefined for an empty route list", () => {
+    expect(pickContinueFrom([])).toBeUndefined();
+  });
+});

--- a/apps/web/tests/unit/home/home-route.test.tsx
+++ b/apps/web/tests/unit/home/home-route.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthStatus } from "../../../src/lib/auth/session";
+import { server } from "../../msw/node";
+import { popularEmptyHandler } from "../../msw/popular";
+import { usersRoutesEmptyHandler } from "../../msw/users";
+import { setLanguages } from "../_i18n";
+import { renderHome } from "./_render";
+
+let mockStatus: AuthStatus = "anonymous";
+vi.mock("../../../src/lib/auth/session", () => ({ useAuthStatus: () => mockStatus }));
+vi.mock("@tanstack/react-router", async (orig) => ({
+  ...(await orig<typeof import("@tanstack/react-router")>()),
+  useNavigate: () => vi.fn(),
+}));
+
+const { HomeView, HomeRoute } = await import("../../../src/routes/index");
+
+beforeEach(() => {
+  setLanguages(["ja-JP"]);
+  server.use(popularEmptyHandler, usersRoutesEmptyHandler);
+});
+afterEach(cleanup);
+
+describe("root route dual state", () => {
+  it("renders the marketing Landing for an anonymous visitor", () => {
+    mockStatus = "anonymous";
+    renderHome(<HomeView />);
+    expect(screen.getByText("アニメ旅行ジャーナル")).toBeTruthy();
+    expect(screen.queryByRole("searchbox")).toBeNull();
+  });
+
+  it("renders the App Home for an authenticated user and navigates on search", async () => {
+    mockStatus = "authenticated";
+    renderHome(<HomeView />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "Suzume" } });
+    fireEvent.click(screen.getByRole("button", { name: "ルートを作る" }));
+    await waitFor(() => { expect(screen.getByText("人気ランキング")).toBeTruthy(); });
+  });
+
+  it("wraps the view in the locale provider via HomeRoute", () => {
+    mockStatus = "anonymous";
+    renderHome(<HomeRoute />);
+    expect(screen.getByText("アニメ旅行ジャーナル")).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/home/popular-ranking.test.tsx
+++ b/apps/web/tests/unit/home/popular-ranking.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PopularRanking } from "../../../src/components/home/PopularRanking";
+import { server } from "../../msw/node";
+import { popularEmptyHandler, popularErrorHandler, popularHandler } from "../../msw/popular";
+import { setLanguages } from "../_i18n";
+import { renderHome } from "./_render";
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(cleanup);
+
+describe("PopularRanking", () => {
+  it("shows a loading status before the ranking resolves", () => {
+    server.use(popularHandler);
+    renderHome(<PopularRanking />);
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it("renders ranked titles linking to their anime pages", async () => {
+    server.use(popularHandler);
+    renderHome(<PopularRanking />);
+    const link = await screen.findByRole("link", { name: /Your Name/ });
+    expect(link.getAttribute("href")).toBe("/anime/1");
+  });
+
+  it("shows the empty state when the catalog has no popular titles", async () => {
+    server.use(popularEmptyHandler);
+    renderHome(<PopularRanking />);
+    expect(await screen.findByText("まだ人気の作品がありません")).toBeTruthy();
+  });
+
+  it("degrades to the empty state when the endpoint fails", async () => {
+    server.use(popularErrorHandler);
+    renderHome(<PopularRanking />);
+    expect(await screen.findByText("まだ人気の作品がありません")).toBeTruthy();
+  });
+
+  it("shows the Chinese title for zh readers when available", async () => {
+    setLanguages(["zh-CN"]);
+    server.use(popularHandler);
+    renderHome(<PopularRanking />);
+    expect(await screen.findByText("你的名字")).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/home/popular.test.ts
+++ b/apps/web/tests/unit/home/popular.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from "vitest";
+import { fetchPopular, popularUrl } from "../../../src/api/popular";
+import { popularRankingOptions } from "../../../src/api/hooks/use-popular";
+import { server } from "../../msw/node";
+import { popularEmptyHandler, popularErrorHandler, popularHandler } from "../../msw/popular";
+
+describe("fetchPopular", () => {
+  it("parses the agent popular payload into contract-shaped rows", async () => {
+    server.use(popularHandler);
+    const result = await fetchPopular();
+    expect(result.bangumi.map((b) => b.title)).toEqual(["Your Name", "Euphonium"]);
+    expect(result.bangumi[0]?.points_count).toBe(12);
+  });
+
+  it("returns an empty list when the catalog has no popular titles", async () => {
+    server.use(popularEmptyHandler);
+    const result = await fetchPopular();
+    expect(result.bangumi).toEqual([]);
+  });
+
+  it("throws when the endpoint fails so the query surfaces an error", async () => {
+    server.use(popularErrorHandler);
+    await expect(fetchPopular()).rejects.toThrow("popular request failed: 500");
+  });
+
+  it("builds the popular URL with an explicit limit", () => {
+    expect(popularUrl(5)).toBe("http://localhost:3000/v1/bangumi/popular?limit=5");
+  });
+
+  it("keys the ranking query by the requested limit", () => {
+    expect(popularRankingOptions(5).queryKey).toEqual(["popular", 5]);
+  });
+});

--- a/apps/web/tests/unit/home/search-box.test.tsx
+++ b/apps/web/tests/unit/home/search-box.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchBox } from "../../../src/components/home/SearchBox";
+import { renderWithLocale, setLanguages } from "../_i18n";
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(cleanup);
+
+describe("SearchBox", () => {
+  it("submits the typed query when the button is clicked", () => {
+    const onSubmit = vi.fn();
+    renderWithLocale(<SearchBox onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "Your Name" } });
+    fireEvent.click(screen.getByRole("button", { name: "ルートを作る" }));
+    expect(onSubmit).toHaveBeenCalledWith("Your Name");
+  });
+
+  it("submits when the user presses Enter", () => {
+    const onSubmit = vi.fn();
+    renderWithLocale(<SearchBox onSubmit={onSubmit} />);
+    const input = screen.getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "Euphonium" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("Euphonium");
+  });
+
+  it("does not submit on other keys", () => {
+    const onSubmit = vi.fn();
+    renderWithLocale(<SearchBox onSubmit={onSubmit} />);
+    fireEvent.keyDown(screen.getByRole("searchbox"), { key: "a" });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/home/search-target.test.ts
+++ b/apps/web/tests/unit/home/search-target.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { chatSearchTarget, makeSearchHandler } from "../../../src/components/home/search-target";
+
+describe("chatSearchTarget", () => {
+  it("builds a /chat A2 target with the trimmed query", () => {
+    expect(chatSearchTarget("  Your Name  ")).toEqual({ to: "/chat", search: { q: "Your Name" } });
+  });
+
+  it("returns null for a blank query so no navigation fires", () => {
+    expect(chatSearchTarget("   ")).toBeNull();
+  });
+});
+
+describe("makeSearchHandler", () => {
+  it("navigates to the chat target for a real query", () => {
+    const navigate = vi.fn();
+    makeSearchHandler(navigate)("Euphonium");
+    expect(navigate).toHaveBeenCalledWith({ to: "/chat", search: { q: "Euphonium" } });
+  });
+
+  it("does not navigate when the query is blank", () => {
+    const navigate = vi.fn();
+    makeSearchHandler(navigate)("");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/home/session.test.tsx
+++ b/apps/web/tests/unit/home/session.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchAuthStatus, useAuthStatus } from "../../../src/lib/auth/session";
+
+const getSessionMock = vi.fn();
+vi.mock("better-auth/client", () => ({
+  createAuthClient: () => ({ getSession: getSessionMock }),
+}));
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  getSessionMock.mockReset();
+});
+
+describe("fetchAuthStatus", () => {
+  it("is anonymous when Neon Auth is not configured", async () => {
+    expect(await fetchAuthStatus()).toBe("anonymous");
+  });
+
+  it("is authenticated when a session is returned", async () => {
+    vi.stubEnv("VITE_NEON_AUTH_BASE_URL", "https://neon.test/auth");
+    getSessionMock.mockResolvedValue({ data: { user: { id: "u1" } } });
+    expect(await fetchAuthStatus()).toBe("authenticated");
+  });
+
+  it("is anonymous when there is no active session", async () => {
+    vi.stubEnv("VITE_NEON_AUTH_BASE_URL", "https://neon.test/auth");
+    getSessionMock.mockResolvedValue({ data: null });
+    expect(await fetchAuthStatus()).toBe("anonymous");
+  });
+
+  it("is anonymous when the auth client throws", async () => {
+    vi.stubEnv("VITE_NEON_AUTH_BASE_URL", "https://neon.test/auth");
+    getSessionMock.mockRejectedValue(new Error("network"));
+    expect(await fetchAuthStatus()).toBe("anonymous");
+  });
+});
+
+describe("useAuthStatus", () => {
+  it("starts pending and resolves via the injected fetcher", async () => {
+    const { result } = renderHook(() => useAuthStatus(() => Promise.resolve("authenticated")));
+    expect(result.current).toBe("pending");
+    await waitFor(() => { expect(result.current).toBe("authenticated"); });
+  });
+});


### PR DESCRIPTION
## S5.5 App Home (発見 / Discovery)

Extends the **single root route** (`apps/web/src/routes/index.tsx`) with a dual state per the spec's root-route ownership rule: the existing S0.6 marketing **Landing** renders for anonymous/pending visitors, and an authenticated **App Home** renders for signed-in users. S0.6's anonymous behavior is preserved untouched (unconfigured/failed auth ⇒ anonymous).

### Blocks (`apps/web/src/components/home/`)
- **SearchBox** — submits the query into `/chat`, reusing S1.1's A2 (`?q=`) entry point.
- **ContinueFromCard** (続きから) — the most recently updated **in-progress (`draft`)** route, queried via `workers/users` `listRoutes` oRPC (**SD-8 final: sessions/routes only, never `user_memory`**). Renders **nothing** for logged-out / unauthorized / no-draft states (graceful empty).
- **PopularRanking** (人気ランキング) — reads the existing agent-side `GET /v1/bangumi/popular` (an existing public endpoint this train does not migrate, so no oRPC contract — shape mirrored + zod-parsed in `src/api/popular.ts`). Degrades to a graceful empty state on an empty catalog or a failed request. Items link to `/anime/:id` (internal-link closure).

### i18n
All three blocks' copy renders in **ja/zh/en** via a new `home` dictionary section.

### Constraints honored
- New code only under `apps/web/src/{components/home,api,lib/auth}` + `routes/index.tsx` + i18n dictionaries. **Did not touch** chat/anime/shiori/landing/route-detail source, `globals.css` tokens, or `packages/contract`.
- TDD (Red→Green→Refactor); no suppressions; ≤10-line functions; semantic (動森) design tokens via Tailwind `var(--color-*)`.

### AC → test mapping
| AC | Test |
|---|---|
| Search box → `/chat` prefill (A2) | `search-target.test.ts`, `search-box.test.tsx`, `home-route.test.tsx` (unit) |
| Logged-in + in-progress route ⇒ 続きから card (users oRPC) | `continue-from-card.test.tsx` + contract-typed MSW `users.ts` (integration) |
| Logged-out / no in-progress ⇒ no 続きから block | `continue-from-card.test.tsx` (empty/unauthorized) |
| 人気ランキング via `GET /v1/bangumi/popular` | `popular.test.ts`, `popular-ranking.test.tsx` (render/empty/error) |
| i18n ja/zh/en for all three blocks | `app-home.test.tsx` (`it.each`) |

### Gate (run in `apps/web`)
- `pnpm run typecheck` ✅ · `pnpm run build` ✅ (routeTree regenerated) · `pnpm run lint:oxlint` ✅ · `pnpm test` ✅ **466 passed**, coverage **99.15 / 95.02 / 99.57 / 99.77** (floor 90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)