### PR TITLE
feat(web): S1.2 turn-waiting ritual + settled footprint + first-token telemetry

### DIFF
--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -5,7 +5,7 @@ import { ColdStart } from "./components/ColdStart";
 import { ErrorBanner } from "./components/ErrorBanner";
 import { HistoryList } from "./components/HistoryList";
 import { MessageList } from "./components/MessageList";
-import { TypingGate } from "./components/TypingIndicator";
+import { WaitingRitual } from "./components/WaitingRitual";
 import { currentChatConfig } from "./config";
 import { deriveEntryState, resolveRouteReference } from "./entry-state";
 import type { ChatEntryState } from "./entry-state";
@@ -18,6 +18,7 @@ import type { BackendHealth } from "./use-backend-health";
 import type { ChatSession } from "./use-chat-session";
 import { useChatSession } from "./use-chat-session";
 import { useConversationHistory } from "./use-conversation-history";
+import { useTurnTiming } from "./use-turn-timing";
 import type { ConversationHistory } from "./use-conversation-history";
 
 export interface ChatPageProps {
@@ -61,13 +62,18 @@ function HistoryLoadingGate({ history, dict }: Readonly<{ history: ConversationH
   );
 }
 
+function ChatMessages({ chat, dict }: Readonly<{ chat: ChatSession; dict: ChatDict }>) {
+  const settledDurationMs = useTurnTiming(chat.status);
+  return <MessageList messages={chat.messages} dict={dict} status={chat.status} settledDurationMs={settledDurationMs} />;
+}
+
 function ChatBody(props: BodyProps) {
   const anchor = useScrollAnchor(props.history.entries.length + props.chat.messages.length);
   return (
     <section className="chat-body">
       <HistoryLoadingGate history={props.history} dict={props.dict} />
       <HistoryList entries={props.history.entries} dict={props.dict} />
-      <ColdStartGate {...props} /><MessageList messages={props.chat.messages} dict={props.dict} /><TypingGate status={props.chat.status} dict={props.dict} /><div ref={anchor} aria-hidden="true" />
+      <ColdStartGate {...props} /><ChatMessages chat={props.chat} dict={props.dict} /><WaitingRitual status={props.chat.status} dict={props.dict} messages={props.chat.messages} /><div ref={anchor} aria-hidden="true" />
     </section>
   );
 }

--- a/apps/web/src/features/chat/components/MessageList.tsx
+++ b/apps/web/src/features/chat/components/MessageList.tsx
@@ -1,36 +1,106 @@
-import type { UIMessage } from "ai";
+import type { ChatStatus, UIMessage } from "ai";
 import type { ChatDict } from "../i18n";
+import { formatElapsed } from "../telemetry";
 import { DataPartCard } from "./DataPartCard";
+import { SettledFootprint } from "./SettledFootprint";
 import { ToolStepBadge } from "./ToolStepBadge";
 
 type Part = UIMessage["parts"][number];
+type ToolPart = Extract<Part, { toolCallId: string }>;
 type PartProps = Readonly<{ part: Part; dict: ChatDict }>;
 
-function isToolPart(part: Part): part is Extract<Part, { toolCallId: string }> {
+function isToolPart(part: Part): part is ToolPart {
   return part.type.startsWith("tool-") || part.type === "dynamic-tool";
 }
 
 function MessagePart({ part, dict }: PartProps) {
   if (part.type === "text") return <p className="chat-bubble">{part.text}</p>;
   if (part.type === "data-response") return <DataPartCard data={part.data} dict={dict} />;
-  if (isToolPart(part)) return <ToolStepBadge type={part.type} state={part.state} />;
   return null;
 }
 
 function partKey(messageId: string, part: Part, index: number): string {
-  if (isToolPart(part)) return part.toolCallId;
   return `${messageId}:${part.type}:${String(index)}`;
 }
 
-function MessageItem({ message, dict }: Readonly<{ message: UIMessage; dict: ChatDict }>) {
-  const parts = message.parts.map((part, index) => (
-    <MessagePart key={partKey(message.id, part, index)} part={part} dict={dict} />
-  ));
-  return <li className={`chat-message chat-message--${message.role}`}>{parts}</li>;
+function ToolBadges({ parts }: Readonly<{ parts: readonly ToolPart[] }>) {
+  return parts.map((part) => <ToolStepBadge key={part.toolCallId} type={part.type} state={part.state} />);
 }
 
-export function MessageList({ messages, dict }: Readonly<{ messages: readonly UIMessage[]; dict: ChatDict }>) {
+type PipelineProps = Readonly<{
+  parts: readonly ToolPart[];
+  settled: boolean;
+  elapsedLabel?: string;
+  dict: ChatDict;
+}>;
+
+function Pipeline({ parts, settled, elapsedLabel, dict }: PipelineProps) {
+  if (parts.length === 0) return null;
+  const badges = <ToolBadges parts={parts} />;
+  if (!settled) return badges;
+  return <SettledFootprint elapsedLabel={elapsedLabel} dict={dict}>{badges}</SettledFootprint>;
+}
+
+function MessageBody({ parts, messageId, dict }: Readonly<{ parts: readonly Part[]; messageId: string; dict: ChatDict }>) {
+  return parts.map((part, index) => (
+    <MessagePart key={partKey(messageId, part, index)} part={part} dict={dict} />
+  ));
+}
+
+type ItemProps = Readonly<{
+  message: UIMessage;
+  dict: ChatDict;
+  settled: boolean;
+  elapsedLabel?: string;
+}>;
+
+function MessageItem({ message, dict, settled, elapsedLabel }: ItemProps) {
+  const tools = message.parts.filter(isToolPart);
+  const rest = message.parts.filter((part) => !isToolPart(part));
+  return (
+    <li className={`chat-message chat-message--${message.role}`}>
+      <Pipeline parts={tools} settled={settled} elapsedLabel={elapsedLabel} dict={dict} />
+      <MessageBody parts={rest} messageId={message.id} dict={dict} />
+    </li>
+  );
+}
+
+function isActive(status: ChatStatus): boolean {
+  return status === "submitted" || status === "streaming";
+}
+
+function elapsedFor(isLast: boolean, settledDurationMs?: number): string | undefined {
+  if (!isLast || settledDurationMs === undefined) return undefined;
+  return formatElapsed(settledDurationMs);
+}
+
+type RowProps = Readonly<{
+  message: UIMessage;
+  isLast: boolean;
+  dict: ChatDict;
+  status: ChatStatus;
+  settledDurationMs?: number;
+}>;
+
+function MessageRow({ message, isLast, dict, status, settledDurationMs }: RowProps) {
+  const settled = !(isLast && isActive(status));
+  return (
+    <MessageItem message={message} dict={dict} settled={settled} elapsedLabel={elapsedFor(isLast, settledDurationMs)} />
+  );
+}
+
+type ListProps = Readonly<{
+  messages: readonly UIMessage[];
+  dict: ChatDict;
+  status: ChatStatus;
+  settledDurationMs?: number;
+}>;
+
+export function MessageList({ messages, dict, status, settledDurationMs }: ListProps) {
   if (messages.length === 0) return null;
-  const items = messages.map((message) => <MessageItem key={message.id} message={message} dict={dict} />);
+  const lastIndex = messages.length - 1;
+  const items = messages.map((message, index) => (
+    <MessageRow key={message.id} message={message} isLast={index === lastIndex} dict={dict} status={status} settledDurationMs={settledDurationMs} />
+  ));
   return <ol className="chat-messages">{items}</ol>;
 }

--- a/apps/web/src/features/chat/components/MoodCard.tsx
+++ b/apps/web/src/features/chat/components/MoodCard.tsx
@@ -1,0 +1,12 @@
+import type { Mood } from "../mood";
+
+/** B2c long-wait card: the title's line over a gradient, with attribution. */
+export function MoodCard({ mood }: Readonly<{ mood: Mood | undefined }>) {
+  if (!mood) return null;
+  return (
+    <figure className="chat-mood entrance-up">
+      <blockquote className="chat-mood__quote">{mood.quote}</blockquote>
+      <figcaption className="chat-mood__source">{mood.source}</figcaption>
+    </figure>
+  );
+}

--- a/apps/web/src/features/chat/components/SettledFootprint.tsx
+++ b/apps/web/src/features/chat/components/SettledFootprint.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import type { ChatDict } from "../i18n";
+
+type Props = Readonly<{ elapsedLabel?: string; dict: ChatDict; children: ReactNode }>;
+
+function FootprintSummary({ elapsedLabel, dict }: Readonly<{ elapsedLabel?: string; dict: ChatDict }>) {
+  return (
+    <summary className="chat-settled__summary">
+      ✓{elapsedLabel ? <span className="chat-settled__elapsed"> {elapsedLabel}</span> : null} ·{" "}
+      {dict.footprintDetails} ▾
+    </summary>
+  );
+}
+
+/** B4: a settled turn's pipeline collapses into one expandable footprint row. */
+export function SettledFootprint({ elapsedLabel, dict, children }: Props) {
+  return (
+    <details className="chat-settled">
+      <FootprintSummary elapsedLabel={elapsedLabel} dict={dict} />
+      {children}
+    </details>
+  );
+}

--- a/apps/web/src/features/chat/components/TypingIndicator.tsx
+++ b/apps/web/src/features/chat/components/TypingIndicator.tsx
@@ -1,4 +1,3 @@
-import type { ChatStatus } from "ai";
 import type { ChatDict } from "../i18n";
 import { FoxAvatar } from "./FoxAvatar";
 
@@ -22,11 +21,4 @@ export function TypingIndicator({ dict }: Props) {
       <TypingDots />
     </div>
   );
-}
-
-type GateProps = Readonly<{ status: ChatStatus; dict: ChatDict }>;
-
-export function TypingGate({ status, dict }: GateProps) {
-  if (status !== "submitted") return null;
-  return <TypingIndicator dict={dict} />;
 }

--- a/apps/web/src/features/chat/components/WaitingRitual.tsx
+++ b/apps/web/src/features/chat/components/WaitingRitual.tsx
@@ -1,0 +1,43 @@
+import type { ChatStatus, UIMessage } from "ai";
+import type { ChatDict } from "../i18n";
+import { pickMood } from "../mood";
+import { useTurnClock } from "../use-turn-clock";
+import { waitingPhase } from "../waiting";
+import type { WaitingPhase } from "../waiting";
+import { MoodCard } from "./MoodCard";
+import { TypingIndicator } from "./TypingIndicator";
+
+type Props = Readonly<{ status: ChatStatus; dict: ChatDict; messages: readonly UIMessage[] }>;
+
+function lastUserText(messages: readonly UIMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message?.role !== "user") continue;
+    return message.parts.map((part) => (part.type === "text" ? part.text : "")).join("");
+  }
+  return "";
+}
+
+function WaitingSubtitle({ dict }: Readonly<{ dict: ChatDict }>) {
+  return <p className="chat-waiting__subtitle">{dict.waitingSubtitle}</p>;
+}
+
+type LayerProps = Readonly<{ phase: WaitingPhase; dict: ChatDict; messages: readonly UIMessage[] }>;
+
+function WaitingLayers({ phase, dict, messages }: LayerProps) {
+  return (
+    <div className="chat-waiting">
+      <TypingIndicator dict={dict} />
+      {phase === "B2a" ? null : <WaitingSubtitle dict={dict} />}
+      {phase === "B2c" ? <MoodCard mood={pickMood(lastUserText(messages))} /> : null}
+    </div>
+  );
+}
+
+/** B2a→B2c waiting ritual: fox typing, a fox subtitle, then a mood card. */
+export function WaitingRitual({ status, dict, messages }: Props) {
+  const active = status === "submitted";
+  const elapsedMs = useTurnClock(active);
+  if (!active) return null;
+  return <WaitingLayers phase={waitingPhase(elapsedMs)} dict={dict} messages={messages} />;
+}

--- a/apps/web/src/features/chat/i18n.ts
+++ b/apps/web/src/features/chat/i18n.ts
@@ -15,6 +15,8 @@ export interface ChatDict {
   readonly preparing: string;
   readonly foxAlt: string;
   readonly thinking: string;
+  readonly waitingSubtitle: string;
+  readonly footprintDetails: string;
 }
 
 const ja: ChatDict = {
@@ -35,6 +37,8 @@ const ja: ChatDict = {
   preparing: "じゅんびちゅう…",
   foxAlt: "アニミチ",
   thinking: "考え中…",
+  waitingSubtitle: "いま さがしてるよ…",
+  footprintDetails: "詳細を見る",
 };
 
 const zh: ChatDict = {
@@ -51,6 +55,8 @@ const zh: ChatDict = {
   preparing: "准备中…",
   foxAlt: "Animichi",
   thinking: "思考中…",
+  waitingSubtitle: "正在帮你找…",
+  footprintDetails: "查看详情",
 };
 
 const en: ChatDict = {
@@ -71,6 +77,8 @@ const en: ChatDict = {
   preparing: "Getting ready…",
   foxAlt: "Animichi",
   thinking: "Thinking…",
+  waitingSubtitle: "Looking that up…",
+  footprintDetails: "View details",
 };
 
 const CHAT_DICTIONARIES: Record<Locale, ChatDict> = { ja, zh, en };

--- a/apps/web/src/features/chat/mood.ts
+++ b/apps/web/src/features/chat/mood.ts
@@ -1,0 +1,18 @@
+/** A B2c mood card: a title's line + attribution shown during a long wait. */
+export interface Mood {
+  readonly quote: string;
+  readonly source: string;
+}
+
+type MoodEntry = Mood & { readonly keyword: string };
+
+const MOODS: readonly MoodEntry[] = [
+  { keyword: "ユーフォ", quote: "ここから、はじまるんだ。", source: "— 響け!ユーフォニアム" },
+  { keyword: "君の名", quote: "君の、名前は——", source: "— 君の名は。" },
+];
+
+/** Match the pending user text to a known title; undefined skips the card. */
+export function pickMood(text: string): Mood | undefined {
+  const entry = MOODS.find((mood) => text.includes(mood.keyword));
+  return entry ? { quote: entry.quote, source: entry.source } : undefined;
+}

--- a/apps/web/src/features/chat/telemetry.ts
+++ b/apps/web/src/features/chat/telemetry.ts
@@ -1,0 +1,26 @@
+/** Frontend-only turn timing signals (first-token SLO is gated server-side). */
+export type ChatTimingKind = "first_token" | "turn";
+
+export interface ChatTimingEvent {
+  readonly kind: ChatTimingKind;
+  readonly ms: number;
+}
+
+export type ChatTimingReporter = (event: ChatTimingEvent) => void;
+
+const latest: Partial<Record<ChatTimingKind, number>> = {};
+
+/** Record a turn timing signal: kept in-memory and marked on the perf timeline. */
+export function recordChatTiming(event: ChatTimingEvent): void {
+  latest[event.kind] = event.ms;
+  performance.mark(`chat:${event.kind}`);
+}
+
+export function lastChatTiming(kind: ChatTimingKind): number | undefined {
+  return latest[kind];
+}
+
+/** Human-readable "9.2s" label for a settled turn's elapsed time. */
+export function formatElapsed(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}

--- a/apps/web/src/features/chat/use-turn-clock.ts
+++ b/apps/web/src/features/chat/use-turn-clock.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef, useState } from "react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+
+const TICK_MS = 250;
+
+function runClock(active: boolean, startedAt: RefObject<number>, set: Dispatch<SetStateAction<number>>) {
+  if (!active) { set(0); return undefined; }
+  startedAt.current = Date.now();
+  const id = setInterval(() => { set(Date.now() - startedAt.current); }, TICK_MS);
+  return () => { clearInterval(id); };
+}
+
+/** Live elapsed-ms ticker for the turn-waiting ritual; zero while inactive. */
+export function useTurnClock(active: boolean): number {
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const startedAt = useRef(0);
+  useEffect(() => runClock(active, startedAt, setElapsedMs), [active]);
+  return elapsedMs;
+}

--- a/apps/web/src/features/chat/use-turn-timing.ts
+++ b/apps/web/src/features/chat/use-turn-timing.ts
@@ -1,0 +1,57 @@
+import type { ChatStatus } from "ai";
+import { useEffect, useRef, useState } from "react";
+import type { ChatTimingReporter } from "./telemetry";
+import { recordChatTiming } from "./telemetry";
+
+interface Tracker {
+  startedAt: number;
+  firstToken: boolean;
+}
+
+function onSubmitted(ref: Tracker): void {
+  ref.startedAt = Date.now();
+  ref.firstToken = false;
+}
+
+function reportFirstToken(ref: Tracker, report: ChatTimingReporter): void {
+  if (ref.firstToken) return;
+  ref.firstToken = true;
+  report({ kind: "first_token", ms: Date.now() - ref.startedAt });
+}
+
+function settleTurn(ref: Tracker, report: ChatTimingReporter): number {
+  const ms = Date.now() - ref.startedAt;
+  ref.startedAt = 0;
+  report({ kind: "turn", ms });
+  return ms;
+}
+
+/** One status transition → the settled turn duration, or undefined mid-turn. */
+function stepTiming(status: ChatStatus, ref: Tracker, report: ChatTimingReporter): number | undefined {
+  if (status === "submitted") { onSubmitted(ref); return undefined; }
+  if (ref.startedAt === 0) return undefined;
+  if (status === "streaming") { reportFirstToken(ref, report); return undefined; }
+  return settleTurn(ref, report);
+}
+
+function applyTiming(
+  status: ChatStatus,
+  ref: Tracker,
+  report: ChatTimingReporter,
+  setLast: (ms: number) => void,
+): void {
+  const ms = stepTiming(status, ref, report);
+  if (ms !== undefined) setLast(ms);
+}
+
+/** Times each turn: first-token latency (submitted→streaming) + total duration. */
+export function useTurnTiming(status: ChatStatus, report: ChatTimingReporter = recordChatTiming) {
+  const [lastDurationMs, setLastDurationMs] = useState<number>();
+  const tracker = useRef<Tracker>({ startedAt: 0, firstToken: false });
+  const reportRef = useRef(report);
+  reportRef.current = report;
+  useEffect(() => {
+    applyTiming(status, tracker.current, reportRef.current, setLastDurationMs);
+  }, [status]);
+  return lastDurationMs;
+}

--- a/apps/web/src/features/chat/waiting.ts
+++ b/apps/web/src/features/chat/waiting.ts
@@ -1,0 +1,11 @@
+/** Elapsed-time thresholds (ms) that escalate the turn-waiting ritual. */
+export const WAITING_THRESHOLDS = { pipeline: 1000, mood: 4000 } as const;
+
+/** B2a running <1s · B2b pipeline 1-4s · B2c mood card ≥4s (states spec §B). */
+export type WaitingPhase = "B2a" | "B2b" | "B2c";
+
+export function waitingPhase(elapsedMs: number): WaitingPhase {
+  if (elapsedMs >= WAITING_THRESHOLDS.mood) return "B2c";
+  if (elapsedMs >= WAITING_THRESHOLDS.pipeline) return "B2b";
+  return "B2a";
+}

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -185,9 +185,56 @@
   color: var(--color-muted-fg);
 }
 
+.chat-waiting {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chat-waiting__subtitle {
+  font-size: 0.8125rem;
+  color: var(--color-muted-fg);
+}
+
+.chat-mood {
+  margin: 0;
+  padding: 0.875rem 1rem;
+  border-radius: 14px;
+  color: var(--color-primary-fg);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  box-shadow: 0 3px 0 var(--shadow-3d);
+}
+
+.chat-mood__quote {
+  margin: 0;
+  font-size: 1rem;
+  text-shadow: 0 1px 2px var(--shadow-3d);
+}
+
+.chat-mood__source {
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
 .chat-footprint {
   font-size: 0.8125rem;
   color: var(--color-muted-fg);
+}
+
+.chat-settled {
+  font-size: 0.8125rem;
+  color: var(--color-muted-fg);
+}
+
+.chat-settled__summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+.chat-settled__elapsed {
+  font-weight: 600;
+  color: var(--color-primary-strong);
 }
 
 .chat-error-banner {

--- a/apps/web/tests/unit/chat/chat-design-css.test.ts
+++ b/apps/web/tests/unit/chat/chat-design-css.test.ts
@@ -37,3 +37,20 @@ describe("B2a typing dots", () => {
     expect(ruleDeclaration(chatCss, ".chat-typing__dot:nth-child(3)", "animation-delay")).toBe("0.3s");
   });
 });
+
+describe("B2c mood card: gradient over semantic tokens", () => {
+  it("paints the quote over a primary-token gradient with light text", () => {
+    expect(ruleDeclaration(chatCss, ".chat-mood", "color")).toBe("var(--color-primary-fg)");
+    expect(ruleDeclaration(chatCss, ".chat-mood", "background")).toContain("var(--color-primary-strong)");
+  });
+
+  it("keeps the quote legible with a text-shadow", () => {
+    expect(ruleDeclaration(chatCss, ".chat-mood__quote", "text-shadow")).toContain("var(--shadow-3d)");
+  });
+});
+
+describe("B4 settled footprint: elapsed emphasis over a semantic token", () => {
+  it("emphasises the elapsed time with the primary-strong token", () => {
+    expect(ruleDeclaration(chatCss, ".chat-settled__elapsed", "color")).toBe("var(--color-primary-strong)");
+  });
+});

--- a/apps/web/tests/unit/chat/chat-page-stream.test.tsx
+++ b/apps/web/tests/unit/chat/chat-page-stream.test.tsx
@@ -44,6 +44,19 @@ describe("send flow over the recorded search stream", () => {
   });
 });
 
+describe("B4 settled footprint", () => {
+  it("collapses the completed pipeline into an expandable footprint row", async () => {
+    server.use(chatStreamHandler("search"));
+    renderChatPage();
+    sendText("ユーフォ");
+    await screen.findByText("宇治の聖地を2件、徒歩ルートにまとめました。");
+    await waitFor(() => {
+      expect(document.querySelector(".chat-settled")).toBeTruthy();
+    });
+    expect(screen.getAllByText(ja.footprintDetails, { exact: false }).length).toBeGreaterThan(0);
+  });
+});
+
 describe("A1 example chips", () => {
   it("sends the chip text as a user message on click", async () => {
     server.use(chatStreamHandler("clarify"));

--- a/apps/web/tests/unit/chat/i18n.test.ts
+++ b/apps/web/tests/unit/chat/i18n.test.ts
@@ -12,6 +12,8 @@ describe("chatDictFor", () => {
     expect(dict.retry.length).toBeGreaterThan(0);
     expect(dict.foxAlt.length).toBeGreaterThan(0);
     expect(dict.thinking.length).toBeGreaterThan(0);
+    expect(dict.waitingSubtitle.length).toBeGreaterThan(0);
+    expect(dict.footprintDetails.length).toBeGreaterThan(0);
   });
 
   it("self-references the fox persona as Animichi in every locale", () => {

--- a/apps/web/tests/unit/chat/message-list.test.tsx
+++ b/apps/web/tests/unit/chat/message-list.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { UIMessage } from "ai";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MessageList } from "../../../src/features/chat/components/MessageList";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+
+const ja = chatDictFor("ja");
+
+afterEach(cleanup);
+
+function textMessage(): UIMessage {
+  return { id: "a1", role: "assistant", parts: [{ type: "text", text: "こんにちは!" }] };
+}
+
+function toolMessage(): UIMessage {
+  const tool = { type: "tool-resolve_anime", toolCallId: "t1", state: "output-available" };
+  return { id: "a2", role: "assistant", parts: [tool] as unknown as UIMessage["parts"] };
+}
+
+describe("MessageList pure-text turn (Empty: B2a→B4, no pipeline)", () => {
+  it("renders a text-only assistant turn without any pipeline or footprint", () => {
+    render(<MessageList messages={[textMessage()]} dict={ja} status="ready" />);
+    expect(screen.getByText("こんにちは!")).toBeTruthy();
+    expect(document.querySelector(".chat-step")).toBeNull();
+    expect(document.querySelector(".chat-settled")).toBeNull();
+  });
+});
+
+describe("MessageList pipeline collapse", () => {
+  it("collapses a settled tool turn into a footprint row with elapsed time", () => {
+    render(<MessageList messages={[toolMessage()]} dict={ja} status="ready" settledDurationMs={9200} />);
+    expect(document.querySelector(".chat-settled")).toBeTruthy();
+    expect(screen.getByText("9.2s")).toBeTruthy();
+  });
+
+  it("keeps the pipeline inline while the turn is still streaming", () => {
+    render(<MessageList messages={[toolMessage()]} dict={ja} status="streaming" />);
+    expect(document.querySelector(".chat-settled")).toBeNull();
+    expect(screen.getByText("resolve_anime")).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/chat/mood-card.test.tsx
+++ b/apps/web/tests/unit/chat/mood-card.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MoodCard } from "../../../src/features/chat/components/MoodCard";
+
+afterEach(cleanup);
+
+describe("B2c MoodCard", () => {
+  it("renders the quote and its attribution when mood data exists", () => {
+    render(<MoodCard mood={{ quote: "ここから、はじまるんだ。", source: "— 響け!ユーフォニアム" }} />);
+    expect(screen.getByText("ここから、はじまるんだ。")).toBeTruthy();
+    expect(screen.getByText("— 響け!ユーフォニアム")).toBeTruthy();
+  });
+
+  it("gracefully skips (renders nothing) when no quote data exists for the title", () => {
+    const { container } = render(<MoodCard mood={undefined} />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/apps/web/tests/unit/chat/mood.test.ts
+++ b/apps/web/tests/unit/chat/mood.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { pickMood } from "../../../src/features/chat/mood";
+
+describe("pickMood", () => {
+  it("returns a quote and its source for a recognised title", () => {
+    const mood = pickMood("ユーフォニアムの聖地に行きたい");
+    expect(mood?.source).toContain("ユーフォニアム");
+    expect(mood?.quote.length).toBeGreaterThan(0);
+  });
+
+  it("returns undefined when no title matches the waiting text", () => {
+    expect(pickMood("近くの聖地をさがして")).toBeUndefined();
+  });
+});

--- a/apps/web/tests/unit/chat/settled-footprint.test.tsx
+++ b/apps/web/tests/unit/chat/settled-footprint.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SettledFootprint } from "../../../src/features/chat/components/SettledFootprint";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+
+const ja = chatDictFor("ja");
+
+afterEach(cleanup);
+
+describe("B4 SettledFootprint", () => {
+  it("collapses the pipeline into an expandable row with the elapsed time", () => {
+    render(
+      <SettledFootprint elapsedLabel="9.2s" dict={ja}>
+        <span>resolve_anime</span>
+      </SettledFootprint>,
+    );
+    expect(screen.getByText("9.2s")).toBeTruthy();
+    expect(screen.getByText(ja.footprintDetails, { exact: false })).toBeTruthy();
+  });
+
+  it("keeps the collapsed pipeline steps in the DOM for expansion", () => {
+    render(
+      <SettledFootprint elapsedLabel="9.2s" dict={ja}>
+        <span>plan_route</span>
+      </SettledFootprint>,
+    );
+    expect(screen.getByText("plan_route")).toBeTruthy();
+  });
+
+  it("omits the elapsed emphasis when no duration is known", () => {
+    const { container } = render(
+      <SettledFootprint dict={ja}>
+        <span>search_bangumi</span>
+      </SettledFootprint>,
+    );
+    expect(container.querySelector(".chat-settled__elapsed")).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/chat/telemetry.test.ts
+++ b/apps/web/tests/unit/chat/telemetry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatElapsed,
+  lastChatTiming,
+  recordChatTiming,
+} from "../../../src/features/chat/telemetry";
+
+describe("recordChatTiming", () => {
+  it("keeps the latest first-token latency retrievable", () => {
+    recordChatTiming({ kind: "first_token", ms: 1234 });
+    expect(lastChatTiming("first_token")).toBe(1234);
+  });
+
+  it("tracks turn duration independently of first-token latency", () => {
+    recordChatTiming({ kind: "first_token", ms: 800 });
+    recordChatTiming({ kind: "turn", ms: 9200 });
+    expect(lastChatTiming("first_token")).toBe(800);
+    expect(lastChatTiming("turn")).toBe(9200);
+  });
+
+  it("emits a performance mark named after the timing kind", () => {
+    performance.clearMarks("chat:first_token");
+    recordChatTiming({ kind: "first_token", ms: 500 });
+    expect(performance.getEntriesByName("chat:first_token").length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatElapsed", () => {
+  it.each([
+    [9200, "9.2s"],
+    [800, "0.8s"],
+    [12000, "12.0s"],
+  ] as const)("renders %ims as %s", (ms, label) => {
+    expect(formatElapsed(ms)).toBe(label);
+  });
+});

--- a/apps/web/tests/unit/chat/typing-indicator.test.tsx
+++ b/apps/web/tests/unit/chat/typing-indicator.test.tsx
@@ -3,10 +3,7 @@
  */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  TypingGate,
-  TypingIndicator,
-} from "../../../src/features/chat/components/TypingIndicator";
+import { TypingIndicator } from "../../../src/features/chat/components/TypingIndicator";
 import { chatDictFor } from "../../../src/features/chat/i18n";
 
 const ja = chatDictFor("ja");
@@ -25,17 +22,5 @@ describe("B2a TypingIndicator", () => {
     render(<TypingIndicator dict={ja} />);
     const status = screen.getByRole("status", { name: ja.thinking });
     expect(status.querySelectorAll('[aria-hidden="true"] *').length).toBe(3);
-  });
-});
-
-describe("TypingGate", () => {
-  it("shows the indicator while a turn is submitted", () => {
-    render(<TypingGate status="submitted" dict={ja} />);
-    expect(screen.getByRole("status", { name: ja.thinking })).toBeTruthy();
-  });
-
-  it.each(["ready", "streaming", "error"] as const)("stays hidden when status is %s", (status) => {
-    render(<TypingGate status={status} dict={ja} />);
-    expect(screen.queryByRole("status", { name: ja.thinking })).toBeNull();
   });
 });

--- a/apps/web/tests/unit/chat/use-turn-clock.test.tsx
+++ b/apps/web/tests/unit/chat/use-turn-clock.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTurnClock } from "../../../src/features/chat/use-turn-clock";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useTurnClock", () => {
+  it("stays at zero while the turn is inactive", () => {
+    const { result } = renderHook(() => useTurnClock(false));
+    act(() => { vi.advanceTimersByTime(5000); });
+    expect(result.current).toBe(0);
+  });
+
+  it("accumulates elapsed milliseconds while the turn is active", () => {
+    const { result } = renderHook(() => useTurnClock(true));
+    act(() => { vi.advanceTimersByTime(2000); });
+    expect(result.current).toBeGreaterThanOrEqual(2000);
+  });
+
+  it("resets to zero once the turn goes inactive again", () => {
+    const { rerender, result } = renderHook(({ active }) => useTurnClock(active), {
+      initialProps: { active: true },
+    });
+    act(() => { vi.advanceTimersByTime(2000); });
+    rerender({ active: false });
+    expect(result.current).toBe(0);
+  });
+});

--- a/apps/web/tests/unit/chat/use-turn-timing.test.tsx
+++ b/apps/web/tests/unit/chat/use-turn-timing.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { ChatStatus } from "ai";
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTurnTiming } from "../../../src/features/chat/use-turn-timing";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function renderTiming(report: (kind: string, ms: number) => void) {
+  const wrapped = ({ kind, ms }: { kind: string; ms: number }) => {
+    report(kind, ms);
+  };
+  return renderHook(({ status }: { status: ChatStatus }) => useTurnTiming(status, wrapped), {
+    initialProps: { status: "ready" as ChatStatus },
+  });
+}
+
+describe("useTurnTiming", () => {
+  it("reports first-token latency on the submitted→streaming transition", () => {
+    const report = vi.fn();
+    const { rerender } = renderTiming(report);
+    rerender({ status: "submitted" });
+    vi.advanceTimersByTime(1200);
+    rerender({ status: "streaming" });
+    expect(report).toHaveBeenCalledWith("first_token", 1200);
+  });
+
+  it("reports and returns the total turn duration once settled", () => {
+    const report = vi.fn();
+    const { rerender, result } = renderTiming(report);
+    rerender({ status: "submitted" });
+    vi.advanceTimersByTime(800);
+    rerender({ status: "streaming" });
+    vi.advanceTimersByTime(8400);
+    rerender({ status: "ready" });
+    expect(report).toHaveBeenCalledWith("turn", 9200);
+    expect(result.current).toBe(9200);
+  });
+
+  it("stays idle when the session starts ready with no turn in flight", () => {
+    const report = vi.fn();
+    const { result } = renderTiming(report);
+    expect(report).not.toHaveBeenCalled();
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/apps/web/tests/unit/chat/waiting-ritual.test.tsx
+++ b/apps/web/tests/unit/chat/waiting-ritual.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { UIMessage } from "ai";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WaitingRitual } from "../../../src/features/chat/components/WaitingRitual";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+
+const ja = chatDictFor("ja");
+
+function userMessage(text: string): UIMessage {
+  return { id: "u1", role: "user", parts: [{ type: "text", text }] };
+}
+
+function renderRitual(text = "ユーフォ") {
+  return render(<WaitingRitual status="submitted" dict={ja} messages={[userMessage(text)]} />);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe("WaitingRitual escalation", () => {
+  it("shows only the fox typing indicator under one second (B2a)", () => {
+    renderRitual();
+    expect(screen.getByRole("status", { name: ja.thinking })).toBeTruthy();
+    expect(screen.queryByText(ja.waitingSubtitle)).toBeNull();
+  });
+
+  it("adds the first-person fox subtitle after one second (B2b)", () => {
+    renderRitual();
+    act(() => { vi.advanceTimersByTime(1500); });
+    expect(screen.getByText(ja.waitingSubtitle)).toBeTruthy();
+  });
+
+  it("adds the mood card for a known title after four seconds (B2c)", () => {
+    renderRitual();
+    act(() => { vi.advanceTimersByTime(4200); });
+    expect(screen.getByText("ここから、はじまるんだ。")).toBeTruthy();
+  });
+
+  it("keeps the mood card hidden for an untitled long wait", () => {
+    renderRitual("近くの聖地");
+    act(() => { vi.advanceTimersByTime(4200); });
+    expect(screen.queryByRole("figure")).toBeNull();
+  });
+
+  it("skips the mood card when the pending turn has no user text to match", () => {
+    const assistant: UIMessage = { id: "a1", role: "assistant", parts: [{ type: "text", text: "…" }] };
+    render(<WaitingRitual status="submitted" dict={ja} messages={[assistant]} />);
+    act(() => { vi.advanceTimersByTime(4200); });
+    expect(screen.queryByRole("figure")).toBeNull();
+  });
+
+  it("ignores non-text parts when reading the pending user title", () => {
+    const parts = [{ type: "step-start" }, { type: "text", text: "ユーフォ" }];
+    const mixed = { id: "u9", role: "user", parts } as unknown as UIMessage;
+    render(<WaitingRitual status="submitted" dict={ja} messages={[mixed]} />);
+    act(() => { vi.advanceTimersByTime(4200); });
+    expect(screen.getByText("ここから、はじまるんだ。")).toBeTruthy();
+  });
+
+  it("renders nothing once the turn is no longer submitted", () => {
+    const { container } = render(
+      <WaitingRitual status="streaming" dict={ja} messages={[userMessage("ユーフォ")]} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/apps/web/tests/unit/chat/waiting.test.ts
+++ b/apps/web/tests/unit/chat/waiting.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { WAITING_THRESHOLDS, waitingPhase } from "../../../src/features/chat/waiting";
+
+describe("waitingPhase escalation (states spec B2a→B2b→B2c)", () => {
+  it.each([
+    [0, "B2a"],
+    [999, "B2a"],
+    [1000, "B2b"],
+    [3999, "B2b"],
+    [4000, "B2c"],
+    [12000, "B2c"],
+  ] as const)("maps %ims of elapsed waiting to %s", (elapsedMs, phase) => {
+    expect(waitingPhase(elapsedMs)).toBe(phase);
+  });
+
+  it("keeps the pipeline threshold below the mood threshold", () => {
+    expect(WAITING_THRESHOLDS.pipeline).toBeLessThan(WAITING_THRESHOLDS.mood);
+  });
+});


### PR DESCRIPTION
## Card #258 (frontend half) — S1.2 Turn-waiting ritual + settled footprint + first-token SLO front-end instrumentation

Implements the front-end half of S1.2 (iter-1). The backend warm-p95 first-token SLO gate is **out of scope** for this card (Tester G2 / follow-up); this PR delivers only the waiting ritual, settled footprint, and front-end timing instrumentation. Base = `feat/frontend-rebuild`. All changes are confined to the chat area (`apps/web/src/features/chat/**` + `apps/web/src/styles/chat.css`); no touching of `use-chat-session.ts` / `use-conversation-history.ts` auth injection.

### What landed
1. **Turn-waiting ritual** (`WaitingRitual` + `waiting.ts` + `use-turn-clock.ts`): after send, escalates by elapsed time — B2a fox typing (<1s) → B2b first-person fox subtitle (1–4s) → B2c mood card (≥4s). Reuses the #400 typing indicator + existing gold/shimmer running-step tokens.
2. **Settled footprint** (`SettledFootprint` + `MessageList` collapse): a completed turn's tool pipeline collapses into a single expandable `<details>` footprint row carrying the turn's elapsed time ("9.2s"). Live-streaming turns keep the inline pipeline.
3. **First-token telemetry** (`telemetry.ts` + `use-turn-timing.ts`): records first-token latency (submitted→streaming) and total turn duration, kept in-memory + emitted as `performance.mark`s. No backend SLO gate.

### AC → test mapping
- B2a only fox typing <1s → `waiting-ritual.test.tsx`
- B2b pipeline/subtitle at 1–4s (badges already tool-part-driven) → `waiting-ritual.test.tsx`, `chat-page-stream.test.tsx`
- Empty: pure-text turn never shows skeleton/pipeline (B2a→B4) → `message-list.test.tsx`
- Error: B2c mood card gracefully skips when no quote data → `mood-card.test.tsx`, `mood.test.ts` (unit)
- Multi-turn: settled state collapses pipeline into one footprint row + elapsed → `settled-footprint.test.tsx`, `chat-page-stream.test.tsx`, `message-list.test.tsx`
- i18n: waiting subtitle + footprint copy in ja/zh/en → `i18n.test.ts`

### Gate (run in `apps/web/`)
- `pnpm run typecheck` — No errors found
- `pnpm run lint:oxlint` — clean (type-aware, --deny-warnings)
- `pnpm run build` — Nitro/Cloudflare build OK (routeTree regenerated)
- `pnpm test` — 569 passed; coverage Stmts 99.07 / Branches 95.11 / Funcs 99.64 / Lines 99.81 (floors 90/90/90/90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)