### PR TITLE
feat(agent): S7.8 - convert translate_anime_title tool return to a named Pydantic model

### DIFF
--- a/apps/agent/agent/agents/tool_outcomes.py
+++ b/apps/agent/agent/agents/tool_outcomes.py
@@ -129,3 +129,17 @@ RouteToolResult: TypeAlias = Annotated[
     RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync | RouteUpstreamDown,
     Field(discriminator="status"),
 ]
+
+
+TranslateTitleSource = Literal["catalog", "llm", "untranslated"]
+
+
+class TranslateTitleResult(BaseModel):
+    """A localized title with provenance, returned by translate_anime_title."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    original: str
+    translated: str
+    source: TranslateTitleSource
+    confidence: float

--- a/apps/agent/agent/agents/web_tools.py
+++ b/apps/agent/agent/agents/web_tools.py
@@ -18,6 +18,7 @@ from pydantic_ai.common_tools.duckduckgo import (
 from pydantic_ai.tools import ToolFuncEither
 
 from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_outcomes import TranslateTitleResult
 from agent.agents.translation import TranslationResult, translate_title
 from agent.agents.web_trust import (
     WebResult,
@@ -110,7 +111,7 @@ async def translate_anime_title(
     *,
     title: str,
     target_language: str,
-) -> dict[str, object]:
+) -> TranslateTitleResult:
     """Translate an anime title through catalog or tool-less localization.
 
     Chinese titles resolve through the authoritative catalog. English, Japanese,
