### PR TITLE
feat(web): S2.2 MODE toggle (FLIP) + map-pin language + gold route pill

### DIFF
--- a/apps/web/src/components/route-detail/MapCard.tsx
+++ b/apps/web/src/components/route-detail/MapCard.tsx
@@ -1,0 +1,85 @@
+import type { RouteDetailCopy } from "../../lib/route-detail/copy";
+import { MODE_EASING, MODE_TRANSITION_MS } from "../../lib/route-detail/mode";
+import type { RouteMode } from "../../lib/route-detail/mode";
+import type { RoutePin } from "../../lib/route-detail/pinState";
+import { ModeToggle } from "./ModeToggle";
+import { RoutePinLayer } from "./RoutePinLayer";
+
+/**
+ * The map card (spec-route-detail §2/§5). A product-specific generative
+ * component (SD-13 catalog): its payload carries a `schema_version` for
+ * additive-only evolution and is partial-tolerant — a payload missing its pins
+ * renders the skeleton slot rather than crashing, so a legacy Chat registry
+ * payload is safe. Idle ⇄ map-expanded is a 360ms FLIP; a gold pill shows N/5.
+ */
+export interface MapCardPayload {
+  readonly schema_version: number;
+  readonly pins?: readonly RoutePin[];
+  readonly progress?: string;
+  readonly placeholder?: string;
+}
+
+interface MapCardProps {
+  readonly payload: MapCardPayload;
+  readonly copy: RouteDetailCopy;
+  readonly mode: RouteMode;
+  readonly onToggle: () => void;
+}
+
+function MapCardSkeleton({ copy }: { readonly copy: RouteDetailCopy }) {
+  return (
+    <div role="status" aria-label={copy.loadingLabel}
+      className="h-36 w-full animate-pulse rounded-2xl bg-[var(--color-muted)]" />
+  );
+}
+
+function RouteProgressPill({ progress, copy }: { readonly progress: string; readonly copy: RouteDetailCopy }) {
+  return (
+    <span aria-label={copy.progressAria}
+      className="rounded-full bg-[var(--color-focus)] px-3 py-1 text-sm font-bold text-[var(--color-fg)]">
+      {progress}
+    </span>
+  );
+}
+
+interface MapHeaderProps extends MapCardProps {
+  readonly progress?: string;
+}
+
+function MapCardHeader({ progress, mode, onToggle, copy }: Omit<MapHeaderProps, "payload">) {
+  return (
+    <div className="flex items-center justify-between">
+      {progress ? <RouteProgressPill progress={progress} copy={copy} /> : null}
+      <ModeToggle mode={mode} onToggle={onToggle} copy={copy} />
+    </div>
+  );
+}
+
+interface MapStageProps {
+  readonly mode: RouteMode;
+  readonly pins: readonly RoutePin[];
+  readonly copy: RouteDetailCopy;
+  readonly placeholder: string;
+}
+
+function MapStage({ mode, pins, copy, placeholder }: MapStageProps) {
+  const minHeight = mode === "expanded" ? "18rem" : "9rem";
+  return (
+    <div style={{ minHeight, transition: `min-height ${String(MODE_TRANSITION_MS)}ms ${MODE_EASING}` }}
+      className="grid place-items-center gap-3 rounded-2xl bg-[var(--color-muted)] p-4 text-[var(--color-muted-fg)]">
+      <span>{placeholder}</span>
+      <RoutePinLayer pins={pins} copy={copy} />
+    </div>
+  );
+}
+
+export function MapCard({ payload, copy, mode, onToggle }: MapCardProps) {
+  if (!payload.pins) return <MapCardSkeleton copy={copy} />;
+  return (
+    <section aria-label="地図" aria-expanded={mode === "expanded"} className="flex flex-col gap-3">
+      <MapCardHeader progress={payload.progress} mode={mode} onToggle={onToggle} copy={copy} />
+      <MapStage mode={mode} pins={payload.pins} copy={copy}
+        placeholder={payload.placeholder ?? copy.mapPlaceholder} />
+    </section>
+  );
+}

