### PR TITLE
feat(web): S5.2 bubble map (area ∝ spot count + shot-angle sheet)

### DIFF
--- a/apps/web/src/features/bubble-map/BubbleMap.tsx
+++ b/apps/web/src/features/bubble-map/BubbleMap.tsx
@@ -1,0 +1,38 @@
+import type { AnimeOverviewCircle, AnimeScene } from "@seichijunrei/contract";
+import { type RefObject, useEffect, useRef, useState } from "react";
+import { BubbleMapPanel } from "./BubbleMapPanel";
+import { type BubbleMapStatus, attachBubbleMap } from "./bubbleMapController";
+import type { BubbleMapCopy } from "./copy";
+
+type Props = Readonly<{
+  circles: readonly AnimeOverviewCircle[];
+  scenes: readonly AnimeScene[];
+  copy: BubbleMapCopy;
+}>;
+
+type StatusSetter = (status: BubbleMapStatus) => void;
+
+const attachToContainer = (
+  container: HTMLDivElement | null,
+  circles: readonly AnimeOverviewCircle[],
+  onStatus: StatusSetter,
+): (() => void) | undefined => {
+  if (!container || circles.length === 0) return undefined;
+  return attachBubbleMap({ container, circles, onStatus });
+};
+
+function useBubbleMapMount(
+  ref: RefObject<HTMLDivElement | null>,
+  circles: readonly AnimeOverviewCircle[],
+  onStatus: StatusSetter,
+): void {
+  useEffect(() => attachToContainer(ref.current, circles, onStatus), [ref, circles, onStatus]);
+}
+
+/** Feature entry: mounts the MapLibre basemap and renders the bubble overlay + sheet on top. */
+export function BubbleMap({ circles, scenes, copy }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [, setStatus] = useState<BubbleMapStatus>("loading");
+  useBubbleMapMount(containerRef, circles, setStatus);
+  return <BubbleMapPanel circles={circles} scenes={scenes} copy={copy} mapContainerRef={containerRef} />;
+}

--- a/apps/web/src/features/bubble-map/BubbleMapPanel.tsx
+++ b/apps/web/src/features/bubble-map/BubbleMapPanel.tsx
@@ -1,0 +1,39 @@
+import type { AnimeOverviewCircle, AnimeScene } from "@seichijunrei/contract";
+import { type Ref, useState } from "react";
+import { CircleBubbleMap } from "./CircleBubbleMap";
+import { SpotSheet } from "./SpotSheet";
+import type { BubbleMapCopy } from "./copy";
+
+type Props = Readonly<{
+  circles: readonly AnimeOverviewCircle[];
+  scenes: readonly AnimeScene[];
+  copy: BubbleMapCopy;
+  mapContainerRef: Ref<HTMLDivElement>;
+}>;
+
+function scenesInRegion(scenes: readonly AnimeScene[], region: string): readonly AnimeScene[] {
+  return scenes.filter((scene) => scene.city === region);
+}
+
+type SheetProps = Readonly<{
+  region: string | null;
+  scenes: readonly AnimeScene[];
+  copy: BubbleMapCopy;
+  onClose: () => void;
+}>;
+
+function RegionSheet({ region, scenes, copy, onClose }: SheetProps) {
+  if (region === null) return null;
+  return <SpotSheet region={region} scenes={scenesInRegion(scenes, region)} copy={copy} onClose={onClose} />;
+}
+
+/** Bubble map + shot-angle sheet: tapping a region bubble opens its 機位 sheet. */
+export function BubbleMapPanel({ circles, scenes, copy, mapContainerRef }: Props) {
+  const [selectedRegion, setSelectedRegion] = useState<string | null>(null);
+  return (
+    <div className="grid gap-4">
+      <CircleBubbleMap circles={circles} copy={copy} selectedRegion={selectedRegion} onSelectRegion={setSelectedRegion} mapContainerRef={mapContainerRef} />
+      <RegionSheet region={selectedRegion} scenes={scenes} copy={copy} onClose={() => { setSelectedRegion(null); }} />
+    </div>
+  );
+}

