### PR TITLE
feat(web): S5.6 programmatic SEO — JSON-LD + hreflang closure (frontend half)

### DIFF
--- a/apps/web/src/features/anime/AnimePage.tsx
+++ b/apps/web/src/features/anime/AnimePage.tsx
@@ -1,10 +1,13 @@
 import type { AnimeOverview } from "@seichijunrei/contract";
 import type { Locale } from "../../i18n/locales";
+import { JsonLd } from "../seo/JsonLd";
+import { seoOrigin } from "../seo/origin";
 import { CirclesSection } from "./CirclesSection";
 import { FactSummaryBlock } from "./FactSummaryBlock";
 import { ScenesSection } from "./ScenesSection";
 import { type AnimeCopy, animeCopyFor } from "./copy";
 import { buildFactSummary, rankScenes } from "./fact-summary";
+import { buildAnimeJsonLd } from "./structured-data";
 
 export type AnimePageProps = Readonly<{ overview: AnimeOverview; locale: Locale }>;
 
@@ -42,9 +45,18 @@ function AnimeFull({ overview, copy }: ViewProps) {
   );
 }
 
+function AnimeBody({ overview, copy }: ViewProps) {
+  if (overview.points_length === 0) return <AnimeEmpty overview={overview} copy={copy} />;
+  return <AnimeFull overview={overview} copy={copy} />;
+}
+
 /** `/anime/:id` presenter: empty-but-valid overviews get the graceful empty state. */
 export function AnimePage({ overview, locale }: AnimePageProps) {
   const copy = animeCopyFor(locale);
-  if (overview.points_length === 0) return <AnimeEmpty overview={overview} copy={copy} />;
-  return <AnimeFull overview={overview} copy={copy} />;
+  return (
+    <>
+      <JsonLd nodes={buildAnimeJsonLd(overview, locale, seoOrigin())} />
+      <AnimeBody overview={overview} copy={copy} />
+    </>
+  );
 }