--- a/apps/web/src/components/route-detail/ModeToggle.tsx
+++ b/apps/web/src/components/route-detail/ModeToggle.tsx
@@ -1,0 +1,24 @@
+import type { RouteDetailCopy } from "../../lib/route-detail/copy";
+import type { RouteMode } from "../../lib/route-detail/mode";
+
+/**
+ * The MODE toggle (spec-route-detail §2): a single control that flips the page
+ * between compact idle and map-expanded. Presentational — the debounce guard and
+ * FLIP timing live in `useRouteMode`; this button only reflects and requests.
+ */
+interface ModeToggleProps {
+  readonly mode: RouteMode;
+  readonly onToggle: () => void;
+  readonly copy: RouteDetailCopy;
+}
+
+export function ModeToggle({ mode, onToggle, copy }: ModeToggleProps) {
+  const expanded = mode === "expanded";
+  const label = expanded ? copy.mapCollapse : copy.mapExpand;
+  return (
+    <button type="button" onClick={onToggle} aria-pressed={expanded}
+      className="rounded-full bg-[var(--color-muted)] px-3 py-1 text-sm font-bold text-[var(--color-fg)]">
+      {label}
+    </button>
+  );
+}

--- a/apps/web/src/components/route-detail/RouteDetailView.tsx
+++ b/apps/web/src/components/route-detail/RouteDetailView.tsx
@@ -7,8 +7,13 @@ import {
   isRouteEmpty,
 } from "../../lib/route-detail/dataState";
 import type { RouteDataState, RouteDetail } from "../../lib/route-detail/dataState";
+import { EXPANDED_SHEET_PX, initialMode, useRouteMode } from "../../lib/route-detail/mode";
+import type { RouteMode } from "../../lib/route-detail/mode";
+import { routeProgressLabel, toRoutePins } from "../../lib/route-detail/pinState";
 import { GoldBar } from "./GoldBar";
 import { Hero } from "./Hero";