--- a/apps/web/src/features/bubble-map/CircleBubbleMap.tsx
+++ b/apps/web/src/features/bubble-map/CircleBubbleMap.tsx
@@ -1,0 +1,71 @@
+import type { AnimeOverviewCircle } from "@seichijunrei/contract";
+import type { CSSProperties, Ref } from "react";
+import type { BubbleMapCopy } from "./copy";
+import { type BubblePlacement, bubblePlacements, hasBubbles } from "./bubbleGeometry";
+
+type Props = Readonly<{
+  circles: readonly AnimeOverviewCircle[];
+  copy: BubbleMapCopy;
+  selectedRegion: string | null;
+  onSelectRegion: (region: string) => void;
+  mapContainerRef: Ref<HTMLDivElement>;
+}>;
+
+type OverlayProps = Omit<Props, "mapContainerRef">;
+
+type BubbleProps = Readonly<{
+  placement: BubblePlacement;
+  copy: BubbleMapCopy;
+  selected: boolean;
+  onSelect: (region: string) => void;
+}>;
+
+const BUBBLE_CLASS =
+  "absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-[var(--color-border)] bg-[var(--color-primary)]/80 text-xs font-bold text-[var(--color-primary-fg)] shadow-md aria-pressed:ring-2 aria-pressed:ring-[var(--color-accent)]";
+
+function bubbleStyle(placement: BubblePlacement): CSSProperties {
+  const diameter = placement.radius * 2;
+  return { width: diameter, height: diameter, left: `${String(placement.leftPct)}%`, top: `${String(placement.topPct)}%` };
+}
+
+function BubbleButton({ placement, copy, selected, onSelect }: BubbleProps) {
+  return (
+    <button type="button" aria-pressed={selected} onClick={() => { onSelect(placement.region); }} style={bubbleStyle(placement)} className={BUBBLE_CLASS}>
+      {placement.region}
+      <span className="block font-normal">{copy.spotUnit(placement.count)}</span>
+    </button>
+  );
+}
+
+function EmptyBubbleMap({ copy }: Readonly<{ copy: BubbleMapCopy }>) {
+  return <p className="grid h-full place-items-center text-center text-[var(--color-muted-fg)]">{copy.empty}</p>;
+}
+
+function BubbleOverlay({ circles, copy, selectedRegion, onSelectRegion }: OverlayProps) {
+  return (
+    <div className="pointer-events-none absolute inset-0 [&_button]:pointer-events-auto">
+      {bubblePlacements(circles).map((placement) => (
+        <BubbleButton key={placement.region} placement={placement} copy={copy} selected={placement.region === selectedRegion} onSelect={onSelectRegion} />
+      ))}
+    </div>
+  );
+}
+
+function MapStage({ mapContainerRef, ...overlay }: Props) {
+  return (
+    <div className="relative aspect-video overflow-hidden rounded-xl bg-[var(--color-card)]">
+      <div ref={mapContainerRef} className="absolute inset-0" aria-hidden />
+      {hasBubbles(overlay.circles) ? <BubbleOverlay {...overlay} /> : <EmptyBubbleMap copy={overlay.copy} />}
+    </div>
+  );
+}
+
+/** Bubble map card: MapLibre basemap underneath, an accessible bubble overlay on top. */
+export function CircleBubbleMap(props: Props) {
+  return (
+    <section aria-labelledby="bubble-map-heading">
+      <h2 id="bubble-map-heading" className="text-lg">{props.copy.heading}</h2>
+      <MapStage {...props} />
+    </section>
+  );
+}