@@ -124,15 +125,16 @@ async def translate_anime_title(
                Examples: "君の名は。", "Your Name", "你的名字"
         target_language: Target language code: "ja", "zh", or "en"
 
-    Returns: {"original": "...", "translated": "...", "source": "catalog|llm|untranslated", "confidence": 0.0-1.0}
+    Returns a TranslateTitleResult: original title, translated text, provenance
+    source (catalog|llm|untranslated), and confidence (0.0-1.0).
     """
     result = await _translate_title(ctx, title, target_language)
-    return {
-        "original": result.original,
-        "translated": result.translated,
-        "source": result.source,
-        "confidence": result.confidence,
-    }
+    return TranslateTitleResult(
+        original=result.original,
+        translated=result.translated,
+        source=result.source,
+        confidence=result.confidence,
+    )
 
 
 async def _translate_title(

--- a/apps/agent/agent/tests/integration/test_tool_outcome_schemas.py
+++ b/apps/agent/agent/tests/integration/test_tool_outcome_schemas.py
@@ -1,0 +1,78 @@
+"""Every named tool-outcome model must emit a real, named JSON schema.
+
+S7.8: FastMCP.from_openapi (S7.4, not yet wired) needs each tool's return
+type to generate a proper outputSchema. This proves model_json_schema()
+produces named `properties` for every discriminated-outcome member and for
+TranslateTitleResult, across module boundaries with no mocking.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from agent.agents.tool_outcomes import (
+    NearbyEmpty,
+    NearbyMissingLocation,
+    NearbyOk,
+    NearbyPlaceAmbiguous,
+    NearbyPlaceUnresolved,
+    NearbyUpstreamDown,
+    ResolveAmbiguous,
+    ResolveNotFound,
+    ResolveResolved,
+    ResolveUpstreamDown,
+    RouteEmpty,
+    RouteOk,
+    RoutePendingSync,
+    RouteStaleRef,
+    RouteUpstreamDown,
+    SearchEmpty,
+    SearchOk,
+    SearchUpstreamDown,
+    TranslateTitleResult,
+)
+
+_ModelWithProperties = tuple[type[BaseModel], frozenset[str]]
+
+_MODELS_WITH_EXPECTED_PROPERTIES: tuple[_ModelWithProperties, ...] = (
+    (ResolveResolved, frozenset({"outcome", "bangumi_id", "anime_title"})),
+    (ResolveAmbiguous, frozenset({"outcome", "clarification_reason", "candidate_ids"})),
+    (ResolveNotFound, frozenset({"outcome", "clarification_reason"})),
+    (ResolveUpstreamDown, frozenset({"outcome"})),
+    (
+        SearchOk,
+        frozenset({"outcome", "result_ref", "row_count", "anime_title", "partial"}),
+    ),
+    (SearchEmpty, frozenset({"outcome", "anime_title", "partial"})),
+    (SearchUpstreamDown, frozenset({"outcome"})),
+    (NearbyOk, frozenset({"outcome", "result_ref", "row_count"})),
+    (NearbyEmpty, frozenset({"outcome"})),
+    (
+        NearbyPlaceAmbiguous,
+        frozenset({"outcome", "clarification_reason", "place_candidate_ids"}),
+    ),
+    (NearbyPlaceUnresolved, frozenset({"outcome", "clarification_reason"})),
+    (NearbyMissingLocation, frozenset({"outcome", "clarification_reason"})),
+    (NearbyUpstreamDown, frozenset({"outcome"})),
+    (RouteOk, frozenset({"status", "route_ref", "point_count", "total_minutes"})),
+    (RouteEmpty, frozenset({"status"})),
+    (RouteStaleRef, frozenset({"status"})),
+    (RoutePendingSync, frozenset({"status"})),
+    (RouteUpstreamDown, frozenset({"status"})),
+    (
+        TranslateTitleResult,
+        frozenset({"original", "translated", "source", "confidence"}),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_properties"), _MODELS_WITH_EXPECTED_PROPERTIES
+)
+def test_tool_outcome_model_emits_named_json_schema(
+    model_type: type[BaseModel], expected_properties: frozenset[str]
+) -> None:
+    schema = model_type.model_json_schema()
+
+    assert set(schema["properties"]) == expected_properties

--- a/apps/agent/agent/tests/unit/test_eval_mock_web.py
+++ b/apps/agent/agent/tests/unit/test_eval_mock_web.py
@@ -20,6 +20,7 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from agent.agents.agent_result import AgentResult
 from agent.agents.animichi_runner import run_animichi_agent
 from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_outcomes import TranslateTitleResult
 from agent.agents.web_tools import translate_anime_title, web_search
 from agent.domain.ports import DatabasePort
 from agent.tests.eval.mock_catalog_client import MockCatalogClient
@@ -142,8 +143,9 @@ async def test_translate_title_injection_bypasses_null_database() -> None:
         _ctx(deps), title="響け！ユーフォニアム", target_language="zh"
     )
 
-    assert result["translated"] == "吹响悠风号"
-    assert result["source"] == "catalog"
+    assert isinstance(result, TranslateTitleResult)
+    assert result.translated == "吹响悠风号"
+    assert result.source == "catalog"
 
 
 async def test_web_search_direct_injection_returns_wrapped_results() -> None:

--- a/apps/agent/agent/tests/unit/test_translate_title_result.py
+++ b/apps/agent/agent/tests/unit/test_translate_title_result.py
@@ -1,0 +1,50 @@
+"""Key-parity and typed-signature guarantees for TranslateTitleResult.
+
+S7.8: translate_anime_title used to return a bare dict[str, object] built
+from these exact four keys. These tests lock in that the new named model
+serializes to the identical key set and that the tool signature is now
+genuinely typed, not just documented as such.
+"""
+
+from __future__ import annotations
+
+from typing import get_type_hints
+
+import pytest
+from pydantic import ValidationError
+
+from agent.agents.tool_outcomes import TranslateTitleResult
+from agent.agents.web_tools import translate_anime_title
+
+_LEGACY_DICT_KEYS = frozenset({"original", "translated", "source", "confidence"})
+
+
+def test_translate_title_result_key_parity_with_legacy_dict() -> None:
+    """The retired dict[str, object] return had exactly these four keys."""
+    result = TranslateTitleResult(
+        original="君の名は。",
+        translated="你的名字",
+        source="catalog",
+        confidence=1.0,
+    )
+
+    assert set(result.model_dump(mode="json").keys()) == _LEGACY_DICT_KEYS
+
+
+def test_translate_title_result_rejects_unknown_fields() -> None:
+    payload = {
+        "original": "a",
+        "translated": "b",
+        "source": "catalog",
+        "confidence": 1.0,
+        "unexpected": "nope",
+    }
+
+    with pytest.raises(ValidationError):
+        TranslateTitleResult.model_validate(payload)
+
+
+def test_translate_anime_title_return_annotation_is_the_named_model() -> None:
+    hints = get_type_hints(translate_anime_title)
+
+    assert hints["return"] is TranslateTitleResult


### PR DESCRIPTION
## Summary

Redo of #418 (closed — built on a 490-commit-stale base) on a fresh `feat/frontend-rebuild` tip. Closes #253.

Re-audited the current tree from scratch rather than reusing the stale diff: the four catalog tools (`resolve_anime`, `search_bangumi`, `search_nearby`, `plan_route`) and `tool_state` (`RuntimeDeps.tool_state: ToolState`, a Pydantic model) were **already converted** by later, unrelated work (the agent-redesign line, PR #349 and follow-ups) before this card was picked back up. The only tool-return still typed as `dict[str, object]` was `translate_anime_title`.

- Adds `TranslateTitleResult` (`apps/agent/agent/agents/tool_outcomes.py`) alongside the existing discriminated outcome models (`ResolveResult`, `SearchToolResult`, `NearbyToolResult`, `RouteToolResult`) — same file, same convention, not a new module, since that convention was already established.
- `translate_anime_title` (`apps/agent/agent/agents/web_tools.py`) now returns `TranslateTitleResult` instead of a hand-built dict with the same four keys (`original`, `translated`, `source`, `confidence`).
- `web_search` is untouched — it already returns `str`, never a dict.
- `tool_state` is untouched — it's already an explicit `ToolState` Pydantic-model field on `RuntimeDeps`, threaded explicitly through every helper (`ctx.deps.tool_state`), with `to_legacy_dict()` already doing the plain-dict boundary serialization the card describes. Nothing left to do there.

## Zero behavior change

`TranslationResult`'s four fields pass straight through into `TranslateTitleResult` unchanged. A key-parity unit test hardcodes the legacy dict's key set and asserts the new model's `model_dump(mode="json").keys()` match exactly.

## Tests (AC=4: unit=2, integration=1, eval=1)

- **unit** — `agent/tests/unit/test_translate_title_result.py`: key-parity against the legacy dict keys, `extra="forbid"` rejects unknown fields, and `translate_anime_title`'s resolved return-type hint is `TranslateTitleResult` (not `dict`).
- **integration** — `agent/tests/integration/test_tool_outcome_schemas.py`: every named tool-outcome model (the four existing discriminated outcomes plus `TranslateTitleResult`) generates a real `model_json_schema()` with the expected named properties — the prerequisite for `FastMCP.from_openapi` (S7.4, still out of scope, not wired here).
- **eval** — `agent/tests/unit/test_eval_mock_web.py::test_translate_title_injection_bypasses_null_database` (the offline `MockCatalogClient`/`NullDatabase` mock-eval test that already exercised this tool end-to-end) updated from dict-subscript assertions to attribute access plus an `isinstance` check; stays green.

## Verification

- `make lint` — clean (ruff check + format).
- `make typecheck` (mypy strict, the project's own gate scope) — clean, 110 source files.
- `make test` — 1227 passed, coverage 87.89% (floor 82%; `tool_outcomes.py` 100%, `web_tools.py` 97%, unchanged pre-existing gap in the untested live-DuckDuckGo branch).
- No live eval run (no MIMO key, per card instructions) — behavior preservation confirmed via the key-parity test plus the offline mock-eval test above.

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test` (1227 passed)
- [x] New integration test (schema generation) passes
- [x] Confirmed zero remaining `dict[str, object]`/`dict[str, Any]` in any `@agent.tool` signature or return type

🤖 Generated with [Claude Code](https://claude.com/claude-code)