--- a/apps/web/src/features/anime/structured-data.ts
+++ b/apps/web/src/features/anime/structured-data.ts
@@ -1,0 +1,86 @@
+import type { AnimeOverview, AnimeScene } from "@seichijunrei/contract";
+import type { Locale } from "../../i18n/locales";
+import { animeTitle } from "./head";
+
+/**
+ * schema.org JSON-LD builders for `/anime/:id` (SD-27 contracted mapping).
+ *
+ * Every value is derived from `AnimeOverview` alone — the public catalog
+ * contract carries no title/eps/datePublished, so the graph stays honest:
+ * a `CreativeWork` whose `additionalProperty` set encodes this work's unique
+ * spot/region/scene counts (SD-27C "one entity, one page + unique data"),
+ * a `BreadcrumbList`, and one licensed `ImageObject` per famous-scene frame.
+ */
+export type JsonLdValue = string | number | boolean | null | JsonLdNode | readonly JsonLdValue[];
+export interface JsonLdNode {
+  readonly [key: string]: JsonLdValue;
+}
+
+const SCHEMA = "https://schema.org";
+const LICENSE = "https://creativecommons.org/licenses/by-nc-sa/4.0/";
+const CREDIT = "Anitabi";
+const HOME_LABEL: Record<Locale, string> = { ja: "ホーム", zh: "首页", en: "Home" };
+const WORK_LABEL: Record<Locale, string> = { ja: "作品", zh: "作品", en: "Anime" };
+
+function canonicalUrl(origin: string, bangumiId: string): string {
+  return `${origin}/anime/${bangumiId}`;
+}
+
+function propertyValue(name: string, value: number | string): JsonLdNode {
+  return { "@type": "PropertyValue", name, value };
+}
+
+function uniqueFacts(overview: AnimeOverview): JsonLdNode[] {
+  return [
+    propertyValue("pilgrimageSpotCount", overview.points_length),
+    propertyValue("regionCount", overview.circles.length),
+    propertyValue("famousSceneCount", overview.scenes.length),
+    propertyValue("topRegions", overview.circles.map((circle) => circle.region).join(", ")),
+  ];
+}
+
+function buildCreativeWork(overview: AnimeOverview, locale: Locale, origin: string): JsonLdNode {
+  const url = canonicalUrl(origin, overview.bangumi_id);
+  return {
+    "@context": SCHEMA, "@type": "CreativeWork", "@id": url, url,
+    inLanguage: locale, name: animeTitle(locale, overview.bangumi_id),
+    additionalProperty: uniqueFacts(overview),
+  };
+}
+
+function listItem(position: number, name: string, item: string): JsonLdNode {
+  return { "@type": "ListItem", position, name, item };
+}
+
+export function buildBreadcrumb(overview: AnimeOverview, locale: Locale, origin: string): JsonLdNode {
+  return {
+    "@context": SCHEMA,
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      listItem(1, HOME_LABEL[locale], `${origin}/`),
+      listItem(2, WORK_LABEL[locale], canonicalUrl(origin, overview.bangumi_id)),
+    ],
+  };
+}
+
+function sceneImage(scene: AnimeScene): JsonLdNode | null {
+  if (scene.screenshot_url === null) return null;
+  return {
+    "@type": "ImageObject", "@id": scene.screenshot_url, contentUrl: scene.screenshot_url,
+    name: scene.name, license: LICENSE, creditText: CREDIT,
+  };
+}
+
+export function buildSceneImages(overview: AnimeOverview): JsonLdNode[] {
+  return overview.scenes
+    .map(sceneImage)
+    .filter((node): node is JsonLdNode => node !== null);
+}
+
+export function buildAnimeJsonLd(overview: AnimeOverview, locale: Locale, origin: string): JsonLdNode[] {
+  return [
+    buildCreativeWork(overview, locale, origin),
+    buildBreadcrumb(overview, locale, origin),
+    ...buildSceneImages(overview),
+  ];
+}

--- a/apps/web/src/features/seo/JsonLd.tsx
+++ b/apps/web/src/features/seo/JsonLd.tsx
@@ -1,0 +1,24 @@
+import type { JsonLdNode } from "../anime/structured-data";
+
+/**
+ * SSR-visible schema.org injector: one `application/ld+json` script per page.
+ *
+ * `<` is escaped to `<` so a `</script>` sequence inside any string value
+ * can never break out of the tag; `dangerouslySetInnerHTML` keeps the JSON
+ * bytes verbatim (React would otherwise HTML-escape `&` in query strings).
+ */
+type Props = Readonly<{ nodes: readonly JsonLdNode[] }>;
+
+function serialize(nodes: readonly JsonLdNode[]): string {
+  return JSON.stringify(nodes).replace(/</g, "\\u003c");
+}
+
+export function JsonLd({ nodes }: Props) {
+  if (nodes.length === 0) return null;
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serialize(nodes) }}
+    />
+  );
+}