--- a/apps/web/src/features/bubble-map/SpotSheet.tsx
+++ b/apps/web/src/features/bubble-map/SpotSheet.tsx
@@ -1,0 +1,67 @@
+import type { AnimeScene } from "@seichijunrei/contract";
+import type { BubbleMapCopy } from "./copy";
+
+type Props = Readonly<{
+  region: string;
+  scenes: readonly AnimeScene[];
+  copy: BubbleMapCopy;
+  onClose: () => void;
+}>;
+
+/** Only real http(s) URLs may hit `<img src>`: `src=""` re-requests the page itself. */
+function hasRenderableShot(url: string | null): url is string {
+  if (url === null || !URL.canParse(url)) return false;
+  const protocol = new URL(url).protocol;
+  return protocol === "https:" || protocol === "http:";
+}
+
+function SpotShot({ scene, copy }: Readonly<{ scene: AnimeScene; copy: BubbleMapCopy }>) {
+  if (!hasRenderableShot(scene.screenshot_url)) {
+    return (
+      <div role="img" aria-label={scene.name} className="grid aspect-video w-full place-items-center rounded-lg bg-[var(--color-muted)] text-xs text-[var(--color-muted-fg)]">
+        {copy.noPhoto}
+      </div>
+    );
+  }
+  return <img src={scene.screenshot_url} alt={scene.name} loading="lazy" className="aspect-video w-full rounded-lg object-cover" />;
+}
+
+function SpotItem({ scene, copy }: Readonly<{ scene: AnimeScene; copy: BubbleMapCopy }>) {
+  return (
+    <li className="rounded-xl bg-[var(--color-card)] p-2">
+      <SpotShot scene={scene} copy={copy} />
+      <p className="mb-0 font-bold">{scene.name}</p>
+      <p className="my-0 text-sm text-[var(--color-muted-fg)]">{copy.shotCount(scene.shot_count)}</p>
+    </li>
+  );
+}
+
+function SpotList({ scenes, copy }: Readonly<{ scenes: readonly AnimeScene[]; copy: BubbleMapCopy }>) {
+  if (scenes.length === 0) {
+    return <p className="text-[var(--color-muted-fg)]">{copy.sheetEmpty}</p>;
+  }
+  return (
+    <ul className="m-0 grid list-none gap-3 p-0">
+      {scenes.map((scene) => <SpotItem key={scene.id} scene={scene} copy={copy} />)}
+    </ul>
+  );
+}
+
+function SheetHeader({ title, close, onClose }: Readonly<{ title: string; close: string; onClose: () => void }>) {
+  return (
+    <header className="mb-3 flex items-center justify-between">
+      <h3 className="m-0 text-base">{title}</h3>
+      <button type="button" onClick={onClose} className="text-sm text-[var(--color-muted-fg)]">{close}</button>
+    </header>
+  );
+}
+
+/** Shot-angle (機位) sheet for a tapped region; graceful when a spot has no photo. */
+export function SpotSheet({ region, scenes, copy, onClose }: Props) {
+  return (
+    <aside role="dialog" aria-label={copy.sheetTitle(region)} className="rounded-2xl bg-[var(--color-bg)] p-4 shadow-lg">
+      <SheetHeader title={copy.sheetTitle(region)} close={copy.close} onClose={onClose} />
+      <SpotList scenes={scenes} copy={copy} />
+    </aside>
+  );
+}

--- a/apps/web/src/features/bubble-map/bubbleGeometry.ts
+++ b/apps/web/src/features/bubble-map/bubbleGeometry.ts
@@ -1,0 +1,63 @@
+import type { AnimeOverviewCircle } from "@seichijunrei/contract";
+
+export const MIN_BUBBLE_RADIUS = 14;
+export const MAX_BUBBLE_RADIUS = 44;
+
+const EDGE_INSET_PCT = 8;
+
+/** Region bubble ready to paint on the overlay: normalized position + area-scaled radius. */
+export interface BubblePlacement {
+  readonly region: string;
+  readonly count: number;
+  readonly radius: number;
+  readonly leftPct: number;
+  readonly topPct: number;
+}
+
+/** Area (πr²) is proportional to spot count, so the radius tracks √count. */
+export function bubbleRadius(count: number, maxCount: number): number {
+  if (maxCount <= 0) return MIN_BUBBLE_RADIUS;
+  const ratio = Math.sqrt(Math.max(count, 0) / maxCount);
+  return MIN_BUBBLE_RADIUS + (MAX_BUBBLE_RADIUS - MIN_BUBBLE_RADIUS) * ratio;
+}
+
+export function circlesMaxCount(circles: readonly AnimeOverviewCircle[]): number {
+  return circles.reduce((max, circle) => Math.max(max, circle.count), 0);
+}
+
+export function hasBubbles(circles: readonly AnimeOverviewCircle[]): boolean {
+  return circles.length > 0;
+}
+
+function projectAxis(value: number, min: number, max: number): number {
+  if (max === min) return 50;
+  return EDGE_INSET_PCT + ((value - min) / (max - min)) * (100 - 2 * EDGE_INSET_PCT);
+}
+
+interface Extent {
+  readonly min: number;
+  readonly max: number;
+}
+
+function extent(values: readonly number[]): Extent {
+  return { min: Math.min(...values), max: Math.max(...values) };
+}
+
+function toPlacement(circle: AnimeOverviewCircle, lat: Extent, lng: Extent, maxCount: number): BubblePlacement {
+  return {
+    region: circle.region,
+    count: circle.count,
+    radius: bubbleRadius(circle.count, maxCount),
+    leftPct: projectAxis(circle.lng, lng.min, lng.max),
+    // Latitude axis is inverted: the northernmost region sits nearest the top.
+    topPct: projectAxis(circle.lat, lat.max, lat.min),
+  };
+}
+
+export function bubblePlacements(circles: readonly AnimeOverviewCircle[]): readonly BubblePlacement[] {
+  if (!hasBubbles(circles)) return [];
+  const lat = extent(circles.map((c) => c.lat));
+  const lng = extent(circles.map((c) => c.lng));
+  const maxCount = circlesMaxCount(circles);
+  return circles.map((circle) => toPlacement(circle, lat, lng, maxCount));
+}