+import { MapCard } from "./MapCard";
+import type { MapCardPayload } from "./MapCard";
 
 /**
  * The route detail shell (spec-route-detail §1): appbar → hero → map card →
@@ -29,14 +34,13 @@ interface RouteBodyProps {
   readonly copy: RouteDetailCopy;
 }
 
-function MapCardSlot({ expanded, copy }: { readonly expanded: boolean; readonly copy: RouteDetailCopy }) {
-  const minHeight = expanded ? "18rem" : "9rem";
-  return (
-    <section aria-label="地図" aria-expanded={expanded} style={{ minHeight }}
-      className="grid place-items-center rounded-2xl bg-[var(--color-muted)] text-[var(--color-muted-fg)]">
-      {copy.mapPlaceholder}
-    </section>
-  );
+function mapCardPayload(detail: RouteDetail, copy: RouteDetailCopy): MapCardPayload {
+  return {
+    schema_version: ROUTE_DETAIL_SCHEMA_VERSION,
+    pins: toRoutePins(detail),
+    progress: routeProgressLabel(detail),
+    placeholder: copy.mapPlaceholder,
+  };
 }
 
 function EmptySpots({ copy }: { readonly copy: RouteDetailCopy }) {
@@ -56,9 +60,20 @@ function TimetablePending({ copy }: { readonly copy: RouteDetailCopy }) {
   );
 }
 
-function TimetableSlot({ detail, copy }: { readonly detail: RouteDetail; readonly copy: RouteDetailCopy }) {
+interface TimetableSlotProps {
+  readonly detail: RouteDetail;
+  readonly copy: RouteDetailCopy;
+  readonly mode: RouteMode;
+}
+
+function TimetableSlot({ detail, copy, mode }: TimetableSlotProps) {
   if (isRouteEmpty(detail)) return <EmptySpots copy={copy} />;
-  return <TimetablePending copy={copy} />;
+  const sheet = mode === "expanded" ? { maxHeight: `${String(EXPANDED_SHEET_PX)}px`, overflowY: "auto" as const } : undefined;
+  return (
+    <div style={sheet} data-mode={mode}>
+      <TimetablePending copy={copy} />
+    </div>
+  );
 }
 
 function goldBarPayload(state: RouteDataState, detail: RouteDetail, copy: RouteDetailCopy) {
@@ -73,14 +88,13 @@ function GoldBarSlot({ detail, state, copy }: RouteBodyProps) {
 }
 
 function RouteDetailBody({ detail, state, copy }: RouteBodyProps) {
-  return (
-    <main className="mx-auto flex max-w-3xl flex-col gap-4 px-4 py-6">
-      <GoldBarSlot detail={detail} state={state} copy={copy} />
-      <Hero detail={detail} state={state} copy={copy} />
-      <MapCardSlot expanded={state === "today"} copy={copy} />
-      <TimetableSlot detail={detail} copy={copy} />
-    </main>
-  );
+  const { mode, toggle } = useRouteMode(initialMode(state));
+  return (<main className="mx-auto flex max-w-3xl flex-col gap-4 px-4 py-6">
+    <GoldBarSlot detail={detail} state={state} copy={copy} />
+    <Hero detail={detail} state={state} copy={copy} />
+    <MapCard payload={mapCardPayload(detail, copy)} copy={copy} mode={mode} onToggle={toggle} />
+    <TimetableSlot detail={detail} copy={copy} mode={mode} />
+  </main>);
 }
 
 export function RouteDetailView({ detail, locale, now }: RouteDetailViewProps) {

--- a/apps/web/src/components/route-detail/RoutePinLayer.tsx
+++ b/apps/web/src/components/route-detail/RoutePinLayer.tsx
@@ -1,0 +1,45 @@
+import type { RouteDetailCopy } from "../../lib/route-detail/copy";
+import { pinBadge, pinSizePx } from "../../lib/route-detail/pinState";
+import type { PinState, RoutePin } from "../../lib/route-detail/pinState";
+
+/**
+ * The map pin layer (spec-route-detail §5 "pin-is-the-picture"): each stop is a
+ * 48px framed marker — 済 ✓ teal, 現在 ★ 58px gold ring, or a plain white
+ * numbered not-yet-visited marker. Token-driven so the palette stays semantic.
+ */
+interface RoutePinLayerProps {
+  readonly pins: readonly RoutePin[];
+  readonly copy: RouteDetailCopy;
+}
+
+const PIN_TONE: Record<PinState, string> = {
+  visited: "bg-[var(--color-map-pin-teal)] text-[var(--color-primary-fg)]",
+  current: "bg-[var(--color-focus)] text-[var(--color-fg)] ring-4 ring-[var(--color-focus)]",
+  unvisited: "bg-[var(--color-bg)] text-[var(--color-fg)] border border-[var(--color-muted-fg)]",
+};
+
+function pinName(state: PinState, copy: RouteDetailCopy): string {
+  if (state === "visited") return copy.pinVisited;
+  return state === "current" ? copy.pinCurrent : copy.pinUnvisited;
+}
+
+function Pin({ pin, copy }: { readonly pin: RoutePin; readonly copy: RouteDetailCopy }) {
+  const size = `${String(pinSizePx(pin.state))}px`;
+  return (
+    <li data-state={pin.state} aria-label={`${pinName(pin.state, copy)} ${pin.label}`}
+      style={{ width: size, height: size }}
+      className={`grid place-items-center rounded-full font-bold ${PIN_TONE[pin.state]}`}>
+      {pinBadge(pin.state) ?? pin.label}
+    </li>
+  );
+}
+
+export function RoutePinLayer({ pins, copy }: RoutePinLayerProps) {
+  return (
+    <ul aria-label="ピン" className="flex flex-wrap items-center gap-2">
+      {pins.map((pin) => (
+        <Pin key={pin.id} pin={pin} copy={copy} />
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/lib/route-detail/copy.ts
+++ b/apps/web/src/lib/route-detail/copy.ts
@@ -9,6 +9,12 @@ export interface RouteDetailCopy {
   readonly goldBar: string;
   readonly completedBadge: (done: number, total: number) => string;
   readonly mapPlaceholder: string;
+  readonly mapExpand: string;
+  readonly mapCollapse: string;
+  readonly progressAria: string;
+  readonly pinVisited: string;
+  readonly pinCurrent: string;
+  readonly pinUnvisited: string;
   readonly timetablePlaceholder: string;
   readonly emptyTitle: string;
   readonly emptyBody: string;
@@ -23,6 +29,12 @@ const ja: RouteDetailCopy = {
   goldBar: "きょうは巡礼日!→歩くモードへ",
   completedBadge: (done, total) => `完走 ${String(done)}/${String(total)} ✓`,
   mapPlaceholder: "地図を準備しています",
+  mapExpand: "地図を広げる",
+  mapCollapse: "地図をたたむ",
+  progressAria: "巡礼の進捗",
+  pinVisited: "訪問済み",
+  pinCurrent: "現在地",
+  pinUnvisited: "未訪問",
   timetablePlaceholder: "スケジュールを準備しています",
   emptyTitle: "このルートにはまだ地点がありません",
   emptyBody: "チャットからスポットを追加すると、ここにルートが表示されます。",
@@ -37,6 +49,12 @@ const zh: RouteDetailCopy = {
   goldBar: "今天是巡礼日!→前往步行模式",
   completedBadge: (done, total) => `完走 ${String(done)}/${String(total)} ✓`,
   mapPlaceholder: "地图准备中",
+  mapExpand: "展开地图",
+  mapCollapse: "收起地图",
+  progressAria: "巡礼进度",
+  pinVisited: "已访问",
+  pinCurrent: "当前",
+  pinUnvisited: "未访问",
   timetablePlaceholder: "行程准备中",
   emptyTitle: "该路线暂无地点",
   emptyBody: "从对话中加入圣地后,这里会显示你的路线。",
@@ -51,6 +69,12 @@ const en: RouteDetailCopy = {
   goldBar: "Today is a pilgrimage day! → to Walk Mode",
   completedBadge: (done, total) => `Complete ${String(done)}/${String(total)} ✓`,
   mapPlaceholder: "Preparing the map",
+  mapExpand: "Expand map",
+  mapCollapse: "Collapse map",
+  progressAria: "Pilgrimage progress",
+  pinVisited: "Visited",
+  pinCurrent: "Current",
+  pinUnvisited: "Not visited",
   timetablePlaceholder: "Preparing the schedule",
   emptyTitle: "This route has no spots yet",
   emptyBody: "Add spots from chat and your route will appear here.",

--- a/apps/web/src/lib/route-detail/mode.ts
+++ b/apps/web/src/lib/route-detail/mode.ts
@@ -1,0 +1,53 @@
+import { useCallback, useRef, useState } from "react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import type { RouteDataState } from "./dataState";
+
+/**
+ * MODE (spec-route-detail §2): a form axis orthogonal to the data state — the
+ * page toggles between a compact "idle" view and a map-expanded view with a
+ * 360ms FLIP transition. Today defaults to expanded; every other state defaults
+ * to idle. Expanding never surfaces the gold bar (that is data-driven).
+ */
+export type RouteMode = "idle" | "expanded";
+
+/** FLIP transition budget, shared with the workbench "graduation" motion. */
+export const MODE_TRANSITION_MS = 360;
+
+/** The FLIP easing curve (spec-route-detail §2). */
+export const MODE_EASING = "cubic-bezier(0.4, 0, 0.2, 1)";
+
+/** The map-expanded timetable collapses into a 352px sheet. */
+export const EXPANDED_SHEET_PX = 352;
+
+export function nextMode(mode: RouteMode): RouteMode {
+  return mode === "idle" ? "expanded" : "idle";
+}
+
+/** Today opens map-expanded; all other data states open idle. */
+export function initialMode(state: RouteDataState): RouteMode {
+  return state === "today" ? "expanded" : "idle";
+}
+
+export interface RouteModeControl {
+  readonly mode: RouteMode;
+  readonly toggle: () => void;
+}
+
+function runToggle(busy: RefObject<boolean>, setMode: Dispatch<SetStateAction<RouteMode>>): void {
+  if (busy.current) return;
+  busy.current = true;
+  setMode(nextMode);
+  window.setTimeout(() => {
+    busy.current = false;
+  }, MODE_TRANSITION_MS);
+}
+
+/** Mode state with a debounce guard so double-taps never half-transition (AC4). */
+export function useRouteMode(initial: RouteMode): RouteModeControl {
+  const [mode, setMode] = useState<RouteMode>(initial);
+  const busy = useRef<boolean>(false);
+  const toggle = useCallback(() => {
+    runToggle(busy, setMode);
+  }, []);
+  return { mode, toggle };
+}

--- a/apps/web/src/lib/route-detail/pinState.ts
+++ b/apps/web/src/lib/route-detail/pinState.ts
@@ -1,0 +1,66 @@
+import type { TimedStop } from "@seichijunrei/contract";
+import { completedTotals, isStopCheckedIn } from "./dataState";
+import type { RouteDetail } from "./dataState";
+
+/**
+ * Map-pin language (spec-route-detail §5 "pin-is-the-picture"): each stop reads
+ * as visited (済 ✓), current (現在 ★ gold ring), or not-yet-visited (white
+ * numbered). Derived purely from check-ins so the map layer stays presentational
+ * and the gold route pill (progress N/total) reuses the same source of truth.
+ */
+export type PinState = "visited" | "current" | "unvisited";
+
+/** A ready-to-render pin: stable id, its ordinal label, and its data state. */
+export interface RoutePin {
+  readonly id: string;
+  readonly label: string;
+  readonly state: PinState;
+}
+
+function routeStops(detail: RouteDetail): readonly TimedStop[] {
+  return detail.itinerary?.stops ?? [];
+}
+
+function firstUnvisitedIndex(detail: RouteDetail): number {
+  return routeStops(detail).findIndex((stop) => !isStopCheckedIn(detail, stop.cluster_id));
+}
+
+/** The one "現在" pin: the next unvisited stop, only while a journey is underway. */
+function currentPinIndex(detail: RouteDetail): number {
+  const { done, total } = completedTotals(detail);
+  if (done === 0 || done >= total) return -1;
+  return firstUnvisitedIndex(detail);
+}
+
+function pinStateOf(detail: RouteDetail, stop: TimedStop, index: number, current: number): PinState {
+  if (isStopCheckedIn(detail, stop.cluster_id)) return "visited";
+  return index === current ? "current" : "unvisited";
+}
+
+/** Map every itinerary stop to its rendered pin, aligned to the timetable order. */
+export function toRoutePins(detail: RouteDetail): readonly RoutePin[] {
+  const current = currentPinIndex(detail);
+  return routeStops(detail).map((stop, index) => ({
+    id: stop.cluster_id,
+    label: String(index + 1),
+    state: pinStateOf(detail, stop, index, current),
+  }));
+}
+
+/** Gold route pill progress copy (spec-route-detail §5: "N/5"). */
+export function routeProgressLabel(detail: RouteDetail): string {
+  const { done, total } = completedTotals(detail);
+  return `${String(done)}/${String(total)}`;
+}
+
+/** Badge glyph overlaid on the pin: ✓ for visited, ★ for current, none otherwise. */
+export function pinBadge(state: PinState): string | null {
+  if (state === "visited") return "✓";
+  if (state === "current") return "★";
+  return null;
+}
+
+/** The current pin swells to a 58px gold ring; every other pin is a 48px frame. */
+export function pinSizePx(state: PinState): number {
+  return state === "current" ? 58 : 48;
+}

--- a/apps/web/tests/unit/route-detail/map-card.test.tsx
+++ b/apps/web/tests/unit/route-detail/map-card.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MapCard } from "../../../src/components/route-detail/MapCard";
+import type { MapCardPayload } from "../../../src/components/route-detail/MapCard";
+import { routeDetailCopyFor } from "../../../src/lib/route-detail/copy";
+import { ROUTE_DETAIL_SCHEMA_VERSION } from "../../../src/lib/route-detail/dataState";
+
+afterEach(cleanup);
+
+const copy = routeDetailCopyFor("ja");
+
+function payload(overrides: Partial<MapCardPayload> = {}): MapCardPayload {
+  return {
+    schema_version: ROUTE_DETAIL_SCHEMA_VERSION,
+    pins: [{ id: "a", label: "1", state: "visited" }],
+    progress: "1/5",
+    ...overrides,
+  };
+}
+
+function mapRegion(): HTMLElement {
+  return screen.getByRole("region", { name: "地図" });
+}
+
+describe("MapCard generative component", () => {
+  it("shows the gold route pill with N/total progress", () => {
+    render(<MapCard payload={payload()} copy={copy} mode="idle" onToggle={vi.fn()} />);
+    expect(screen.getByLabelText(copy.progressAria).textContent).toBe("1/5");
+  });
+
+  it("reflects the expanded mode on the map region", () => {
+    render(<MapCard payload={payload()} copy={copy} mode="expanded" onToggle={vi.fn()} />);
+    expect(mapRegion().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("stays collapsed in idle mode", () => {
+    render(<MapCard payload={payload()} copy={copy} mode="idle" onToggle={vi.fn()} />);
+    expect(mapRegion().getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("requests a toggle when the mode control is pressed", () => {
+    const onToggle = vi.fn();
+    render(<MapCard payload={payload()} copy={copy} mode="idle" onToggle={onToggle} />);
+    fireEvent.click(screen.getByRole("button", { name: copy.mapExpand }));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it("renders the skeleton slot instead of crashing when pins are missing", () => {
+    render(<MapCard payload={{ schema_version: ROUTE_DETAIL_SCHEMA_VERSION }} copy={copy} mode="idle" onToggle={vi.fn()} />);
+    expect(screen.queryByRole("region", { name: "地図" })).toBeNull();
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it("tolerates a legacy payload missing progress by hiding the pill", () => {
+    render(<MapCard payload={payload({ schema_version: 0, progress: undefined })} copy={copy} mode="idle" onToggle={vi.fn()} />);
+    expect(screen.queryByLabelText(copy.progressAria)).toBeNull();
+    expect(mapRegion()).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/route-detail/mode-persistence.test.tsx
+++ b/apps/web/tests/unit/route-detail/mode-persistence.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { RouteDetailView } from "../../../src/components/route-detail/RouteDetailView";
+import type { RouteDetail } from "../../../src/lib/route-detail/dataState";
+
+afterEach(cleanup);
+
+const NOW = new Date("2026-07-20T09:00:00");
+
+function makeDetail(overrides: Partial<RouteDetail> = {}): RouteDetail {
+  return {
+    id: "r1",
+    title: "Loop",
+    status: "saved",
+    scheduledDate: "2026-07-19",
+    itinerary: {
+      stops: [
+        { cluster_id: "a", name: "A", arrive: "09:00", depart: "09:30", dwell_minutes: 30, lat: 34.9, lng: 135.8, photo_count: 1 },
+        { cluster_id: "b", name: "B", arrive: "10:00", depart: "10:30", dwell_minutes: 30, lat: 34.9, lng: 135.8, photo_count: 1 },
+      ],
+      legs: [],
+      total_minutes: 60,
+      total_distance_m: 500,
+    },
+    checkins: [],
+    pointCount: 2,
+    ...overrides,
+  };
+}
+
+function mapRegion(): HTMLElement {
+  return screen.getByRole("region", { name: "地図" });
+}
+
+describe("MODE persistence across a check-in re-render (AC5)", () => {
+  it("keeps the expanded mode after a check-in event updates the route", () => {
+    const { rerender } = render(<RouteDetailView detail={makeDetail()} locale="ja" now={NOW} />);
+    fireEvent.click(screen.getByRole("button", { name: "地図を広げる" }));
+    expect(mapRegion().getAttribute("aria-expanded")).toBe("true");
+
+    rerender(<RouteDetailView detail={makeDetail({ checkins: ["a"] })} locale="ja" now={NOW} />);
+    expect(mapRegion().getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/apps/web/tests/unit/route-detail/mode-toggle.test.tsx
+++ b/apps/web/tests/unit/route-detail/mode-toggle.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ModeToggle } from "../../../src/components/route-detail/ModeToggle";
+import { routeDetailCopyFor } from "../../../src/lib/route-detail/copy";
+
+afterEach(cleanup);
+
+const copy = routeDetailCopyFor("ja");
+
+describe("ModeToggle", () => {
+  it("labels itself expand and is unpressed when idle", () => {
+    render(<ModeToggle mode="idle" onToggle={vi.fn()} copy={copy} />);
+    const button = screen.getByRole("button", { name: copy.mapExpand });
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("labels itself collapse and is pressed when expanded", () => {
+    render(<ModeToggle mode="expanded" onToggle={vi.fn()} copy={copy} />);
+    const button = screen.getByRole("button", { name: copy.mapCollapse });
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("requests a toggle on click", () => {
+    const onToggle = vi.fn();
+    render(<ModeToggle mode="idle" onToggle={onToggle} copy={copy} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/tests/unit/route-detail/mode.test.tsx
+++ b/apps/web/tests/unit/route-detail/mode.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MODE_TRANSITION_MS,
+  initialMode,
+  nextMode,
+  useRouteMode,
+} from "../../../src/lib/route-detail/mode";
+
+afterEach(cleanup);
+
+describe("mode transitions", () => {
+  it("flips idle to expanded and back", () => {
+    expect(nextMode("idle")).toBe("expanded");
+    expect(nextMode("expanded")).toBe("idle");
+  });
+
+  it("opens expanded on the today state and idle otherwise", () => {
+    expect(initialMode("today")).toBe("expanded");
+    expect(initialMode("weekday")).toBe("idle");
+    expect(initialMode("completed")).toBe("idle");
+  });
+});
+
+function ModeHarness() {
+  const { mode, toggle } = useRouteMode("idle");
+  return (
+    <button type="button" onClick={toggle}>
+      {mode}
+    </button>
+  );
+}
+
+describe("useRouteMode debounce guard", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("switches mode on a single toggle", () => {
+    render(<ModeHarness />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("button").textContent).toBe("expanded");
+  });
+
+  it("ignores a rapid second toggle until the transition finishes", () => {
+    render(<ModeHarness />);
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("button").textContent).toBe("expanded");
+  });
+
+  it("accepts the next toggle after the transition window elapses", () => {
+    render(<ModeHarness />);
+    fireEvent.click(screen.getByRole("button"));
+    vi.advanceTimersByTime(MODE_TRANSITION_MS);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("button").textContent).toBe("idle");
+  });
+});

--- a/apps/web/tests/unit/route-detail/pin-state.test.ts
+++ b/apps/web/tests/unit/route-detail/pin-state.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { TimedItinerary, TimedStop } from "@seichijunrei/contract";
+import type { RouteDetail } from "../../../src/lib/route-detail/dataState";
+import {
+  pinBadge,
+  pinSizePx,
+  routeProgressLabel,
+  toRoutePins,
+} from "../../../src/lib/route-detail/pinState";
+
+function stop(clusterId: string): TimedStop {
+  return {
+    cluster_id: clusterId,
+    name: clusterId,
+    arrive: "09:00",
+    depart: "09:30",
+    dwell_minutes: 30,
+    lat: 34.9,
+    lng: 135.8,
+    photo_count: 2,
+  };
+}
+
+function itinerary(ids: readonly string[]): TimedItinerary {
+  return { stops: ids.map(stop), legs: [], total_minutes: 60, total_distance_m: 1000 };
+}
+
+function makeDetail(overrides: Partial<RouteDetail> = {}): RouteDetail {
+  return {
+    id: "r1",
+    title: "Loop",
+    status: "saved",
+    scheduledDate: null,
+    itinerary: itinerary(["a", "b", "c"]),
+    checkins: [],
+    pointCount: 3,
+    ...overrides,
+  };
+}
+
+describe("toRoutePins map-pin language", () => {
+  it("marks every pin unvisited when there are no check-ins", () => {
+    const pins = toRoutePins(makeDetail());
+    expect(pins.map((p) => p.state)).toEqual(["unvisited", "unvisited", "unvisited"]);
+  });
+
+  it("lights the first unvisited stop as current once a journey is underway", () => {
+    const pins = toRoutePins(makeDetail({ checkins: ["a"] }));
+    expect(pins.map((p) => p.state)).toEqual(["visited", "current", "unvisited"]);
+  });
+
+  it("marks every pin visited and none current when the route is completed", () => {
+    const pins = toRoutePins(makeDetail({ checkins: ["a", "b", "c"] }));
+    expect(pins.map((p) => p.state)).toEqual(["visited", "visited", "visited"]);
+  });
+
+  it("labels pins by their one-based timetable order", () => {
+    const pins = toRoutePins(makeDetail());
+    expect(pins.map((p) => p.label)).toEqual(["1", "2", "3"]);
+  });
+
+  it("yields no pins when the itinerary is still pending", () => {
+    expect(toRoutePins(makeDetail({ itinerary: null }))).toEqual([]);
+  });
+});
+
+describe("routeProgressLabel gold pill", () => {
+  it("renders done over total", () => {
+    expect(routeProgressLabel(makeDetail({ checkins: ["a"] }))).toBe("1/3");
+  });
+
+  it("stays 0/0 rather than breaking when no itinerary is loaded", () => {
+    expect(routeProgressLabel(makeDetail({ itinerary: null }))).toBe("0/0");
+  });
+});
+
+describe("pin presentation", () => {
+  it("overlays ✓ on visited, ★ on current, and nothing on unvisited", () => {
+    expect(pinBadge("visited")).toBe("✓");
+    expect(pinBadge("current")).toBe("★");
+    expect(pinBadge("unvisited")).toBeNull();
+  });
+
+  it("swells the current pin to 58px and keeps others at 48px", () => {
+    expect(pinSizePx("current")).toBe(58);
+    expect(pinSizePx("visited")).toBe(48);
+    expect(pinSizePx("unvisited")).toBe(48);
+  });
+});

--- a/apps/web/tests/unit/route-detail/route-pin-layer.test.tsx
+++ b/apps/web/tests/unit/route-detail/route-pin-layer.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { RoutePinLayer } from "../../../src/components/route-detail/RoutePinLayer";
+import { routeDetailCopyFor } from "../../../src/lib/route-detail/copy";
+import type { RoutePin } from "../../../src/lib/route-detail/pinState";
+
+afterEach(cleanup);
+
+const copy = routeDetailCopyFor("ja");
+
+const PINS: readonly RoutePin[] = [
+  { id: "a", label: "1", state: "visited" },
+  { id: "b", label: "2", state: "current" },
+  { id: "c", label: "3", state: "unvisited" },
+];
+
+function pin(name: string): HTMLElement {
+  return screen.getByRole("listitem", { name });
+}
+
+describe("RoutePinLayer map-pin language", () => {
+  it("renders each pin with its data state", () => {
+    render(<RoutePinLayer pins={PINS} copy={copy} />);
+    expect(pin(`${copy.pinVisited} 1`).getAttribute("data-state")).toBe("visited");
+    expect(pin(`${copy.pinCurrent} 2`).getAttribute("data-state")).toBe("current");
+    expect(pin(`${copy.pinUnvisited} 3`).getAttribute("data-state")).toBe("unvisited");
+  });
+
+  it("overlays ✓ on visited and ★ on current, keeps the number on unvisited", () => {
+    render(<RoutePinLayer pins={PINS} copy={copy} />);
+    expect(pin(`${copy.pinVisited} 1`).textContent).toBe("✓");
+    expect(pin(`${copy.pinCurrent} 2`).textContent).toBe("★");
+    expect(pin(`${copy.pinUnvisited} 3`).textContent).toBe("3");
+  });
+
+  it("swells the current pin to 58px", () => {
+    render(<RoutePinLayer pins={PINS} copy={copy} />);
+    expect(pin(`${copy.pinCurrent} 2`).style.width).toBe("58px");
+    expect(pin(`${copy.pinUnvisited} 3`).style.width).toBe("48px");
+  });
+
+  it("renders nothing but the empty list when there are no pins", () => {
+    render(<RoutePinLayer pins={[]} copy={copy} />);
+    expect(screen.getByRole("list", { name: "ピン" }).childElementCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Card #266 — S2.2 (iter-2)

Implements the route-detail MODE axis, map-pin language, and gold route pill on top of the #264 shell. Base = `feat/frontend-rebuild`.

### Delivered (AC per iter-2 S2.2)
1. **MODE toggle (FLIP)** — `useRouteMode` drives idle ⇄ map-expanded with a 360ms `cubic-bezier(0.4,0,0.2,1)` transition; today defaults expanded, others idle. A ref-based debounce guard means a rapid double-tap never half-transitions (AC4). The map-expanded timetable collapses into a 352px sheet.
2. **Map-pin language** — `toRoutePins` derives visited / current / unvisited purely from check-ins; `RoutePinLayer` renders 済 ✓ teal, 現在 ★ 58px gold ring, and white numbered not-yet-visited markers using semantic tokens (`--color-map-pin-teal`, `--color-focus`). Zero check-ins → all unvisited, no crash (AC3).
3. **Gold route pill** — `--color-focus` pill showing N/total progress, always present.
4. **Generative contract (SD-13)** — `MapCard` carries `schema_version` and is partial-tolerant: missing pins → skeleton slot; legacy payload missing progress → pill hidden, never crashes. Covered by unit tests in lieu of Storybook (none in apps/web, matching #264's GoldBar).
5. **MODE persistence** — mode survives a check-in re-render (AC5).

### Scope
Only touches `apps/web/src/components/route-detail/**`, `apps/web/src/lib/route-detail/**`, and matching tests. `RoutePinLayer` placed in the route-detail component dir to respect the card boundary (no shared `components/map/` edits). No contract/globals/other-feature changes.

### Gates (all green)
- `pnpm run typecheck` ✓
- `pnpm run lint:oxlint` (--deny-warnings) ✓
- `pnpm test` — 561 passed / 106 files; coverage 99.13% stmts / 95.27% branches / 99.64% fns / 99.81% lines (floor 90/90/90/90)
- `pnpm run build` ✓ (routeTree unchanged — no new routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)