### PR TITLE
feat(agent): S7.8 - agent tool typing tech-debt cleanup

### DIFF
--- a/apps/agent/agent/agents/catalog_adapter.py
+++ b/apps/agent/agent/agents/catalog_adapter.py
@@ -1,13 +1,14 @@
-"""Adapt typed Catalog models into the agent's tool-state payload shapes.
+"""Adapt typed Catalog models into the agent's named tool-result models.
 
 The data tools call the Catalog service and receive typed
-``PilgrimagePoint`` / ``Route`` models. This module re-shapes those typed
-models into the dict payloads consumed by the response builder,
-``_summarize_for_llm`` and the output_validator, so they keep working unchanged.
+``PilgrimagePoint`` / ``Route`` models. This module re-shapes those into the
+named ``ResolveAnimeResult`` / ``SearchToolResult`` / ``RouteToolResult``
+models the tools return (``tool_runtime`` serializes them to dicts at the
+tool_state/response boundary, so response_builder.py keeps working unchanged).
 
 No DB, no upstream Anitabi/Bangumi clients are imported here — only deterministic
-shaping helpers (``_build_nearby_groups`` / ``rewrite_image_urls`` /
-``optimize_route``) shared with the live route/answer handlers.
+shaping helpers (``_build_nearby_groups`` / ``rewrite_image_urls``) shared with
+the live ``plan_selected`` handler.
 """
 
 from __future__ import annotations
@@ -15,6 +16,19 @@ from __future__ import annotations
 from typing import Literal
 
 from agent.agents.handlers._helpers import _build_nearby_groups, rewrite_image_urls
+from agent.agents.runtime_models import (
+    NearbyGroupModel,
+    PilgrimagePointModel,
+    ResultsMetadataModel,
+    ResultsSummaryModel,
+)
+from agent.agents.tool_results import (
+    ResolveAnimeResult,
+    ResolveCandidate,
+    RouteSummary,
+    RouteToolResult,
+    SearchToolResult,
+)
 from agent.clients.catalog_client import PilgrimagePoint, Route
 
 SearchTool = Literal["search_bangumi", "search_nearby"]
@@ -30,48 +44,59 @@ def _rows_from_points(points: list[PilgrimagePoint]) -> list[dict[str, object]]:
     return rewrite_image_urls([_point_to_row(p) for p in points])
 
 
-def _search_metadata(points: list[PilgrimagePoint]) -> dict[str, object]:
+def _typed_rows(points: list[PilgrimagePoint]) -> list[PilgrimagePointModel]:
+    """Serialize + proxy-rewrite points, validated back into typed rows."""
+    return [
+        PilgrimagePointModel.model_validate(row) for row in _rows_from_points(points)
+    ]
+
+
+def _search_metadata(points: list[PilgrimagePoint]) -> ResultsMetadataModel:
     """Derive anime title/cover metadata from the first point, if any."""
     if not points:
-        return {}
+        return ResultsMetadataModel()
     head = points[0]
-    return {
-        "anime_title": head.title,
-        "anime_title_cn": head.title_cn,
-        "cover_url": head.cover_url,
-        "data_origin": "catalog",
-        "source": "catalog",
-    }
+    return ResultsMetadataModel(
+        anime_title=head.title,
+        anime_title_cn=head.title_cn,
+        cover_url=head.cover_url,
+        data_origin="catalog",
+        source="catalog",
+    )
 
 
 def build_search_payload(
     points: list[PilgrimagePoint], *, tool: SearchTool
-) -> dict[str, object]:
-    """Shape catalog points into the search/nearby tool_state payload."""
-    rows = _rows_from_points(points)
+) -> SearchToolResult:
+    """Shape catalog points into the search/nearby tool result."""
+    rows = _typed_rows(points)
     empty = not rows
-    return {
-        "rows": rows,
-        "items": rows,
-        "row_count": len(rows),
-        "strategy": "geo" if tool == "search_nearby" else "bangumi",
-        "metadata": _search_metadata(points),
-        "nearby_groups": _build_nearby_groups(rows),
-        "status": "empty" if empty else "ok",
-        "empty": empty,
-        "summary": {"count": len(rows), "source": "catalog", "cache": "miss"},
-    }
+    nearby_groups = [
+        NearbyGroupModel.model_validate(g)
+        for g in _build_nearby_groups(_rows_from_points(points))
+    ]
+    return SearchToolResult(
+        rows=rows,
+        items=rows,
+        row_count=len(rows),
+        strategy="geo" if tool == "search_nearby" else "bangumi",
+        metadata=_search_metadata(points),
+        nearby_groups=nearby_groups,
+        status="empty" if empty else "ok",
+        empty=empty,
+        summary=ResultsSummaryModel(count=len(rows), source="catalog", cache="miss"),
+    )
 
 
-def _candidate(point: PilgrimagePoint) -> dict[str, object]:
+def _candidate(point: PilgrimagePoint) -> ResolveCandidate:
     """Build a resolve/clarify candidate from a catalog point."""
-    return {
-        "title": point.title or point.title_cn,
-        "bangumi_id": point.bangumi_id,
-        "cover_url": point.cover_url,
-        "city": "",
-        "points_count": 0,
-    }
+    return ResolveCandidate(
+        title=point.title or point.title_cn,
+        bangumi_id=point.bangumi_id,
+        cover_url=point.cover_url,
+        city="",
+        points_count=0,
+    )
 
 
 def _unique_works(points: list[PilgrimagePoint]) -> list[PilgrimagePoint]:
@@ -85,42 +110,43 @@ def _unique_works(points: list[PilgrimagePoint]) -> list[PilgrimagePoint]:
     return works
 
 
-def build_resolve_payload(points: list[PilgrimagePoint]) -> dict[str, object]:
-    """Shape catalog points into the resolve_anime tool_state payload.
+def build_resolve_payload(points: list[PilgrimagePoint]) -> ResolveAnimeResult:
+    """Shape catalog points into the resolve_anime result.
 
-    Single work -> resolved {bangumi_id, title, candidates}; multiple distinct
-    works -> {ambiguous: True, candidates}; no points -> empty (signals failure).
+    Single work -> resolved (bangumi_id, title, candidates); multiple distinct
+    works -> ambiguous=True + candidates; no points -> empty candidates
+    (signals failure to the caller via ``bool(result.candidates)``).
     """
     works = _unique_works(points)
     if not works:
-        return {}
+        return ResolveAnimeResult()
     candidates = [_candidate(w) for w in works]
     if len(works) == 1:
         head = works[0]
-        return {
-            "bangumi_id": head.bangumi_id,
-            "title": head.title or head.title_cn,
-            "candidates": candidates,
-        }
-    return {"ambiguous": True, "candidates": candidates}
+        return ResolveAnimeResult(
+            bangumi_id=head.bangumi_id,
+            title=head.title or head.title_cn,
+            candidates=candidates,
+        )
+    return ResolveAnimeResult(ambiguous=True, candidates=candidates)
 
 
-def build_route_payload(route: Route) -> dict[str, object]:
-    """Shape a catalog Route into the plan_route tool_state payload."""
-    ordered = _rows_from_points(route.ordered_points)
+def build_route_payload(route: Route) -> RouteToolResult:
+    """Shape a catalog Route into the plan_route result."""
+    ordered = _typed_rows(route.ordered_points)
     itinerary = route.timed_itinerary
-    return {
-        "ordered_points": ordered,
-        "timed_itinerary": itinerary.model_dump(mode="json"),
-        "point_count": route.point_count,
-        "cover_url": route.cover_url,
-        "status": "ok",
-        "summary": {
-            "point_count": route.point_count,
-            "total_minutes": itinerary.total_minutes,
-            "total_distance_m": itinerary.total_distance_m,
-            "clusters": itinerary.spot_count,
-            "with_coordinates": len(ordered),
-            "without_coordinates": 0,
-        },
-    }
+    return RouteToolResult(
+        ordered_points=ordered,
+        timed_itinerary=itinerary,
+        point_count=route.point_count,
+        cover_url=route.cover_url,
+        status="ok",
+        summary=RouteSummary(
+            point_count=route.point_count,
+            total_minutes=itinerary.total_minutes,
+            total_distance_m=itinerary.total_distance_m,
+            clusters=itinerary.spot_count,
+            with_coordinates=len(ordered),
+            without_coordinates=0,
+        ),
+    )

--- a/apps/agent/agent/agents/catalog_tools.py
+++ b/apps/agent/agent/agents/catalog_tools.py
@@ -8,7 +8,10 @@ the result with the same plumbing the legacy path uses (``tool_runtime``).
 
 from __future__ import annotations
 
+from typing import Literal, TypeVar, overload
+
 import httpx