--- a/apps/web/src/features/seo/hreflangGraph.ts
+++ b/apps/web/src/features/seo/hreflangGraph.ts
@@ -1,0 +1,58 @@
+import type { HreflangLink } from "../anime/head";
+import { LOCALES } from "../../i18n/locales";
+
+/**
+ * Site-wide hreflang closure verification (SD-27C).
+ *
+ * S5.1's bootstrap covers a single page's alternates; this closes the loop
+ * across every programmatic page: each page must expose all locales plus
+ * `x-default`, and every cross-link must be reciprocal (if page A points to
+ * page B, B must point back at A). A defect list is returned rather than a
+ * bare boolean so link-graph tests can assert *why* the loop is broken.
+ */
+export interface HreflangPage {
+  readonly url: string;
+  readonly links: readonly HreflangLink[];
+}
+
+const REQUIRED: readonly string[] = [...LOCALES, "x-default"];
+
+function missingLangs(page: HreflangPage): string[] {
+  const present = new Set(page.links.map((link) => link.hrefLang));
+  return REQUIRED.filter((lang) => !present.has(lang));
+}
+
+function completenessDefects(page: HreflangPage): string[] {
+  return missingLangs(page).map((lang) => `${page.url} missing ${lang} variant`);
+}
+
+function localeHrefs(page: HreflangPage): string[] {
+  return page.links.filter((link) => link.hrefLang !== "x-default").map((link) => link.href);
+}
+
+function linksBack(target: HreflangPage, url: string): boolean {
+  return localeHrefs(target).includes(url);
+}
+
+function brokenHref(page: HreflangPage, byUrl: Map<string, HreflangPage>, href: string): boolean {
+  const target = byUrl.get(href);
+  return target !== undefined && target.url !== page.url && !linksBack(target, page.url);
+}
+
+function reciprocityDefects(page: HreflangPage, byUrl: Map<string, HreflangPage>): string[] {
+  return localeHrefs(page)
+    .filter((href) => brokenHref(page, byUrl, href))
+    .map((href) => `${page.url} not reciprocal with ${href}`);
+}
+
+export function findHreflangDefects(pages: readonly HreflangPage[]): string[] {
+  const byUrl = new Map(pages.map((page) => [page.url, page] as const));
+  return pages.flatMap((page) => [
+    ...completenessDefects(page),
+    ...reciprocityDefects(page, byUrl),
+  ]);
+}
+
+export function isHreflangClosed(pages: readonly HreflangPage[]): boolean {
+  return findHreflangDefects(pages).length === 0;
+}

--- a/apps/web/src/features/seo/origin.ts
+++ b/apps/web/src/features/seo/origin.ts
@@ -1,0 +1,14 @@
+import { resolveOrigin } from "../../api/config";
+
+/**
+ * Absolute site origin for SEO/JSON-LD URLs, resolved without touching the
+ * anime route's loader: the browser's `location` on the client, the deploy's
+ * `VITE_SITE_ORIGIN` / request context on the server (via `resolveOrigin`).
+ */
+export function currentLocation(): { readonly origin: string } | undefined {
+  return typeof window === "undefined" ? undefined : window.location;
+}
+
+export function seoOrigin(location = currentLocation()): string {
+  return resolveOrigin(import.meta.env, location);
+}

--- a/apps/web/tests/unit/anime/anime-page.test.tsx
+++ b/apps/web/tests/unit/anime/anime-page.test.tsx
@@ -91,3 +91,29 @@ describe("AnimePage empty state", () => {
     expect(headingText()).toContain("Pilgrimage");
   });
 });