--- a/apps/web/src/features/bubble-map/bubbleMapController.ts
+++ b/apps/web/src/features/bubble-map/bubbleMapController.ts
@@ -1,0 +1,83 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import type { AnimeOverviewCircle } from "@seichijunrei/contract";
+import type { LngLatBoundsLike, Map as MapLibreMap } from "maplibre-gl";
+import { createMapStyle } from "../map-spike/mapStyle";
+
+export type BubbleMapStatus = "loading" | "ready" | "fallback";
+
+export type MountBubbleMapOptions = Readonly<{
+  container: HTMLElement;
+  circles: readonly AnimeOverviewCircle[];
+  onStatus: (status: BubbleMapStatus) => void;
+}>;
+
+export type BubbleMapHandle = Readonly<{ destroy: () => void }>;
+
+let protocolReady = false;
+
+const registerProtocol = async (gl: typeof import("maplibre-gl")): Promise<void> => {
+  if (protocolReady) return;
+  const { Protocol } = await import("pmtiles");
+  gl.addProtocol("pmtiles", new Protocol({ metadata: true }).tile);
+  protocolReady = true;
+};
+
+const circlesBounds = (circles: readonly AnimeOverviewCircle[]): LngLatBoundsLike => {
+  const lngs = circles.map((c) => c.lng);
+  const lats = circles.map((c) => c.lat);
+  return [
+    [Math.min(...lngs), Math.min(...lats)],
+    [Math.max(...lngs), Math.max(...lats)],
+  ];
+};
+
+// Frame the tile basemap around the region cluster; the bubble overlay renders on top in React.
+const fitToCircles = (map: MapLibreMap, circles: readonly AnimeOverviewCircle[]): void => {
+  if (circles.length === 0) return;
+  map.fitBounds(circlesBounds(circles), { padding: 64, maxZoom: 12, animate: false });
+};
+
+const createMap = (gl: typeof import("maplibre-gl"), container: HTMLElement): MapLibreMap => {
+  return new gl.Map({ container, style: createMapStyle("pmtiles"), attributionControl: { compact: true } });
+};
+
+const onMapLoad = (map: MapLibreMap, options: MountBubbleMapOptions): void => {
+  fitToCircles(map, options.circles);
+  options.onStatus("ready");
+};
+
+const wireEvents = (map: MapLibreMap, options: MountBubbleMapOptions): void => {
+  map.on("load", () => { onMapLoad(map, options); });
+  map.on("error", () => { options.onStatus("fallback"); });
+};
+
+export const mountBubbleMap = async (options: MountBubbleMapOptions): Promise<BubbleMapHandle> => {
+  const gl = await import("maplibre-gl");
+  await registerProtocol(gl);
+  const map = createMap(gl, options.container);
+  wireEvents(map, options);
+  return { destroy: () => { map.remove(); } };
+};
+
+interface Attachment {
+  handle: BubbleMapHandle | null;
+  active: boolean;
+}
+
+const storeHandle = (attachment: Attachment, handle: BubbleMapHandle): void => {
+  if (!attachment.active) {
+    handle.destroy();
+    return;
+  }
+  attachment.handle = handle;
+};
+
+// Bridges the async mount into React's synchronous effect-cleanup contract.
+export const attachBubbleMap = (options: MountBubbleMapOptions): (() => void) => {
+  const attachment: Attachment = { handle: null, active: true };
+  void mountBubbleMap(options).then((handle) => { storeHandle(attachment, handle); });
+  return () => {
+    attachment.active = false;
+    attachment.handle?.destroy();
+  };
+};