+from pydantic import BaseModel
 from pydantic_ai import ModelRetry, RunContext
 
 from agent.agents.catalog_adapter import (
@@ -20,17 +23,26 @@ from agent.agents.catalog_adapter import (
 from agent.agents.models import ToolName
 from agent.agents.runtime_deps import RuntimeDeps
 from agent.agents.sql_agent import KNOWN_LOCATIONS
+from agent.agents.tool_results import (
+    ResolveAnimeResult,
+    RouteToolResult,
+    SearchToolPreview,
+    SearchToolResult,
+)
 from agent.agents.tool_runtime import (
     _emit_step,
     _localize_city_names,
     _record_step,
     _summarize_for_llm,
 )
+from agent.agents.tool_state import ToolState
 from agent.clients.catalog_client import CatalogClientProtocol, PilgrimagePoint
 from agent.clients.errors import APIError
 
 _NO_DATA_ERROR = "No catalog data"
 _TRANSIENT_ERRORS = (APIError, httpx.TransportError, httpx.TimeoutException)
+
+T = TypeVar("T", bound=BaseModel)
 
 
 async def _store_catalog_result(
@@ -38,25 +50,83 @@ async def _store_catalog_result(
     *,
     tool: ToolName,
     params: dict[str, object],
-    payload: dict[str, object],
+    payload: T,
     success: bool,
-) -> dict[str, object]:
+) -> T | None:
     """Record + emit a catalog-sourced tool result, mirroring _run_handler."""
+    if not success:
+        await _record_catalog_failure(deps, tool=tool, params=params)
+        return None
+    return await _record_catalog_success(
+        deps, tool=tool, params=params, payload=payload
+    )
+
+
+async def _record_catalog_failure(
+    deps: RuntimeDeps, *, tool: ToolName, params: dict[str, object]
+) -> None:
+    """Record + emit a "no data" step; nothing is written to tool_state."""
     _record_step(
         deps,
         tool=tool.value,
-        success=success,
+        success=False,
         params=params,
-        data=payload or None,
-        error=None if success else _NO_DATA_ERROR,
+        data=None,
+        error=_NO_DATA_ERROR,
     )
-    if success:
-        _localize_city_names(payload, deps.locale)
-        deps.tool_state[tool.value] = payload
-        await _emit_step(deps, tool.value, "done", payload)
-        return _summarize_for_llm(tool, payload)
     await _emit_step(deps, tool.value, "failed", {"error": _NO_DATA_ERROR})
-    return {}
+    return None
+
+
+async def _record_catalog_success(
+    deps: RuntimeDeps, *, tool: ToolName, params: dict[str, object], payload: T
+) -> T:
+    """Store the serialized payload in tool_state and emit the "done" step."""
+    data = payload.model_dump(mode="json")
+    _localize_city_names(data, deps.locale)
+    _record_step(
+        deps, tool=tool.value, success=True, params=params, data=data, error=None
+    )
+    deps.tool_state[tool.value] = data
+    await _emit_step(deps, tool.value, "done", data)
+    return payload
+
+
+def _has_results(
+    tool: ToolName, payload: ResolveAnimeResult | SearchToolResult
+) -> bool:
+    """True when the shaped payload carries usable data.
+
+    Mirrors the legacy ``bool(dict)`` truthiness check: resolve_anime "fails"
+    when it found no candidates; a shaped search payload is always truthy
+    (matches the pre-existing behavior where search_bangumi never signals
+    failure through this path, even with zero rows).
+    """
+    if isinstance(payload, ResolveAnimeResult):
+        return bool(payload.candidates)
+    return True
+
+
+@overload
+async def _run_catalog_search(
+    ctx: RunContext[RuntimeDeps],
+    catalog: CatalogClientProtocol,
+    *,
+    tool: Literal[ToolName.RESOLVE_ANIME],
+    query: str,
+    params: dict[str, object],
+) -> ResolveAnimeResult | None: ...
+
+
+@overload
+async def _run_catalog_search(
+    ctx: RunContext[RuntimeDeps],
+    catalog: CatalogClientProtocol,
+    *,
+    tool: Literal[ToolName.SEARCH_BANGUMI],
+    query: str,
+    params: dict[str, object],
+) -> SearchToolResult | SearchToolPreview | None: ...
 
 
 async def _run_catalog_search(
@@ -66,7 +136,7 @@ async def _run_catalog_search(
     tool: ToolName,
     query: str,
     params: dict[str, object],
-) -> dict[str, object]:
+) -> ResolveAnimeResult | SearchToolResult | SearchToolPreview | None:
     """Resolve/search via catalog.search() and store the shaped payload."""
     await _emit_step(ctx.deps, tool.value, "running", {})
     try:
@@ -74,12 +144,17 @@ async def _run_catalog_search(
     except _TRANSIENT_ERRORS as exc:
         raise ModelRetry(f"Catalog search unavailable, please retry. ({exc})") from exc
     payload = _shape_search_or_resolve(tool, points)
-    return await _store_catalog_result(
-        ctx.deps, tool=tool, params=params, payload=payload, success=bool(payload)
+    stored = await _store_catalog_result(
+        ctx.deps,
+        tool=tool,
+        params=params,
+        payload=payload,
+        success=_has_results(tool, payload),
     )
+    return _summarize_for_llm(tool, stored) if stored is not None else None
 
 
-def _bangumi_search_query(state: dict[str, object], bangumi_id: str) -> str:
+def _bangumi_search_query(state: ToolState, bangumi_id: str) -> str:
     """Pick the catalog query for search_bangumi: resolved title, else id.
 
     The catalog search path is title/query based, so prefer the title captured
@@ -95,7 +170,7 @@ def _bangumi_search_query(state: dict[str, object], bangumi_id: str) -> str:
 
 def _shape_search_or_resolve(
     tool: ToolName, points: list[PilgrimagePoint]
-) -> dict[str, object]:
+) -> ResolveAnimeResult | SearchToolResult:
     """Pick the resolve vs search payload shape for catalog points."""
     if tool == ToolName.RESOLVE_ANIME:
         return build_resolve_payload(points)
@@ -105,9 +180,7 @@ def _shape_search_or_resolve(
     return build_search_payload(points, tool=search_tool)
 
 
-def _geocode_for_catalog(
-    location: str, state: dict[str, object]
-) -> tuple[float, float] | None:
+def _geocode_for_catalog(location: str, state: ToolState) -> tuple[float, float] | None:
     """Resolve coords from session state, then deterministic KNOWN_LOCATIONS.
 
     Stays upstream-free: no LLM, no Google Geocoding. The catalog service owns
@@ -127,7 +200,7 @@ async def _run_catalog_nearby(
     location: str,
     radius: int,
     params: dict[str, object],
-) -> dict[str, object]:
+) -> SearchToolResult | SearchToolPreview | None:
     """Geo-search via catalog.nearby() and store the shaped payload."""
     coords = _geocode_for_catalog(location, ctx.deps.tool_state)
     if coords is None:
@@ -141,16 +214,21 @@ async def _run_catalog_nearby(
     except _TRANSIENT_ERRORS as exc:
         raise ModelRetry(f"Catalog nearby unavailable, please retry. ({exc})") from exc
     payload = build_search_payload(points, tool="search_nearby")
-    return await _store_catalog_result(
+    stored = await _store_catalog_result(
         ctx.deps,
         tool=ToolName.SEARCH_NEARBY,
         params=params,
         payload=payload,
-        success=bool(payload.get("rows")),
+        success=bool(payload.rows),
+    )
+    return (
+        _summarize_for_llm(ToolName.SEARCH_NEARBY, stored)
+        if stored is not None
+        else None
     )
 
 
-def _point_ids_from_state(state: dict[str, object]) -> list[str]:
+def _point_ids_from_state(state: ToolState) -> list[str]:
     """Collect point ids from the most recent search results in tool_state."""
     search = state.get("search_bangumi") or state.get("search_nearby")
     rows = search.get("rows") if isinstance(search, dict) else None
@@ -168,7 +246,7 @@ async def _run_catalog_route(
     catalog: CatalogClientProtocol,
     *,
     params: dict[str, object],
-) -> dict[str, object]:
+) -> RouteToolResult | None:
     """Plan a route via catalog.route() over the searched point ids."""
     point_ids = _point_ids_from_state(ctx.deps.tool_state)
     if not point_ids:
@@ -182,6 +260,9 @@ async def _run_catalog_route(
     except _TRANSIENT_ERRORS as exc:
         raise ModelRetry(f"Catalog route unavailable, please retry. ({exc})") from exc
     payload = build_route_payload(route)
+    # No LLM-facing summarization for plan_route: _summarize_for_llm only
+    # shrinks search_bangumi/search_nearby results, so the full typed result
+    # is what the tool returns here too.
     return await _store_catalog_result(
         ctx.deps,
         tool=ToolName.PLAN_ROUTE,

--- a/apps/agent/agent/agents/pilgrimage_agent.py
+++ b/apps/agent/agent/agents/pilgrimage_agent.py
@@ -32,6 +32,7 @@ from agent.agents.runtime_models import (
     RouteResponseModel,
     SearchResponseModel,
 )
+from agent.agents.tool_state import ToolState
 
 COMPACT_THRESHOLD = 40  # ~5 turns × 8 messages/turn
 _KEEP_RECENT = 8  # Keep latest turn fully uncompressed
@@ -311,7 +312,7 @@ def _inject_session_context(ctx: RunContext[RuntimeDeps]) -> str:
     return "\n## Current session state\n" + "\n".join(f"- {p}" for p in parts)
 
 
-def _add_resolve_context(state: dict[str, object], parts: list[str]) -> None:
+def _add_resolve_context(state: ToolState, parts: list[str]) -> None:
     resolve_data = state.get("resolve_anime")
     if not isinstance(resolve_data, dict):
         return
@@ -321,7 +322,7 @@ def _add_resolve_context(state: dict[str, object], parts: list[str]) -> None:
         parts.append(f"Current anime: {title} (bangumi_id={bid})")
 
 
-def _add_search_context(state: dict[str, object], parts: list[str]) -> None:
+def _add_search_context(state: ToolState, parts: list[str]) -> None:
     search_data = state.get("search_bangumi")
     if not isinstance(search_data, dict):
         return
@@ -332,7 +333,7 @@ def _add_search_context(state: dict[str, object], parts: list[str]) -> None:
     parts.append(f"Search results available: {row_count} spots{suffix}")
 
 
-def _add_nearby_context(state: dict[str, object], parts: list[str]) -> None:
+def _add_nearby_context(state: ToolState, parts: list[str]) -> None:
     search_nearby = state.get("search_nearby")
     if not isinstance(search_nearby, dict):
         return
@@ -340,7 +341,7 @@ def _add_nearby_context(state: dict[str, object], parts: list[str]) -> None:
     parts.append(f"Nearby search results available: {row_count} spots")
 
 
-def _add_clarify_context(state: dict[str, object], parts: list[str]) -> None:
+def _add_clarify_context(state: ToolState, parts: list[str]) -> None:
     if state.get("pending_clarify"):
         parts.append(
             "Previous turn ended with clarification "

--- a/apps/agent/agent/agents/pilgrimage_tools.py
+++ b/apps/agent/agent/agents/pilgrimage_tools.py
@@ -26,6 +26,14 @@ from agent.agents.handlers import execute_answer_question, execute_greet_user
 from agent.agents.models import ToolName
 from agent.agents.pilgrimage_agent import pilgrimage_agent
 from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_results import (
+    ClarifyToolResult,
+    MessageToolResult,
+    ResolveAnimeResult,
+    RouteToolResult,
+    SearchToolPreview,
+    SearchToolResult,
+)
 from agent.agents.tool_runtime import _run_ephemeral, run_clarify
 from agent.clients.catalog_client import CatalogClientProtocol
 
@@ -44,7 +52,9 @@ def _require_catalog(deps: RuntimeDeps) -> CatalogClientProtocol:
 
 
 @pilgrimage_agent.tool
-async def resolve_anime(ctx: RunContext[RuntimeDeps], title: str) -> dict[str, object]:
+async def resolve_anime(
+    ctx: RunContext[RuntimeDeps], title: str
+) -> ResolveAnimeResult | None:
     """Look up an anime by title and return its unique database identifier.
 
     Call this FIRST whenever the user mentions an anime by name.
@@ -82,7 +92,7 @@ async def search_bangumi(
     *,
     episode: int = -1,
     force_refresh: bool = False,
-) -> dict[str, object]:
+) -> SearchToolResult | SearchToolPreview | None:
     """Find real-world pilgrimage filming locations for a specific anime.
 
     Call this AFTER resolve_anime returns a bangumi_id.
@@ -134,7 +144,7 @@ async def search_nearby(
     *,
     location: str,
     radius: int = 0,
-) -> dict[str, object]:
+) -> SearchToolResult | SearchToolPreview | None:
     """Find anime pilgrimage spots near a real-world location using geo search.
 
     Use this for location-based queries like "宇治站附近", "spots near Kyoto".
@@ -168,7 +178,7 @@ async def plan_route(
     origin: str = "",
     pacing: str = "",
     start_time: str = "",
-) -> dict[str, object]:
+) -> RouteToolResult | None:
     """Create an optimized walking route from the pilgrimage points found by search_bangumi.
 
     IMPORTANT: You must call search_bangumi BEFORE this tool. plan_route uses
@@ -204,7 +214,9 @@ async def plan_route(
 
 
 @pilgrimage_agent.tool
-async def greet_user(ctx: RunContext[RuntimeDeps], message: str) -> dict[str, object]:
+async def greet_user(
+    ctx: RunContext[RuntimeDeps], message: str
+) -> MessageToolResult | None:
     """Respond to greetings and "what can you do?" questions.
 
     Use ONLY for: "hi", "hello", "你好", "こんにちは", "你是谁", "what can you do?",
@@ -226,7 +238,9 @@ async def greet_user(ctx: RunContext[RuntimeDeps], message: str) -> dict[str, ob
 
 
 @pilgrimage_agent.tool
-async def general_qa(ctx: RunContext[RuntimeDeps], answer: str) -> dict[str, object]:
+async def general_qa(
+    ctx: RunContext[RuntimeDeps], answer: str
+) -> MessageToolResult | None:
     """Answer general questions about anime pilgrimage (etiquette, tips, costs, planning).
 
     Use for questions like:
@@ -255,7 +269,7 @@ async def clarify(
     *,
     question: str,
     options: list[str] | None = None,
-) -> dict[str, object]:
+) -> ClarifyToolResult:
     """Ask the user a clarification question when you cannot proceed confidently.
 
     Use when:

--- a/apps/agent/agent/agents/runtime_deps.py
+++ b/apps/agent/agent/agents/runtime_deps.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
 from agent.agents.agent_result import StepRecord
+from agent.agents.tool_state import ToolState, new_tool_state
 from agent.clients.catalog_client import CatalogClientProtocol
 from agent.domain.ports import DatabasePort
 
@@ -28,12 +29,15 @@ class RuntimeDeps:
 
     on_step: OnStep | None = None
 
-    # Mutable per-run state accumulated during the agent run.
+    # Mutable per-run state accumulated during the agent run. ``ToolState`` is
+    # an explicit, nominal NewType (S7.8) — call sites can no longer confuse it
+    # with an arbitrary ``dict[str, object]``.
+    #
     # ponytail: mixes two concerns — fixed session fields (origin_lat/lng, locale,
     # last_location, resolve_candidates, pending_clarify) that should be typed
     # dataclass fields, plus ToolName-keyed tool results (genuinely dynamic, legit).
-    # Reads are all literal-key. Cleanup (split into typed session state + a
-    # dict[ToolName, ...] results map, ~8 files) deferred to the Wave 3 agent→Worker
-    # runtime rewrite — see memory project_tool_state_followup.
-    tool_state: dict[str, object] = field(default_factory=dict)
+    # Reads are all literal-key. Splitting the *values* into a typed session
+    # state + a dict[ToolName, ...] results map (~8 files) is deferred to the
+    # Wave 3 agent→Worker runtime rewrite — see memory project_tool_state_followup.
+    tool_state: ToolState = field(default_factory=new_tool_state)
     steps: list[StepRecord] = field(default_factory=list)

--- a/apps/agent/agent/agents/tool_results.py
+++ b/apps/agent/agent/agents/tool_results.py
@@ -1,0 +1,153 @@
+"""Named Pydantic result models for the pilgrimage agent's tool functions.
+
+Every ``@agent.tool`` / ``@agent.tool_plain`` function returns one of these
+models instead of ``dict[str, object]``, so a future ``FastMCP.from_openapi``
+introspection can generate a proper ``outputSchema`` per tool. Field names,
+defaults, and nesting mirror the legacy dict payloads exactly — this module
+is a type-narrowing layer, not a behavior change.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from agent.agents.models import TimedItinerary
+from agent.agents.runtime_models import (
+    NearbyGroupModel,
+    PilgrimagePointModel,
+    ResultsMetadataModel,
+    ResultsSummaryModel,
+)
+
+# ── resolve_anime ────────────────────────────────────────────────────────
+
+
+class ResolveCandidate(BaseModel):
+    """A single anime work matched by resolve_anime."""
+
+    title: str
+    bangumi_id: str
+    cover_url: str = ""
+    city: str = ""
+    points_count: int = 0
+
+
+class ResolveAnimeResult(BaseModel):
+    """Result of resolve_anime: a single match, an ambiguous set, or none."""
+
+    bangumi_id: str = ""
+    title: str = ""
+    ambiguous: bool = False
+    candidates: list[ResolveCandidate] = Field(default_factory=list)
+
+
+# ── search_bangumi / search_nearby ──────────────────────────────────────
+
+
+class SearchToolResult(BaseModel):
+    """Full result of search_bangumi / search_nearby, stored in tool_state."""
+
+    rows: list[PilgrimagePointModel] = Field(default_factory=list)
+    items: list[PilgrimagePointModel] = Field(default_factory=list)
+    row_count: int = 0
+    strategy: str = ""
+    metadata: ResultsMetadataModel = Field(default_factory=ResultsMetadataModel)
+    nearby_groups: list[NearbyGroupModel] = Field(default_factory=list)
+    status: str = "ok"
+    empty: bool = False
+    summary: ResultsSummaryModel = Field(default_factory=ResultsSummaryModel)
+
+
+class SearchPreviewRow(BaseModel):
+    """A minimal row shown to the LLM when a search result is large."""
+
+    name: str
+    episode: int
+
+
+class SearchToolPreview(BaseModel):
+    """Compact LLM-facing summary of a large SearchToolResult.
+
+    Never stored in tool_state — the full SearchToolResult is always what
+    reaches the response mapper; this is only what the model sees inline.
+    """
+
+    row_count: int = 0
+    status: str = "ok"
+    metadata: ResultsMetadataModel = Field(default_factory=ResultsMetadataModel)
+    preview: list[SearchPreviewRow] = Field(default_factory=list)
+    note: str = ""
+
+
+# ── plan_route ───────────────────────────────────────────────────────────
+
+
+class RouteSummary(BaseModel):
+    """Route-specific summary counters (distinct shape from search summary)."""
+
+    point_count: int = 0
+    total_minutes: int = 0
+    total_distance_m: float = 0.0
+    clusters: int = 0
+    with_coordinates: int = 0
+    without_coordinates: int = 0
+
+
+class RouteToolResult(BaseModel):
+    """Full result of plan_route, stored in tool_state."""
+
+    ordered_points: list[PilgrimagePointModel] = Field(default_factory=list)
+    timed_itinerary: TimedItinerary = Field(default_factory=TimedItinerary)
+    point_count: int = 0
+    cover_url: str = ""
+    status: str = "ok"
+    summary: RouteSummary = Field(default_factory=RouteSummary)
+
+
+# ── greet_user / general_qa ──────────────────────────────────────────────
+
+
+class MessageToolResult(BaseModel):
+    """Shared result shape for the two ephemeral echo tools."""
+
+    message: str = ""
+    status: str = "info"
+
+
+# ── clarify ──────────────────────────────────────────────────────────────
+
+
+class ClarifyCandidate(BaseModel):
+    """An enriched clarify candidate. cover_url is None when unknown."""
+
+    title: str
+    cover_url: str | None = None
+    spot_count: int = 0
+    city: str = ""
+
+
+class ClarifyToolResult(BaseModel):
+    """Result of the clarify tool.
+
+    ``action_required`` signals to the LLM that it must stop and return
+    clarify_response now. Without it, some models (e.g. DeepSeek V4 Flash)
+    continue calling search_bangumi instead of waiting for user input.
+    """
+
+    question: str = ""
+    options: list[str] = Field(default_factory=list)
+    candidates: list[ClarifyCandidate] = Field(default_factory=list)
+    status: str = "needs_clarification"
+    action_required: str = "return clarify_response"
+
+
+# ── translate_anime_title ────────────────────────────────────────────────
+
+
+class TranslateTitleResult(BaseModel):
+    """Result of translate_anime_title."""
+
+    original: str
+    translated: str
+    source: str
+    confidence: float

--- a/apps/agent/agent/agents/tool_runtime.py
+++ b/apps/agent/agent/agents/tool_runtime.py
@@ -9,7 +9,9 @@ greet/qa handlers; the catalog read path lives in ``catalog_tools``.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from typing import TypeVar
 
+from pydantic import BaseModel
 from pydantic_ai import RunContext
 
 from agent.agents.agent_result import StepRecord
@@ -17,7 +19,17 @@ from agent.agents.geo_names import localized_city_name
 from agent.agents.handlers import HandlerResult
 from agent.agents.models import PlanStep, ToolName
 from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_results import (
+    ClarifyToolResult,
+    MessageToolResult,
+    SearchPreviewRow,
+    SearchToolPreview,
+    SearchToolResult,
+)
+from agent.agents.tool_state import ToolState
 from agent.agents.tools import enrich_clarify_candidates
+
+T = TypeVar("T", bound=BaseModel)
 
 
 async def _emit_step(
@@ -60,38 +72,32 @@ def _localize_city_names(data: dict[str, object], locale: str) -> None:
             row["city"] = localized_city_name(row["city"], locale)
 
 
-def _summarize_for_llm(tool: ToolName, data: dict[str, object]) -> dict[str, object]:
+def _build_preview(data: SearchToolResult) -> SearchToolPreview:
+    """Shrink a large SearchToolResult into a compact LLM-facing preview."""
+    title = data.metadata.anime_title
+    preview_rows = [
+        SearchPreviewRow(name=r.name, episode=r.episode) for r in data.rows[:5]
+    ]
+    return SearchToolPreview(
+        row_count=data.row_count,
+        status=data.status,
+        metadata=data.metadata,
+        preview=preview_rows,
+        note=f"Found {data.row_count} pilgrimage spots{' for ' + title if title else ''}. "
+        "Full data is available — proceed to return a search_response.",
+    )
+
+
+def _summarize_for_llm(tool: ToolName, data: T) -> T | SearchToolPreview:
     """Return a compact summary of tool results for the LLM.
 
     Full data is kept in tool_state and SSE events for the frontend.
     The LLM only needs enough context to decide its next action.
     """
-    if tool not in (ToolName.SEARCH_BANGUMI, ToolName.SEARCH_NEARBY):
-        return data
-
-    rows = data.get("rows")
-    if not isinstance(rows, list) or len(rows) <= 5:
-        return data
-
-    row_count = data.get("row_count", len(rows))
-    metadata = data.get("metadata")
-    title = ""
-    if isinstance(metadata, dict):
-        title = str(metadata.get("anime_title", "") or "")
-
-    preview_rows = [
-        {k: row[k] for k in ("name", "episode") if k in row}
-        for row in rows[:5]
-        if isinstance(row, dict)
-    ]
-    return {
-        "row_count": row_count,
-        "status": data.get("status", "ok"),
-        "metadata": metadata,
-        "preview": preview_rows,
-        "note": f"Found {row_count} pilgrimage spots{' for ' + title if title else ''}. "
-        "Full data is available — proceed to return a search_response.",
-    }
+    is_search_tool = tool in (ToolName.SEARCH_BANGUMI, ToolName.SEARCH_NEARBY)
+    if is_search_tool and isinstance(data, SearchToolResult) and len(data.rows) > 5:
+        return _build_preview(data)
+    return data
 
 
 async def _run_ephemeral(
@@ -99,10 +105,8 @@ async def _run_ephemeral(
     *,
     tool: ToolName,
     params: dict[str, object],
-    handler: Callable[
-        [PlanStep, dict[str, object], object, object], Awaitable[HandlerResult]
-    ],
-) -> dict[str, object]:
+    handler: Callable[[PlanStep, ToolState, object, object], Awaitable[HandlerResult]],
+) -> MessageToolResult | None:
     """Run an upstream-free handler (greet/qa) and record/emit its result.
 
     Ephemeral handlers echo their LLM-supplied payload and never touch the DB,
@@ -143,22 +147,20 @@ async def _run_ephemeral(
             observation=result.error or "",
         )
 
-    return _summarize_for_llm(tool, result.data) if result.data else {}
+    return MessageToolResult.model_validate(result.data) if result.data else None
 
 
 async def run_clarify(
     deps: RuntimeDeps, *, question: str, options: list[str] | None
-) -> dict[str, object]:
-    """Enrich candidates and record/emit a clarification request payload."""
+) -> ClarifyToolResult:
+    """Enrich candidates and record/emit a clarification request."""
     normalized_options = list(options) if options else []
     await _emit_step(deps, ToolName.CLARIFY.value, "running", {})
     candidates = await enrich_clarify_candidates(deps, normalized_options)
-    payload: dict[str, object] = {
-        "question": question,
-        "options": normalized_options,
-        "candidates": candidates,
-        "status": "needs_clarification",
-    }
+    result = ClarifyToolResult(
+        question=question, options=normalized_options, candidates=candidates
+    )
+    payload = result.model_dump(mode="json")
     deps.tool_state[ToolName.CLARIFY.value] = payload
     deps.tool_state["pending_clarify"] = True
     _record_step(
@@ -170,8 +172,4 @@ async def run_clarify(
         error=None,
     )
     await _emit_step(deps, ToolName.CLARIFY.value, "done", payload)
-    # Signal to the LLM that it must stop and return clarify_response now.
-    # Without this, some models (e.g. DeepSeek V4 Flash) continue calling
-    # search_bangumi instead of waiting for user input.
-    payload["action_required"] = "return clarify_response"
-    return payload
+    return result

--- a/apps/agent/agent/agents/tool_state.py
+++ b/apps/agent/agent/agents/tool_state.py
@@ -1,0 +1,24 @@
+"""Explicit named type for the agent's shared per-run tool call state.
+
+Replaces the implicit convention of threading a bare ``dict[str, object]``
+through tool and handler call chains, where nothing in the signature
+distinguished "the shared tool state" from any other dict. ``ToolState`` is
+nominally distinct so every function that reads/writes it documents that
+intent — while remaining exactly ``dict[str, object]`` at runtime (a
+``NewType`` has zero runtime cost and changes no behavior).
+
+Splitting ``ToolState``'s *stored values* into a fully typed session-state +
+per-tool-results shape is a separate, larger effort — see the docstring on
+``RuntimeDeps.tool_state``.
+"""
+
+from __future__ import annotations
+
+from typing import NewType
+
+ToolState = NewType("ToolState", dict[str, object])
+
+
+def new_tool_state() -> ToolState:
+    """Build an empty ``ToolState`` for a fresh agent run."""
+    return ToolState({})

--- a/apps/agent/agent/agents/tools.py
+++ b/apps/agent/agent/agents/tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import structlog
 
 from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_results import ClarifyCandidate
 from agent.clients.catalog_client import PilgrimagePoint
 
 logger = structlog.get_logger(__name__)
@@ -19,7 +20,7 @@ _IO_ERRORS = (OSError, RuntimeError, ValueError)
 
 async def enrich_clarify_candidates(
     deps: RuntimeDeps, titles: list[str]
-) -> list[dict[str, object]]:
+) -> list[ClarifyCandidate]:
     """Enrich clarify candidate titles with cover/city/spot_count.
 
     DB-first → Catalog fallback → write-through (best-effort). The clarify path
@@ -32,7 +33,7 @@ async def enrich_clarify_candidates(
 
     by_title = await _db_lookup(deps, titles)
 
-    candidates: list[dict[str, object]] = []
+    candidates: list[ClarifyCandidate] = []
     for title in titles:
         row = by_title.get(title, {})
         bangumi_id = row.get("bangumi_id")
@@ -71,22 +72,22 @@ async def _db_lookup(
     return result
 
 
-def _candidate_from_row(title: str, row: dict[str, object]) -> dict[str, object]:
-    """Build a candidate dict from a DB row."""
+def _candidate_from_row(title: str, row: dict[str, object]) -> ClarifyCandidate:
+    """Build a candidate from a DB row."""
     cover_url = row.get("cover_url")
     points_count = row.get("points_count")
     city = row.get("city")
-    return {
-        "title": title,
-        "cover_url": cover_url if isinstance(cover_url, str) and cover_url else None,
-        "spot_count": int(points_count or 0)
+    return ClarifyCandidate(
+        title=title,
+        cover_url=cover_url if isinstance(cover_url, str) and cover_url else None,
+        spot_count=int(points_count or 0)
         if isinstance(points_count, int | float)
         else 0,
-        "city": str(city or "") if isinstance(city, str | None) else "",
-    }
+        city=str(city or "") if isinstance(city, str | None) else "",
+    )
 
 
-async def _catalog_fallback(deps: RuntimeDeps, title: str) -> dict[str, object]:
+async def _catalog_fallback(deps: RuntimeDeps, title: str) -> ClarifyCandidate:
     """Resolve via the Catalog service and write-through (best-effort).
 
     The first search hit carries the candidate's ``bangumi_id`` + ``cover_url``;
@@ -102,12 +103,12 @@ async def _catalog_fallback(deps: RuntimeDeps, title: str) -> dict[str, object]:
 
     cover_url = first.cover_url or None
     await _write_through(deps, title, first.bangumi_id, cover_url)
-    return {
-        "title": title,
-        "cover_url": cover_url,
-        "spot_count": len(points),
-        "city": "",
-    }
+    return ClarifyCandidate(
+        title=title,
+        cover_url=cover_url,
+        spot_count=len(points),
+        city="",
+    )
 
 
 async def _catalog_search(deps: RuntimeDeps, title: str) -> list[PilgrimagePoint]:
@@ -119,9 +120,9 @@ async def _catalog_search(deps: RuntimeDeps, title: str) -> list[PilgrimagePoint
         return []
 
 
-def _minimal_candidate(title: str) -> dict[str, object]:
+def _minimal_candidate(title: str) -> ClarifyCandidate:
     """A safe candidate when the catalog yields no enrichment data."""
-    return {"title": title, "cover_url": None, "spot_count": 0, "city": ""}
+    return ClarifyCandidate(title=title, cover_url=None, spot_count=0, city="")
 
 
 async def _write_through(

--- a/apps/agent/agent/agents/web_tools.py
+++ b/apps/agent/agent/agents/web_tools.py
@@ -11,6 +11,7 @@ from pydantic_ai import RunContext
 
 from agent.agents.pilgrimage_agent import pilgrimage_agent
 from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_results import TranslateTitleResult
 from agent.agents.translation import translate_title
 
 
@@ -71,7 +72,7 @@ async def translate_anime_title(
     *,
     title: str,
     target_language: str,
-) -> dict[str, object]:
+) -> TranslateTitleResult:
     """Translate an anime title to a target language using authoritative sources.
 
     This tool searches Bangumi, 萌娘百科, and Wikipedia for the community-accepted
@@ -92,9 +93,9 @@ async def translate_anime_title(
         target_locale=target_language,
         db=ctx.deps.db,
     )
-    return {
-        "original": result.original,
-        "translated": result.translated,
-        "source": result.source,
-        "confidence": result.confidence,
-    }
+    return TranslateTitleResult(
+        original=result.original,
+        translated=result.translated,
+        source=result.source,
+        confidence=result.confidence,
+    )

--- a/apps/agent/agent/tests/integration/test_tool_output_schemas.py
+++ b/apps/agent/agent/tests/integration/test_tool_output_schemas.py
@@ -1,0 +1,74 @@
+"""Integration test: AC4 — tool result models generate proper output schemas.
+
+S7.8's stated goal is clearing the typing prerequisite for a future
+``FastMCP.from_openapi`` MCP server (S7.4) so it can generate a per-tool
+``outputSchema``. No FastMCP wiring exists yet in this codebase (S7.4 is a
+separate, not-yet-started story) — this test instead proves the artifact
+FastMCP.from_openapi would need: every tool function's return annotation
+resolves to named Pydantic model(s) whose ``model_json_schema()`` exposes
+concrete, named ``properties`` — not a generic ``{"type": "object"}`` schema
+with no shape. No DB, no live model — pure static/schema introspection.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+from pydantic import BaseModel
+
+from agent.agents import pilgrimage_tools, web_tools
+
+_TOOL_FUNCTIONS: dict[str, object] = {
+    "resolve_anime": pilgrimage_tools.resolve_anime,
+    "search_bangumi": pilgrimage_tools.search_bangumi,
+    "search_nearby": pilgrimage_tools.search_nearby,
+    "plan_route": pilgrimage_tools.plan_route,
+    "greet_user": pilgrimage_tools.greet_user,
+    "general_qa": pilgrimage_tools.general_qa,
+    "clarify": pilgrimage_tools.clarify,
+    "translate_anime_title": web_tools.translate_anime_title,
+}
+
+
+def _named_models_in(annotation: object) -> list[type[BaseModel]]:
+    """Unwrap a Union/Optional annotation into its concrete named model types."""
+    args = typing.get_args(annotation)
+    if not args:
+        return (
+            [annotation]
+            if isinstance(annotation, type) and issubclass(annotation, BaseModel)
+            else []
+        )
+    models: list[type[BaseModel]] = []
+    for arg in args:
+        if arg is not type(None):
+            models.extend(_named_models_in(arg))
+    return models
+
+
+def _models_for(name: str) -> list[type[BaseModel]]:
+    annotation = typing.get_type_hints(_TOOL_FUNCTIONS[name])["return"]
+    return _named_models_in(annotation)
+
+
+@pytest.mark.parametrize("name", sorted(_TOOL_FUNCTIONS))
+def test_tool_return_schema_has_named_properties(name: str) -> None:
+    """Each tool's model(s) expose real field names, not a generic object schema."""
+    models = _models_for(name)
+    assert models, f"{name} resolves to no Pydantic model"
+    for model in models:
+        schema = model.model_json_schema()
+        assert schema.get("type") == "object"
+        assert schema.get("properties"), (
+            f"{model.__name__} (from {name}) has no named properties: {schema}"
+        )
+
+
+@pytest.mark.parametrize("name", sorted(_TOOL_FUNCTIONS))
+def test_tool_return_schema_property_names_are_not_generic(name: str) -> None:
+    """Guard against silently regressing back to a dict[str, object]-shaped model."""
+    for model in _models_for(name):
+        properties = model.model_json_schema()["properties"]
+        assert set(properties) != {"key", "value"}, model.__name__
+        assert all(isinstance(key, str) and key for key in properties)

--- a/apps/agent/agent/tests/unit/test_catalog_adapter.py
+++ b/apps/agent/agent/tests/unit/test_catalog_adapter.py
@@ -1,9 +1,9 @@
 """Unit tests for the catalog payload adapter.
 
 The adapter converts typed Catalog models (PilgrimagePoint / Route) into the
-``tool_state`` payload shapes the response builder and output_validator expect
-(mirroring the legacy handler payloads), so swapping the data source is invisible
-to the rest of the agent.
+named tool-result models the response builder and output_validator expect
+(mirroring the legacy handler payloads), so swapping the data source is
+invisible to the rest of the agent.
 """
 
 from __future__ import annotations
@@ -18,6 +18,11 @@ from agent.agents.catalog_adapter import (
 from agent.agents.handlers._helpers import (
     _build_nearby_groups,
     rewrite_image_urls,
+)
+from agent.agents.tool_results import (
+    ResolveAnimeResult,
+    RouteToolResult,
+    SearchToolResult,
 )
 from agent.clients.catalog_client import PilgrimagePoint, Route
 from agent.tests.eval.mock_catalog_client import MockCatalogClient
@@ -37,83 +42,88 @@ def _point(pid: str = "p1", bangumi_id: str = "160209") -> PilgrimagePoint:
     )
 
 
+def test_build_search_payload_returns_search_tool_result() -> None:
+    payload = build_search_payload([_point(), _point("p2")], tool="search_bangumi")
+    assert isinstance(payload, SearchToolResult)
+
+
 def test_build_search_payload_has_rows_and_row_count() -> None:
     payload = build_search_payload([_point(), _point("p2")], tool="search_bangumi")
-    assert payload["row_count"] == 2
-    assert len(payload["rows"]) == 2
+    assert payload.row_count == 2
+    assert len(payload.rows) == 2
 
 
 def test_build_search_payload_status_ok_when_points() -> None:
     payload = build_search_payload([_point()], tool="search_bangumi")
-    assert payload["status"] == "ok"
+    assert payload.status == "ok"
 
 
 def test_build_search_payload_status_empty_when_no_points() -> None:
     payload = build_search_payload([], tool="search_bangumi")
-    assert payload["status"] == "empty"
+    assert payload.status == "empty"
 
 
 def test_build_search_payload_sets_anime_title_metadata() -> None:
     payload = build_search_payload([_point()], tool="search_bangumi")
-    metadata = payload["metadata"]
-    assert isinstance(metadata, dict)
-    assert metadata["anime_title"] == "君の名は。"
+    assert payload.metadata.anime_title == "君の名は。"
 
 
 def test_build_search_payload_builds_nearby_groups() -> None:
     payload = build_search_payload([_point()], tool="search_nearby")
-    groups = payload["nearby_groups"]
-    assert isinstance(groups, list)
-    assert groups[0]["bangumi_id"] == "160209"
+    assert payload.nearby_groups[0].bangumi_id == "160209"
+
+
+def test_build_resolve_payload_returns_resolve_anime_result() -> None:
+    payload = build_resolve_payload([_point()])
+    assert isinstance(payload, ResolveAnimeResult)
 
 
 def test_build_resolve_payload_single_match_returns_bangumi_id() -> None:
     payload = build_resolve_payload([_point()])
-    assert payload["bangumi_id"] == "160209"
-    assert payload["title"] == "君の名は。"
+    assert payload.bangumi_id == "160209"
+    assert payload.title == "君の名は。"
 
 
 def test_build_resolve_payload_includes_candidates() -> None:
     payload = build_resolve_payload([_point()])
-    candidates = payload["candidates"]
-    assert isinstance(candidates, list)
-    assert candidates[0]["bangumi_id"] == "160209"
+    assert payload.candidates[0].bangumi_id == "160209"
 
 
 def test_build_resolve_payload_multiple_works_is_ambiguous() -> None:
     payload = build_resolve_payload([_point("p1", "160209"), _point("p2", "100403")])
-    assert payload["ambiguous"] is True
-    candidates = payload["candidates"]
-    assert isinstance(candidates, list)
-    assert len(candidates) == 2
+    assert payload.ambiguous is True
+    assert len(payload.candidates) == 2
 
 
 def test_build_resolve_payload_empty_when_no_points() -> None:
     payload = build_resolve_payload([])
-    assert payload == {}
+    assert payload.candidates == []
+
+
+async def test_build_route_payload_returns_route_tool_result() -> None:
+    route: Route = await MockCatalogClient().route(["p_euph_1", "p_euph_2"])
+    payload = build_route_payload(route)
+    assert isinstance(payload, RouteToolResult)
 
 
 async def test_build_route_payload_from_catalog_route() -> None:
     route: Route = await MockCatalogClient().route(["p_euph_1", "p_euph_2"])
     payload = build_route_payload(route)
-    assert payload["point_count"] == 2
-    assert payload["status"] == "ok"
-    itinerary = payload["timed_itinerary"]
-    assert isinstance(itinerary, dict)
-    assert itinerary["spot_count"] == 2
+    assert payload.point_count == 2
+    assert payload.status == "ok"
+    assert payload.timed_itinerary.spot_count == 2
 
 
 async def test_build_route_payload_summary_has_coordinate_counts() -> None:
     route: Route = await MockCatalogClient().route(["p_euph_1", "p_euph_2"])
-    summary = build_route_payload(route)["summary"]
-    assert isinstance(summary, dict)
-    assert summary["with_coordinates"] == 2
-    assert summary["without_coordinates"] == 0
+    summary = build_route_payload(route).summary
+    assert summary.with_coordinates == 2
+    assert summary.without_coordinates == 0
 
 
 def test_build_route_payload_empty_route_has_zero_points() -> None:
     payload = build_route_payload(Route())
-    assert payload["point_count"] == 0
+    assert payload.point_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/apps/agent/agent/tests/unit/test_catalog_tools.py
+++ b/apps/agent/agent/tests/unit/test_catalog_tools.py
@@ -1,0 +1,79 @@
+"""Unit tests for the catalog-result store pipeline in catalog_tools.
+
+tool_state must keep storing plain dict[str, object] (unchanged consumers in
+response_builder.py / chat.py), while the tool function itself now returns
+the named model instance to the caller.
+"""
+
+from __future__ import annotations
+
+from agent.agents.catalog_tools import _store_catalog_result
+from agent.agents.models import ToolName
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.runtime_models import PilgrimagePointModel
+from agent.agents.tool_results import ResolveAnimeResult, SearchToolResult
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+
+def _deps() -> RuntimeDeps:
+    return RuntimeDeps(db=object(), locale="ja", query="q", catalog=MockCatalogClient())
+
+
+def _row(name: str) -> PilgrimagePointModel:
+    return PilgrimagePointModel(id=name, name=name, latitude=1.0, longitude=1.0)
+
+
+async def test_store_catalog_result_stores_dict_shape_in_tool_state() -> None:
+    deps = _deps()
+    payload = SearchToolResult(rows=[_row("a")], row_count=1)
+    await _store_catalog_result(
+        deps, tool=ToolName.SEARCH_BANGUMI, params={}, payload=payload, success=True
+    )
+    stored = deps.tool_state["search_bangumi"]
+    assert isinstance(stored, dict)
+    assert stored["row_count"] == 1
+
+
+async def test_store_catalog_result_returns_typed_payload_unchanged() -> None:
+    deps = _deps()
+    payload = SearchToolResult(rows=[_row("a")], row_count=1)
+    result = await _store_catalog_result(
+        deps, tool=ToolName.SEARCH_BANGUMI, params={}, payload=payload, success=True
+    )
+    assert result is payload
+
+
+async def test_store_catalog_result_failure_returns_none() -> None:
+    deps = _deps()
+    result = await _store_catalog_result(
+        deps,
+        tool=ToolName.RESOLVE_ANIME,
+        params={},
+        payload=ResolveAnimeResult(),
+        success=False,
+    )
+    assert result is None
+
+
+async def test_store_catalog_result_failure_does_not_populate_tool_state() -> None:
+    deps = _deps()
+    await _store_catalog_result(
+        deps,
+        tool=ToolName.RESOLVE_ANIME,
+        params={},
+        payload=ResolveAnimeResult(),
+        success=False,
+    )
+    assert "resolve_anime" not in deps.tool_state
+
+
+async def test_store_catalog_result_records_failed_step() -> None:
+    deps = _deps()
+    await _store_catalog_result(
+        deps,
+        tool=ToolName.RESOLVE_ANIME,
+        params={},
+        payload=ResolveAnimeResult(),
+        success=False,
+    )
+    assert deps.steps[-1].success is False

--- a/apps/agent/agent/tests/unit/test_tool_result_key_parity.py
+++ b/apps/agent/agent/tests/unit/test_tool_result_key_parity.py
@@ -1,0 +1,134 @@
+"""Unit tests: AC3 regression signal — new models emit the legacy dict keys.
+
+S7.8 is type-narrowing only: no output key may be added, dropped, or renamed
+relative to the pre-refactor ``dict[str, object]`` payloads that reached
+``tool_state`` / ``agent_result_to_response`` / ``PublicAPIResponse``. This
+hardcodes those legacy key sets (from the dicts the tool functions built
+before this refactor) and asserts the new models' ``model_dump(mode="json")``
+still produces exactly the same keys.
+
+This is the CI-safe stand-in for the live trajectory comparison eval
+(``agent/tests/eval/test_agent_eval.py::test_agent``), which needs a live
+model + DB and is not run in this worktree.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.agents.tool_results import (
+    ClarifyCandidate,
+    ClarifyToolResult,
+    MessageToolResult,
+    ResolveAnimeResult,
+    ResolveCandidate,
+    RouteToolResult,
+    SearchToolResult,
+    TranslateTitleResult,
+)
+
+# Legacy dict[str, object] key sets, verbatim from the pre-S7.8 source.
+_LEGACY_SEARCH_KEYS = {
+    "rows",
+    "items",
+    "row_count",
+    "strategy",
+    "metadata",
+    "nearby_groups",
+    "status",
+    "empty",
+    "summary",
+}
+_LEGACY_RESOLVE_CANDIDATE_KEYS = {
+    "title",
+    "bangumi_id",
+    "cover_url",
+    "city",
+    "points_count",
+}
+_LEGACY_RESOLVE_RESOLVED_KEYS = {"bangumi_id", "title", "candidates"}
+_LEGACY_RESOLVE_AMBIGUOUS_KEYS = {"ambiguous", "candidates"}
+_LEGACY_ROUTE_KEYS = {
+    "ordered_points",
+    "timed_itinerary",
+    "point_count",
+    "cover_url",
+    "status",
+    "summary",
+}
+_LEGACY_MESSAGE_KEYS = {"message", "status"}
+_LEGACY_CLARIFY_CANDIDATE_KEYS = {"title", "cover_url", "spot_count", "city"}
+# tool_state["clarify"] always ended up with action_required too — the
+# original code mutated the same dict object after storing/emitting it.
+_LEGACY_CLARIFY_KEYS = {
+    "question",
+    "options",
+    "candidates",
+    "status",
+    "action_required",
+}
+_LEGACY_TRANSLATE_KEYS = {"original", "translated", "source", "confidence"}
+
+
+def test_search_tool_result_matches_legacy_dict_keys() -> None:
+    keys = set(SearchToolResult().model_dump(mode="json").keys())
+    assert keys == _LEGACY_SEARCH_KEYS
+
+
+def test_resolve_candidate_matches_legacy_dict_keys() -> None:
+    keys = set(
+        ResolveCandidate(title="t", bangumi_id="1").model_dump(mode="json").keys()
+    )
+    assert keys == _LEGACY_RESOLVE_CANDIDATE_KEYS
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (
+            ResolveAnimeResult(bangumi_id="1", title="t", candidates=[]),
+            _LEGACY_RESOLVE_RESOLVED_KEYS,
+        ),
+        (
+            ResolveAnimeResult(ambiguous=True, candidates=[]),
+            _LEGACY_RESOLVE_AMBIGUOUS_KEYS,
+        ),
+    ],
+)
+def test_resolve_anime_result_is_superset_of_legacy_keys(
+    result: ResolveAnimeResult, expected: set[str]
+) -> None:
+    """The legacy dict only ever carried ONE of these two key subsets; the
+    unified model always carries both (extra defaulted fields), which no
+    consumer distinguishes from absence — see catalog_adapter.build_resolve_payload.
+    """
+    keys = set(result.model_dump(mode="json").keys())
+    assert expected <= keys
+
+
+def test_route_tool_result_matches_legacy_dict_keys() -> None:
+    keys = set(RouteToolResult().model_dump(mode="json").keys())
+    assert keys == _LEGACY_ROUTE_KEYS
+
+
+def test_message_tool_result_matches_legacy_dict_keys() -> None:
+    keys = set(MessageToolResult().model_dump(mode="json").keys())
+    assert keys == _LEGACY_MESSAGE_KEYS
+
+
+def test_clarify_candidate_matches_legacy_dict_keys() -> None:
+    keys = set(ClarifyCandidate(title="t").model_dump(mode="json").keys())
+    assert keys == _LEGACY_CLARIFY_CANDIDATE_KEYS
+
+
+def test_clarify_tool_result_matches_legacy_stored_dict_keys() -> None:
+    keys = set(ClarifyToolResult().model_dump(mode="json").keys())
+    assert keys == _LEGACY_CLARIFY_KEYS
+
+
+def test_translate_title_result_matches_legacy_dict_keys() -> None:
+    result = TranslateTitleResult(
+        original="a", translated="b", source="db", confidence=1.0
+    )
+    keys = set(result.model_dump(mode="json").keys())
+    assert keys == _LEGACY_TRANSLATE_KEYS

--- a/apps/agent/agent/tests/unit/test_tool_results.py
+++ b/apps/agent/agent/tests/unit/test_tool_results.py
@@ -1,0 +1,97 @@
+"""Unit tests for the named Pydantic result models of the catalog tools.
+
+Covers resolve_anime / search_bangumi / search_nearby / plan_route — the four
+tools whose results flow through ``tool_state`` into ``PublicAPIResponse``.
+Each test asserts the model serializes to the exact key set the legacy
+``dict[str, object]`` payload used, so the response mapper sees no change.
+"""
+
+from __future__ import annotations
+
+from agent.agents.tool_results import (
+    ResolveAnimeResult,
+    ResolveCandidate,
+    RouteSummary,
+    RouteToolResult,
+    SearchPreviewRow,
+    SearchToolPreview,
+    SearchToolResult,
+)
+
+
+def test_resolve_candidate_serializes_expected_keys() -> None:
+    candidate = ResolveCandidate(
+        title="君の名は。", bangumi_id="160209", cover_url="c.jpg"
+    )
+    dumped = candidate.model_dump(mode="json")
+    assert set(dumped) == {"title", "bangumi_id", "cover_url", "city", "points_count"}
+
+
+def test_resolve_anime_result_resolved_shape() -> None:
+    result = ResolveAnimeResult(
+        bangumi_id="160209",
+        title="君の名は。",
+        candidates=[ResolveCandidate(title="君の名は。", bangumi_id="160209")],
+    )
+    dumped = result.model_dump(mode="json")
+    assert dumped["bangumi_id"] == "160209"
+    assert dumped["ambiguous"] is False
+    assert len(dumped["candidates"]) == 1
+
+
+def test_resolve_anime_result_empty_has_no_candidates() -> None:
+    assert ResolveAnimeResult().candidates == []
+
+
+def test_search_tool_result_key_order_matches_legacy_payload() -> None:
+    result = SearchToolResult(row_count=0, strategy="bangumi")
+    assert list(result.model_dump(mode="json").keys()) == [
+        "rows",
+        "items",
+        "row_count",
+        "strategy",
+        "metadata",
+        "nearby_groups",
+        "status",
+        "empty",
+        "summary",
+    ]
+
+
+def test_search_tool_result_defaults_status_ok() -> None:
+    assert SearchToolResult().status == "ok"
+
+
+def test_search_preview_row_has_name_and_episode() -> None:
+    row = SearchPreviewRow(name="須賀神社", episode=1)
+    assert row.model_dump(mode="json") == {"name": "須賀神社", "episode": 1}
+
+
+def test_search_tool_preview_carries_note_and_preview_rows() -> None:
+    preview = SearchToolPreview(
+        row_count=12,
+        preview=[SearchPreviewRow(name="a", episode=1)],
+        note="Found 12 spots",
+    )
+    assert preview.row_count == 12
+    assert preview.note == "Found 12 spots"
+    assert len(preview.preview) == 1
+
+
+def test_route_tool_result_key_order_matches_legacy_payload() -> None:
+    result = RouteToolResult()
+    assert list(result.model_dump(mode="json").keys()) == [
+        "ordered_points",
+        "timed_itinerary",
+        "point_count",
+        "cover_url",
+        "status",
+        "summary",
+    ]
+
+
+def test_route_summary_default_counts_are_zero() -> None:
+    summary = RouteSummary()
+    assert summary.point_count == 0
+    assert summary.with_coordinates == 0
+    assert summary.without_coordinates == 0

--- a/apps/agent/agent/tests/unit/test_tool_results_ephemeral.py
+++ b/apps/agent/agent/tests/unit/test_tool_results_ephemeral.py
@@ -1,0 +1,60 @@
+"""Unit tests for the named result models of the ephemeral/text tools.
+
+Covers greet_user / general_qa / clarify / translate_anime_title — tools that
+never touch ``tool_state``'s search/route contract but still need a named
+return type instead of ``dict[str, object]``.
+"""
+
+from __future__ import annotations
+
+from agent.agents.tool_results import (
+    ClarifyCandidate,
+    ClarifyToolResult,
+    MessageToolResult,
+    TranslateTitleResult,
+)
+
+
+def test_message_tool_result_defaults_status_info() -> None:
+    result = MessageToolResult(message="hi")
+    assert result.model_dump(mode="json") == {"message": "hi", "status": "info"}
+
+
+def test_clarify_candidate_allows_none_cover_url() -> None:
+    candidate = ClarifyCandidate(title="test")
+    assert candidate.cover_url is None
+
+
+def test_clarify_candidate_serializes_null_cover_url() -> None:
+    candidate = ClarifyCandidate(title="test", cover_url=None)
+    assert candidate.model_dump(mode="json")["cover_url"] is None
+
+
+def test_clarify_tool_result_default_shape() -> None:
+    result = ClarifyToolResult(question="which one?", options=["a", "b"])
+    dumped = result.model_dump(mode="json")
+    assert dumped["question"] == "which one?"
+    assert dumped["options"] == ["a", "b"]
+    assert dumped["status"] == "needs_clarification"
+    assert dumped["action_required"] == "return clarify_response"
+
+
+def test_clarify_tool_result_carries_candidates() -> None:
+    result = ClarifyToolResult(
+        question="q",
+        candidates=[ClarifyCandidate(title="A"), ClarifyCandidate(title="B")],
+    )
+    assert [c.title for c in result.candidates] == ["A", "B"]
+
+
+def test_translate_title_result_shape() -> None:
+    result = TranslateTitleResult(
+        original="君の名は。", translated="Your Name", source="db", confidence=0.9
+    )
+    dumped = result.model_dump(mode="json")
+    assert dumped == {
+        "original": "君の名は。",
+        "translated": "Your Name",
+        "source": "db",
+        "confidence": 0.9,
+    }

--- a/apps/agent/agent/tests/unit/test_tool_runtime.py
+++ b/apps/agent/agent/tests/unit/test_tool_runtime.py
@@ -1,0 +1,119 @@
+"""Unit tests for tool_runtime: summarization, ephemeral tools, clarify."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from agent.agents.handlers import execute_answer_question, execute_greet_user
+from agent.agents.models import ToolName
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.runtime_models import PilgrimagePointModel, ResultsMetadataModel
+from agent.agents.tool_results import (
+    ClarifyToolResult,
+    MessageToolResult,
+    ResolveAnimeResult,
+    SearchToolPreview,
+    SearchToolResult,
+)
+from agent.agents.tool_runtime import _run_ephemeral, _summarize_for_llm, run_clarify
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+
+def _deps() -> RuntimeDeps:
+    return RuntimeDeps(db=object(), locale="ja", query="q", catalog=MockCatalogClient())
+
+
+def _ctx(deps: RuntimeDeps) -> object:
+    """Stand-in for RunContext[RuntimeDeps] — only .deps is read."""
+    ctx = MagicMock()
+    ctx.deps = deps
+    return ctx
+
+
+def _row(name: str, episode: int = 1) -> PilgrimagePointModel:
+    return PilgrimagePointModel(
+        id=name, name=name, latitude=1.0, longitude=1.0, episode=episode
+    )
+
+
+def test_summarize_for_llm_passes_through_resolve_anime() -> None:
+    payload = ResolveAnimeResult(bangumi_id="1", title="t")
+    assert _summarize_for_llm(ToolName.RESOLVE_ANIME, payload) is payload
+
+
+def test_summarize_for_llm_passes_through_small_search_result() -> None:
+    payload = SearchToolResult(rows=[_row("a")], row_count=1)
+    assert _summarize_for_llm(ToolName.SEARCH_BANGUMI, payload) is payload
+
+
+def test_summarize_for_llm_previews_large_search_result() -> None:
+    rows = [_row(f"p{i}", i) for i in range(7)]
+    payload = SearchToolResult(rows=rows, row_count=7, status="ok")
+    summary = _summarize_for_llm(ToolName.SEARCH_BANGUMI, payload)
+    assert isinstance(summary, SearchToolPreview)
+    assert summary.row_count == 7
+    assert len(summary.preview) == 5
+
+
+def test_summarize_for_llm_preview_note_mentions_anime_title() -> None:
+    rows = [_row(f"p{i}", i) for i in range(6)]
+    metadata = ResultsMetadataModel(anime_title="響け")
+    payload = SearchToolResult(rows=rows, row_count=6, metadata=metadata)
+    summary = _summarize_for_llm(ToolName.SEARCH_NEARBY, payload)
+    assert isinstance(summary, SearchToolPreview)
+    assert "響け" in summary.note
+
+
+async def test_run_ephemeral_greet_user_returns_message_tool_result() -> None:
+    deps = _deps()
+    result = await _run_ephemeral(
+        _ctx(deps),
+        tool=ToolName.GREET_USER,
+        params={"message": "hi"},
+        handler=execute_greet_user,
+    )
+    assert result == MessageToolResult(message="hi", status="info")
+
+
+async def test_run_ephemeral_stores_dict_shape_in_tool_state() -> None:
+    deps = _deps()
+    await _run_ephemeral(
+        _ctx(deps),
+        tool=ToolName.GREET_USER,
+        params={"message": "hi"},
+        handler=execute_greet_user,
+    )
+    assert deps.tool_state["greet_user"] == {"message": "hi", "status": "info"}
+
+
+async def test_run_ephemeral_answer_question_returns_message_tool_result() -> None:
+    deps = _deps()
+    result = await _run_ephemeral(
+        _ctx(deps),
+        tool=ToolName.ANSWER_QUESTION,
+        params={"answer": "42"},
+        handler=execute_answer_question,
+    )
+    assert result == MessageToolResult(message="42", status="info")
+
+
+async def test_run_clarify_returns_clarify_tool_result() -> None:
+    deps = _deps()
+    result = await run_clarify(deps, question="which?", options=["A", "B"])
+    assert isinstance(result, ClarifyToolResult)
+    assert result.question == "which?"
+    assert [c.title for c in result.candidates] == ["A", "B"]
+
+
+async def test_run_clarify_sets_pending_clarify_flag() -> None:
+    deps = _deps()
+    await run_clarify(deps, question="q", options=None)
+    assert deps.tool_state["pending_clarify"] is True
+
+
+async def test_run_clarify_stores_dict_with_action_required() -> None:
+    deps = _deps()
+    await run_clarify(deps, question="q", options=["A"])
+    stored = deps.tool_state["clarify"]
+    assert isinstance(stored, dict)
+    assert stored["action_required"] == "return clarify_response"

--- a/apps/agent/agent/tests/unit/test_tool_signatures_are_typed.py
+++ b/apps/agent/agent/tests/unit/test_tool_signatures_are_typed.py
@@ -1,0 +1,71 @@
+"""Unit tests: AC1 — every tool function returns a named Pydantic model.
+
+Introspects each ``@agent.tool`` function's return type annotation directly,
+proving a future ``FastMCP.from_openapi`` would see a named model schema
+instead of a generic ``dict[str, object]``.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+from pydantic import BaseModel
+
+from agent.agents import pilgrimage_tools, web_tools
+
+_TOOL_FUNCTIONS: dict[str, object] = {
+    "resolve_anime": pilgrimage_tools.resolve_anime,
+    "search_bangumi": pilgrimage_tools.search_bangumi,
+    "search_nearby": pilgrimage_tools.search_nearby,
+    "plan_route": pilgrimage_tools.plan_route,
+    "greet_user": pilgrimage_tools.greet_user,
+    "general_qa": pilgrimage_tools.general_qa,
+    "clarify": pilgrimage_tools.clarify,
+    "web_search": web_tools.web_search,
+    "translate_anime_title": web_tools.translate_anime_title,
+}
+
+
+def _return_type(func: object) -> object:
+    return typing.get_type_hints(func)["return"]
+
+
+def _named_models_in(annotation: object) -> list[type]:
+    """Unwrap a Union/Optional annotation into its concrete named model types."""
+    args = typing.get_args(annotation)
+    if not args:
+        return [annotation] if isinstance(annotation, type) else []
+    models: list[type] = []
+    for arg in args:
+        if arg is not type(None):
+            models.extend(_named_models_in(arg))
+    return models
+
+
+def test_nine_tool_functions_are_covered() -> None:
+    assert len(_TOOL_FUNCTIONS) == 9
+
+
+@pytest.mark.parametrize("name", sorted(_TOOL_FUNCTIONS))
+def test_tool_return_type_is_not_a_bare_dict(name: str) -> None:
+    annotation = _return_type(_TOOL_FUNCTIONS[name])
+    assert typing.get_origin(annotation) is not dict, (
+        f"{name} still returns a bare dict: {annotation}"
+    )
+
+
+@pytest.mark.parametrize(
+    "name", sorted(n for n in _TOOL_FUNCTIONS if n != "web_search")
+)
+def test_tool_return_type_resolves_to_named_pydantic_models(name: str) -> None:
+    """Every tool except web_search (a plain str summary) names Pydantic models."""
+    annotation = _return_type(_TOOL_FUNCTIONS[name])
+    models = _named_models_in(annotation)
+    assert models, f"{name} has no named model in its return annotation: {annotation}"
+    assert all(issubclass(m, BaseModel) for m in models), models
+
+
+def test_web_search_returns_a_plain_str_by_design() -> None:
+    """web_search never returned dict[str, object] — flagged, not converted."""
+    assert _return_type(web_tools.web_search) is str

--- a/apps/agent/agent/tests/unit/test_tool_state.py
+++ b/apps/agent/agent/tests/unit/test_tool_state.py
@@ -1,0 +1,44 @@
+"""Unit tests for the explicit ToolState type.
+
+ToolState replaces the implicit convention of threading a bare
+``dict[str, object]`` through tool/handler call chains — a NewType gives
+every signature a self-documenting, nominal type while remaining a plain
+dict at runtime (zero behavior change).
+"""
+
+from __future__ import annotations
+
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_state import ToolState, new_tool_state
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+
+def test_new_tool_state_returns_empty_dict() -> None:
+    assert new_tool_state() == {}
+
+
+def test_new_tool_state_supports_dict_mutation() -> None:
+    state = new_tool_state()
+    state["resolve_anime"] = {"bangumi_id": "1"}
+    assert state["resolve_anime"] == {"bangumi_id": "1"}
+
+
+def test_tool_state_wraps_plain_dict_unchanged() -> None:
+    raw: dict[str, object] = {"pending_clarify": True}
+    assert ToolState(raw) is raw
+
+
+def test_runtime_deps_tool_state_defaults_to_new_tool_state() -> None:
+    deps = RuntimeDeps(db=object(), locale="ja", query="q", catalog=MockCatalogClient())
+    assert deps.tool_state == {}
+
+
+def test_runtime_deps_tool_state_instances_are_independent() -> None:
+    deps_a = RuntimeDeps(
+        db=object(), locale="ja", query="q", catalog=MockCatalogClient()
+    )
+    deps_b = RuntimeDeps(
+        db=object(), locale="ja", query="q", catalog=MockCatalogClient()
+    )
+    deps_a.tool_state["resolve_anime"] = {"bangumi_id": "1"}
+    assert deps_b.tool_state == {}

--- a/apps/agent/agent/tests/unit/test_tool_state_explicit_params.py
+++ b/apps/agent/agent/tests/unit/test_tool_state_explicit_params.py
@@ -1,0 +1,42 @@
+"""Unit tests: AC2 — tool_state is threaded via explicit ToolState parameters.
+
+Every function that reads/writes the shared per-run tool state now declares
+that parameter as ``ToolState`` (a nominal NewType), never a bare, anonymous
+``dict[str, object]`` mixed in with unrelated positional dict arguments.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from agent.agents import catalog_tools, pilgrimage_agent
+from agent.agents.tool_state import ToolState
+
+_STATE_READING_FUNCTIONS: dict[str, object] = {
+    "_add_resolve_context": pilgrimage_agent._add_resolve_context,
+    "_add_search_context": pilgrimage_agent._add_search_context,
+    "_add_nearby_context": pilgrimage_agent._add_nearby_context,
+    "_add_clarify_context": pilgrimage_agent._add_clarify_context,
+    "_bangumi_search_query": catalog_tools._bangumi_search_query,
+    "_geocode_for_catalog": catalog_tools._geocode_for_catalog,
+    "_point_ids_from_state": catalog_tools._point_ids_from_state,
+}
+
+
+def test_five_state_reading_functions_and_more_are_covered() -> None:
+    assert len(_STATE_READING_FUNCTIONS) == 7
+
+
+def test_every_state_reading_function_declares_tool_state_param() -> None:
+    for name, func in _STATE_READING_FUNCTIONS.items():
+        hints = typing.get_type_hints(func)
+        assert ToolState in hints.values(), (
+            f"{name} does not declare a ToolState-typed parameter: {hints}"
+        )
+
+
+def test_runtime_deps_tool_state_field_is_tool_state_typed() -> None:
+    from agent.agents.runtime_deps import RuntimeDeps
+
+    hints = typing.get_type_hints(RuntimeDeps)
+    assert hints["tool_state"] is ToolState

--- a/apps/agent/agent/tests/unit/test_tools.py
+++ b/apps/agent/agent/tests/unit/test_tools.py
@@ -36,12 +36,12 @@ async def test_enrich_clarify_candidates_keeps_order_and_defaults() -> None:
         deps, ["凉宫春日的忧郁", "凉宫春日的消失"]
     )
 
-    assert [c["title"] for c in candidates] == ["凉宫春日的忧郁", "凉宫春日的消失"]
-    assert candidates[0]["cover_url"] == "https://example.com/a.jpg"
-    assert candidates[0]["spot_count"] == 12
-    assert candidates[0]["city"] == "西宫"
-    assert candidates[1]["cover_url"] is None
-    assert candidates[1]["spot_count"] == 0
+    assert [c.title for c in candidates] == ["凉宫春日的忧郁", "凉宫春日的消失"]
+    assert candidates[0].cover_url == "https://example.com/a.jpg"
+    assert candidates[0].spot_count == 12
+    assert candidates[0].city == "西宫"
+    assert candidates[1].cover_url is None
+    assert candidates[1].spot_count == 0
 
 
 async def test_enrich_clarify_candidates_falls_back_to_catalog_and_writes_through() -> (
@@ -69,7 +69,7 @@ async def test_enrich_clarify_candidates_falls_back_to_catalog_and_writes_throug
 
     # The catalog's first hit carries the bangumi_id (160209), cover, and the
     # work's point count — no Bangumi gateway is consulted.
-    assert candidates[0]["cover_url"] == "https://example.test/cover/160209.jpg"
-    assert candidates[0]["spot_count"] == 2
+    assert candidates[0].cover_url == "https://example.test/cover/160209.jpg"
+    assert candidates[0].spot_count == 2
     db.bangumi.upsert_bangumi_title.assert_awaited_once_with("你的名字", "160209")
     db.bangumi.upsert_bangumi.assert_awaited()

--- a/apps/agent/agent/tests/unit/test_tools_helpers.py
+++ b/apps/agent/agent/tests/unit/test_tools_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_results import ClarifyCandidate
 from agent.agents.tools import (
     _candidate_from_row,
     _catalog_fallback,
@@ -53,17 +54,17 @@ def test_candidate_from_row_with_full_data() -> None:
         "city": "京都",
     }
     c = _candidate_from_row("響け", row)
-    assert c["title"] == "響け"
-    assert c["cover_url"] == "https://example.com/img.jpg"
-    assert c["spot_count"] == 5
-    assert c["city"] == "京都"
+    assert c.title == "響け"
+    assert c.cover_url == "https://example.com/img.jpg"
+    assert c.spot_count == 5
+    assert c.city == "京都"
 
 
 def test_candidate_from_row_with_empty_data() -> None:
     c = _candidate_from_row("test", {})
-    assert c["cover_url"] is None
-    assert c["spot_count"] == 0
-    assert c["city"] == ""
+    assert c.cover_url is None
+    assert c.spot_count == 0
+    assert c.city == ""
 
 
 class _FailingCatalog:
@@ -89,7 +90,7 @@ class _FailingCatalog:
 
 def test_minimal_candidate_shape() -> None:
     c = _minimal_candidate("test")
-    assert c == {"title": "test", "cover_url": None, "spot_count": 0, "city": ""}
+    assert c == ClarifyCandidate(title="test", cover_url=None, spot_count=0, city="")
 
 
 async def test_catalog_search_returns_empty_on_error() -> None:
@@ -103,9 +104,9 @@ async def test_catalog_fallback_returns_minimal_on_error() -> None:
     catalog: CatalogClientProtocol = _FailingCatalog()
     deps = RuntimeDeps(db=MagicMock(spec=[]), locale="zh", query="q", catalog=catalog)
     result = await _catalog_fallback(deps, "test")
-    assert result["title"] == "test"
-    assert result["cover_url"] is None
-    assert result["spot_count"] == 0
+    assert result.title == "test"
+    assert result.cover_url is None
+    assert result.spot_count == 0
 
 
 async def test_catalog_fallback_resolves_via_catalog() -> None:
@@ -114,8 +115,8 @@ async def test_catalog_fallback_resolves_via_catalog() -> None:
     db.bangumi.upsert_bangumi = AsyncMock(return_value=None)
     deps = RuntimeDeps(db=db, locale="zh", query="q", catalog=MockCatalogClient())
     result = await _catalog_fallback(deps, "你的名字")
-    assert result["cover_url"] == "https://example.test/cover/160209.jpg"
-    assert result["spot_count"] == 2
+    assert result.cover_url == "https://example.test/cover/160209.jpg"
+    assert result.spot_count == 2
     db.bangumi.upsert_bangumi_title.assert_awaited_once_with("你的名字", "160209")
 
 


### PR DESCRIPTION
## Summary

Closes #253 (S7.8). Converts the 9 `@agent.tool` functions' `dict[str, object]` returns into named Pydantic models, and makes `tool_state` an explicit typed parameter instead of an implicit ordering convention — clearing the typing prerequisite for the future MCP server (S7.4) so `FastMCP.from_openapi` can generate a proper `outputSchema` per tool.

This is **type-narrowing only** — no output key, value, or ordering changes. `tool_state`'s *stored values* still serialize to plain `dict[str, object]` at the `tool_runtime`/`catalog_tools` boundary (via `model_dump(mode="json")`), so `response_builder.py` and `chat.py`'s `on_complete` merge (both do `isinstance(tool_payload, dict)`) keep working completely unchanged.

### Tools converted (old → new)

| Tool | Old return | New return |
|---|---|---|
| `resolve_anime` | `dict[str, object]` | `ResolveAnimeResult \| None` |
| `search_bangumi` | `dict[str, object]` | `SearchToolResult \| SearchToolPreview \| None` |
| `search_nearby` | `dict[str, object]` | `SearchToolResult \| SearchToolPreview \| None` |
| `plan_route` | `dict[str, object]` | `RouteToolResult \| None` |
| `greet_user` | `dict[str, object]` | `MessageToolResult \| None` |
| `general_qa` | `dict[str, object]` | `MessageToolResult \| None` |
| `clarify` | `dict[str, object]` | `ClarifyToolResult` |
| `translate_anime_title` | `dict[str, object]` | `TranslateTitleResult` |
| `web_search` | **already `str`** | unchanged — not a `dict[str,object]`, no conversion needed |

All new models live in `apps/agent/agent/agents/tool_results.py`. Nested shapes reuse existing models where they already matched (`PilgrimagePointModel`, `ResultsMetadataModel`, `ResultsSummaryModel`, `NearbyGroupModel` from `runtime_models.py`).

### tool_state — explicit parameter

Added `ToolState = NewType("ToolState", dict[str, object])` in the new `apps/agent/agent/agents/tool_state.py`. `RuntimeDeps.tool_state` and every helper that reads/writes it (`_add_resolve_context`, `_add_search_context`, `_add_nearby_context`, `_add_clarify_context` in `pilgrimage_agent.py`; `_bangumi_search_query`, `_geocode_for_catalog`, `_point_ids_from_state` in `catalog_tools.py`; the ephemeral-handler `Callable` type in `tool_runtime.py`) now declare `ToolState` instead of a bare, anonymous `dict[str, object]`. Splitting `tool_state`'s *stored values* into a fully typed session-state shape is a separate, larger effort explicitly deferred to the Wave 3 agent→Worker rewrite (documented in `RuntimeDeps.tool_state`'s docstring) — out of scope here.

### Behavior preservation

- `_store_catalog_result`/`_run_catalog_search`/`_run_catalog_nearby`/`_run_catalog_route` (catalog_tools.py) build the typed model, then serialize once via `model_dump(mode="json")` for `tool_state`/SSE — the exact dict shape that reached `agent_result_to_response` before is unchanged.
- Old `bool(payload)` truthiness checks (which don't work on Pydantic models — they're always truthy) were replaced with explicit, named checks that reproduce the same control flow: `_has_results()` mirrors resolve_anime's "empty candidates = failure" and search_bangumi's "always succeeds" quirk exactly; `search_nearby`'s `bool(payload.rows)` replaces `bool(payload.get("rows"))`.
- `ClarifyToolResult.action_required` is now a fixed field (always `"return clarify_response"`) instead of being added via post-hoc dict mutation after storage/emission — verified nothing reads its absence; the emitted value is identical.
- `_summarize_for_llm`'s search-result preview shrinking (>5 rows) still only affects what the LLM sees as the tool-call result — never `tool_state`, so it never reached the response builder before or after.

## AC verification

| AC | Test type | Where |
|---|---|---|
| All 9 tools return named Pydantic models; mypy --strict passes | unit | `test_tool_signatures_are_typed.py` (introspects `typing.get_type_hints` on each tool) + `make typecheck` (94 source files, clean) |
| `tool_state` is an explicit typed parameter, not implicit ordering | unit | `test_tool_state.py`, `test_tool_state_explicit_params.py` |
| Regression: refactor is pure type-narrowing, no behavior change | eval | `test_tool_result_key_parity.py` (CI-safe stand-in — asserts each new model's `model_dump(mode="json")` key set matches the legacy dict verbatim); the live trajectory comparison eval (`agent/tests/eval/test_agent_eval.py::test_agent`, MockCatalogClient-based offline eval tests in `test_agent_eval_mock_runtime.py`) all still pass unchanged — **not re-run live here (no MIMO key in this worktree)**, will run in CI/nightly per S7.1's baseline |
| `outputSchema` corresponds to named model fields, not generic object | integration | `test_tool_output_schemas.py` — **no `FastMCP.from_openapi` wiring exists yet in this codebase** (S7.4 is a separate, not-yet-started story); this test proves the artifact it will need: every tool's model(s) generate a `model_json_schema()` with concrete named `properties`, not a generic `{"type": "object"}`. Flagging FastMCP wiring itself as out-of-scope follow-up (S7.4). |

## Test plan

- [x] `make typecheck` — 94 source files, no issues
- [x] `make lint` (ruff format + check) — clean
- [x] `make test` (unit) — 841 passed, 80.79% coverage (was 772 passed / 80.06% before this PR — both up)
- [x] New integration test (`test_tool_output_schemas.py`) — 16 passed, no DB required
- [x] Offline eval-style tests (`test_agent_eval_mock.py`, `test_agent_eval_mock_runtime.py`) that drive the full agent → tool call chain end-to-end via `MockCatalogClient` — all pass unchanged
- [ ] Live trajectory comparison eval (`test_agent_eval.py::test_agent`) — intentionally not run in this worktree (needs live model + real DB); will run in CI/nightly

Note: `make test-integration`'s DB-backed tests (testcontainer Postgres) fail with `relation "bangumi" does not exist` in this worktree — confirmed via `git stash` to reproduce identically on the pre-existing base commit, so it's a pre-existing environment/migration-seeding issue unrelated to this change, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)