### PR TITLE
feat(ci): tier the agent eval gate — L0 smoke on PRs, L1 nightly (#228, #227)

### DIFF
--- a/.github/workflows/agent-eval-nightly.yml
+++ b/.github/workflows/agent-eval-nightly.yml
@@ -17,6 +17,13 @@ on:
 permissions:
   contents: read
 
+# One nightly (or dispatched) run at a time — an overlapping second run would burn real
+# MIMO_API_KEY spend for no benefit. cancel-in-progress stays false: cancelling a live LLM
+# eval run wastes the tokens it already spent, so a second trigger queues instead.
+concurrency:
+  group: agent-eval-nightly
+  cancel-in-progress: false
+
 env:
   PYTHON_VERSION: "3.11"
   NODE_VERSION: "24"

--- a/.github/workflows/agent-eval-nightly.yml
+++ b/.github/workflows/agent-eval-nightly.yml
@@ -39,15 +39,15 @@ jobs:
 
       - run: uv python install ${{ env.PYTHON_VERSION }}
 
-      - run: uv sync --all-extras
+      - run: uv sync --frozen --all-extras
 
       - name: Run L1 full trajectory eval (uncapped — owns the statistical baseline)
-        run: uv run pytest agent/tests/eval/test_agent_eval.py::test_agent_trajectory -v -m integration --no-cov -x
+        run: uv run --frozen pytest agent/tests/eval/test_agent_eval.py::test_agent_trajectory -v -m integration --no-cov -x
         env:
           EVAL_MODEL: openai:mimo-v2.5@https://api.xiaomimimo.com/v1
           MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
 
       - name: Run translation eval
-        run: uv run pytest agent/tests/eval/test_translation.py -v -m integration --no-cov -x
+        run: uv run --frozen pytest agent/tests/eval/test_translation.py -v -m integration --no-cov -x
         env:
           MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}

--- a/.github/workflows/agent-eval-nightly.yml
+++ b/.github/workflows/agent-eval-nightly.yml
@@ -1,0 +1,53 @@
+# Standalone top-level workflow (see .claude/rules/ci.md: codeql.yml / dependabot-agent.yml
+# precedent) — kept separate from ci.yml so the nightly cron cadence never rides along with
+# every push/PR trigger in the main CI matrix (ci.yml's own jobs largely key off
+# `github.event_name != 'pull_request'`, which a shared `schedule:` trigger would also flip
+# true for, running the entire component-CI fan-out nightly for no reason).
+name: Agent Eval (L1 nightly)
+
+# SD-30 §① trigger axis: the uncapped L1 full suite runs nightly + on manual dispatch —
+# never on PRs (see ci.yml's agent-eval-smoke for the PR-gated, capped L0 tier). This job
+# owns the statistical baseline (agent/tests/eval/baselines/agent_l4_trajectory_<model>.json)
+# via the existing finish_cli_report bootstrap/paired-comparison gate (agent/tests/eval/gate.py).
+on:
+  schedule:
+    - cron: "14 19 * * *" # 19:14 UTC daily (~03:14 next-day CST) — low-traffic, off the hour
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.11"
+  NODE_VERSION: "24"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  agent-eval-full:
+    name: Agent Eval (L1 full, uncapped)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/agent
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+        with:
+          python: "true"
+
+      - run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - run: uv sync --all-extras
+
+      - name: Run L1 full trajectory eval (uncapped — owns the statistical baseline)
+        run: uv run pytest agent/tests/eval/test_agent_eval.py::test_agent_trajectory -v -m integration --no-cov -x
+        env:
+          EVAL_MODEL: openai:mimo-v2.5@https://api.xiaomimimo.com/v1
+          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+
+      - name: Run translation eval
+        run: uv run pytest agent/tests/eval/test_translation.py -v -m integration --no-cov -x
+        env:
+          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,10 @@ jobs:
             # drives ci-agent's lint/type/test/coverage). agents/** carries the system prompt
             # (animichi_agent.py), the ModelRetry/output_validator/repeat-guard hooks, the
             # runner's usage-limit + error-classification guardrails, and the model-resolution
-            # glue (base.py); model_aliases.py is the concrete provider/thinking-mode registry.
-            agent_behavior: ['apps/agent/agent/agents/**', 'apps/agent/agent/config/model_aliases.py']
+            # glue (base.py); model_aliases.py is the concrete provider/thinking-mode registry;
+            # settings.py is where the production model spec actually lives (default_agent_model,
+            # model_attempt_timeout) — a PR flipping the prod model would live here, not in agents/**.
+            agent_behavior: ['apps/agent/agent/agents/**', 'apps/agent/agent/config/model_aliases.py', 'apps/agent/agent/config/settings.py']
             frontend: ['frontend/**']
             web: ['apps/web/**']
             worker: ['worker/**']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       catalog: ${{ steps.f.outputs.catalog }}
       users: ${{ steps.f.outputs.users }}
       agent: ${{ steps.f.outputs.agent }}
+      agent_behavior: ${{ steps.f.outputs.agent_behavior }}
       frontend: ${{ steps.f.outputs.frontend }}
       web: ${{ steps.f.outputs.web }}
       contract: ${{ steps.f.outputs.contract }}
@@ -47,6 +48,14 @@ jobs:
             catalog: ['workers/catalog/**', 'packages/contract/**']
             users: ['workers/users/**', 'packages/contract/**']
             agent: ['apps/agent/**', 'packages/contract/**']