--- a/apps/web/src/features/bubble-map/copy.ts
+++ b/apps/web/src/features/bubble-map/copy.ts
@@ -1,0 +1,56 @@
+import type { Locale } from "../../i18n/locales";
+
+/**
+ * Trilingual copy for the bubble map, local to the feature (the shared
+ * dictionary JSONs are a parallel-card hotspot; feature-local copy keeps
+ * S5.2 conflict-free, mirroring the S5.1 anime-page convention).
+ */
+export interface BubbleMapCopy {
+  readonly heading: string;
+  readonly empty: string;
+  readonly spotUnit: (n: number) => string;
+  readonly sheetTitle: (region: string) => string;
+  readonly sheetEmpty: string;
+  readonly noPhoto: string;
+  readonly shotCount: (n: number) => string;
+  readonly close: string;
+}
+
+const ja: BubbleMapCopy = {
+  heading: "エリア別バブルマップ",
+  empty: "地図に表示できる聖地エリアがまだありません",
+  spotUnit: (n) => `${String(n)}件`,
+  sheetTitle: (region) => `${region} の機位`,
+  sheetEmpty: "このエリアの機位情報はまだありません",
+  noPhoto: "写真はまだありません",
+  shotCount: (n) => `カット数 ${String(n)}`,
+  close: "閉じる",
+};
+
+const zh: BubbleMapCopy = {
+  heading: "按地区分布气泡地图",
+  empty: "暂无可在地图上展示的圣地地区",
+  spotUnit: (n) => `${String(n)}处`,
+  sheetTitle: (region) => `${region} 的机位`,
+  sheetEmpty: "该地区暂无机位信息",
+  noPhoto: "暂无照片",
+  shotCount: (n) => `镜头数 ${String(n)}`,
+  close: "关闭",
+};
+
+const en: BubbleMapCopy = {
+  heading: "Bubble map by area",
+  empty: "No pilgrimage areas to plot on the map yet",
+  spotUnit: (n) => `${String(n)} spots`,
+  sheetTitle: (region) => `Shot angles in ${region}`,
+  sheetEmpty: "No shot-angle spots recorded for this area yet",
+  noPhoto: "No photo yet",
+  shotCount: (n) => `${String(n)} shots`,
+  close: "Close",
+};
+
+const COPY: Record<Locale, BubbleMapCopy> = { ja, zh, en };
+
+export function bubbleMapCopyFor(locale: Locale): BubbleMapCopy {
+  return COPY[locale];
+}

--- a/apps/web/tests/unit/bubble-map/bubble-geometry.test.ts
+++ b/apps/web/tests/unit/bubble-map/bubble-geometry.test.ts
@@ -1,0 +1,99 @@
+import type { AnimeOverviewCircle } from "@seichijunrei/contract";
+import { describe, expect, it } from "vitest";
+import {
+  type BubblePlacement,
+  MAX_BUBBLE_RADIUS,
+  MIN_BUBBLE_RADIUS,
+  bubblePlacements,
+  bubbleRadius,
+  circlesMaxCount,
+  hasBubbles,
+} from "../../../src/features/bubble-map/bubbleGeometry";
+
+function circle(overrides: Partial<AnimeOverviewCircle>): AnimeOverviewCircle {
+  return { region: "Tokyo", count: 1, lat: 35.68, lng: 139.76, ...overrides };
+}
+
+function placeOf(circles: readonly AnimeOverviewCircle[], region: string): BubblePlacement {
+  const found = bubblePlacements(circles).find((placement) => placement.region === region);
+  if (!found) throw new Error(`no placement for ${region}`);
+  return found;
+}
+
+describe("bubbleRadius (area proportional to spot count)", () => {
+  it("maps the busiest region to the maximum radius", () => {
+    expect(bubbleRadius(8, 8)).toBe(MAX_BUBBLE_RADIUS);
+  });
+
+  it("floors a zero-count region at the minimum radius", () => {
+    expect(bubbleRadius(0, 8)).toBe(MIN_BUBBLE_RADIUS);
+  });
+
+  it("grows monotonically with the spot count", () => {
+    expect(bubbleRadius(4, 8)).toBeGreaterThan(bubbleRadius(1, 8));
+  });
+
+  it("scales by area so radius tracks the square root of count", () => {
+    const quarter = bubbleRadius(2, 8);
+    const span = MAX_BUBBLE_RADIUS - MIN_BUBBLE_RADIUS;
+    expect(quarter - MIN_BUBBLE_RADIUS).toBeCloseTo(span * 0.5, 5);
+  });
+
+  it("falls back to the minimum radius when no region has spots", () => {
+    expect(bubbleRadius(0, 0)).toBe(MIN_BUBBLE_RADIUS);
+  });
+});
+
+describe("circlesMaxCount", () => {
+  it("returns the largest spot count across regions", () => {
+    expect(circlesMaxCount([circle({ count: 2 }), circle({ count: 5 })])).toBe(5);
+  });
+
+  it("returns zero for no regions", () => {
+    expect(circlesMaxCount([])).toBe(0);
+  });
+});
+
+describe("hasBubbles", () => {
+  it("is false with no circles", () => {
+    expect(hasBubbles([])).toBe(false);
+  });
+
+  it("is true for a single region", () => {
+    expect(hasBubbles([circle({})])).toBe(true);
+  });
+});
+
+describe("bubblePlacements", () => {
+  it("centers a single region so it never renders off-canvas", () => {
+    const only = placeOf([circle({ count: 3 })], "Tokyo");
+    expect(only.leftPct).toBe(50);
+    expect(only.topPct).toBe(50);
+  });
+
+  it("places a northern region above a southern one", () => {
+    const circles = [
+      circle({ region: "Sapporo", lat: 43.06, lng: 141.35, count: 1 }),
+      circle({ region: "Naha", lat: 26.21, lng: 127.68, count: 1 }),
+    ];
+    expect(placeOf(circles, "Sapporo").topPct).toBeLessThan(placeOf(circles, "Naha").topPct);
+  });
+
+  it("places an eastern region right of a western one", () => {
+    const circles = [
+      circle({ region: "Fukuoka", lat: 33.59, lng: 130.4, count: 1 }),
+      circle({ region: "Tokyo", lat: 35.68, lng: 139.76, count: 1 }),
+    ];
+    expect(placeOf(circles, "Tokyo").leftPct).toBeGreaterThan(placeOf(circles, "Fukuoka").leftPct);
+  });
+
+  it("carries the region name, count, and count-scaled radius", () => {
+    const circles = [
+      circle({ region: "Big", count: 8, lat: 35, lng: 139 }),
+      circle({ region: "Small", count: 1, lat: 34, lng: 138 }),
+    ];
+    const big = placeOf(circles, "Big");
+    expect(big.count).toBe(8);
+    expect(big.radius).toBeGreaterThan(placeOf(circles, "Small").radius);
+  });
+});

