### PR TITLE
test(web): make authHeaders network dependency hermetic

### DIFF
--- a/apps/web/tests/setup/auth-hermetic.ts
+++ b/apps/web/tests/setup/auth-hermetic.ts
@@ -1,0 +1,9 @@
+import { beforeEach, vi } from "vitest";
+
+// Neutralize any ambient VITE_NEON_AUTH_BASE_URL (e.g. a dev machine's
+// apps/web/.env.local) so `fetchAuthToken` takes the "not configured -> undefined"
+// path instead of hitting a real Neon Auth origin. Keeps `authHeaders()` hermetic
+// (anonymous) for every consumer test; auth-specific tests re-stub their own value.
+beforeEach(() => {
+  vi.stubEnv("VITE_NEON_AUTH_BASE_URL", "");
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     css: true,
     include: ["tests/unit/**/*.test.ts", "tests/unit/**/*.test.tsx"],
     globalSetup: ["tests/setup/generate-route-tree.ts"],
-    setupFiles: ["tests/setup/msw-lifecycle.ts"],
+    setupFiles: ["tests/setup/auth-hermetic.ts", "tests/setup/msw-lifecycle.ts"],
     environmentOptions: { jsdom: { url: "http://localhost:3000" } },
     coverage: {
       provider: "istanbul",


### PR DESCRIPTION
## Problem

#386 introduced `fetchAuthToken()` (reads `VITE_NEON_AUTH_BASE_URL`, fetches the Neon Auth `/token` origin) behind `authHeaders()`. Consumer tests (chat / home / route-detail) that render authenticated `users()` transport never mocked this network dependency. On any dev machine with a legitimate `apps/web/.env.local` (operator config containing `VITE_NEON_AUTH_BASE_URL`), `authHeaders()` → `getAuthToken()` → `fetchAuthToken()` makes a **real** network call to staging `/token`, hanging the async render and timing out ~21 tests as false-red. This is a repeat of the #376 neon-auth hermetic regression — a new network dependency was not isolated in tests.

## Fix

Add a global setup file `apps/web/tests/setup/auth-hermetic.ts` (registered in `vitest.config.ts` `setupFiles`, before `msw-lifecycle.ts`) that stubs `VITE_NEON_AUTH_BASE_URL=""` before every test. This drives `fetchAuthToken` down its "not configured → return undefined" branch — no fetch is issued, so `authHeaders()` is deterministically anonymous for every consumer test regardless of machine or `.env.local` contents.

No production code changed. Only `apps/web/tests/**` + `vitest.config.ts`.

### Auth-injection tests still verify real Bearer headers

The #386 auth tests own their env/module mocks and override the global stub, so they keep verifying real behavior:
- `auth-session.test.ts` — `vi.mock`s `neonAuth`, drives `fetchAuthToken` return values (Bearer inject, cache, expiry).
- `orpc-users-auth.test.ts` — `vi.mock`s `authSession.authHeaders`, asserts the `Authorization: Bearer …` header reaches the wire.
- `neon-auth.test.ts` — stubs its own `VITE_NEON_AUTH_BASE_URL` in `beforeEach` / `vi.unstubAllEnvs` in `afterEach`.

## Verification

Reproduced the hang first by pointing `.env.local` at a non-routable auth origin (`http://192.0.2.1/auth`): `chat-page-stream` went 6 failed / 1 passed (timeouts). After the fix:

- **(a) With `apps/web/.env.local` present** (`VITE_NEON_AUTH_BASE_URL=http://192.0.2.1/auth`, blackhole): `pnpm test` → **100 files / 533 tests passed**.
- **(b) Without `apps/web/.env.local`**: `pnpm test` → **100 files / 533 tests passed**.
- `pnpm run typecheck` → clean.
- `pnpm run lint:oxlint` (type-aware, `--deny-warnings`) → clean.
- `pnpm run build` → succeeds (routeTree regenerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)