+            # SD-30 path-filter rule (shared verbatim with iter-1 S1.13, per the second-pass
+            # spec review): prompt/instructions + model-config + guardrail files ONLY — not
+            # every apps/agent/** change (that broader scope still gates `agent` above, which
+            # drives ci-agent's lint/type/test/coverage). agents/** carries the system prompt
+            # (animichi_agent.py), the ModelRetry/output_validator/repeat-guard hooks, the
+            # runner's usage-limit + error-classification guardrails, and the model-resolution
+            # glue (base.py); model_aliases.py is the concrete provider/thinking-mode registry.
+            agent_behavior: ['apps/agent/agent/agents/**', 'apps/agent/agent/config/model_aliases.py']
             frontend: ['frontend/**']
             web: ['apps/web/**']
             worker: ['worker/**']
@@ -180,13 +189,19 @@ jobs:
           supabase migration list --db-url "$SUPABASE_DB_URL"
           supabase db push --dry-run --db-url "$SUPABASE_DB_URL"
 
-  # ── Agent eval (deferred — see `&& false`) ───────────────────
+  # ── Agent eval: L0 smoke (SD-30 §① — required PR gate) ────────
+  # Path-filter scope = the SD-30 rule above (`agent_behavior`): prompt/model-config/
+  # guardrail files only. Capped ~80-case trajectory run; EVAL_SMOKE=1 turns the
+  # normally report-only capped run into an enforced one — zero-errored cases plus the
+  # deterministic direct_gates (thrash) — without ever touching the statistical
+  # baseline. The uncapped L1 suite (baseline + statistical gate + translation eval)
+  # runs nightly instead of on every PR — see agent-eval-nightly.yml.
 
-  agent-eval:
-    name: Agent Eval (655 cases)
+  agent-eval-smoke:
+    name: Agent Eval (L0 smoke, ~80 cases)
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.agent == 'true') && false }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.agent_behavior == 'true' }}
     defaults:
       run:
         working-directory: apps/agent
@@ -202,16 +217,13 @@ jobs:
 
       - run: uv sync --all-extras
 
-      - name: Run agent eval
-        run: uv run pytest agent/tests/eval/test_agent_eval.py -v -m integration --no-cov -x
+      - name: Run L0 smoke trajectory eval (zero-errored + direct gates)
+        run: uv run pytest agent/tests/eval/test_agent_eval.py::test_agent_trajectory -v -m integration --no-cov -x
         env:
           EVAL_MODEL: openai:mimo-v2.5@https://api.xiaomimimo.com/v1
           MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
-
-      - name: Run translation eval
-        run: uv run pytest agent/tests/eval/test_translation.py -v -m integration --no-cov -x
-        env:
-          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+          EVAL_SMOKE: "1"
+          EVAL_MAX_CASES: "80"
 
   # ── Neon test infrastructure (non-gating during calibration) ──
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,10 +215,10 @@ jobs:
 
       - run: uv python install ${{ env.PYTHON_VERSION }}
 
-      - run: uv sync --all-extras
+      - run: uv sync --frozen --all-extras
 
       - name: Run L0 smoke trajectory eval (zero-errored + direct gates)
-        run: uv run pytest agent/tests/eval/test_agent_eval.py::test_agent_trajectory -v -m integration --no-cov -x
+        run: uv run --frozen pytest agent/tests/eval/test_agent_eval.py::test_agent_trajectory -v -m integration --no-cov -x
         env:
           EVAL_MODEL: openai:mimo-v2.5@https://api.xiaomimimo.com/v1
           MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}

--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -131,6 +131,15 @@ EVAL_MAX_CASES=50 uv run python -m agent.tests.eval.run_agent_eval ...  # capped
 Direct thrash gates (req≤12 / tool≤6 / repeat=0 / p95≤6) are **report-only** until `DIRECT_GATE_ENFORCE=1`
 (owner calibrates first). Capped runs never read/write baselines.
 