--- a/apps/web/tests/unit/bubble-map/bubble-map-panel.test.tsx
+++ b/apps/web/tests/unit/bubble-map/bubble-map-panel.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { AnimeOverview } from "@seichijunrei/contract";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { animeOverviewOptions } from "../../../src/api/hooks/use-anime-overview";
+import { makeQueryClient } from "../../../src/api/query-client";
+import { BubbleMapPanel } from "../../../src/features/bubble-map/BubbleMapPanel";
+import { bubbleMapCopyFor } from "../../../src/features/bubble-map/copy";
+import { animeOverviewHandler } from "../../msw/anime-overview";
+import { server } from "../../msw/node";
+
+afterEach(cleanup);
+beforeEach(() => { server.use(animeOverviewHandler); });
+
+const copy = bubbleMapCopyFor("en");
+
+/** Contract-typed loader: fetch the public overview through the shared query options. */
+async function loadOverview(bangumiId: string): Promise<AnimeOverview> {
+  const client = makeQueryClient();
+  return client.fetchQuery(animeOverviewOptions(bangumiId));
+}
+
+function renderPanel(overview: AnimeOverview) {
+  render(
+    <BubbleMapPanel
+      circles={overview.circles}
+      scenes={overview.scenes}
+      copy={copy}
+      mapContainerRef={createRef<HTMLDivElement>()}
+    />,
+  );
+}
+
+describe("BubbleMapPanel with contract-typed overview data", () => {
+  it("renders a bubble per region loaded from the catalog contract", async () => {
+    renderPanel(await loadOverview("123"));
+    expect(screen.getByRole("button", { name: /Tokyo/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Takayama/ })).toBeTruthy();
+  });
+
+  it("opens the region's shot-angle sheet on tap, filtered to its scenes", async () => {
+    renderPanel(await loadOverview("123"));
+    await userEvent.click(screen.getByRole("button", { name: /Tokyo/ }));
+    const sheet = screen.getByRole("dialog", { name: /Tokyo/ });
+    expect(sheet.textContent).toContain("Suga Shrine Stairs");
+  });
+
+  it("falls back to the empty area message for a region with no scenes", async () => {
+    renderPanel(await loadOverview("123"));
+    await userEvent.click(screen.getByRole("button", { name: /Takayama/ }));
+    expect(screen.getByText(copy.sheetEmpty)).toBeTruthy();
+  });
+
+  it("closes the sheet when the close control is pressed", async () => {
+    renderPanel(await loadOverview("123"));
+    await userEvent.click(screen.getByRole("button", { name: /Tokyo/ }));
+    await userEvent.click(screen.getByRole("button", { name: copy.close }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("shows the empty map state for a cataloged id with zero regions", async () => {
+    renderPanel(await loadOverview("999"));
+    expect(screen.getByText(copy.empty)).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/bubble-map/circle-bubble-map.test.tsx
+++ b/apps/web/tests/unit/bubble-map/circle-bubble-map.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { AnimeOverviewCircle } from "@seichijunrei/contract";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CircleBubbleMap } from "../../../src/features/bubble-map/CircleBubbleMap";
+import { bubbleMapCopyFor } from "../../../src/features/bubble-map/copy";
+
+afterEach(cleanup);
+
+const copy = bubbleMapCopyFor("en");
+
+const CIRCLES: readonly AnimeOverviewCircle[] = [
+  { region: "Tokyo", count: 2, lat: 35.68, lng: 139.76 },
+  { region: "Takayama", count: 6, lat: 36.14, lng: 137.25 },
+];
+
+function renderMap(circles: readonly AnimeOverviewCircle[], onSelect = vi.fn()) {
+  render(
+    <CircleBubbleMap
+      circles={circles}
+      copy={copy}
+      selectedRegion={null}
+      onSelectRegion={onSelect}
+      mapContainerRef={createRef<HTMLDivElement>()}
+    />,
+  );
+  return onSelect;
+}
+
+describe("CircleBubbleMap bubbles", () => {
+  it("renders one bubble per region with its spot count", () => {
+    renderMap(CIRCLES);
+    expect(screen.getByRole("button", { name: /Tokyo/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Takayama/ })).toBeTruthy();
+  });
+
+  it("sizes the busier region's bubble larger than the quieter one", () => {
+    renderMap(CIRCLES);
+    const tokyo = screen.getByRole("button", { name: /Tokyo/ });
+    const takayama = screen.getByRole("button", { name: /Takayama/ });
+    const size = (el: HTMLElement) => Number.parseFloat(el.style.width);
+    expect(size(takayama)).toBeGreaterThan(size(tokyo));
+  });
+
+  it("renders a single bubble when every spot is in one region", () => {
+    renderMap([{ region: "Uji", count: 4, lat: 34.88, lng: 135.8 }]);
+    expect(screen.getByRole("button", { name: /Uji/ })).toBeTruthy();
+    expect(screen.queryByText(copy.empty)).toBeNull();
+  });
+
+  it("shows the empty state instead of a blank map when there are no regions", () => {
+    renderMap([]);
+    expect(screen.getByText(copy.empty)).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});
+
+describe("CircleBubbleMap interaction", () => {
+  it("reports the tapped region to the caller", async () => {
+    const onSelect = renderMap(CIRCLES);
+    await userEvent.click(screen.getByRole("button", { name: /Takayama/ }));
+    expect(onSelect).toHaveBeenCalledWith("Takayama");
+  });
+});

--- a/apps/web/tests/unit/bubble-map/copy.test.ts
+++ b/apps/web/tests/unit/bubble-map/copy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { LOCALES } from "../../../src/i18n/locales";
+import { bubbleMapCopyFor } from "../../../src/features/bubble-map/copy";
+
+describe("bubbleMapCopyFor", () => {
+  it("provides copy for every supported locale", () => {
+    for (const locale of LOCALES) {
+      const copy = bubbleMapCopyFor(locale);
+      expect(copy.heading.length).toBeGreaterThan(0);
+      expect(copy.empty.length).toBeGreaterThan(0);
+      expect(copy.close.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("interpolates the region and counts for every locale's formatters", () => {
+    for (const locale of LOCALES) {
+      const copy = bubbleMapCopyFor(locale);
+      expect(copy.sheetTitle("Tokyo")).toContain("Tokyo");
+      expect(copy.spotUnit(3)).toContain("3");
+      expect(copy.shotCount(7)).toContain("7");
+    }
+  });
+});

--- a/apps/web/tests/unit/bubble-map/spot-sheet.test.tsx
+++ b/apps/web/tests/unit/bubble-map/spot-sheet.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { AnimeScene } from "@seichijunrei/contract";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SpotSheet } from "../../../src/features/bubble-map/SpotSheet";
+import { bubbleMapCopyFor } from "../../../src/features/bubble-map/copy";
+
+afterEach(cleanup);
+
+const copy = bubbleMapCopyFor("en");
+
+function scene(overrides: Partial<AnimeScene>): AnimeScene {
+  return {
+    id: "s1",
+    name: "Suga Shrine Stairs",
+    screenshot_url: "https://cdn.test/s1.jpg",
+    shot_count: 5,
+    lat: 35.68,
+    lng: 139.71,
+    city: "Tokyo",
+    ...overrides,
+  };
+}
+
+function renderSheet(scenes: readonly AnimeScene[], onClose = vi.fn()) {
+  render(<SpotSheet region="Tokyo" scenes={scenes} copy={copy} onClose={onClose} />);
+  return onClose;
+}
+
+describe("SpotSheet", () => {
+  it("titles the sheet with the tapped region", () => {
+    renderSheet([scene({})]);
+    expect(screen.getByRole("dialog", { name: /Tokyo/ })).toBeTruthy();
+  });
+
+  it("renders the shot photo when the scene has a renderable url", () => {
+    renderSheet([scene({})]);
+    const img = screen.getByRole("img", { name: "Suga Shrine Stairs" });
+    expect(img.tagName).toBe("IMG");
+  });
+
+  it("shows a photo-less spot gracefully instead of a blank sheet", () => {
+    renderSheet([scene({ screenshot_url: null })]);
+    expect(screen.getByText("Suga Shrine Stairs")).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Suga Shrine Stairs" }).tagName).not.toBe("IMG");
+    expect(document.querySelector("img")).toBeNull();
+  });
+
+  it("shows an empty-area message when the region has no spots at all", () => {
+    renderSheet([]);
+    expect(screen.getByText(copy.sheetEmpty)).toBeTruthy();
+  });
+
+  it("closes when the close control is pressed", async () => {
+    const onClose = renderSheet([scene({})]);
+    await userEvent.click(screen.getByRole("button", { name: copy.close }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -25,6 +25,16 @@ export default defineConfig({
         // browser AC (S0.4). Same §0.6 exclude-ledger rationale as mapController.ts (surfaced when
         // routes/** entered the sweep in C0.1).
         "src/routes/_dev/map-spike.tsx",
+        // Bubble-map WebGL basemap glue: instantiates maplibre-gl (real GL context + dynamic
+        // imports), unrunnable under jsdom. Its pure inputs (bubbleGeometry) are unit-covered and
+        // the interactive bubble overlay/sheet are DOM-covered; the live mount is an S5.2 browser AC
+        // (Tester). Same §0.6 exclude-ledger rationale as mapController.ts.
+        "src/features/bubble-map/bubbleMapController.ts",
+        // BubbleMap entry only owns the ref + effect that mounts the basemap (attachBubbleMap ->
+        // bubbleMapController above); it cannot render under jsdom for the same GL reason. The
+        // testable state/overlay/sheet live in BubbleMapPanel. Same §0.6 exclude-ledger rationale
+        // as routes/_dev/map-spike.tsx.
+        "src/features/bubble-map/BubbleMap.tsx",
       ],
       thresholds: { statements: 90, branches: 90, functions: 90, lines: 90 },
     },


### PR DESCRIPTION
## S5.2 Bubble map (card #269)

Region-aggregated bubble map for the anime public page, fed by the public `catalog.animeOverview` `circles[]`. Bubble **area is proportional to spot count**; tapping a region opens a shot-angle (機位) `SpotSheet` filtered to that region's scenes.

Scope is a self-contained feature under `apps/web/src/features/bubble-map/` — no edits to anime/chat/shiori/landing/route-detail or `packages/contract`, per card constraints. Wiring into the `/anime/:id` page (which would touch anime files) is a follow-up.

### AC coverage (iter-5 S5.2)
- **Happy path** — bubbles render sized by spot count, region names resolved from the contract circles (`CircleBubbleMap` + `bubbleGeometry`).
- **Empty** — a single-region anime renders one bubble (not a blank map); zero regions renders the empty-state copy.
- **Error** — a region whose spot has zero photos still opens the sheet, showing the non-photo spot with a graceful placeholder (`SpotSheet`), not a blank sheet.

### Architecture
Pure/testable logic (`bubbleGeometry`, `copy`, `CircleBubbleMap` overlay, `SpotSheet`, `BubbleMapPanel`) split from the MapLibre basemap glue (`bubbleMapController`, `BubbleMap`), which is coverage-excluded via the vitest §0.6 ledger — same rationale as the map spike's `mapController.ts`. The interactive bubble layer is an accessible HTML overlay (keyboard + screen-reader), so it is unit-tested; the GL tile basemap is an S5.2 browser AC (Tester).

### Tests
MSW **contract-typed loader** test (fetches via `animeOverviewOptions`), bubble radius/placement logic, region scene-filtering, empty-map and photo-less-spot states. bubble-map feature coverage: statements 98.6% / functions 100% / lines 100%.

### Gates (apps/web)
- `pnpm run typecheck` — clean
- `pnpm run lint:oxlint` — clean (`--deny-warnings`)
- `pnpm test` — pass; global coverage 99.06/94.76/99.65/99.81 (floor 90)
- `pnpm run build` — succeeds (routeTree regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)