+
+function jsonLdNodes(container: HTMLElement): Record<string, unknown>[] {
+  const el = container.querySelector('script[type="application/ld+json"]');
+  return el === null ? [] : (JSON.parse(el.innerHTML) as Record<string, unknown>[]);
+}
+
+describe("AnimePage JSON-LD", () => {
+  it("injects a CreativeWork + BreadcrumbList graph into the page body", () => {
+    const { container } = render(<AnimePage overview={fullOverviewFixture} locale="ja" />);
+    const types = jsonLdNodes(container).map((node) => node["@type"]);
+    expect(types).toContain("CreativeWork");
+    expect(types).toContain("BreadcrumbList");
+  });
+
+  it("varies non-template field values with the work's actual data", () => {
+    const { container } = render(<AnimePage overview={fullOverviewFixture} locale="ja" />);
+    const work = jsonLdNodes(container).find((node) => node["@type"] === "CreativeWork");
+    const props = work?.additionalProperty as Record<string, unknown>[];
+    expect(props.find((p) => p.name === "pilgrimageSpotCount")?.value).toBe(6);
+  });
+
+  it("still emits valid JSON-LD for a zero-spot work", () => {
+    const { container } = render(<AnimePage overview={emptyOverviewFixture("404404")} locale="ja" />);
+    expect(jsonLdNodes(container).some((node) => node["@type"] === "CreativeWork")).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/anime/structured-data.test.ts
+++ b/apps/web/tests/unit/anime/structured-data.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { JsonLdNode } from "../../../src/features/anime/structured-data";
+import {
+  buildAnimeJsonLd,
+  buildBreadcrumb,
+  buildSceneImages,
+} from "../../../src/features/anime/structured-data";
+import { emptyOverviewFixture, fullOverviewFixture } from "../../msw/anime-overview";
+
+const ORIGIN = "https://animichi.example";
+
+function nodeOfType(nodes: readonly JsonLdNode[], type: string): JsonLdNode {
+  const node = nodes.find((entry) => entry["@type"] === type);
+  if (!node) throw new Error(`missing ${type}`);
+  return node;
+}
+
+describe("buildAnimeJsonLd main entity", () => {
+  it("types the work as CreativeWork with a canonical @id and locale", () => {
+    const work = nodeOfType(buildAnimeJsonLd(fullOverviewFixture, "en", ORIGIN), "CreativeWork");
+    expect(work["@context"]).toBe("https://schema.org");
+    expect(work["@id"]).toBe("https://animichi.example/anime/123");
+    expect(work.inLanguage).toBe("en");
+  });
+
+  it("carries per-anime unique field values, not a title-swapped template", () => {
+    const work = nodeOfType(buildAnimeJsonLd(fullOverviewFixture, "ja", ORIGIN), "CreativeWork");
+    const props = work.additionalProperty as JsonLdNode[];
+    const spots = props.find((p) => p.name === "pilgrimageSpotCount");
+    const regions = props.find((p) => p.name === "topRegions");
+    expect(spots?.value).toBe(6);
+    expect(regions?.value).toContain("Takayama");
+  });
+});
+
+describe("buildBreadcrumb", () => {
+  it("renders a Home > work BreadcrumbList with sequential positions", () => {
+    const crumb = buildBreadcrumb(fullOverviewFixture, "en", ORIGIN);
+    const items = crumb.itemListElement as JsonLdNode[];
+    expect(crumb["@type"]).toBe("BreadcrumbList");
+    expect(items.map((i) => i.position)).toEqual([1, 2]);
+    expect(items[0]?.item).toBe("https://animichi.example/");
+  });
+
+  it("excludes scene anchors from the breadcrumb item urls", () => {
+    const crumb = buildBreadcrumb(fullOverviewFixture, "ja", ORIGIN);
+    const items = crumb.itemListElement as { readonly item: string }[];
+    for (const item of items) expect(item.item).not.toContain("#");
+  });
+});
+
+describe("buildSceneImages", () => {
+  it("emits a licensed ImageObject per scene screenshot with attribution", () => {
+    const images = buildSceneImages(fullOverviewFixture);
+    expect(images).toHaveLength(2);
+    expect(images[0]?.["@type"]).toBe("ImageObject");
+    expect(images[0]?.license).toBe("https://creativecommons.org/licenses/by-nc-sa/4.0/");
+    expect(images[0]?.creditText).toBe("Anitabi");
+    expect(images[0]?.contentUrl).toBe("https://cdn.test/scene-2.jpg");
+  });
+
+  it("skips scenes without a screenshot url", () => {
+    const scenes = fullOverviewFixture.scenes.map((scene) => ({ ...scene, screenshot_url: null }));
+    expect(buildSceneImages({ ...fullOverviewFixture, scenes })).toHaveLength(0);
+  });
+});
+
+describe("buildAnimeJsonLd empty state", () => {
+  it("still returns valid CreativeWork + BreadcrumbList for a zero-spot work", () => {
+    const nodes = buildAnimeJsonLd(emptyOverviewFixture("404404"), "ja", ORIGIN);
+    expect(nodeOfType(nodes, "CreativeWork")["@id"]).toBe("https://animichi.example/anime/404404");
+    expect(nodeOfType(nodes, "BreadcrumbList")).toBeTruthy();
+    expect(nodes.some((n) => n["@type"] === "ImageObject")).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/seo/hreflang-graph.test.ts
+++ b/apps/web/tests/unit/seo/hreflang-graph.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { animeAlternates } from "../../../src/features/anime/head";
+import { findHreflangDefects, isHreflangClosed } from "../../../src/features/seo/hreflangGraph";
+
+const ORIGIN = "https://animichi.example";
+
+function animePage(id: string) {
+  return { url: `${ORIGIN}/anime/${id}`, links: animeAlternates(ORIGIN, id) };
+}
+
+describe("isHreflangClosed", () => {
+  it("passes when every anime page carries all locales plus x-default", () => {
+    expect(isHreflangClosed([animePage("123"), animePage("456")])).toBe(true);
+  });
+
+  it("fails when a page is missing a language variant", () => {
+    const broken = animePage("123");
+    const links = broken.links.filter((link) => link.hrefLang !== "en");
+    expect(isHreflangClosed([{ url: broken.url, links }])).toBe(false);
+  });
+});
+
+describe("findHreflangDefects", () => {
+  it("reports no defects for a closed trilingual graph", () => {
+    expect(findHreflangDefects([animePage("123")])).toEqual([]);
+  });
+
+  it("flags a missing x-default fallback", () => {
+    const page = animePage("123");
+    const links = page.links.filter((link) => link.hrefLang !== "x-default");
+    const defects = findHreflangDefects([{ url: page.url, links }]);
+    expect(defects.some((defect) => defect.includes("x-default"))).toBe(true);
+  });
+
+  it("flags a non-reciprocal cross-link between two pages", () => {
+    const good = animePage("123");
+    const tampered = {
+      url: `${ORIGIN}/anime/456`,
+      links: good.links,
+    };
+    const defects = findHreflangDefects([good, tampered]);
+    expect(defects.some((defect) => defect.includes("reciprocal"))).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/seo/json-ld.test.tsx
+++ b/apps/web/tests/unit/seo/json-ld.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { JsonLdNode } from "../../../src/features/anime/structured-data";
+import { JsonLd } from "../../../src/features/seo/JsonLd";
+
+afterEach(cleanup);
+
+const NODES: JsonLdNode[] = [
+  { "@context": "https://schema.org", "@type": "CreativeWork", "@id": "https://x/anime/1" },
+  { "@context": "https://schema.org", "@type": "BreadcrumbList" },
+];
+
+function scriptEl(container: HTMLElement): HTMLScriptElement {
+  const el = container.querySelector('script[type="application/ld+json"]');
+  if (!el) throw new Error("no json-ld script");
+  return el as HTMLScriptElement;
+}
+
+describe("JsonLd", () => {
+  it("serializes the node graph into an application/ld+json script", () => {
+    const { container } = render(<JsonLd nodes={NODES} />);
+    const parsed = JSON.parse(scriptEl(container).innerHTML) as JsonLdNode[];
+    expect(parsed).toHaveLength(2);
+    expect(parsed.map((node) => node["@type"])).toContain("CreativeWork");
+  });
+
+  it("escapes angle brackets to prevent script-tag breakout", () => {
+    const { container } = render(<JsonLd nodes={[{ "@type": "Thing", name: "a<b" }]} />);
+    expect(scriptEl(container).innerHTML).not.toContain("<b");
+    expect(scriptEl(container).innerHTML).toContain("\\u003c");
+  });
+
+  it("renders nothing when the node graph is empty", () => {
+    const { container } = render(<JsonLd nodes={[]} />);
+    expect(container.querySelector("script")).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/seo/origin.test.ts
+++ b/apps/web/tests/unit/seo/origin.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { currentLocation, seoOrigin } from "../../../src/features/seo/origin";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("currentLocation", () => {
+  it("returns the browser location when window is present", () => {
+    expect(currentLocation()).toBe(window.location);
+  });
+
+  it("returns undefined off the browser", () => {
+    vi.stubGlobal("window", undefined);
+    expect(currentLocation()).toBeUndefined();
+  });
+});
+
+describe("seoOrigin", () => {
+  it("prefers an explicit location origin", () => {
+    expect(seoOrigin({ origin: "https://animichi.example" })).toBe("https://animichi.example");
+  });
+
+  it("falls back to the ambient browser origin", () => {
+    expect(seoOrigin()).toBe(window.location.origin);
+  });
+});


### PR DESCRIPTION
## Card #278 — S5.6 Programmatic SEO (frontend half)

Front half of S5.6 (spec: `docs/superpowers/specs/2026-07-06-frontend-rebuild/iter-5.md`). Depends on #267 anime page (fact-summary + hreflang bootstrap in `features/anime/head.ts`).

### What's delivered
1. **JSON-LD structured data** (`features/anime/structured-data.ts`), built from `AnimeOverview` alone (no contract change):
   - `CreativeWork` with per-anime `additionalProperty` (spot/region/scene counts + top regions) — satisfies SD-27C "one entity, one page + unique data" (values vary with the work's actual data, not a title-swapped template).
   - `BreadcrumbList` (Home > work), scene anchors excluded from item URLs.
   - Licensed `ImageObject` per famous-scene frame: `contentUrl` + `license` (CC BY-NC-SA) + `creditText` (Anitabi) — Anitabi attribution + Google Images licensable markup.
   - Empty (zero-spot) works still emit valid minimal JSON-LD.
2. **SSR-visible injection** (`features/seo/JsonLd.tsx`): one `application/ld+json` script rendered in the page body; `<` escaped to prevent `</script>` breakout. The anime **route/loader is untouched** — JSON-LD is wired in via the `AnimePage` presenter + a tested `seoOrigin` helper (`features/seo/origin.ts`).
3. **Site-wide hreflang closure** (`features/seo/hreflangGraph.ts`): completeness (all locales + `x-default`) and reciprocity link-graph verification, returning a defect list so tests assert *why* the loop is broken.

### Out of scope (backend half)
Sitemap generation, IndexNow push, `lastmod` hash comparison, and the new-title SLA live in `scripts/` + the catalog Worker cron — outside this card's allowed paths (`features/anime/**`, `features/seo/**`, `public/**`).

### Note on JSON-LD fields
`AnimeOverview` carries no `name`/`alternateName`/`eps`/`datePublished`/cover, and the card forbids touching `packages/contract` and the anime loader. So `@type` is `CreativeWork` (not `eps`-typed `TVSeries`/`Movie`) and the graph stays honest — per-anime uniqueness is carried by the `additionalProperty` counts. Upgrading to `TVSeries`/`Movie` + `datePublished` requires a contract enrichment story (backend).

### Gate (run individually, all green)
- `pnpm run typecheck` — clean
- `pnpm run lint:oxlint` — clean
- `pnpm run build` — clean (routeTree generated)
- `pnpm test` — 104 files / 555 tests passed; coverage 99.12% stmts / 95.03% branches / 99.64% fns / 99.81% lines (floor 90)

### Tests (per-AC)
- `tests/unit/anime/structured-data.test.ts` — CreativeWork typing/unique data, BreadcrumbList anchor-free, ImageObject license+credit, empty-state validity.
- `tests/unit/anime/anime-page.test.tsx` — SSR JSON-LD presence + unique-data integration.
- `tests/unit/seo/json-ld.test.tsx` — serialization, `<` escaping, empty graph.
- `tests/unit/seo/hreflang-graph.test.ts` — closure, missing variant, missing x-default, non-reciprocal cross-link.
- `tests/unit/seo/origin.test.ts` — origin resolution branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)