+**CI tiering (SD-30, #228/#227).** `EVAL_SMOKE=1` turns a capped run from report-only into an
+enforced L0 gate: zero-errored cases + the deterministic direct thrash gates (unconditionally,
+independent of `DIRECT_GATE_ENFORCE`) — it still never reads or writes the baseline. CI wires this
+as `agent-eval-smoke` in `ci.yml` (`EVAL_SMOKE=1 EVAL_MAX_CASES=80`, required on PRs that touch
+`agents/**` or `config/model_aliases.py`). The uncapped L1 suite — owning the statistical baseline
+via `finish_cli_report`/`gate.py` — runs nightly + on `workflow_dispatch` only, in the standalone
+`agent-eval-nightly.yml` (never on PRs, so its cron cadence doesn't ride along with the PR/push
+matrix in `ci.yml`).
+
 **Post-redesign full-655 numbers (2026-07-17, the re-baseline candidate — NOT yet the committed baseline;
 the owner signs off per the redesign spec §7):**
 

--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -128,8 +128,8 @@ cd apps/agent && uv run python -m agent.tests.eval.run_agent_eval \
   --eval-model "openai:mimo-v2.5@https://api.xiaomimimo.com/v1"   # full 655
 EVAL_MAX_CASES=50 uv run python -m agent.tests.eval.run_agent_eval ...  # capped = report-only, no baseline/gate
 ```
-Direct thrash gates (req≤12 / tool≤6 / repeat=0 / p95≤6) are **report-only** until `DIRECT_GATE_ENFORCE=1`
-(owner calibrates first). Capped runs never read/write baselines.
+Direct thrash gates (req≤12 / tool≤10 / repeat=0 / p95≤8 — `agent/tests/eval/direct_gates.py`) are
+**report-only** until `DIRECT_GATE_ENFORCE=1` (owner calibrates first). Capped runs never read/write baselines.
 
 **CI tiering (SD-30, #228/#227).** `EVAL_SMOKE=1` turns a capped run from report-only into an
 enforced L0 gate: zero-errored cases + the deterministic direct thrash gates (unconditionally,

--- a/apps/agent/agent/tests/eval/eval_gate_flow.py
+++ b/apps/agent/agent/tests/eval/eval_gate_flow.py
@@ -64,6 +64,10 @@ class NoEvaluatedCases(RuntimeError):
     """Raised when every eval case failed during task execution."""
 
 
+class SmokeRequiresCappedRun(RuntimeError):
+    """Raised when EVAL_SMOKE=1 is set but the run resolved to uncapped."""
+
+
 def _scores(report: AgentReport) -> ScoreMap:
     avg = report.averages()
     if avg is None:
@@ -155,9 +159,21 @@ def _run_gate(
 ) -> list[str] | None:
     if capped:
         return _run_capped_gate(gate_input)
+    _refuse_uncapped_smoke()
     enforce_direct = _direct_gate_enforced()
     _print_direct_metrics(gate_input, include_p95=True, enforced=enforce_direct)
     return _run_uncapped_gate(gate_input, layer, baselines_dir, enforce_direct)
+
+
+def _refuse_uncapped_smoke() -> None:
+    """Never silently drop EVAL_SMOKE=1 into the uncapped statistical gate."""
+    if not _smoke_enforced():
+        return
+    raise SmokeRequiresCappedRun(
+        "EVAL_SMOKE=1 requires a capped run (EVAL_MAX_CASES below the dataset "
+        f"size, currently {len(ALL_CASES)} cases) — refusing to silently fall "
+        "through to the uncapped statistical gate."
+    )
 
 
 def _run_capped_gate(gate_input: GateInput) -> list[str]:

--- a/apps/agent/agent/tests/eval/eval_gate_flow.py
+++ b/apps/agent/agent/tests/eval/eval_gate_flow.py
@@ -129,10 +129,17 @@ def _write_baseline(
     )
 
 
-def _capped_notice(case_count: int) -> None:
+def _capped_mode_label(*, smoke: bool) -> str:
+    if smoke:
+        return "smoke-enforced (zero-errors + direct gates)"
+    return "report-only"
+
+
+def _capped_notice(case_count: int, *, smoke: bool) -> None:
+    label = _capped_mode_label(smoke=smoke)
     print(
-        f"\nCAPPED eval run: {case_count}/{len(ALL_CASES)} cases; "
-        "report-only (no baseline read/write/gate)."
+        f"\nCAPPED eval run: {case_count}/{len(ALL_CASES)} cases; {label} "
+        "(no baseline read/write/statistical gate)."
     )
 
 
@@ -146,12 +153,41 @@ def gate_report(
 def _run_gate(
     gate_input: GateInput, layer: str, baselines_dir: Path, *, capped: bool
 ) -> list[str] | None:
-    enforce_direct = _direct_gate_enforced() and not capped
-    _print_direct_metrics(gate_input, capped=capped, enforced=enforce_direct)
     if capped:
-        _capped_notice(gate_input.case_count)
-        return []
+        return _run_capped_gate(gate_input)
+    enforce_direct = _direct_gate_enforced()
+    _print_direct_metrics(gate_input, include_p95=True, enforced=enforce_direct)
     return _run_uncapped_gate(gate_input, layer, baselines_dir, enforce_direct)
+
+
+def _run_capped_gate(gate_input: GateInput) -> list[str]:
+    """L0 smoke tier: never touches the baseline; EVAL_SMOKE=1 makes it enforce."""
+    smoke = _smoke_enforced()
+    _print_direct_metrics(gate_input, include_p95=smoke, enforced=smoke)
+    _capped_notice(gate_input.case_count, smoke=smoke)
+    if not smoke:
+        return []
+    return _smoke_gate_failures(gate_input)
+
+
+def _smoke_gate_failures(gate_input: GateInput) -> list[str]:
+    return [
+        *_smoke_error_failures(gate_input),
+        *direct_thrash_gate(gate_input.trajectories),
+    ]
+
+
+def _smoke_error_failures(gate_input: GateInput) -> list[str]:
+    if gate_input.errored_count == 0:
+        return []
+    return [
+        f"{gate_input.errored_count}/{gate_input.case_count} cases errored "
+        "(EVAL_SMOKE requires zero errors)."
+    ]
+
+
+def _smoke_enforced() -> bool:
+    return os.environ.get("EVAL_SMOKE") == "1"
 
 
 def _run_uncapped_gate(
@@ -170,10 +206,10 @@ def _run_uncapped_gate(
 
 
 def _print_direct_metrics(
-    gate_input: GateInput, *, capped: bool, enforced: bool
+    gate_input: GateInput, *, include_p95: bool, enforced: bool
 ) -> None:
     print_direct_thrash_metrics(
-        gate_input.trajectories, include_p95=not capped, enforced=enforced
+        gate_input.trajectories, include_p95=include_p95, enforced=enforced
     )
 
 

--- a/apps/agent/agent/tests/unit/test_ci_eval_gate_workflow.py
+++ b/apps/agent/agent/tests/unit/test_ci_eval_gate_workflow.py
@@ -61,6 +61,7 @@ def test_agent_behavior_filter_scopes_to_prompt_model_guardrail_files() -> None:
         "apps/agent/agent/agents/base.py",  # model-resolution glue
         "apps/agent/agent/agents/web_trust.py",  # injection-defense guardrail
         "apps/agent/agent/config/model_aliases.py",  # model-config registry
+        "apps/agent/agent/config/settings.py",  # default_agent_model, model_attempt_timeout
     ]
     excluded = [
         "apps/web/src/routes/index.tsx",

--- a/apps/agent/agent/tests/unit/test_ci_eval_gate_workflow.py
+++ b/apps/agent/agent/tests/unit/test_ci_eval_gate_workflow.py
@@ -1,0 +1,118 @@
+"""Structural checks on the CI eval-gate wiring (cards #228, #227).
+
+Deterministic and offline: parses .github/workflows/ci.yml and
+agent-eval-nightly.yml as plain text — no live GitHub Actions run, no live
+model (see docstrings on individual tests for the AC each one covers). The
+workflow files ARE the spec for trigger/gate wiring; these tests pin that
+contract so a future edit can't silently regress it.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from fnmatch import fnmatch
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_NIGHTLY_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "agent-eval-nightly.yml"
+
+
+def _filter_patterns(source: str, filter_name: str) -> list[str]:
+    match = re.search(
+        rf"(?m)^\s+{re.escape(filter_name)}:\s*(?P<value>\[.*\])\s*$", source
+    )
+    assert match is not None, f"missing paths-filter entry: {filter_name}"
+    return ast.literal_eval(match["value"])
+
+
+def _named_workflow_job(source: str, job_id: str) -> str:
+    job = re.search(
+        rf"(?ms)^  {re.escape(job_id)}:\s*$\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\s*$|\Z)",
+        source,
+    )
+    assert job is not None, f"missing workflow job: {job_id}"
+    return job["body"]
+
+
+def _matches_any(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch(path, pattern) for pattern in patterns)
+
+
+def _top_level_block(source: str, key: str) -> str:
+    block = re.search(
+        rf"(?ms)^{re.escape(key)}:\s*$\n(?P<body>.*?)(?=^[a-zA-Z0-9_-]+:\s*$|\Z)",
+        source,
+    )
+    assert block is not None, f"missing top-level key: {key}"
+    return block["body"]
+
+
+def test_agent_behavior_filter_scopes_to_prompt_model_guardrail_files() -> None:
+    """Card #228 AC2 (integration): only prompt/model-config/guardrail files
+    trigger L0 smoke — not every apps/agent/** change, and not apps/web/**."""
+    patterns = _filter_patterns(
+        _CI_WORKFLOW.read_text(encoding="utf-8"), "agent_behavior"
+    )
+
+    included = [
+        "apps/agent/agent/agents/animichi_agent.py",  # prompt + ModelRetry/output_validator
+        "apps/agent/agent/agents/base.py",  # model-resolution glue
+        "apps/agent/agent/agents/web_trust.py",  # injection-defense guardrail
+        "apps/agent/agent/config/model_aliases.py",  # model-config registry
+    ]
+    excluded = [
+        "apps/web/src/routes/index.tsx",
+        "apps/agent/agent/infrastructure/observability/runtime.py",  # telemetry helper
+        "apps/agent/agent/interfaces/fastapi_service.py",
+    ]
+
+    assert all(_matches_any(path, patterns) for path in included)
+    assert not any(_matches_any(path, patterns) for path in excluded)
+
+
+def test_agent_behavior_filter_is_narrower_than_the_full_agent_filter() -> None:
+    """The broad `agent` filter (drives lint/type/test) still covers every
+    `agent_behavior` file; `agent_behavior` itself must be the smaller set."""
+    source = _CI_WORKFLOW.read_text(encoding="utf-8")
+    agent_patterns = _filter_patterns(source, "agent")
+    behavior_patterns = _filter_patterns(source, "agent_behavior")
+
+    assert _matches_any("apps/agent/agent/agents/animichi_agent.py", agent_patterns)
+    assert behavior_patterns != agent_patterns
+
+
+def test_smoke_job_has_no_kill_switch_and_wires_the_zero_error_direct_gate() -> None:
+    """Card #228 AC1 + AC3 (integration): the `&& false` kill-switch is gone and
+    the job runs the capped trajectory case in smoke-enforce mode."""
+    job = _named_workflow_job(
+        _CI_WORKFLOW.read_text(encoding="utf-8"), "agent-eval-smoke"
+    )
+
+    assert "&& false" not in job
+    assert "needs.changes.outputs.agent_behavior" in job
+    assert 'EVAL_SMOKE: "1"' in job
+    assert 'EVAL_MAX_CASES: "80"' in job
+    assert "test_agent_eval.py::test_agent_trajectory" in job
+    assert "test_translation.py" not in job  # translation stays L1-only (nightly)
+
+
+def test_no_disabled_eval_gate_remains_in_ci() -> None:
+    """Regression tripwire: the always-off `&& false` gate must never return."""
+    assert "&& false" not in _CI_WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_nightly_runs_uncapped_gate_on_schedule_and_dispatch_only() -> None:
+    """Card #228 AC4 (unit) + #227 AC2 (eval): L1 owns the statistical baseline,
+    triggers on a cron schedule + manual dispatch, and never on a PR."""
+    nightly = _NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+    triggers = _top_level_block(nightly, "on")
+
+    assert re.search(r'(?m)^\s*-\s*cron:\s*"[^"]+"', triggers)
+    assert re.search(r"(?m)^\s*workflow_dispatch:\s*$", triggers)
+    assert "pull_request:" not in triggers
+    assert "push:" not in triggers
+    assert "EVAL_MAX_CASES" not in nightly  # uncapped: owns baseline + statistical gate
+    assert "test_agent_eval.py::test_agent_trajectory" in nightly
+    assert "test_translation.py" in nightly

--- a/apps/agent/agent/tests/unit/test_eval_gate_equivalence.py
+++ b/apps/agent/agent/tests/unit/test_eval_gate_equivalence.py
@@ -137,6 +137,7 @@ def test_finish_cli_report_golden_and_entry_verdicts(
     expected_failures: list[str] | None,
     expected_exit: int,
 ) -> None:
+    monkeypatch.delenv("EVAL_SMOKE", raising=False)
     payload, baseline, capped = _fixture(fixture_name)
     direct_target = _configure(
         monkeypatch, tmp_path / "direct", payload, baseline, capped

--- a/apps/agent/agent/tests/unit/test_eval_gate_io.py
+++ b/apps/agent/agent/tests/unit/test_eval_gate_io.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from agent.tests.eval.eval_harness import ALL_CASES, DEFAULT_MODEL_ID, METRIC_NAMES
 from agent.tests.eval.gate import (
     BaselineRecord,
     baseline_path,
@@ -72,6 +73,27 @@ def test_committed_baselines_validate() -> None:
     assert len(paths) == 3
     for path in paths:
         BaselineRecord.model_validate_json(path.read_text())
+
+
+def test_l4_trajectory_baseline_is_current_for_the_live_dataset() -> None:
+    """Card #227 AC1: the L1 baseline must track today's live dataset.
+
+    read_baseline_record returns None for a missing OR stale (wrong case count
+    or metric vocabulary) baseline — a stronger, CI-checkable "is current"
+    invariant than test_committed_baselines_validate's schema-only check.
+    """
+    record = read_baseline_record(
+        "agent_l4_trajectory",
+        DEFAULT_MODEL_ID,
+        baselines_dir=_BASELINES_DIR,
+        expected_case_count=len(ALL_CASES),
+        expected_metrics=METRIC_NAMES,
+    )
+
+    assert record is not None
+    assert record.case_count == len(ALL_CASES)
+    assert record.errored_count == 0
+    assert set(record.scores) == set(METRIC_NAMES)
 
 
 def test_read_returns_none_for_missing_file(tmp_path: Path) -> None:

--- a/apps/agent/agent/tests/unit/test_eval_smoke_gate.py
+++ b/apps/agent/agent/tests/unit/test_eval_smoke_gate.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from agent.tests.eval.direct_gates import TrajectoryCase
-from agent.tests.eval.eval_gate_flow import GateInput, _run_gate
+from agent.tests.eval.eval_gate_flow import GateInput, SmokeRequiresCappedRun, _run_gate
 from agent.tests.eval.gate import baseline_path
 
 _MODEL = "fixture"
@@ -87,4 +87,16 @@ def test_capped_report_stays_report_only_without_eval_smoke(
     failures = _run_gate(broken, _LAYER, tmp_path, capped=True)
 
     assert failures == []
+    assert _baseline_untouched(tmp_path)
+
+
+def test_smoke_without_a_capped_run_fails_loudly_instead_of_silently_ignoring(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EVAL_SMOKE", "1")
+    clean = _gate_input(errored_count=0, trajectory=TrajectoryCase("ok", requests=5))
+
+    with pytest.raises(SmokeRequiresCappedRun, match="requires a capped run"):
+        _run_gate(clean, _LAYER, tmp_path, capped=False)
+
     assert _baseline_untouched(tmp_path)

--- a/apps/agent/agent/tests/unit/test_eval_smoke_gate.py
+++ b/apps/agent/agent/tests/unit/test_eval_smoke_gate.py
@@ -1,0 +1,90 @@
+"""EVAL_SMOKE=1 capped-gate enforcement — the L0 smoke tier's red-line gate.
+
+Card #228: a capped eval run is normally report-only (no gate at all). Setting
+EVAL_SMOKE=1 makes it assert zero-errored cases and run the deterministic
+direct thrash gate, while it still never reads or writes the statistical
+baseline file (that stays L1-only, see test_eval_gate_equivalence.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.tests.eval.direct_gates import TrajectoryCase
+from agent.tests.eval.eval_gate_flow import GateInput, _run_gate
+from agent.tests.eval.gate import baseline_path
+
+_MODEL = "fixture"
+_LAYER = "agent"
+
+
+def _gate_input(*, errored_count: int, trajectory: TrajectoryCase) -> GateInput:
+    return GateInput(
+        model=_MODEL,
+        dataset="agent_eval_v3",
+        tier="trajectory",
+        case_count=1,
+        evaluated_count=1 - errored_count,
+        errored_count=errored_count,
+        scores={},
+        cases={},
+        trajectories=(trajectory,),
+    )
+
+
+def _baseline_untouched(tmp_path: Path) -> bool:
+    return not baseline_path(_LAYER, _MODEL, tmp_path).exists()
+
+
+def test_smoke_gate_passes_on_clean_capped_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EVAL_SMOKE", "1")
+    clean = _gate_input(errored_count=0, trajectory=TrajectoryCase("ok", requests=5))
+
+    failures = _run_gate(clean, _LAYER, tmp_path, capped=True)
+
+    assert failures == []
+    assert _baseline_untouched(tmp_path)
+
+
+def test_smoke_gate_fails_on_errored_case(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EVAL_SMOKE", "1")
+    errored = _gate_input(errored_count=1, trajectory=TrajectoryCase("e0", requests=5))
+
+    failures = _run_gate(errored, _LAYER, tmp_path, capped=True)
+
+    assert failures is not None and any("1/1 cases errored" in f for f in failures)
+    assert _baseline_untouched(tmp_path)
+
+
+def test_smoke_gate_fails_on_direct_gate_violation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EVAL_SMOKE", "1")
+    thrashing = _gate_input(
+        errored_count=0, trajectory=TrajectoryCase("thrash", requests=13)
+    )
+
+    failures = _run_gate(thrashing, _LAYER, tmp_path, capped=True)
+
+    assert failures is not None and any("requests=13" in f for f in failures)
+    assert _baseline_untouched(tmp_path)
+
+
+def test_capped_report_stays_report_only_without_eval_smoke(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EVAL_SMOKE", raising=False)
+    broken = _gate_input(
+        errored_count=1, trajectory=TrajectoryCase("thrash", requests=13)
+    )
+
+    failures = _run_gate(broken, _LAYER, tmp_path, capped=True)
+
+    assert failures == []
+    assert _baseline_untouched(tmp_path)


### PR DESCRIPTION
## Summary

Closes the always-off `agent-eval` job (`if: ... && false`) and replaces it with SD-30's tiered eval gate.

- **#228 (S0.1 eval gate tiering):** a new `agent_behavior` path filter in the `changes` job (`apps/agent/agent/agents/**` + `apps/agent/agent/config/model_aliases.py` + `apps/agent/agent/config/settings.py` — prompt/instructions, guardrails, and model-config only, not every `apps/agent/**` change) gates a new required `agent-eval-smoke` job: a capped ~80-case trajectory run with `EVAL_SMOKE=1`.
- **#227 (S7.1 eval gate unfreeze + baseline):** the committed L1 baseline (`agent_l4_trajectory_openai-mimo-v2.5-...json`) is confirmed current (662/662 cases, 0 errors) and pinned with a new regression test. The uncapped L1 suite — which owns that baseline via the existing `finish_cli_report`/`gate.py` bootstrap + paired-comparison gate — now runs nightly via a new standalone workflow.

## Path filter chosen (and why)

```yaml
agent_behavior: ['apps/agent/agent/agents/**', 'apps/agent/agent/config/model_aliases.py', 'apps/agent/agent/config/settings.py']
```

- `apps/agent/agent/agents/**` carries the system prompt (`animichi_agent.py`'s `_INSTRUCTIONS`), the guardrails (`ModelRetry`/`output_validator`/repeat-guard hooks in the same file, plus the prompt-injection/source-tiering guardrails in `web_trust.py`/`source_tiering.py`), the runner's usage-limit + error-classification behavior (`animichi_runner.py`), and the model-resolution glue (`base.py`).
- `apps/agent/agent/config/model_aliases.py` is the concrete provider/base-url/thinking-mode registry — the actual "which model runs" surface.
- `apps/agent/agent/config/settings.py` is where the *production* model spec actually lives (`default_agent_model`, `model_attempt_timeout`) — added in review round 1 (see below) after Fable flagged that a PR flipping the prod model would land here, not in `model_aliases.py`/`agents/**`, and would have skipped the smoke gate.
- This resolves the **S0.1 vs S1.13 path-filter conflict** flagged in the second-pass spec review (`docs/superpowers/specs/2026-07-06-review-codex.md:19`): S0.1 originally described gating on all of `apps/agent/**`; the authoritative SD-30 rule (shared verbatim with iter-1 S1.13) is prompt/model/guardrail-scoped. This PR implements the narrower SD-30 rule, not the old S0.1 wording.
- Deliberately **excluded**: the rest of `apps/agent/**` (interfaces, domain, infrastructure, clients, tests) — those still gate the existing broad `agent` filter that drives `ci-agent`'s lint/type/test/coverage, just not the (real-money) eval-smoke job. A telemetry helper in `agent/infrastructure/observability/` is the AC2 example case and is correctly excluded (test-covered).

## Smoke-enforce mechanism

A capped eval run (`EVAL_MAX_CASES`) was already report-only by design (`exec_tiers.py::cap_cases` + the capped branch in `eval_gate_flow.py`) — no baseline read/write, no gate at all, even with `DIRECT_GATE_ENFORCE=1`. New `EVAL_SMOKE=1` env var turns a capped run into an **enforced** L0 gate:

- Asserts **zero errored cases**.
- Runs the deterministic `direct_gates` thrash checks (request/tool-call limits, repeated identical calls, request p95) — unconditionally, independent of `DIRECT_GATE_ENFORCE`.
- Still **never** reads or writes the statistical baseline file — that stays exclusively owned by the uncapped L1 tier.
- **Fails loudly if misconfigured** (review round 1): if `EVAL_SMOKE=1` resolves to an *uncapped* run (e.g. `EVAL_MAX_CASES` set above the dataset size), `_refuse_uncapped_smoke` raises `SmokeRequiresCappedRun` instead of silently falling through to the uncapped statistical gate with `EVAL_SMOKE` ignored.

Implementation: `agent/tests/eval/eval_gate_flow.py` — `_run_capped_gate` / `_smoke_gate_failures` / `_smoke_error_failures` / `_smoke_enforced` / `_refuse_uncapped_smoke`. Unit-tested against synthetic `GateInput` objects in `agent/tests/unit/test_eval_smoke_gate.py` (no live model): clean pass, errored-case failure, direct-gate-violation failure, "no `EVAL_SMOKE` ⇒ still report-only", and "`EVAL_SMOKE=1` + uncapped ⇒ loud failure" — each asserting the baseline file is untouched.

## Cron schedule

`agent-eval-nightly.yml` (new standalone workflow, same pattern as `codeql.yml`/`dependabot-agent.yml` per `.claude/rules/ci.md`) triggers on `schedule: - cron: "14 19 * * *"` (19:14 UTC daily, ≈03:14 next-day China Standard Time) + `workflow_dispatch`. Kept as a **separate file** rather than adding `schedule:` to `ci.yml`'s own `on:` block, because `ci.yml`'s existing jobs mostly key off `github.event_name != 'pull_request'`, which a shared `schedule:` trigger would also flip true for — that would silently run the *entire* component-CI fan-out (ci-agent, ci-catalog, ci-frontend, ci-web, ci-worker, db-validate, security, …) every night for no reason. A standalone file avoids that blast radius entirely. It also now has a `concurrency: { group: agent-eval-nightly, cancel-in-progress: false }` (review round 1) so an overlapping nightly + `workflow_dispatch` run queues instead of both burning `MIMO_API_KEY` spend.

`agent-eval-smoke`'s own trigger is intentionally **not** "always run on push" (unlike the free-compute component-CI jobs) — it's gated strictly on `needs.changes.outputs.agent_behavior == 'true'` (plus a `workflow_dispatch` operator override), because it spends real `MIMO_API_KEY` budget per run and `contract-openapi-drift` already establishes this stricter-gating precedent in the same file.

## Documented follow-up (not built here, per explicit instruction)

SD-30 specifies a **layered bootstrap 95% CI + paired comparison** gate: bootstrap resampling for large-sample metrics, **Clopper-Pearson exact CI for small-sample layers** (e.g. the L2 adversarial tier), and **CI-overlap = flag-but-don't-block** (not a hard pass/fail). The existing `agent/tests/eval/gate.py::bootstrap_gate`/`error_rate_gate` already implement a (non-layered) bootstrap 95% CI + paired comparison across all cases uniformly — a good chunk of SD-30's statistical intent — but do **not** yet implement per-tier layering, the Clopper-Pearson small-sample branch, or the "flag, don't block" indeterminate state. Per this card's explicit instruction, I did not build that now; this PR only wires the *existing* gate into the new nightly job. Follow-up: a dedicated story to add tier-aware Clopper-Pearson handling + indeterminate-flagging to `gate.py`.

## Review round 1 (Fable — APPROVE with fixes, applied)

- **P2-2 (path-filter false negative):** added `apps/agent/agent/config/settings.py` to `agent_behavior` (see above) + updated `test_agent_behavior_filter_scopes_to_prompt_model_guardrail_files`.
- **P3-1 (hermeticity):** `test_eval_gate_equivalence.py`'s capped-run golden case now `monkeypatch.delenv("EVAL_SMOKE", raising=False)` first (mirrors the `DIRECT_GATE_ENFORCE` precedent at `test_eval_direct_gates.py:116`) — verified locally that the test broke with `EVAL_SMOKE=1` exported pre-fix and passes post-fix.
- **P3-2 (smoke must be capped):** new `SmokeRequiresCappedRun` + `_refuse_uncapped_smoke` guard (see Smoke-enforce mechanism above), test-covered.
- **P3-4 (stale doc):** `apps/agent/AGENTS.md`'s thrash-gate numbers corrected to `tool≤10`/`p95≤8` to match `direct_gates.py` (were stale at `tool≤6`/`p95≤6`).
- **nit (nightly concurrency):** added `concurrency:` group to `agent-eval-nightly.yml`.
- **Not touched, per the coordinator's note:** branch-protection / required-checks (P2-1) — a repo-settings change, not YAML.

## AC checklist

**#228 — S0.1 eval gate tiering** (AC total 4, all covered):
1. *(integration)* PR touching a prompt/model-config/guardrail file triggers L0 smoke and passes on a clean run → `test_eval_smoke_gate.py::test_smoke_gate_passes_on_clean_capped_report` + `test_ci_eval_gate_workflow.py::test_agent_behavior_filter_scopes_to_prompt_model_guardrail_files` (trigger condition).
2. *(integration)* A PR touching only `apps/web/**` or an `apps/agent/**` file outside scope (telemetry helper) does not trigger the eval job → `test_ci_eval_gate_workflow.py::test_agent_behavior_filter_scopes_to_prompt_model_guardrail_files` + `::test_agent_behavior_filter_is_narrower_than_the_full_agent_filter`. **This PR is itself a live example**: it only touches `.github/workflows/**` and `apps/agent/agent/tests/**` + `apps/agent/AGENTS.md`, so `agent-eval-smoke` correctly shows `skipping` in this PR's own checks.
3. *(integration)* A broken case fails the job / blocks merge (required check) → `test_eval_smoke_gate.py::test_smoke_gate_fails_on_errored_case` + `::test_smoke_gate_fails_on_direct_gate_violation`; job-required wiring pinned by `test_ci_eval_gate_workflow.py::test_smoke_job_has_no_kill_switch_and_wires_the_zero_error_direct_gate` + `::test_no_disabled_eval_gate_remains_in_ci`. **Manual follow-up needed:** add "Agent Eval (L0 smoke, ~80 cases)" to the branch-protection required-status-checks list for `main` in repo Settings — that's a GitHub admin action outside any file in this repo (P2-1, the coordinator is handling separately).
4. *(unit)* Nightly cron triggers L1 on schedule (asserted via workflow schedule, not a real wait) → `test_ci_eval_gate_workflow.py::test_nightly_runs_uncapped_gate_on_schedule_and_dispatch_only`.

**#227 — S7.1 eval gate unfreeze + baseline** (AC total 3, all covered):
1. *(eval)* Full L1 baseline captured + committed → already present and current (`agent_l4_trajectory_openai-mimo-v2.5-https---api.xiaomimimo.com-v1.json`, 662/662 cases, 0 errors, committed 2026-07-20); now pinned as a standing regression test: `test_eval_gate_io.py::test_l4_trajectory_baseline_is_current_for_the_live_dataset`.
2. *(eval)* Comparison eval after behavior-touching changes uses the SD-30 statistical gate → the nightly `agent-eval-nightly.yml` job runs the uncapped trajectory eval through the same `finish_cli_report` path that owns baseline read/write + `bootstrap_gate`/`error_rate_gate`; wiring pinned by `test_ci_eval_gate_workflow.py::test_nightly_runs_uncapped_gate_on_schedule_and_dispatch_only`. (Layered/Clopper-Pearson refinement is the documented follow-up above, not built here.)
3. *(eval)* Zero agent-behavior changes ⇒ comparison passes trivially → already covered by pre-existing tests I did not duplicate: `test_eval_gate_stats.py::test_identical_scores_pass`, `::test_error_rate_gate_tolerates_identical_rates`, and `test_eval_gate_equivalence.py::test_finish_cli_report_golden_and_entry_verdicts[clean_pass]` (all pass today).

## CI status on this PR — two known, non-blocking-for-this-card findings

Verified live on this PR (`Agent CI / Python CI` pass, `Python integration (Neon)` pass, `Security / actionlint` pass, `changes` pass, `agent-eval-smoke` correctly `skipping`). Two checks are red and I'm flagging both explicitly rather than leaving them unexplained:

1. **`Security / Semgrep (SAST)` — pre-existing, unrelated to this PR.** The single finding is `dangerouslySetInnerHTML` in `apps/web/src/features/seo/JsonLd.tsx:21`, added by `ffcf1991` (S5.6, already on `feat/frontend-rebuild` before this branch existed). Semgrep scans the whole tree, not just the diff, so this fails on `feat/frontend-rebuild` today regardless of this PR. None of my changed files are anywhere near `apps/web/`. Out of scope for #228/#227 — not touched here.
2. **`SonarCloud Code Analysis` — `new_security_rating` gate, down to 2 verified-non-applicable findings.** Sonar's `githubactions` ruleset flagged 5 issues on the new `agent-eval-nightly.yml` (whole new file ⇒ all lines count as "new code") plus one line I rewrote in `ci.yml`: 4× `S8544` ("lock resolved versions") and 1× `S8541` ("omit --no-build") per `uv sync`/`uv run` line. I fixed the 4 `S8544` findings by adding `--frozen` to every `uv sync`/`uv run` call I own in this PR (verified locally: `uv sync --frozen --all-extras` succeeds cleanly against the committed lockfile). I could **not** fix the remaining 2 `S8541` findings the suggested way: `uv sync --frozen --all-extras --no-build` fails locally with `` Distribution `animichi==0.1.0 @ editable+.` can't be installed because it is marked as `--no-build` but has no binary distribution `` — `apps/agent` installs itself in editable mode, which always needs a build step, so `--no-build` is not a viable flag for *any* `uv sync` in this repo (all 7 call sites across every workflow file use the same pattern, not just mine). This is a rule mismatched to this ecosystem's normal usage, not something my diff introduced. Needs either a SonarCloud project-admin marking these 2 issues "Won't Fix" (I don't have that access), or a maintainer decision to merge past this specific gate with the reasoning above.

## Test plan
- [x] `make lint` (ruff check + format) — clean
- [x] `make typecheck` (mypy strict, `agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/ agent/tests/eval/`) — clean (110 files)
- [x] `uv run pytest agent/tests/unit/` — 1235 passed, 87.88% coverage (floor 82%)
- [x] `make test-integration` (offline Docker arm) — 68 passed, 22 skipped (unrelated live-endpoint skips)
- [x] `actionlint` on all touched workflow files — clean, locally and in CI (`Security / actionlint` passes)
- [x] Verified live on the PR: `Agent CI / Python CI` pass, `Python integration (Neon)` pass, `agent-eval-smoke` correctly skips (this PR doesn't touch `agent_behavior`-scoped files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
