### PR TITLE
feat(web): D1-D9 in-character fallback states for the chat UI (#272 frontend half)

### DIFF
--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -1,8 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useLocale } from "../../i18n/context";
+import { classifyFailure } from "../../lib/chat/errorClassifier";
+import type { ChatErrorState, FailureSignal } from "../../lib/chat/errorClassifier";
+import { ChatActionsProvider } from "./chat-actions";
+import type { ChatActions } from "./chat-actions";
 import { ChatInput } from "./components/ChatInput";
 import { ColdStart } from "./components/ColdStart";
 import { ErrorBanner } from "./components/ErrorBanner";
+import { TurnFailure } from "./components/ErrorStates/TurnFailure";
+import type { TurnFailureView } from "./components/ErrorStates/TurnFailure";
 import { HistoryList } from "./components/HistoryList";
 import { MessageList } from "./components/MessageList";
 import { WaitingRitual } from "./components/WaitingRitual";
@@ -18,6 +24,8 @@ import type { BackendHealth } from "./use-backend-health";
 import type { ChatSession } from "./use-chat-session";
 import { useChatSession } from "./use-chat-session";
 import { useConversationHistory } from "./use-conversation-history";
+import { useStreamRecovery } from "./use-stream-recovery";
+import { useTurnTimeout } from "./use-turn-timeout";
 import { useTurnTiming } from "./use-turn-timing";
 import type { ConversationHistory } from "./use-conversation-history";
 
@@ -30,6 +38,7 @@ type ShellProps = Readonly<{
   dict: ChatDict;
   chat: ChatSession;
   history: ConversationHistory;
+  failure: TurnFailureView | undefined;
   onRetry: () => void;
   onSend: (text: string) => void;
 }>;
@@ -73,7 +82,7 @@ function ChatBody(props: BodyProps) {
     <section className="chat-body">
       <HistoryLoadingGate history={props.history} dict={props.dict} />
       <HistoryList entries={props.history.entries} dict={props.dict} />
-      <ColdStartGate {...props} /><ChatMessages chat={props.chat} dict={props.dict} /><WaitingRitual status={props.chat.status} dict={props.dict} messages={props.chat.messages} /><div ref={anchor} aria-hidden="true" />
+      <ColdStartGate {...props} /><ChatMessages chat={props.chat} dict={props.dict} /><TurnFailure view={props.failure} dict={props.dict} /><WaitingRitual status={props.chat.status} dict={props.dict} messages={props.chat.messages} /><div ref={anchor} aria-hidden="true" />
     </section>
   );
 }
@@ -100,29 +109,45 @@ function ChatShell(props: ShellProps) {
   );
 }
 
-function useSendText(chat: ChatSession): (text: string) => void {
-  const { sendMessage } = chat;
-  return useCallback((text: string) => void sendMessage({ text }), [sendMessage]);
+/** Send, plus the D6-style retry: drop the failed turn's partial and resubmit. */
+function useTurnActions(chat: ChatSession): ChatActions {
+  const { sendMessage, clearError, regenerate } = chat;
+  const send = useCallback((text: string) => void sendMessage({ text }), [sendMessage]);
+  const regen = useCallback(() => { clearError(); void regenerate(); }, [clearError, regenerate]);
+  return useMemo(() => ({ send, regenerate: regen }), [send, regen]);
 }
 
-/**
- * A5 retry distinguishes the two failure sources: a failed healthz probe is
- * re-probed, while a failed stream turn is regenerated (the AI SDK drops the
- * partial assistant message and resubmits the turn).
- */
-function useRetry(chat: ChatSession, retryHealth: () => void): () => void {
-  const { error, clearError, regenerate } = chat;
-  return useCallback(() => {
-    retryHealth();
-    if (!error) return;
-    clearError();
-    void regenerate();
-  }, [error, clearError, regenerate, retryHealth]);
+function turnFailureSignal(lastStatus: number | undefined): FailureSignal {
+  if (lastStatus !== undefined && lastStatus >= 400) return { kind: "http", status: lastStatus };
+  return { kind: "stream-abort" };
 }
 
-function entryStateOf(search: ChatSearch, health: BackendHealth, chat: ChatSession): ChatEntryState {
+function isActiveTurn(status: ChatSession["status"]): boolean {
+  return status === "submitted" || status === "streaming";
+}
+
+function turnFailureState(chat: ChatSession, timedOut: boolean): ChatErrorState | undefined {
+  if (isActiveTurn(chat.status)) return undefined;
+  if (timedOut) return "D5";
+  if (chat.error === undefined) return undefined;
+  return classifyFailure(turnFailureSignal(chat.lastHttpStatus())) ?? "D4";
+}
+
+/** Compose the D4/D5/D8 view: watchdog + classification + P6 recovery. */
+function useTurnFailure(chat: ChatSession, baseUrl: string): TurnFailureView | undefined {
+  const timeout = useTurnTimeout(chat.status, () => void chat.stop());
+  const recovery = useStreamRecovery(baseUrl, chat, chat.sessionIdOf);
+  const state = turnFailureState(chat, timeout.timedOut);
+  const onRetry = useCallback(() => { timeout.reset(); recovery.recover(); }, [timeout, recovery]);
+  const onExpiredResume = useCallback(() => { timeout.reset(); recovery.recoverExpired(); }, [timeout, recovery]);
+  if (state === undefined) return undefined;
+  return { state, onRetry, onExpiredResume, recovering: recovery.recovering };
+}
+
+/** A5 covers backend reachability only; stream failures render inline D-strips. */
+function entryStateOf(search: ChatSearch, health: BackendHealth): ChatEntryState {
   return deriveEntryState({
-    healthy: health.status !== "down" && chat.error === undefined,
+    healthy: health.status !== "down",
     query: search.q,
     sessionId: search.session,
     routeReference: resolveRouteReference(search.route),
@@ -143,14 +168,16 @@ function useChatState(search: ChatSearch) {
   const health = useBackendHealth(config.baseUrl);
   const chat = useChatSession(config.chatUrl, search.session);
   const history = useConversationHistory(config.baseUrl, search.session);
-  return { health, chat, history };
+  return { config, health, chat, history };
 }
 
 export function ChatPage({ search }: ChatPageProps) {
-  const { health, chat, history } = useChatState(search);
-  const onSend = useSendText(chat);
-  useAutoSendFromQuery(search, health, onSend);
-  const entry = entryStateOf(search, health, chat);
-  const onRetry = useRetry(chat, health.retry);
-  return <ChatShell entry={entry} dict={chatDictFor(useLocale())} chat={chat} history={history} onRetry={onRetry} onSend={onSend} />;
+  const { config, health, chat, history } = useChatState(search);
+  const actions = useTurnActions(chat);
+  useAutoSendFromQuery(search, health, actions.send);
+  return (
+    <ChatActionsProvider actions={actions}>
+      <ChatShell entry={entryStateOf(search, health)} dict={chatDictFor(useLocale())} chat={chat} history={history} failure={useTurnFailure(chat, config.baseUrl)} onRetry={health.retry} onSend={actions.send} />
+    </ChatActionsProvider>
+  );
 }

--- a/apps/web/src/features/chat/chat-actions.tsx
+++ b/apps/web/src/features/chat/chat-actions.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+
+/** Turn-level actions the fallback cards may trigger (spec §D chips/retries). */
+export interface ChatActions {
+  readonly send: (text: string) => void;
+  readonly regenerate: () => void;
+}
+
+const ChatActionsContext = createContext<ChatActions | null>(null);
+
+type ProviderProps = Readonly<{ actions: ChatActions; children: ReactNode }>;
+
+/** Context instead of prop-drilling send/regenerate through the card tree. */
+export function ChatActionsProvider({ actions, children }: ProviderProps) {
+  return <ChatActionsContext.Provider value={actions}>{children}</ChatActionsContext.Provider>;
+}
+
+export function useChatActions(): ChatActions {
+  const actions = useContext(ChatActionsContext);
+  if (!actions) throw new Error("useChatActions must be used within a ChatActionsProvider");
+  return actions;
+}

--- a/apps/web/src/features/chat/components/DataPartCard.tsx
+++ b/apps/web/src/features/chat/components/DataPartCard.tsx
@@ -1,15 +1,22 @@
 import type { ChatDataPart } from "@seichijunrei/contract";
+import type { ReactNode } from "react";
+import { classifyFailure } from "../../../lib/chat/errorClassifier";
+import type { ChatErrorState } from "../../../lib/chat/errorClassifier";
 import { isIntentOnly, parseChatDataPart } from "../data-parts";
 import type { ChatDict } from "../i18n";
 import { intentRegistry } from "../registry";
+import { EnvelopeFallback } from "./ErrorStates/EnvelopeFallback";
+import { ShortRouteNotice } from "./ErrorStates/ShortRouteNotice";
 
 type CardProps = Readonly<{ data: unknown; dict: ChatDict }>;
+type PartProps = Readonly<{ part: ChatDataPart; dict: ChatDict }>;
+type IntentProps = PartProps & Readonly<{ appendix?: ReactNode }>;
 
 function FallbackCard({ dict }: Readonly<{ dict: ChatDict }>) {
   return <p className="chat-card chat-card--fallback">{dict.fallbackCard}</p>;
 }
 
-function SkeletonCard({ part, dict }: Readonly<{ part: ChatDataPart; dict: ChatDict }>) {
+function SkeletonCard({ part, dict }: PartProps) {
   return (
     <p className="chat-card chat-card--skeleton" role="status" aria-busy="true" data-intent={part.intent}>
       {dict.preparing}
@@ -17,24 +24,39 @@ function SkeletonCard({ part, dict }: Readonly<{ part: ChatDataPart; dict: ChatD
   );
 }
 
-function IntentCard({ part, dict }: Readonly<{ part: ChatDataPart; dict: ChatDict }>) {
+function IntentCard({ part, dict, appendix }: IntentProps) {
   const Body = intentRegistry[part.intent];
   return (
     <article className="chat-card" data-intent={part.intent}>
       {part.message ? <p className="chat-card__message">{part.message}</p> : null}
       <Body part={part} dict={dict} />
+      {appendix}
     </article>
   );
 }
 
+type SettledProps = PartProps & Readonly<{ state: ChatErrorState | undefined }>;
+
+/**
+ * Settled envelopes classify first (issue #272 §D): a D-state renders its
+ * in-character fallback instead of — or for D3, alongside — the intent card.
+ */
+function SettledCard({ part, dict, state }: SettledProps) {
+  if (state === "D3") return <IntentCard part={part} dict={dict} appendix={<ShortRouteNotice dict={dict} />} />;
+  if (state !== undefined) return <EnvelopeFallback state={state} dict={dict} />;
+  return <IntentCard part={part} dict={dict} />;
+}
+
 /**
  * Renderer for a streamed `data-response` part. The payload is validated at
- * this trust boundary; invalid parts get the fallback card, the intent-first
- * frame gets a skeleton, and full frames render through the intent registry.
+ * this trust boundary; invalid parts get the fallback card and full frames
+ * classify then render. A skeleton covers intent-first frames — except failed
+ * intents, whose fallback shows immediately (an error never wears a skeleton).
  */
 export function DataPartCard({ data, dict }: CardProps) {
   const part = parseChatDataPart(data);
   if (!part) return <FallbackCard dict={dict} />;
-  if (isIntentOnly(part)) return <SkeletonCard part={part} dict={dict} />;
-  return <IntentCard part={part} dict={dict} />;
+  const state = classifyFailure({ kind: "envelope", part });
+  if (isIntentOnly(part) && state === undefined) return <SkeletonCard part={part} dict={dict} />;
+  return <SettledCard part={part} dict={dict} state={state} />;
 }

--- a/apps/web/src/features/chat/components/ErrorStates/EnvelopeFallback.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/EnvelopeFallback.tsx
@@ -1,0 +1,68 @@
+import { useChatActions } from "../../chat-actions";
+import type { ChatDict } from "../../i18n";
+import type { ChatErrorState } from "../../../../lib/chat/errorClassifier";
+import { FallbackRetryButton } from "./FallbackRetryButton";
+
+type Props = Readonly<{ state: ChatErrorState; dict: ChatDict }>;
+type DictProps = Readonly<{ dict: ChatDict }>;
+
+const CHIP_TONES = ["explore", "walk", "primary"] as const;
+
+function SuggestionChips({ dict }: DictProps) {
+  const { send } = useChatActions();
+  const chips = dict.chips.map((chip, index) => (
+    <button key={chip} type="button" className="chat-chip" data-tone={CHIP_TONES[index]} onClick={() => { send(chip); }}>
+      {chip}
+    </button>
+  ));
+  return <div className="chat-chips">{chips}</div>;
+}
+
+function RecognitionFallback({ dict }: DictProps) {
+  return (
+    <article className="chat-card chat-card--fallback-state" data-fallback="D1">
+      <p className="chat-fallback__subtitle">{dict.errorStates.d1Subtitle}</p>
+      <p className="chat-card__message">{dict.errorStates.d1Title}</p>
+      <p className="chat-fallback__hint">{dict.errorStates.d1Hint}</p>
+      <SuggestionChips dict={dict} />
+    </article>
+  );
+}
+
+function NoSpotsFallback({ dict }: DictProps) {
+  return (
+    <article className="chat-card chat-card--fallback-state" data-fallback="D2">
+      <p className="chat-card__message">{dict.errorStates.d2Title}</p>
+      <p className="chat-fallback__hint">{dict.errorStates.d2Hint}</p>
+      <SuggestionChips dict={dict} />
+    </article>
+  );
+}
+
+function apologyCopy(state: "D5" | "D6", dict: ChatDict): { message: string; retry: string } {
+  const states = dict.errorStates;
+  if (state === "D5") return { message: states.d5Message, retry: states.d5Retry };
+  return { message: states.d6Message, retry: states.d6Retry };
+}
+
+function ApologyFallback({ state, dict }: Readonly<{ state: "D5" | "D6"; dict: ChatDict }>) {
+  const { regenerate } = useChatActions();
+  const copy = apologyCopy(state, dict);
+  return (
+    <article className="chat-card chat-card--fallback-state" data-fallback={state} role="alert">
+      <p className="chat-card__message">{copy.message}</p>
+      <FallbackRetryButton label={copy.retry} onClick={regenerate} className="chat-fallback__retry" />
+    </article>
+  );
+}
+
+/**
+ * Settled-envelope fallbacks (D1 recognition failure, D2 zero spots, D5/D6
+ * apologies). Copy comes exclusively from the dictionary — wire error details
+ * (ModelRetry, output_validator, codes) never reach the DOM.
+ */
+export function EnvelopeFallback({ state, dict }: Props) {
+  if (state === "D1") return <RecognitionFallback dict={dict} />;
+  if (state === "D2") return <NoSpotsFallback dict={dict} />;
+  return <ApologyFallback state={state === "D5" ? "D5" : "D6"} dict={dict} />;
+}

--- a/apps/web/src/features/chat/components/ErrorStates/FallbackRetryButton.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/FallbackRetryButton.tsx
@@ -1,0 +1,15 @@
+type Props = Readonly<{
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  className: string;
+}>;
+
+/** Shared press-style action button for the D-state fallbacks. */
+export function FallbackRetryButton({ label, onClick, disabled, className }: Props) {
+  return (
+    <button type="button" className={className} onClick={onClick} disabled={disabled}>
+      {label}
+    </button>
+  );
+}

--- a/apps/web/src/features/chat/components/ErrorStates/MapFallback.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/MapFallback.tsx
@@ -1,0 +1,45 @@
+import type { ChatDict } from "../../i18n";
+
+type Props = Readonly<{ dict: ChatDict; lat?: number; lng?: number }>;
+
+function mapAppUrl(lat: number, lng: number): string {
+  return `https://www.google.com/maps/search/?api=1&query=${String(lat)},${String(lng)}`;
+}
+
+const DOODLE_TRAIL = "M4 34 C14 22 24 30 32 20 C40 10 52 16 60 8";
+
+function DoodleTrail() {
+  return (
+    <path d={DOODLE_TRAIL} fill="none" stroke="currentColor" strokeWidth="2" strokeDasharray="4 4" strokeLinecap="round" />
+  );
+}
+
+function MapDoodle() {
+  return (
+    <svg className="chat-map-fallback__doodle" viewBox="0 0 64 40" aria-hidden="true">
+      <DoodleTrail />
+      <circle cx="32" cy="20" r="4" fill="currentColor" />
+      <circle cx="60" cy="8" r="3" fill="none" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  );
+}
+
+function MapAppLink({ dict, lat, lng }: Props) {
+  if (lat === undefined || lng === undefined) return null;
+  return (
+    <a className="chat-map-fallback__open" href={mapAppUrl(lat, lng)} target="_blank" rel="noreferrer">
+      {dict.errorStates.d7Open}
+    </a>
+  );
+}
+
+/** D7: static-map failure degrades to a drawn doodle, never a broken image. */
+export function MapFallback(props: Props) {
+  return (
+    <figure className="chat-map-fallback">
+      <MapDoodle />
+      <figcaption>{props.dict.errorStates.d7Message}</figcaption>
+      <MapAppLink {...props} />
+    </figure>
+  );
+}

--- a/apps/web/src/features/chat/components/ErrorStates/SceneThumb.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/SceneThumb.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { ChatDict } from "../../i18n";
 
 type Props = Readonly<{ src?: string; alt: string; ep?: number; dict: ChatDict }>;
@@ -19,6 +19,7 @@ function ScenePlaceholder({ alt, label }: Readonly<{ alt: string; label?: string
 /** D9: a scene still that degrades to a gradient placeholder + episode label. */
 export function SceneThumb({ src, alt, ep, dict }: Props) {
   const [failed, setFailed] = useState(false);
+  useEffect(() => { setFailed(false); }, [src]);
   if (src === undefined || failed) return <ScenePlaceholder alt={alt} label={episodeLabel(dict, ep)} />;
   return (
     <img className="chat-scene-thumb" src={src} alt={alt} loading="lazy" onError={() => { setFailed(true); }} />

--- a/apps/web/src/features/chat/components/ErrorStates/SceneThumb.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/SceneThumb.tsx
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import type { ChatDict } from "../../i18n";
+
+type Props = Readonly<{ src?: string; alt: string; ep?: number; dict: ChatDict }>;
+
+function episodeLabel(dict: ChatDict, ep?: number): string | undefined {
+  if (ep === undefined) return undefined;
+  return dict.errorStates.d9Episode.replace("{ep}", String(ep));
+}
+
+function ScenePlaceholder({ alt, label }: Readonly<{ alt: string; label?: string }>) {
+  return (
+    <span className="chat-scene-thumb chat-scene-thumb--fallback" role="img" aria-label={alt}>
+      {label}
+    </span>
+  );
+}
+
+/** D9: a scene still that degrades to a gradient placeholder + episode label. */
+export function SceneThumb({ src, alt, ep, dict }: Props) {
+  const [failed, setFailed] = useState(false);
+  if (src === undefined || failed) return <ScenePlaceholder alt={alt} label={episodeLabel(dict, ep)} />;
+  return (
+    <img className="chat-scene-thumb" src={src} alt={alt} loading="lazy" onError={() => { setFailed(true); }} />
+  );
+}

--- a/apps/web/src/features/chat/components/ErrorStates/SessionExpired.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/SessionExpired.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { LoginModal } from "../../../../components/auth/LoginModal";
+import type { ChatDict } from "../../i18n";
+import { FallbackRetryButton } from "./FallbackRetryButton";
+
+type Props = Readonly<{ dict: ChatDict; onResume: () => void; recovering?: boolean }>;
+
+type ActionProps = Readonly<{
+  dict: ChatDict;
+  onLogin: () => void;
+  onResume: () => void;
+  recovering?: boolean;
+}>;
+
+function ExpiryActions({ dict, onLogin, onResume, recovering }: ActionProps) {
+  return (
+    <span className="chat-session-expired__actions">
+      <FallbackRetryButton label={dict.errorStates.d8Login} onClick={onLogin} className="chat-session-expired__login" />
+      <FallbackRetryButton label={dict.errorStates.d8Resume} onClick={onResume} disabled={recovering} className="chat-session-expired__resume" />
+    </span>
+  );
+}
+
+/**
+ * D8: an inline session-expiry banner. The conversation stays mounted — login
+ * opens in place and resume re-reads the session's final state afterwards.
+ */
+export function SessionExpired({ dict, onResume, recovering }: Props) {
+  const [loginOpen, setLoginOpen] = useState(false);
+  return (
+    <div className="chat-session-expired" role="alert">
+      <span>{dict.errorStates.d8Message}</span>
+      <ExpiryActions dict={dict} onLogin={() => { setLoginOpen(true); }} onResume={onResume} recovering={recovering} />
+      <LoginModal open={loginOpen} onClose={() => { setLoginOpen(false); }} />
+    </div>
+  );
+}

--- a/apps/web/src/features/chat/components/ErrorStates/ShortRouteNotice.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/ShortRouteNotice.tsx
@@ -1,0 +1,17 @@
+import { useChatActions } from "../../chat-actions";
+import type { ChatDict } from "../../i18n";
+
+/**
+ * D3: fewer than three route points. The spot cards above stay rendered;
+ * this notice explains the short walk and proposes widening the search.
+ */
+export function ShortRouteNotice({ dict }: Readonly<{ dict: ChatDict }>) {
+  const { send } = useChatActions();
+  const chip = dict.errorStates.d3Chip;
+  return (
+    <div className="chat-short-route" data-fallback="D3">
+      <p className="chat-short-route__notice">{dict.errorStates.d3Notice}</p>
+      <button type="button" className="chat-chip" data-tone="primary" onClick={() => { send(chip); }}>{chip}</button>
+    </div>
+  );
+}

--- a/apps/web/src/features/chat/components/ErrorStates/StreamInterruption.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/StreamInterruption.tsx
@@ -1,0 +1,32 @@
+import type { ChatDict } from "../../i18n";
+import { FallbackRetryButton } from "./FallbackRetryButton";
+
+export type InterruptionShape = "D4" | "D5";
+
+type Props = Readonly<{
+  state: InterruptionShape;
+  dict: ChatDict;
+  onRetry: () => void;
+  recovering?: boolean;
+}>;
+
+function copyFor(state: InterruptionShape, dict: ChatDict): { message: string; retry: string } {
+  const states = dict.errorStates;
+  if (state === "D5") return { message: states.d5Message, retry: states.d5Retry };
+  return { message: states.d4Message, retry: states.d4Retry };
+}
+
+/**
+ * D4/D5: an inline retry strip at the interruption point. Rendered content
+ * above it stays mounted; retry re-fetches the session's final state instead
+ * of resuming the broken stream (P6 disconnect-recovery semantics).
+ */
+export function StreamInterruption({ state, dict, onRetry, recovering }: Props) {
+  const copy = copyFor(state, dict);
+  return (
+    <div className="chat-interruption" role="alert" data-state={state}>
+      <span>{copy.message}</span>
+      <FallbackRetryButton label={copy.retry} onClick={onRetry} disabled={recovering} className="chat-interruption__retry" />
+    </div>
+  );
+}

--- a/apps/web/src/features/chat/components/ErrorStates/TurnFailure.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/TurnFailure.tsx
@@ -1,0 +1,23 @@
+import type { ChatErrorState } from "../../../../lib/chat/errorClassifier";
+import type { ChatDict } from "../../i18n";
+import { SessionExpired } from "./SessionExpired";
+import { StreamInterruption } from "./StreamInterruption";
+
+export interface TurnFailureView {
+  readonly state: ChatErrorState;
+  readonly onRetry: () => void;
+  readonly onExpiredResume: () => void;
+  readonly recovering: boolean;
+}
+
+type Props = Readonly<{ view: TurnFailureView | undefined; dict: ChatDict }>;
+
+/** Inline turn-failure surface: the D8 expiry banner or the D4/D5 retry strip. */
+export function TurnFailure({ view, dict }: Props) {
+  if (!view) return null;
+  if (view.state === "D8") {
+    return <SessionExpired dict={dict} onResume={view.onExpiredResume} recovering={view.recovering} />;
+  }
+  const shape = view.state === "D5" ? "D5" : "D4";
+  return <StreamInterruption state={shape} dict={dict} onRetry={view.onRetry} recovering={view.recovering} />;
+}

--- a/apps/web/src/features/chat/components/cards.tsx
+++ b/apps/web/src/features/chat/components/cards.tsx
@@ -1,5 +1,6 @@
 import type { ChatDataPart } from "@seichijunrei/contract";
 import type { ChatDict } from "../i18n";
+import { SceneThumb } from "./ErrorStates/SceneThumb";
 
 export type IntentCardProps = Readonly<{ part: ChatDataPart; dict: ChatDict }>;
 
@@ -24,9 +25,13 @@ function candidatesOf(part: ChatDataPart) {
   return data && "candidates" in data ? (data.candidates ?? []) : [];
 }
 
-type PartOnlyProps = Readonly<{ part: ChatDataPart }>;
-
-type SpotRow = Readonly<{ id?: string; name?: string }>;
+type SpotRow = Readonly<{
+  id?: string;
+  name?: string;
+  screenshot_url?: string;
+  ep?: number;
+  episode?: number;
+}>;
 
 /** Streamed routes may carry spots only as `route.ordered_points` objects. */
 function routeSpotsOf(part: ChatDataPart): SpotRow[] {
@@ -43,24 +48,38 @@ function spotsOf(part: ChatDataPart): SpotRow[] {
   return rows.length > 0 ? rows : routeSpotsOf(part);
 }
 
-function SpotList({ part }: PartOnlyProps) {
+function epOf(row: SpotRow): number | undefined {
+  return row.ep ?? row.episode;
+}
+
+/** The thumb renders only for rows that carry a still; D9 degrades it. */
+function SpotItem({ row, dict }: Readonly<{ row: SpotRow; dict: ChatDict }>) {
+  return (
+    <li className="chat-spot">
+      {row.screenshot_url ? <SceneThumb src={row.screenshot_url} alt={row.name ?? ""} ep={epOf(row)} dict={dict} /> : null}
+      <span>{row.name}</span>
+    </li>
+  );
+}
+
+function SpotList({ part, dict }: IntentCardProps) {
   const rows = spotsOf(part);
   if (rows.length === 0) return null;
-  const items = rows.map((row) => <li key={row.id ?? row.name}>{row.name}</li>);
+  const items = rows.map((row) => <SpotItem key={row.id ?? row.name} row={row} dict={dict} />);
   return <ul className="chat-card__spots">{items}</ul>;
 }
 
-export function SearchCard({ part }: IntentCardProps) {
+export function SearchCard({ part, dict }: IntentCardProps) {
   const results = resultsOf(part);
   return (
     <div className="chat-card__body">
       {results?.title ? <p className="chat-card__title">{results.title}</p> : null}
-      <SpotList part={part} />
+      <SpotList part={part} dict={dict} />
     </div>
   );
 }
 
-function RouteStats({ part }: PartOnlyProps) {
+function RouteStats({ part }: Readonly<{ part: ChatDataPart }>) {
   const route = routeOf(part);
   if (!route) return null;
   return (
@@ -70,11 +89,11 @@ function RouteStats({ part }: PartOnlyProps) {
   );
 }
 
-export function RouteCard({ part }: IntentCardProps) {
+export function RouteCard({ part, dict }: IntentCardProps) {
   return (
     <div className="chat-card__body">
       <RouteStats part={part} />
-      <SpotList part={part} />
+      <SpotList part={part} dict={dict} />
     </div>
   );
 }
@@ -91,22 +110,4 @@ export function ClarifyCard({ part }: IntentCardProps) {
 
 export function ProseCard(_props: IntentCardProps) {
   return null;
-}
-
-function ErrorList({ part }: PartOnlyProps) {
-  const errors = part.errors ?? [];
-  if (errors.length === 0) return null;
-  const items = errors.map((error) => (
-    <li key={`${error.code}:${error.message}`}>{error.message}</li>
-  ));
-  return <ul className="chat-card__errors">{items}</ul>;
-}
-
-export function ErrorCard({ part, dict }: IntentCardProps) {
-  return (
-    <div className="chat-card__body" role="alert">
-      {part.message ? null : <p className="chat-card__message">{dict.errorCard}</p>}
-      <ErrorList part={part} />
-    </div>
-  );
 }

--- a/apps/web/src/features/chat/i18n.ts
+++ b/apps/web/src/features/chat/i18n.ts
@@ -1,5 +1,28 @@
 import type { Locale } from "../../i18n/locales";
 
+/** In-character copy for the nine D1-D9 fallback states (issue #272 S1.6). */
+export interface ChatErrorStatesDict {
+  readonly d1Title: string;
+  readonly d1Hint: string;
+  readonly d1Subtitle: string;
+  readonly d2Title: string;
+  readonly d2Hint: string;
+  readonly d3Notice: string;
+  readonly d3Chip: string;
+  readonly d4Message: string;
+  readonly d4Retry: string;
+  readonly d5Message: string;
+  readonly d5Retry: string;
+  readonly d6Message: string;
+  readonly d6Retry: string;
+  readonly d7Message: string;
+  readonly d7Open: string;
+  readonly d8Message: string;
+  readonly d8Login: string;
+  readonly d8Resume: string;
+  readonly d9Episode: string;
+}
+
 /** Chat-page copy, kept feature-local to avoid the shared dictionary hot file. */
 export interface ChatDict {
   readonly greeting: string;
@@ -17,7 +40,74 @@ export interface ChatDict {
   readonly thinking: string;
   readonly waitingSubtitle: string;
   readonly footprintDetails: string;
+  readonly errorStates: ChatErrorStatesDict;
 }
+
+const jaErrorStates: ChatErrorStatesDict = {
+  d1Title: "ごめんね、その作品が見つからなかった…",
+  d1Hint: "つづりを確かめるか、原題でためしてみて。あらすじを教えてくれたら当ててみるよ",
+  d1Subtitle: "うーん、見つからない…",
+  d2Title: "この作品はまだ Anitabi に聖地が登録されていないみたい",
+  d2Hint: "べつの作品でさがしてみる?",
+  d3Notice: "スポットが少なめだから、みじかいおさんぽになりそう",
+  d3Chip: "近くの別作品も足す?",
+  d4Message: "接続が切れました",
+  d4Retry: "再試行",
+  d5Message: "時間がかかりすぎているみたい",
+  d5Retry: "もう一度",
+  d6Message: "ごめんね、うまく答えられなかった。言い方を変えてみてね",
+  d6Retry: "もう一度ためす",
+  d7Message: "地図をよみこめなかった…",
+  d7Open: "地図アプリで開く",
+  d8Message: "セッションが切れちゃった。ログインし直すと、この会話のつづきから話せるよ",
+  d8Login: "ログインする",
+  d8Resume: "つづきを読み込む",
+  d9Episode: "第{ep}話",
+};
+
+const zhErrorStates: ChatErrorStatesDict = {
+  d1Title: "抱歉,没找到这部作品…",
+  d1Hint: "检查一下拼写,或试试原文标题。告诉我一句剧情,我来猜猜看",
+  d1Subtitle: "嗯…找不到呢…",
+  d2Title: "这部作品好像还没有圣地被收录进 Anitabi",
+  d2Hint: "要不要换部作品试试?",
+  d3Notice: "地点有点少,会是一段短短的散步",
+  d3Chip: "要不要把附近别的作品也加进来?",
+  d4Message: "连接断开了",
+  d4Retry: "重试",
+  d5Message: "花的时间有点太久了",
+  d5Retry: "再试一次",
+  d6Message: "抱歉,这次没答好。换个说法试试吧",
+  d6Retry: "再试一次",
+  d7Message: "地图加载不出来…",
+  d7Open: "在地图应用中打开",
+  d8Message: "会话过期了。重新登录就能接着聊,内容不会丢",
+  d8Login: "去登录",
+  d8Resume: "继续加载",
+  d9Episode: "第{ep}集",
+};
+
+const enErrorStates: ChatErrorStatesDict = {
+  d1Title: "Sorry, I couldn't find that title…",
+  d1Hint: "Check the spelling or try the original title. Tell me a bit of the plot and I'll take a guess",
+  d1Subtitle: "Hmm, nothing turned up…",
+  d2Title: "This work doesn't seem to have any spots on Anitabi yet",
+  d2Hint: "Want to try another title?",
+  d3Notice: "Only a few spots, so this will be a short stroll",
+  d3Chip: "Add a nearby work too?",
+  d4Message: "The connection dropped",
+  d4Retry: "Retry",
+  d5Message: "This is taking too long",
+  d5Retry: "Try again",
+  d6Message: "Sorry, I couldn't quite answer that. Try phrasing it differently",
+  d6Retry: "Try again",
+  d7Message: "The map wouldn't load…",
+  d7Open: "Open in a map app",
+  d8Message: "Your session expired. Sign in again to pick up right where we left off",
+  d8Login: "Sign in",
+  d8Resume: "Reload the conversation",
+  d9Episode: "Ep. {ep}",
+};
 
 const ja: ChatDict = {
   greeting: "アニミチだよ。どのアニメの聖地をめぐってみたい?",
@@ -39,6 +129,7 @@ const ja: ChatDict = {
   thinking: "考え中…",
   waitingSubtitle: "いま さがしてるよ…",
   footprintDetails: "詳細を見る",
+  errorStates: jaErrorStates,
 };
 
 const zh: ChatDict = {
@@ -57,6 +148,7 @@ const zh: ChatDict = {
   thinking: "思考中…",
   waitingSubtitle: "正在帮你找…",
   footprintDetails: "查看详情",
+  errorStates: zhErrorStates,
 };
 
 const en: ChatDict = {
@@ -79,6 +171,7 @@ const en: ChatDict = {
   thinking: "Thinking…",
   waitingSubtitle: "Looking that up…",
   footprintDetails: "View details",
+  errorStates: enErrorStates,
 };
 
 const CHAT_DICTIONARIES: Record<Locale, ChatDict> = { ja, zh, en };

--- a/apps/web/src/features/chat/i18n.ts
+++ b/apps/web/src/features/chat/i18n.ts
@@ -33,7 +33,6 @@ export interface ChatDict {
   readonly retry: string;
   readonly historyFootprint: string;
   readonly fallbackCard: string;
-  readonly errorCard: string;
   readonly historyError: string;
   readonly preparing: string;
   readonly foxAlt: string;
@@ -122,7 +121,6 @@ const ja: ChatDict = {
   retry: "再試行",
   historyFootprint: "これまでのやり取り",
   fallbackCard: "この内容はうまく表示できませんでした",
-  errorCard: "ごめんね、エラーが起きちゃった。もう一度ためしてみてね",
   historyError: "過去の会話を読み込めませんでした",
   preparing: "じゅんびちゅう…",
   foxAlt: "アニミチ",
@@ -141,7 +139,6 @@ const zh: ChatDict = {
   retry: "重试",
   historyFootprint: "之前的对话",
   fallbackCard: "这段内容暂时无法显示",
-  errorCard: "抱歉,出错了。请再试一次",
   historyError: "无法加载之前的对话",
   preparing: "准备中…",
   foxAlt: "Animichi",
@@ -164,7 +161,6 @@ const en: ChatDict = {
   retry: "Retry",
   historyFootprint: "Earlier conversation",
   fallbackCard: "This part could not be displayed",
-  errorCard: "Sorry, something went wrong. Please try again",
   historyError: "Couldn't load this conversation",
   preparing: "Getting ready…",
   foxAlt: "Animichi",

--- a/apps/web/src/features/chat/registry.ts
+++ b/apps/web/src/features/chat/registry.ts
@@ -1,9 +1,14 @@
 import type { ChatDataPart } from "@seichijunrei/contract";
 import type { ComponentType } from "react";
-import { ClarifyCard, ErrorCard, ProseCard, RouteCard, SearchCard } from "./components/cards";
+import { ClarifyCard, ProseCard, RouteCard, SearchCard } from "./components/cards";
 import type { IntentCardProps } from "./components/cards";
 
-/** intent → card body. Later chat cards extend this map, not the renderer. */
+/**
+ * intent → card body. Later chat cards extend this map, not the renderer.
+ * `error`/`unknown` envelopes are intercepted by the D-state classifier in
+ * DataPartCard before this registry is consulted (issue #272 §D6), so their
+ * entries are unreachable prose placeholders.
+ */
 export const intentRegistry: Record<ChatDataPart["intent"], ComponentType<IntentCardProps>> = {
   search_bangumi: SearchCard,
   search_nearby: SearchCard,
@@ -15,6 +20,6 @@ export const intentRegistry: Record<ChatDataPart["intent"], ComponentType<Intent
   general_qa: ProseCard,
   greet_user: ProseCard,
   blocked: ProseCard,
-  error: ErrorCard,
+  error: ProseCard,
   unknown: ProseCard,
 };

--- a/apps/web/src/features/chat/use-chat-session.ts
+++ b/apps/web/src/features/chat/use-chat-session.ts
@@ -3,7 +3,7 @@ import { ChatResponseDataPart } from "@seichijunrei/contract";
 import type { ChatDataPart } from "@seichijunrei/contract";
 import { DefaultChatTransport } from "ai";
 import type { UIMessage } from "ai";
-import { useRef } from "react";
+import { useCallback, useRef } from "react";
 import type { RefObject } from "react";
 import { authHeaders } from "../../lib/auth/authSession";
 
@@ -25,6 +25,7 @@ const dataPartSchemas = {
 interface SessionTracker {
   scope: string;
   id: string | undefined;
+  lastHttpStatus: number | undefined;
 }
 type SessionRef = RefObject<SessionTracker>;
 
@@ -41,9 +42,9 @@ function scopeOf(sessionId?: string): string {
 
 /** Track the server-assigned session id, reset whenever the URL identity changes. */
 function useSessionTracker(sessionId: string | undefined, scope: string): SessionRef {
-  const ref = useRef<SessionTracker>({ scope, id: sessionId });
+  const ref = useRef<SessionTracker>({ scope, id: sessionId, lastHttpStatus: undefined });
   if (ref.current.scope !== scope) {
-    ref.current = { scope, id: sessionId };
+    ref.current = { scope, id: sessionId, lastHttpStatus: undefined };
   }
   return ref;
 }
@@ -71,10 +72,21 @@ function createScopedChat(chatUrl: string, scope: string, ref: SessionRef): Chat
   });
 }
 
+/** Record each chat response's HTTP status so failures classify (401 → D8). */
+function createTrackingFetch(ref: SessionRef): typeof globalThis.fetch {
+  return async (input, init) => {
+    ref.current.lastHttpStatus = undefined;
+    const response = await globalThis.fetch(input, init);
+    ref.current.lastHttpStatus = response.status;
+    return response;
+  };
+}
+
 function createSessionTransport(chatUrl: string, ref: SessionRef): DefaultChatTransport<ChatUIMessage> {
   return new DefaultChatTransport({
     api: chatUrl,
     headers: () => sessionHeaders(ref.current.id),
+    fetch: createTrackingFetch(ref),
   });
 }
 
@@ -116,7 +128,9 @@ export function useChatSession(chatUrl: string, sessionId?: string) {
   const scope = scopeOf(sessionId);
   const ref = useSessionTracker(sessionId, scope);
   const chat = useScopedChat(chatUrl, scope, ref);
-  return useChat<ChatUIMessage>({ chat });
+  const sessionIdOf = useCallback(() => ref.current.id, [ref]);
+  const lastHttpStatus = useCallback(() => ref.current.lastHttpStatus, [ref]);
+  return { ...useChat<ChatUIMessage>({ chat }), sessionIdOf, lastHttpStatus };
 }
 
 export type ChatSession = ReturnType<typeof useChatSession>;

--- a/apps/web/src/features/chat/use-conversation-history.ts
+++ b/apps/web/src/features/chat/use-conversation-history.ts
@@ -30,8 +30,10 @@ function toEntry(row: z.infer<typeof HistoryRow>): HistoryEntry {
   return { role: row.role, content: row.content, intent: row.response_data?.intent };
 }
 
-/** Anonymous when signed out (existing behaviour); adds a Bearer token once signed in. */
-async function fetchHistory(baseUrl: string, sessionId: string): Promise<HistoryEntry[]> {
+/** Anonymous when signed out (existing behaviour); adds a Bearer token once signed in.
+ * Also the D4/D8 recovery read: the client re-fetches the session's final
+ * state here instead of resuming a broken stream (P6 semantics). */
+export async function fetchHistory(baseUrl: string, sessionId: string): Promise<HistoryEntry[]> {
   const headers = await authHeaders();
   const response = await fetch(conversationMessagesUrl(baseUrl, sessionId), { headers });
   if (!response.ok) throw new Error(`messages responded ${String(response.status)}`);

--- a/apps/web/src/features/chat/use-stream-recovery.ts
+++ b/apps/web/src/features/chat/use-stream-recovery.ts
@@ -27,7 +27,7 @@ function toRecoveredMessage(entry: HistoryEntry, index: number): ChatUIMessage {
 
 async function replaceWithFinalState(baseUrl: string, chat: RecoverableChat, sessionId: string): Promise<void> {
   const entries = await fetchHistory(baseUrl, sessionId);
-  chat.setMessages(entries.map(toRecoveredMessage));
+  chat.setMessages(entries.map((entry, index) => toRecoveredMessage(entry, index)));
   chat.clearError();
 }
 

--- a/apps/web/src/features/chat/use-stream-recovery.ts
+++ b/apps/web/src/features/chat/use-stream-recovery.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState } from "react";
+import { clearAuthToken } from "../../lib/auth/authSession";
+import type { ChatUIMessage } from "./use-chat-session";
+import { fetchHistory } from "./use-conversation-history";
+import type { HistoryEntry } from "./use-conversation-history";
+
+export interface StreamRecovery {
+  readonly recover: () => void;
+  readonly recoverExpired: () => void;
+  readonly recovering: boolean;
+}
+
+/** The slice of the chat session the recovery flow drives. */
+export interface RecoverableChat {
+  readonly setMessages: (messages: ChatUIMessage[]) => void;
+  readonly clearError: () => void;
+  readonly regenerate: () => Promise<void>;
+}
+
+function toRecoveredMessage(entry: HistoryEntry, index: number): ChatUIMessage {
+  return {
+    id: `recovered-${String(index)}`,
+    role: entry.role === "user" ? "user" : "assistant",
+    parts: [{ type: "text", text: entry.content }],
+  };
+}
+
+async function replaceWithFinalState(baseUrl: string, chat: RecoverableChat, sessionId: string): Promise<void> {
+  const entries = await fetchHistory(baseUrl, sessionId);
+  chat.setMessages(entries.map(toRecoveredMessage));
+  chat.clearError();
+}
+
+interface RecoveryRun {
+  readonly baseUrl: string;
+  readonly chat: RecoverableChat;
+  readonly sessionId: string | undefined;
+  readonly setRecovering: (value: boolean) => void;
+}
+
+function runRecovery({ baseUrl, chat, sessionId, setRecovering }: RecoveryRun): void {
+  if (!sessionId) { chat.clearError(); void chat.regenerate(); return; }
+  setRecovering(true);
+  void replaceWithFinalState(baseUrl, chat, sessionId)
+    .catch(() => undefined)
+    .finally(() => { setRecovering(false); });
+}
+
+/**
+ * P6 disconnect-recovery semantics: a broken AI SDK stream is never resumed.
+ * With a known session the client re-reads the session's final state via
+ * GET /v1/conversations/{id}/messages; without one (nothing persisted yet)
+ * the failed turn is regenerated instead.
+ */
+export function useStreamRecovery(baseUrl: string, chat: RecoverableChat, sessionIdOf: () => string | undefined): StreamRecovery {
+  const [recovering, setRecovering] = useState(false);
+  const recover = useCallback(() => {
+    runRecovery({ baseUrl, chat, sessionId: sessionIdOf(), setRecovering });
+  }, [baseUrl, chat, sessionIdOf]);
+  const recoverExpired = useCallback(() => { clearAuthToken(); recover(); }, [recover]);
+  return { recover, recoverExpired, recovering };
+}

--- a/apps/web/src/features/chat/use-turn-timeout.ts
+++ b/apps/web/src/features/chat/use-turn-timeout.ts
@@ -1,0 +1,31 @@
+import type { ChatStatus } from "ai";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+
+export const TURN_TIMEOUT_MS = 60_000;
+
+export interface TurnTimeout {
+  readonly timedOut: boolean;
+  readonly reset: () => void;
+}
+
+function isActiveTurn(status: ChatStatus): boolean {
+  return status === "submitted" || status === "streaming";
+}
+
+function armWatchdog(stopRef: RefObject<() => void>, setTimedOut: (value: boolean) => void): () => void {
+  setTimedOut(false);
+  const id = setTimeout(() => { setTimedOut(true); stopRef.current(); }, TURN_TIMEOUT_MS);
+  return () => { clearTimeout(id); };
+}
+
+/** D5 watchdog: a turn running past 60s is stopped and flagged for fallback. */
+export function useTurnTimeout(status: ChatStatus, stop: () => void): TurnTimeout {
+  const [timedOut, setTimedOut] = useState(false);
+  const stopRef = useRef(stop);
+  stopRef.current = stop;
+  const active = isActiveTurn(status);
+  useEffect(() => (active ? armWatchdog(stopRef, setTimedOut) : undefined), [active]);
+  const reset = useCallback(() => { setTimedOut(false); }, []);
+  return { timedOut, reset };
+}

--- a/apps/web/src/lib/chat/errorClassifier.ts
+++ b/apps/web/src/lib/chat/errorClassifier.ts
@@ -36,8 +36,16 @@ function classifyFailureCode(code: string): ChatErrorState {
   return "D6";
 }
 
+/**
+ * `clarify` is exempt from the blanket `success === false` rule: the backend's
+ * invalid-selection response arrives as a failed clarify envelope whose card
+ * already carries the recovery (re-pick a candidate) — classifying it D6 would
+ * put `regenerate` behind the retry button and reproduce the same failure.
+ */
 function isFailedEnvelope(part: ChatDataPart): boolean {
-  return part.intent === "error" || part.intent === "unknown" || part.success === false;
+  if (part.intent === "error" || part.intent === "unknown") return true;
+  if (part.intent === "clarify") return false;
+  return part.success === false;
 }
 
 function resultRowCount(part: ChatDataPart): number | undefined {

--- a/apps/web/src/lib/chat/errorClassifier.ts
+++ b/apps/web/src/lib/chat/errorClassifier.ts
@@ -1,0 +1,82 @@
+import type { ChatDataPart } from "@seichijunrei/contract";
+
+/** D1-D9 fallback states from spec-chat-page-states.md §D (issue #272 S1.6). */
+export type ChatErrorState = "D1" | "D2" | "D3" | "D4" | "D5" | "D6" | "D7" | "D8" | "D9";
+
+export type ImageSurface = "map" | "scene";
+
+/**
+ * Client-observable failure signals. Each variant is a raw observation
+ * (HTTP status, aborted stream, watchdog, settled envelope, image error);
+ * the classifier owns the mapping onto the nine fallback states.
+ */
+export type FailureSignal =
+  | { readonly kind: "http"; readonly status: number }
+  | { readonly kind: "stream-abort" }
+  | { readonly kind: "timeout" }
+  | { readonly kind: "envelope"; readonly part: ChatDataPart }
+  | { readonly kind: "image"; readonly surface: ImageSurface };
+
+const ROUTE_MINIMUM_POINTS = 3;
+const D1_CODE_MARKERS = ["not_found", "no_bangumi", "invalid_station"];
+
+function classifyHttpStatus(status: number): ChatErrorState {
+  if (status === 401 || status === 403) return "D8";
+  if (status === 408 || status === 504) return "D5";
+  return "D4";
+}
+
+function firstErrorCode(part: ChatDataPart): string {
+  return part.errors?.[0]?.code ?? "";
+}
+
+function classifyFailureCode(code: string): ChatErrorState {
+  if (D1_CODE_MARKERS.some((marker) => code.includes(marker))) return "D1";
+  if (code.includes("timeout")) return "D5";
+  return "D6";
+}
+
+function isFailedEnvelope(part: ChatDataPart): boolean {
+  return part.intent === "error" || part.intent === "unknown" || part.success === false;
+}
+
+function resultRowCount(part: ChatDataPart): number | undefined {
+  const data = part.data;
+  const results = data && "results" in data ? data.results : undefined;
+  return results?.rows?.length ?? results?.row_count;
+}
+
+function routePointCount(part: ChatDataPart): number | undefined {
+  const data = part.data;
+  const route = data && "route" in data ? data.route : undefined;
+  return route?.point_count ?? route?.ordered_points?.length;
+}
+
+function classifySearchEnvelope(part: ChatDataPart): ChatErrorState | undefined {
+  return resultRowCount(part) === 0 ? "D2" : undefined;
+}
+
+function classifyRouteEnvelope(part: ChatDataPart): ChatErrorState | undefined {
+  const points = routePointCount(part);
+  if (points === undefined || points >= ROUTE_MINIMUM_POINTS) return undefined;
+  return points === 0 ? "D2" : "D3";
+}
+
+function classifyEnvelope(part: ChatDataPart): ChatErrorState | undefined {
+  if (isFailedEnvelope(part)) return classifyFailureCode(firstErrorCode(part));
+  const intent = part.intent;
+  if (intent === "search_bangumi" || intent === "search_nearby") return classifySearchEnvelope(part);
+  if (intent === "plan_route" || intent === "plan_selected" || intent === "plan_multi") {
+    return classifyRouteEnvelope(part);
+  }
+  return undefined;
+}
+
+/** Map one failure signal onto its D1-D9 state; healthy envelopes return undefined. */
+export function classifyFailure(signal: FailureSignal): ChatErrorState | undefined {
+  if (signal.kind === "http") return classifyHttpStatus(signal.status);
+  if (signal.kind === "stream-abort") return "D4";
+  if (signal.kind === "timeout") return "D5";
+  if (signal.kind === "image") return signal.surface === "map" ? "D7" : "D9";
+  return classifyEnvelope(signal.part);
+}

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -295,6 +295,149 @@
   cursor: not-allowed;
 }
 
+/* D1-D9 fallback states (issue #272 S1.6) — semantic tokens only. */
+
+.chat-interruption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.625rem 1rem;
+  border-radius: 14px;
+  background: var(--color-error-bg);
+  color: var(--color-error-strong);
+}
+
+.chat-interruption__retry,
+.chat-session-expired__login,
+.chat-session-expired__resume {
+  border: 0;
+  border-radius: 10px;
+  min-height: 36px;
+  padding: 0.375rem 0.875rem;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  box-shadow: 0 2px 0 var(--shadow-3d);
+  cursor: pointer;
+}
+
+.chat-interruption__retry:disabled,
+.chat-session-expired__resume:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.chat-session-expired {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
+  border-radius: 14px;
+  border-left: 4px solid var(--color-warning-fg);
+  background: var(--color-muted);
+  color: var(--color-fg);
+}
+
+.chat-session-expired__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.chat-card--fallback-state {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.chat-fallback__subtitle {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--color-muted-fg);
+}
+
+.chat-fallback__hint {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--color-muted-fg);
+}
+
+.chat-fallback__retry {
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  min-height: 44px;
+  padding: 0.5rem 1rem;
+  background: var(--color-card);
+  color: var(--color-fg);
+  box-shadow: 0 3px 0 var(--shadow-3d);
+  cursor: pointer;
+}
+
+.chat-short-route {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px dashed var(--color-border);
+}
+
+.chat-short-route__notice {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--color-muted-fg);
+}
+
+.chat-spot {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.chat-scene-thumb {
+  flex-shrink: 0;
+  width: 3.5rem;
+  height: 2.25rem;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.chat-scene-thumb--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  color: var(--color-primary-fg);
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.chat-map-fallback {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 1rem;
+  border: 1px dashed var(--color-border);
+  border-radius: 14px;
+  background: var(--color-muted);
+  color: var(--color-muted-fg);
+}
+
+.chat-map-fallback__doodle {
+  width: 4rem;
+  height: 2.5rem;
+  color: var(--color-primary-strong);
+}
+
+.chat-map-fallback__open {
+  font-weight: 700;
+  color: var(--color-primary-strong);
+}
+
 @keyframes chat-pulse {
   50% {
     opacity: 0.6;

--- a/apps/web/tests/msw/chat-handlers.ts
+++ b/apps/web/tests/msw/chat-handlers.ts
@@ -78,6 +78,63 @@ export function chatStreamHandler(
   });
 }
 
+/** Bare HTTP failure on the chat endpoint (401 expiry → D8, 5xx → D4). */
+export function chatHttpErrorHandler(status: number): HttpHandler {
+  return http.post(CHAT_URL, () => new HttpResponse(null, { status }));
+}
+
+function droppingBody(head: string): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (head !== "") controller.enqueue(new TextEncoder().encode(head));
+      controller.error(new Error("connection lost"));
+    },
+  });
+}
+
+/** Replays the recording head, then drops the connection mid-stream (D4). */
+export function chatStreamDropHandler(name: ChatStreamFixture): HttpHandler {
+  const recorded = chatStreamFixture(name);
+  const head = recorded.slice(0, recorded.indexOf('data: {"type":"data-response"'));
+  return http.post(CHAT_URL, () => new HttpResponse(droppingBody(head), { headers: SSE_HEADERS }));
+}
+
+/** Drops the connection before any frame arrives (D4 before-first-chunk). */
+export function chatStreamImmediateDropHandler(): HttpHandler {
+  return http.post(CHAT_URL, () => new HttpResponse(droppingBody(""), { headers: SSE_HEADERS }));
+}
+
+export type FinalFramePatch = (envelope: Record<string, unknown>) => Record<string, unknown>;
+
+function patchFinalFrameLine(line: string, patch: FinalFramePatch): string {
+  if (!line.startsWith('data: {"type":"data-response"')) return line;
+  const frame = JSON.parse(line.slice("data: ".length)) as { data: Record<string, unknown> };
+  if (!("success" in frame.data)) return line;
+  frame.data = patch(frame.data);
+  return `data: ${JSON.stringify(frame)}`;
+}
+
+/**
+ * Replay a recording with its final full envelope transformed. D-state
+ * variants (D1/D2/D6/D9) are derived from the real capture this way until the
+ * backend error-boundary hook (issue #272's other half) ships recordings of
+ * the actual failure envelopes.
+ */
+export function chatStreamPatchedHandler(
+  name: ChatStreamFixture,
+  patch: FinalFramePatch,
+  options: ChatStreamOptions = {},
+): HttpHandler {
+  const patched = streamText(name, options)
+    .split("\n")
+    .map((line) => patchFinalFrameLine(line, patch))
+    .join("\n");
+  return http.post(CHAT_URL, ({ request }) => {
+    options.spy?.(request);
+    return sseResponse(patched);
+  });
+}
+
 /** Replays the recording up to (excluding) the first data-response frame and holds the stream open. */
 export function chatStreamHeldOpenHandler(name: ChatStreamFixture): HttpHandler {
   const recorded = chatStreamFixture(name);

--- a/apps/web/tests/unit/chat/chat-page-envelope-states.test.tsx
+++ b/apps/web/tests/unit/chat/chat-page-envelope-states.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { setLanguages } from "../_i18n";
+import { chatStreamHandler, chatStreamPatchedHandler } from "../../msw/chat-handlers";
+import type { FinalFramePatch } from "../../msw/chat-handlers";
+import { server } from "../../msw/node";
+import { renderChatPage } from "./_chat-page";
+
+const ja = chatDictFor("ja");
+const states = ja.errorStates;
+
+beforeEach(() => {
+  setLanguages(["ja"]);
+});
+
+function sendText(text: string) {
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: text } });
+  fireEvent.click(screen.getByRole("button", { name: ja.send }));
+}
+
+function failedEnvelopePatch(code: string, technical: string): FinalFramePatch {
+  return () => ({ intent: "error", success: false, status: "error", errors: [{ code, message: technical }] });
+}
+
+const zeroSpotsPatch: FinalFramePatch = (envelope) => ({
+  ...envelope,
+  data: { route: { ordered_points: [], point_count: 0 } },
+});
+
+const BROKEN_SCENE_POINT = {
+  id: "p1",
+  name: "宇治橋",
+  bangumi_id: "12345",
+  episode: 8,
+  latitude: 34.891,
+  longitude: 135.807,
+  screenshot_url: "/broken/scene.webp",
+};
+
+const brokenScenePatch: FinalFramePatch = (envelope) => ({
+  ...envelope,
+  data: { route: { ordered_points: [BROKEN_SCENE_POINT], point_count: 2 } },
+});
+
+describe("D1 recognition failure", () => {
+  it("renders the apology card with hints and the example chips again", async () => {
+    server.use(chatStreamPatchedHandler("search", failedEnvelopePatch("anime_not_found", "resolver miss")));
+    renderChatPage();
+    sendText("知らない作品");
+    expect(await screen.findByText(states.d1Title)).toBeTruthy();
+    expect(screen.getByText(states.d1Subtitle)).toBeTruthy();
+    expect(screen.getByRole("button", { name: ja.chips[0] })).toBeTruthy();
+    expect(screen.queryByText("resolver miss")).toBeNull();
+  });
+});
+
+describe("D2 zero pilgrimage spots", () => {
+  it("renders the no-spots copy with neighbouring suggestions", async () => {
+    server.use(chatStreamPatchedHandler("search", zeroSpotsPatch));
+    renderChatPage();
+    sendText("マイナー作品");
+    expect(await screen.findByText(states.d2Title)).toBeTruthy();
+    expect(screen.getByRole("button", { name: ja.chips[1] })).toBeTruthy();
+  });
+});
+
+describe("D3 short route", () => {
+  it("keeps the spot cards and proposes adding a nearby work", async () => {
+    server.use(chatStreamHandler("search"));
+    renderChatPage();
+    sendText("ユーフォ");
+    expect(await screen.findByText(states.d3Notice)).toBeTruthy();
+    expect(screen.getByText("宇治橋")).toBeTruthy();
+    expect(screen.getByRole("button", { name: states.d3Chip })).toBeTruthy();
+  });
+});
+
+describe("D6 validation rejection", () => {
+  it("renders only the in-character apology, never the technical detail", async () => {
+    const technical = "ModelRetry exhausted after output_validator rejection";
+    server.use(chatStreamPatchedHandler("search", failedEnvelopePatch("output_validation_failed", technical)));
+    renderChatPage();
+    sendText("ユーフォ");
+    expect(await screen.findByText(states.d6Message)).toBeTruthy();
+    expect(screen.queryByText(/ModelRetry/)).toBeNull();
+    expect(screen.queryByText(/output_validator/)).toBeNull();
+    expect(screen.getByRole("button", { name: states.d6Retry })).toBeTruthy();
+  });
+
+  it("retries the turn from the apology card", async () => {
+    server.use(chatStreamPatchedHandler("search", failedEnvelopePatch("output_validation_failed", "rejected")));
+    renderChatPage();
+    sendText("ユーフォ");
+    await screen.findByText(states.d6Message);
+    server.use(chatStreamHandler("search"));
+    fireEvent.click(screen.getByRole("button", { name: states.d6Retry }));
+    expect(await screen.findByText("宇治の聖地を2件、徒歩ルートにまとめました。")).toBeTruthy();
+  });
+});
+
+describe("D9 scene image 404", () => {
+  it("degrades the scene thumb to a gradient placeholder with the episode label", async () => {
+    server.use(chatStreamPatchedHandler("search", brokenScenePatch));
+    renderChatPage();
+    sendText("ユーフォ");
+    const img = await screen.findByRole("img", { name: "宇治橋" });
+    fireEvent.error(img);
+    expect(screen.getByText("第8話")).toBeTruthy();
+    expect(document.querySelector("img.chat-scene-thumb")).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/chat/chat-page-fallbacks.test.tsx
+++ b/apps/web/tests/unit/chat/chat-page-fallbacks.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { setLanguages } from "../_i18n";
+import {
+  chatHttpErrorHandler,
+  chatStreamDropHandler,
+  chatStreamImmediateDropHandler,
+  conversationMessagesHandler,
+} from "../../msw/chat-handlers";
+import { server } from "../../msw/node";
+import { chatSearch, renderChatPage } from "./_chat-page";
+
+const ja = chatDictFor("ja");
+const states = ja.errorStates;
+
+beforeEach(() => {
+  setLanguages(["ja"]);
+});
+
+function sendText(text: string) {
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: text } });
+  fireEvent.click(screen.getByRole("button", { name: ja.send }));
+}
+
+const FINAL_STATE = [
+  { role: "user", content: "ユーフォ" },
+  { role: "assistant", content: "宇治の聖地を2件、徒歩ルートにまとめました。" },
+];
+
+describe("D4 mid-stream interruption", () => {
+  it("shows the inline retry strip and preserves the already-rendered content", async () => {
+    server.use(chatStreamDropHandler("search"));
+    renderChatPage();
+    sendText("ユーフォ");
+    expect(await screen.findByText(states.d4Message)).toBeTruthy();
+    expect(screen.getByText("ユーフォ")).toBeTruthy();
+    expect(screen.getByRole("button", { name: states.d4Retry })).toBeTruthy();
+    expect(screen.getByRole("textbox").hasAttribute("disabled")).toBe(false);
+  });
+
+  it("recovers by re-reading the session's final state, not by resuming the stream", async () => {
+    const seen: string[] = [];
+    server.use(conversationMessagesHandler("s-1", []), chatStreamDropHandler("search"));
+    renderChatPage(chatSearch({ session: "s-1" }));
+    await waitFor(() => { expect(screen.getByRole("textbox").hasAttribute("disabled")).toBe(false); });
+    sendText("ユーフォ");
+    await screen.findByText(states.d4Message);
+    server.use(conversationMessagesHandler("s-1", FINAL_STATE, (request) => seen.push(request.url)));
+    fireEvent.click(screen.getByRole("button", { name: states.d4Retry }));
+    expect(await screen.findByText("宇治の聖地を2件、徒歩ルートにまとめました。")).toBeTruthy();
+    expect(seen[0]).toContain("/v1/conversations/s-1/messages");
+    expect(screen.getByText("ユーフォ")).toBeTruthy();
+    expect(screen.queryByText(states.d4Message)).toBeNull();
+  });
+});
+
+describe("D4 before the first chunk", () => {
+  it("still shows a retry entry point instead of a stuck spinner", async () => {
+    server.use(chatStreamImmediateDropHandler());
+    renderChatPage();
+    sendText("ユーフォ");
+    expect(await screen.findByText(states.d4Message)).toBeTruthy();
+    expect(screen.getByRole("button", { name: states.d4Retry })).toBeTruthy();
+    expect(document.querySelector(".chat-typing")).toBeNull();
+    expect(screen.getByText("ユーフォ")).toBeTruthy();
+  });
+});
+
+describe("D8 session expiry", () => {
+  it("shows the inline expiry banner while keeping the conversation", async () => {
+    server.use(chatHttpErrorHandler(401));
+    renderChatPage();
+    sendText("こんにちは");
+    expect(await screen.findByText(states.d8Message)).toBeTruthy();
+    expect(screen.getByText("こんにちは")).toBeTruthy();
+    expect(screen.getByRole("button", { name: states.d8Login })).toBeTruthy();
+  });
+
+  it("resumes in place with the session's final state after re-login", async () => {
+    server.use(conversationMessagesHandler("s-1", []), chatHttpErrorHandler(401));
+    renderChatPage(chatSearch({ session: "s-1" }));
+    await waitFor(() => { expect(screen.getByRole("textbox").hasAttribute("disabled")).toBe(false); });
+    sendText("ユーフォ");
+    await screen.findByText(states.d8Message);
+    server.use(conversationMessagesHandler("s-1", FINAL_STATE));
+    fireEvent.click(screen.getByRole("button", { name: states.d8Resume }));
+    expect(await screen.findByText("宇治の聖地を2件、徒歩ルートにまとめました。")).toBeTruthy();
+    expect(screen.queryByText(states.d8Message)).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/chat/data-part-card.test.tsx
+++ b/apps/web/tests/unit/chat/data-part-card.test.tsx
@@ -2,7 +2,8 @@
  * @vitest-environment jsdom
  */
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatActionsProvider } from "../../../src/features/chat/chat-actions";
 import { DataPartCard } from "../../../src/features/chat/components/DataPartCard";
 import { chatDictFor } from "../../../src/features/chat/i18n";
 
@@ -11,7 +12,11 @@ afterEach(cleanup);
 const dict = chatDictFor("ja");
 
 function renderPart(data: unknown) {
-  return render(<DataPartCard data={data} dict={dict} />);
+  return render(
+    <ChatActionsProvider actions={{ send: vi.fn(), regenerate: vi.fn() }}>
+      <DataPartCard data={data} dict={dict} />
+    </ChatActionsProvider>,
+  );
 }
 
 describe("DataPartCard", () => {
@@ -34,6 +39,15 @@ describe("DataPartCard", () => {
     expect(screen.getByText("宇治の聖地を2件、徒歩ルートにまとめました。")).toBeTruthy();
     expect(screen.getByText("宇治橋")).toBeTruthy();
     expect(screen.getByText(/12/)).toBeTruthy();
+  });
+
+  it("appends the D3 short-route notice while keeping the spot cards", () => {
+    renderPart({
+      intent: "plan_route",
+      data: { route: { ordered_points: [{ id: "p1", name: "宇治橋" }], point_count: 1 } },
+    });
+    expect(screen.getByText("宇治橋")).toBeTruthy();
+    expect(screen.getByText(dict.errorStates.d3Notice)).toBeTruthy();
   });
 
   it("renders clarify candidates as options", () => {
@@ -80,33 +94,33 @@ describe("DataPartCard intent bodies", () => {
   });
 });
 
-describe("DataPartCard error intent", () => {
-  it("renders the envelope message and each error detail as an alert", () => {
+describe("DataPartCard failed envelopes", () => {
+  it("renders the D6 apology instead of the raw error details", () => {
     renderPart({
       intent: "error",
       message: "モデルに接続できませんでした",
       errors: [
-        { code: "provider_unavailable", message: "provider timed out" },
-        { code: "retry_exhausted", message: "all retries failed" },
+        { code: "retry_exhausted", message: "ModelRetry exhausted after output_validator rejection" },
       ],
       data: {},
     });
-    const alert = screen.getByRole("alert");
-    expect(alert).toBeTruthy();
-    expect(screen.getByText("モデルに接続できませんでした")).toBeTruthy();
-    expect(screen.getByText("provider timed out")).toBeTruthy();
-    expect(screen.getByText("all retries failed")).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toContain(dict.errorStates.d6Message);
+    expect(screen.queryByText(/ModelRetry/)).toBeNull();
+    expect(screen.queryByText("モデルに接続できませんでした")).toBeNull();
   });
 
-  it("falls back to localized copy when the envelope has no message", () => {
-    renderPart({ intent: "error", data: {} });
-    expect(screen.getByRole("alert")).toBeTruthy();
-    expect(screen.getByText(dict.errorCard)).toBeTruthy();
+  it("routes a not-found failure onto the D1 recognition fallback", () => {
+    renderPart({
+      intent: "error",
+      errors: [{ code: "anime_not_found", message: "resolver miss" }],
+      data: {},
+    });
+    expect(screen.getByText(dict.errorStates.d1Title)).toBeTruthy();
+    expect(screen.queryByText("resolver miss")).toBeNull();
   });
 
-  it("keeps the localized fallback out of the card when a message exists", () => {
-    renderPart({ intent: "error", message: "接続エラー", data: {} });
-    expect(screen.getByText("接続エラー")).toBeTruthy();
-    expect(screen.queryByText(dict.errorCard)).toBeNull();
+  it("routes an empty search result onto the D2 no-spots fallback", () => {
+    renderPart({ intent: "search_bangumi", data: { results: { rows: [] } } });
+    expect(screen.getByText(dict.errorStates.d2Title)).toBeTruthy();
   });
 });

--- a/apps/web/tests/unit/chat/data-part-card.test.tsx
+++ b/apps/web/tests/unit/chat/data-part-card.test.tsx
@@ -123,4 +123,16 @@ describe("DataPartCard failed envelopes", () => {
     renderPart({ intent: "search_bangumi", data: { results: { rows: [] } } });
     expect(screen.getByText(dict.errorStates.d2Title)).toBeTruthy();
   });
+
+  it("renders a failed clarify as candidates, not the D6 dead-loop apology", () => {
+    renderPart({
+      intent: "clarify",
+      success: false,
+      status: "invalid_selection",
+      message: "どの作品でしょうか?",
+      data: { candidates: [{ id: "1", title: "涼宮ハルヒの憂鬱" }] },
+    });
+    expect(screen.getByText("涼宮ハルヒの憂鬱")).toBeTruthy();
+    expect(screen.queryByText(dict.errorStates.d6Message)).toBeNull();
+  });
 });

--- a/apps/web/tests/unit/chat/envelope-fallback.test.tsx
+++ b/apps/web/tests/unit/chat/envelope-fallback.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatActionsProvider } from "../../../src/features/chat/chat-actions";
+import type { ChatActions } from "../../../src/features/chat/chat-actions";
+import { EnvelopeFallback } from "../../../src/features/chat/components/ErrorStates/EnvelopeFallback";
+import { ShortRouteNotice } from "../../../src/features/chat/components/ErrorStates/ShortRouteNotice";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+
+afterEach(cleanup);
+
+const ja = chatDictFor("ja");
+
+function actions(overrides: Partial<ChatActions> = {}): ChatActions {
+  return { send: vi.fn(), regenerate: vi.fn(), ...overrides };
+}
+
+function renderWithActions(ui: ReactElement, acted: ChatActions) {
+  return render(<ChatActionsProvider actions={acted}>{ui}</ChatActionsProvider>);
+}
+
+describe("EnvelopeFallback D1 (recognition failure)", () => {
+  it("apologises with the fox subtitle, hints, and the example chips again", () => {
+    renderWithActions(<EnvelopeFallback state="D1" dict={ja} />, actions());
+    expect(screen.getByText(ja.errorStates.d1Subtitle)).toBeTruthy();
+    expect(screen.getByText(ja.errorStates.d1Title)).toBeTruthy();
+    expect(screen.getByText(ja.errorStates.d1Hint)).toBeTruthy();
+    for (const chip of ja.chips) expect(screen.getByRole("button", { name: chip })).toBeTruthy();
+  });
+
+  it("sends a suggestion chip as the next user message", () => {
+    const send = vi.fn();
+    renderWithActions(<EnvelopeFallback state="D1" dict={ja} />, actions({ send }));
+    fireEvent.click(screen.getByRole("button", { name: ja.chips[1] }));
+    expect(send).toHaveBeenCalledWith(ja.chips[1]);
+  });
+});
+
+describe("EnvelopeFallback D2 (zero pilgrimage spots)", () => {
+  it("explains the empty catalog and offers neighbouring suggestions", () => {
+    renderWithActions(<EnvelopeFallback state="D2" dict={ja} />, actions());
+    expect(screen.getByText(ja.errorStates.d2Title)).toBeTruthy();
+    expect(screen.getByText(ja.errorStates.d2Hint)).toBeTruthy();
+    expect(screen.getByRole("button", { name: ja.chips[0] })).toBeTruthy();
+  });
+});
+
+describe("EnvelopeFallback D6 (validation rejection)", () => {
+  it("shows only the in-character apology and retries via regenerate", () => {
+    const regenerate = vi.fn();
+    renderWithActions(<EnvelopeFallback state="D6" dict={ja} />, actions({ regenerate }));
+    expect(screen.getByRole("alert").textContent).toContain(ja.errorStates.d6Message);
+    fireEvent.click(screen.getByRole("button", { name: ja.errorStates.d6Retry }));
+    expect(regenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("never surfaces ModelRetry or output_validator vocabulary", () => {
+    renderWithActions(<EnvelopeFallback state="D6" dict={ja} />, actions());
+    expect(document.body.textContent).not.toContain("ModelRetry");
+    expect(document.body.textContent).not.toContain("output_validator");
+  });
+});
+
+describe("EnvelopeFallback D5 (settled timeout envelope)", () => {
+  it("keeps the same retry shape with the timeout copy", () => {
+    const regenerate = vi.fn();
+    renderWithActions(<EnvelopeFallback state="D5" dict={ja} />, actions({ regenerate }));
+    expect(screen.getByRole("alert").textContent).toContain(ja.errorStates.d5Message);
+    fireEvent.click(screen.getByRole("button", { name: ja.errorStates.d5Retry }));
+    expect(regenerate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ShortRouteNotice (D3)", () => {
+  it("keeps the spot cards and proposes adding a nearby work", () => {
+    const send = vi.fn();
+    renderWithActions(<ShortRouteNotice dict={ja} />, actions({ send }));
+    expect(screen.getByText(ja.errorStates.d3Notice)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: ja.errorStates.d3Chip }));
+    expect(send).toHaveBeenCalledWith(ja.errorStates.d3Chip);
+  });
+});

--- a/apps/web/tests/unit/chat/error-classifier.test.ts
+++ b/apps/web/tests/unit/chat/error-classifier.test.ts
@@ -1,0 +1,112 @@
+import type { ChatDataPart } from "@seichijunrei/contract";
+import { describe, expect, it } from "vitest";
+import { classifyFailure } from "../../../src/lib/chat/errorClassifier";
+
+type SearchIntent = "search_bangumi" | "search_nearby";
+
+function searchPart(intent: SearchIntent, results?: Record<string, unknown>): ChatDataPart {
+  const data = results === undefined ? undefined : { results };
+  return { intent, success: true, data };
+}
+
+function routePart(route?: Record<string, unknown>): ChatDataPart {
+  const data = route === undefined ? undefined : { route };
+  return { intent: "plan_route", success: true, data };
+}
+
+function failedPart(intent: "error" | "unknown", code?: string): ChatDataPart {
+  const errors = code === undefined ? [] : [{ code, message: "internal detail" }];
+  if (intent === "error") return { intent: "error", success: false, errors };
+  return { intent: "unknown", success: false, errors };
+}
+
+function prosePart(intent: "clarify" | "greet_user"): ChatDataPart {
+  if (intent === "clarify") return { intent: "clarify", success: true };
+  return { intent: "greet_user", success: true };
+}
+
+describe("classifyFailure: transport signals", () => {
+  it.each([
+    [401, "D8"],
+    [403, "D8"],
+    [408, "D5"],
+    [504, "D5"],
+    [500, "D4"],
+    [502, "D4"],
+  ] as const)("maps HTTP %d onto %s", (status, expected) => {
+    expect(classifyFailure({ kind: "http", status })).toBe(expected);
+  });
+
+  it("maps a mid-stream abort onto the D4 interruption state", () => {
+    expect(classifyFailure({ kind: "stream-abort" })).toBe("D4");
+  });
+
+  it("maps the 60s turn watchdog onto the D5 timeout state", () => {
+    expect(classifyFailure({ kind: "timeout" })).toBe("D5");
+  });
+});
+
+describe("classifyFailure: image signals", () => {
+  it.each([
+    ["map", "D7"],
+    ["scene", "D9"],
+  ] as const)("maps a failed %s image onto %s", (surface, expected) => {
+    expect(classifyFailure({ kind: "image", surface })).toBe(expected);
+  });
+});
+
+describe("classifyFailure: failed envelopes", () => {
+  it.each([
+    ["error", "anime_not_found", "D1"],
+    ["unknown", "no_bangumi_found", "D1"],
+    ["error", "invalid_station", "D1"],
+    ["error", "agent_timeout", "D5"],
+    ["error", "pipeline_error", "D6"],
+    ["error", "output_validation_failed", "D6"],
+    ["unknown", undefined, "D6"],
+  ] as const)("maps a failed %s envelope with code %s onto %s", (intent, code, expected) => {
+    const part = failedPart(intent, code);
+    expect(classifyFailure({ kind: "envelope", part })).toBe(expected);
+  });
+
+  it("treats success=false on a non-error intent as a D6 rejection", () => {
+    const part = { intent: "plan_route", success: false, errors: [] } as ChatDataPart;
+    expect(classifyFailure({ kind: "envelope", part })).toBe("D6");
+  });
+});
+
+describe("classifyFailure: empty and short result envelopes", () => {
+  it.each([
+    ["search_bangumi", { rows: [] }, "D2"],
+    ["search_bangumi", { row_count: 0 }, "D2"],
+    ["search_nearby", { rows: [] }, "D2"],
+  ] as const)("maps %s with %o onto %s", (intent, results, expected) => {
+    const part = searchPart(intent, results);
+    expect(classifyFailure({ kind: "envelope", part })).toBe(expected);
+  });
+
+  it("maps a route that collapsed to zero points onto D2", () => {
+    const part = routePart({ point_count: 0 });
+    expect(classifyFailure({ kind: "envelope", part })).toBe("D2");
+  });
+
+  it.each([
+    [{ point_count: 2 }],
+    [{ ordered_points: [{ id: "p1", name: "宇治橋" }] }],
+  ])("maps a short route %o onto D3", (route) => {
+    expect(classifyFailure({ kind: "envelope", part: routePart(route) })).toBe("D3");
+  });
+});
+
+describe("classifyFailure: healthy envelopes stay unclassified", () => {
+  it.each([
+    ["search with rows", searchPart("search_bangumi", { rows: [{ id: "p1" }, { id: "p2" }, { id: "p3" }] })],
+    ["search without result evidence", searchPart("search_bangumi")],
+    ["route with three points", routePart({ point_count: 3 })],
+    ["route without point evidence", routePart()],
+    ["clarify", prosePart("clarify")],
+    ["greeting", prosePart("greet_user")],
+  ])("leaves a healthy %s envelope alone", (_label, part) => {
+    expect(classifyFailure({ kind: "envelope", part })).toBeUndefined();
+  });
+});

--- a/apps/web/tests/unit/chat/error-classifier.test.ts
+++ b/apps/web/tests/unit/chat/error-classifier.test.ts
@@ -73,6 +73,11 @@ describe("classifyFailure: failed envelopes", () => {
     const part = { intent: "plan_route", success: false, errors: [] } as ChatDataPart;
     expect(classifyFailure({ kind: "envelope", part })).toBe("D6");
   });
+
+  it("never swallows a failed clarify envelope into D6 (its card carries the recovery)", () => {
+    const part: ChatDataPart = { intent: "clarify", success: false, status: "invalid_selection" };
+    expect(classifyFailure({ kind: "envelope", part })).toBeUndefined();
+  });
 });
 
 describe("classifyFailure: empty and short result envelopes", () => {

--- a/apps/web/tests/unit/chat/error-i18n.test.ts
+++ b/apps/web/tests/unit/chat/error-i18n.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { LOCALES } from "../../../src/i18n/locales";
+
+const STATES = ["d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9"] as const;
+
+/** Wire/internal vocabulary that must never surface in user-facing fallback copy. */
+const TECHNICAL_MARKERS = [
+  "modelretry",
+  "output_validator",
+  "validation",
+  "traceback",
+  "exception",
+  "http",
+  "500",
+];
+
+const JAPANESE_SCRIPT = /[぀-ヿ一-鿿]/u;
+
+function errorCopyOf(locale: (typeof LOCALES)[number]): readonly [string, string][] {
+  return Object.entries(chatDictFor(locale).errorStates);
+}
+
+describe("chat error-state dictionary coverage", () => {
+  it.each(LOCALES)("covers all nine D-states with non-empty %s copy", (locale) => {
+    const entries = errorCopyOf(locale);
+    for (const [, value] of entries) expect(value.length).toBeGreaterThan(0);
+    for (const state of STATES) {
+      expect(entries.some(([key]) => key.startsWith(state))).toBe(true);
+    }
+  });
+
+  it("writes the ja fallback copy in Japanese so a ja user never sees leaked English", () => {
+    for (const [key, value] of errorCopyOf("ja")) {
+      expect(JAPANESE_SCRIPT.test(value), `ja errorStates.${key} must contain Japanese script`).toBe(true);
+    }
+  });
+
+  it("keeps each locale's D6 apology distinct from the others", () => {
+    expect(chatDictFor("ja").errorStates.d6Message).not.toBe(chatDictFor("en").errorStates.d6Message);
+    expect(chatDictFor("zh").errorStates.d6Message).not.toBe(chatDictFor("en").errorStates.d6Message);
+  });
+});
+
+describe("D6 copy never leaks technical details", () => {
+  it.each(LOCALES)("keeps ModelRetry/output_validator vocabulary out of every %s string", (locale) => {
+    for (const [key, value] of errorCopyOf(locale)) {
+      for (const marker of TECHNICAL_MARKERS) {
+        expect(value.toLowerCase(), `${locale} errorStates.${key} leaks "${marker}"`).not.toContain(marker);
+      }
+    }
+  });
+});

--- a/apps/web/tests/unit/chat/error-states-media.test.tsx
+++ b/apps/web/tests/unit/chat/error-states-media.test.tsx
@@ -41,6 +41,14 @@ describe("SceneThumb (D9 scene image 404)", () => {
     render(<SceneThumb alt="Uji Bridge" ep={8} dict={chatDictFor("en")} />);
     expect(screen.getByText("Ep. 8")).toBeTruthy();
   });
+
+  it("retries the image when a later render corrects the source", () => {
+    const view = render(<SceneThumb src="/scenes/gone.webp" alt="宇治橋" ep={8} dict={ja} />);
+    fireEvent.error(screen.getByRole("img", { name: "宇治橋" }));
+    expect(document.querySelector("img")).toBeNull();
+    view.rerender(<SceneThumb src="/scenes/fixed.webp" alt="宇治橋" ep={8} dict={ja} />);
+    expect(document.querySelector("img")?.getAttribute("src")).toBe("/scenes/fixed.webp");
+  });
 });
 
 describe("MapFallback (D7 map failure)", () => {

--- a/apps/web/tests/unit/chat/error-states-media.test.tsx
+++ b/apps/web/tests/unit/chat/error-states-media.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MapFallback } from "../../../src/features/chat/components/ErrorStates/MapFallback";
+import { SceneThumb } from "../../../src/features/chat/components/ErrorStates/SceneThumb";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+
+afterEach(cleanup);
+
+const ja = chatDictFor("ja");
+
+describe("SceneThumb (D9 scene image 404)", () => {
+  it("renders the scene image while the source is healthy", () => {
+    render(<SceneThumb src="/scenes/ok.webp" alt="宇治橋" ep={8} dict={ja} />);
+    expect(document.querySelector("img")?.getAttribute("alt")).toBe("宇治橋");
+  });
+
+  it("degrades to a gradient placeholder with the episode label when the image 404s", () => {
+    render(<SceneThumb src="/scenes/gone.webp" alt="宇治橋" ep={8} dict={ja} />);
+    fireEvent.error(screen.getByRole("img", { name: "宇治橋" }));
+    expect(screen.getByText("第8話")).toBeTruthy();
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.getByRole("img", { name: "宇治橋" })).toBeTruthy();
+  });
+
+  it("shows the placeholder immediately when the row has no image at all", () => {
+    render(<SceneThumb alt="宇治橋" ep={3} dict={ja} />);
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.getByText("第3話")).toBeTruthy();
+  });
+
+  it("keeps the placeholder accessible when the episode is unknown", () => {
+    render(<SceneThumb alt="宇治橋" dict={ja} />);
+    expect(screen.getByRole("img", { name: "宇治橋" })).toBeTruthy();
+    expect(screen.queryByText(/第.*話/u)).toBeNull();
+  });
+
+  it("localises the episode label per locale", () => {
+    render(<SceneThumb alt="Uji Bridge" ep={8} dict={chatDictFor("en")} />);
+    expect(screen.getByText("Ep. 8")).toBeTruthy();
+  });
+});
+
+describe("MapFallback (D7 map failure)", () => {
+  it("renders the in-character message and an external map app link", () => {
+    render(<MapFallback dict={ja} lat={34.89} lng={135.8} />);
+    expect(screen.getByText(ja.errorStates.d7Message)).toBeTruthy();
+    const link = screen.getByRole("link", { name: ja.errorStates.d7Open });
+    expect(link.getAttribute("href")).toContain("34.89,135.8");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("keeps the illustration decorative and drops the link without coordinates", () => {
+    render(<MapFallback dict={ja} />);
+    expect(screen.getByText(ja.errorStates.d7Message)).toBeTruthy();
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(document.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+  });
+});

--- a/apps/web/tests/unit/chat/error-states-turn.test.tsx
+++ b/apps/web/tests/unit/chat/error-states-turn.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionExpired } from "../../../src/features/chat/components/ErrorStates/SessionExpired";
+import { StreamInterruption } from "../../../src/features/chat/components/ErrorStates/StreamInterruption";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { renderWithLocale, setLanguages } from "../_i18n";
+
+beforeEach(() => { setLanguages(["ja"]); });
+afterEach(cleanup);
+
+const ja = chatDictFor("ja");
+
+describe("StreamInterruption (D4 mid-stream drop)", () => {
+  it("announces the interruption and retries on the inline button", () => {
+    const onRetry = vi.fn();
+    renderWithLocale(<StreamInterruption state="D4" dict={ja} onRetry={onRetry} />);
+    expect(screen.getByRole("alert").textContent).toContain(ja.errorStates.d4Message);
+    fireEvent.click(screen.getByRole("button", { name: ja.errorStates.d4Retry }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("locks the retry button while a recovery is in flight", () => {
+    renderWithLocale(<StreamInterruption state="D4" dict={ja} onRetry={vi.fn()} recovering />);
+    expect(screen.getByRole("button", { name: ja.errorStates.d4Retry }).hasAttribute("disabled")).toBe(true);
+  });
+});
+
+describe("StreamInterruption (D5 timeout)", () => {
+  it("keeps the same retry shape with the timeout copy", () => {
+    const onRetry = vi.fn();
+    renderWithLocale(<StreamInterruption state="D5" dict={ja} onRetry={onRetry} />);
+    expect(screen.getByRole("alert").textContent).toContain(ja.errorStates.d5Message);
+    fireEvent.click(screen.getByRole("button", { name: ja.errorStates.d5Retry }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SessionExpired (D8)", () => {
+  it("announces the expiry without discarding the surrounding conversation", () => {
+    renderWithLocale(<SessionExpired dict={ja} onResume={vi.fn()} />);
+    expect(screen.getByRole("alert").textContent).toContain(ja.errorStates.d8Message);
+  });
+
+  it("opens the login dialog inline so the chat never unmounts", () => {
+    renderWithLocale(<SessionExpired dict={ja} onResume={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: ja.errorStates.d8Login }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("resumes the conversation from the inline banner", () => {
+    const onResume = vi.fn();
+    renderWithLocale(<SessionExpired dict={ja} onResume={onResume} />);
+    fireEvent.click(screen.getByRole("button", { name: ja.errorStates.d8Resume }));
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("locks the resume button while recovery is in flight", () => {
+    renderWithLocale(<SessionExpired dict={ja} onResume={vi.fn()} recovering />);
+    expect(screen.getByRole("button", { name: ja.errorStates.d8Resume }).hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/chat/use-chat-session.test.tsx
+++ b/apps/web/tests/unit/chat/use-chat-session.test.tsx
@@ -7,6 +7,7 @@ import { useChatSession } from "../../../src/features/chat/use-chat-session";
 import { server } from "../../msw/node";
 import {
   CHAT_URL,
+  chatHttpErrorHandler,
   chatStreamControlledHandler,
   chatStreamHandler,
   chatStreamHeldOpenHandler,
@@ -117,6 +118,25 @@ describe("session switch resets the chat instance", () => {
     const count = view.result.current.messages.length;
     view.rerender({ sessionId: "A" });
     expect(view.result.current.messages.length).toBe(count);
+  });
+});
+
+describe("failure-signal observability", () => {
+  it("exposes the captured session id for disconnect recovery", async () => {
+    server.use(chatStreamHandler("search", { sessionId: "srv-7" }));
+    const view = renderSession();
+    await sendAndSettle(view, "ユーフォ");
+    expect(view.result.current.sessionIdOf()).toBe("srv-7");
+  });
+
+  it("records the HTTP status of a rejected chat request for classification", async () => {
+    server.use(chatHttpErrorHandler(401));
+    const view = renderSession("s-1");
+    await act(async () => view.result.current.sendMessage({ text: "こんにちは" }));
+    await waitFor(() => {
+      expect(view.result.current.error).toBeTruthy();
+    });
+    expect(view.result.current.lastHttpStatus()).toBe(401);
   });
 });
 

--- a/apps/web/tests/unit/chat/use-stream-recovery.test.tsx
+++ b/apps/web/tests/unit/chat/use-stream-recovery.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useStreamRecovery } from "../../../src/features/chat/use-stream-recovery";
+import { clearAuthToken } from "../../../src/lib/auth/authSession";
+import {
+  conversationMessagesErrorHandler,
+  conversationMessagesHandler,
+} from "../../msw/chat-handlers";
+import { TEST_ORIGIN } from "../../msw/fixtures";
+import { server } from "../../msw/node";
+
+vi.mock(import("../../../src/lib/auth/authSession"), { spy: true });
+
+function fakeChat() {
+  return { setMessages: vi.fn(), clearError: vi.fn(), regenerate: vi.fn().mockResolvedValue(undefined) };
+}
+
+function renderRecovery(chat: ReturnType<typeof fakeChat>, sessionId?: string) {
+  return renderHook(() => useStreamRecovery(TEST_ORIGIN, chat, () => sessionId));
+}
+
+describe("useStreamRecovery without a persisted session", () => {
+  it("falls back to regenerating the failed turn", () => {
+    const chat = fakeChat();
+    const view = renderRecovery(chat);
+    act(() => { view.result.current.recover(); });
+    expect(chat.clearError).toHaveBeenCalledTimes(1);
+    expect(chat.regenerate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useStreamRecovery with a persisted session", () => {
+  const FINAL_STATE = [
+    { role: "user", content: "ユーフォ" },
+    { role: "assistant", content: "宇治の聖地を2件、徒歩ルートにまとめました。" },
+  ];
+
+  it("re-reads the session's final state from GET /v1/conversations/{id}/messages", async () => {
+    const seen: string[] = [];
+    server.use(conversationMessagesHandler("s-9", FINAL_STATE, (request) => seen.push(request.url)));
+    const chat = fakeChat();
+    const view = renderRecovery(chat, "s-9");
+    act(() => { view.result.current.recover(); });
+    await waitFor(() => { expect(chat.setMessages).toHaveBeenCalledTimes(1); });
+    expect(seen[0]).toContain("/v1/conversations/s-9/messages");
+    expect(chat.clearError).toHaveBeenCalledTimes(1);
+    expect(chat.regenerate).not.toHaveBeenCalled();
+  });
+
+  it("maps the fetched rows onto user/assistant text messages", async () => {
+    server.use(conversationMessagesHandler("s-9", FINAL_STATE));
+    const chat = fakeChat();
+    const view = renderRecovery(chat, "s-9");
+    act(() => { view.result.current.recover(); });
+    await waitFor(() => { expect(chat.setMessages).toHaveBeenCalledTimes(1); });
+    const messages = chat.setMessages.mock.calls[0]?.[0] as {
+      role: string;
+      parts: { type: string; text: string }[];
+    }[];
+    expect(messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(messages[1]?.parts[0]?.text).toBe("宇治の聖地を2件、徒歩ルートにまとめました。");
+  });
+
+  it("keeps the failure state when the final-state fetch itself fails", async () => {
+    server.use(conversationMessagesErrorHandler("s-9", 500));
+    const chat = fakeChat();
+    const view = renderRecovery(chat, "s-9");
+    act(() => { view.result.current.recover(); });
+    await waitFor(() => { expect(view.result.current.recovering).toBe(false); });
+    expect(chat.setMessages).not.toHaveBeenCalled();
+    expect(chat.clearError).not.toHaveBeenCalled();
+  });
+
+  it("drops the cached auth token before an expired-session resume", async () => {
+    server.use(conversationMessagesHandler("s-9", []));
+    const chat = fakeChat();
+    const view = renderRecovery(chat, "s-9");
+    act(() => { view.result.current.recoverExpired(); });
+    expect(clearAuthToken).toHaveBeenCalledTimes(1);
+    await waitFor(() => { expect(chat.setMessages).toHaveBeenCalled(); });
+  });
+});

--- a/apps/web/tests/unit/chat/use-turn-timeout.test.tsx
+++ b/apps/web/tests/unit/chat/use-turn-timeout.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { ChatStatus } from "ai";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TURN_TIMEOUT_MS, useTurnTimeout } from "../../../src/features/chat/use-turn-timeout";
+
+beforeEach(() => { vi.useFakeTimers(); });
+afterEach(() => { vi.useRealTimers(); });
+
+function renderTimeout(stop: () => void, status: ChatStatus = "submitted") {
+  return renderHook((props: { status: ChatStatus }) => useTurnTimeout(props.status, stop), {
+    initialProps: { status },
+  });
+}
+
+describe("useTurnTimeout (D5 watchdog)", () => {
+  it("stays quiet when the turn settles inside the budget", () => {
+    const stop = vi.fn();
+    const view = renderTimeout(stop);
+    act(() => { vi.advanceTimersByTime(TURN_TIMEOUT_MS - 1); });
+    view.rerender({ status: "ready" });
+    act(() => { vi.advanceTimersByTime(TURN_TIMEOUT_MS); });
+    expect(stop).not.toHaveBeenCalled();
+    expect(view.result.current.timedOut).toBe(false);
+  });
+
+  it("stops the turn and raises the flag once the 60s budget elapses", () => {
+    const stop = vi.fn();
+    const view = renderTimeout(stop);
+    act(() => { vi.advanceTimersByTime(TURN_TIMEOUT_MS); });
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(view.result.current.timedOut).toBe(true);
+  });
+
+  it("keeps a single watchdog across the submitted-to-streaming upgrade", () => {
+    const stop = vi.fn();
+    const view = renderTimeout(stop);
+    act(() => { vi.advanceTimersByTime(TURN_TIMEOUT_MS / 2); });
+    view.rerender({ status: "streaming" });
+    act(() => { vi.advanceTimersByTime(TURN_TIMEOUT_MS / 2); });
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the flag when the next turn starts", () => {
+    const view = renderTimeout(vi.fn());
+    act(() => { vi.advanceTimersByTime(TURN_TIMEOUT_MS); });
+    view.rerender({ status: "ready" });
+    view.rerender({ status: "submitted" });
+    expect(view.result.current.timedOut).toBe(false);
+  });
+
+  it("resets on demand for the retry flow", () => {
+    const view = renderTimeout(vi.fn());
+    act(() => { vi.advanceTimersByTime(TURN_TIMEOUT_MS); });
+    act(() => { view.result.current.reset(); });
+    expect(view.result.current.timedOut).toBe(false);
+  });
+});

--- a/e2e/fixtures/chat-stream.ts
+++ b/e2e/fixtures/chat-stream.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Browser-suite twins of apps/web/tests/msw/chat-handlers.ts: replay the REAL
+ * agent stream recordings, with the same minimal patching discipline (session
+ * id injection, final-envelope transforms for the D-state variants until the
+ * backend error-boundary hook ships recordings of the actual failure frames).
+ */
+const FIXTURE_DIR = join(__dirname, "..", "..", "apps", "agent", "tests", "fixtures", "chat_stream");
+
+export const SSE_HEADERS = {
+  "content-type": "text/event-stream",
+  "x-vercel-ai-ui-message-stream": "v1",
+};
+
+export type ChatStreamFixture = "search" | "clarify" | "error";
+
+export function chatStreamRecording(name: ChatStreamFixture): string {
+  return readFileSync(join(FIXTURE_DIR, `${name}.sse`), "utf8");
+}
+
+export type EnvelopePatch = (envelope: Record<string, unknown>) => Record<string, unknown>;
+
+interface DataResponseFrame {
+  data: Record<string, unknown>;
+}
+
+function isFullFinalFrame(line: string): boolean {
+  return line.startsWith('data: {"type":"data-response"');
+}
+
+function patchLine(line: string, patch: EnvelopePatch): string {
+  if (!isFullFinalFrame(line)) return line;
+  const frame = JSON.parse(line.slice("data: ".length)) as DataResponseFrame;
+  if (!("success" in frame.data)) return line;
+  frame.data = patch(frame.data);
+  return `data: ${JSON.stringify(frame)}`;
+}
+
+/** Transform the recording's final full envelope (skeleton frames untouched). */
+export function patchFinalFrame(recording: string, patch: EnvelopePatch): string {
+  return recording.split("\n").map((line) => patchLine(line, patch)).join("\n");
+}
+
+/** The recordings capture a null session id; inject one for recovery flows. */
+export function patchSessionId(recording: string, sessionId: string): string {
+  return patchFinalFrame(recording, (envelope) => ({ ...envelope, session_id: sessionId }));
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,7 +6,7 @@
     "test:headed": "playwright test --headed",
     "test:public": "playwright test public-pages.spec.ts middleware-redirect.spec.ts login-modal.spec.ts",
     "test:auth": "playwright test auth-flow.spec.ts",
-    "test:web": "playwright test web-404.spec.ts"
+    "test:web": "playwright test web-404.spec.ts web-chat-error-states.spec.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1"

--- a/e2e/web-chat-error-states.spec.ts
+++ b/e2e/web-chat-error-states.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test } from "@playwright/test";
+import type { Page, Route } from "@playwright/test";
+import { chatDictFor } from "../apps/web/src/features/chat/i18n";
+import { SSE_HEADERS, chatStreamRecording, patchFinalFrame, patchSessionId } from "./fixtures/chat-stream";
+import type { EnvelopePatch } from "./fixtures/chat-stream";
+
+/**
+ * Issue #272 (S1.6) browser ACs: each simulated D-state trigger renders its
+ * prescribed in-character fallback — never a bare error or a blank screen.
+ * D7 (map failure) has no live trigger in the chat flow yet (no map card is
+ * rendered there); the MapFallback component is unit-covered and this spec
+ * gains a D7 case when the chat map card lands.
+ */
+test.use({
+  baseURL: process.env.E2E_WEB_BASE_URL ?? "http://localhost:3000",
+  locale: "ja-JP",
+});
+
+const ja = chatDictFor("ja");
+const states = ja.errorStates;
+
+const failedEnvelope = (code: string): EnvelopePatch => () => ({
+  intent: "error",
+  success: false,
+  status: "error",
+  errors: [{ code, message: "ModelRetry exhausted after output_validator rejection" }],
+});
+
+const zeroSpots: EnvelopePatch = (envelope) => ({
+  ...envelope,
+  data: { route: { ordered_points: [], point_count: 0 } },
+});
+
+const brokenScene: EnvelopePatch = (envelope) => ({
+  ...envelope,
+  data: {
+    route: {
+      ordered_points: [
+        { id: "p1", name: "宇治橋", bangumi_id: "12345", episode: 8, latitude: 34.891, longitude: 135.807, screenshot_url: "/broken/scene.webp" },
+      ],
+      point_count: 2,
+    },
+  },
+});
+
+async function fulfillSse(route: Route, body: string): Promise<void> {
+  await route.fulfill({ status: 200, headers: SSE_HEADERS, body });
+}
+
+/** The healthz probe only fires from the hydrated client, so awaiting it
+ * guarantees the composer's React handlers are attached before interacting. */
+async function openChat(page: Page): Promise<void> {
+  await page.route("**/healthz", (route) => route.fulfill({ json: { status: "ok" } }));
+  const hydrated = page.waitForResponse((response) => response.url().includes("/healthz"));
+  await page.goto("/chat");
+  await hydrated;
+}
+
+async function send(page: Page, text: string): Promise<void> {
+  await page.getByRole("textbox").fill(text);
+  await page.getByRole("button", { name: ja.send }).click();
+}
+
+async function routeChatStream(page: Page, body: string): Promise<void> {
+  await page.route("**/v1/chat", (route) => fulfillSse(route, body));
+}
+
+test("D1 recognition failure renders the apology card with suggestion chips", async ({ page }) => {
+  await routeChatStream(page, patchFinalFrame(chatStreamRecording("search"), failedEnvelope("anime_not_found")));
+  await openChat(page);
+  await send(page, "知らない作品");
+  await expect(page.getByText(states.d1Title)).toBeVisible();
+  await expect(page.getByText(states.d1Subtitle)).toBeVisible();
+  await expect(page.getByRole("button", { name: ja.chips[0] })).toBeVisible();
+});
+
+test("D2 zero spots renders the no-spots copy with recommendations", async ({ page }) => {
+  await routeChatStream(page, patchFinalFrame(chatStreamRecording("search"), zeroSpots));
+  await openChat(page);
+  await send(page, "マイナー作品");
+  await expect(page.getByText(states.d2Title)).toBeVisible();
+  await expect(page.getByRole("button", { name: ja.chips[1] })).toBeVisible();
+});
+
+test("D3 short route keeps the spot cards and proposes widening", async ({ page }) => {
+  await routeChatStream(page, chatStreamRecording("search"));
+  await openChat(page);
+  await send(page, "ユーフォ");
+  await expect(page.getByText(states.d3Notice)).toBeVisible();
+  await expect(page.getByText("宇治橋")).toBeVisible();
+  await expect(page.getByRole("button", { name: states.d3Chip })).toBeVisible();
+});
+
+test("D4 interruption before the first chunk shows a retry entry, not a stuck spinner", async ({ page }) => {
+  await page.route("**/v1/chat", (route) => route.abort("connectionreset"));
+  await openChat(page);
+  await send(page, "ユーフォ");
+  await expect(page.getByText(states.d4Message)).toBeVisible();
+  await expect(page.getByRole("button", { name: states.d4Retry })).toBeVisible();
+  await expect(page.locator(".chat-typing")).toHaveCount(0);
+  await expect(page.getByText("ユーフォ")).toBeVisible();
+});
+
+test("D4 recovery re-reads the session's final state and preserves the conversation", async ({ page }) => {
+  await routeChatStream(page, patchSessionId(chatStreamRecording("search"), "s-e2e"));
+  await openChat(page);
+  await send(page, "ユーフォ");
+  await expect(page.getByText("宇治の聖地を2件、徒歩ルートにまとめました。")).toBeVisible();
+  await page.route("**/v1/chat", (route) => route.abort("connectionreset"));
+  await send(page, "続きも教えて");
+  await expect(page.getByText(states.d4Message)).toBeVisible();
+  await page.route("**/v1/conversations/s-e2e/messages", (route) =>
+    route.fulfill({
+      json: {
+        messages: [
+          { role: "user", content: "ユーフォ" },
+          { role: "assistant", content: "宇治の聖地を2件、徒歩ルートにまとめました。" },
+          { role: "user", content: "続きも教えて" },
+          { role: "assistant", content: "つづきはこの2か所だよ。" },
+        ],
+      },
+    }),
+  );
+  await page.getByRole("button", { name: states.d4Retry }).click();
+  await expect(page.getByText("つづきはこの2か所だよ。")).toBeVisible();
+  await expect(page.getByText(states.d4Message)).toHaveCount(0);
+  await expect(page.getByText("宇治の聖地を2件、徒歩ルートにまとめました。")).toBeVisible();
+});
+
+test("D5 timeout swaps the stuck turn for the same-shape retry", async ({ page }) => {
+  await page.route("**/v1/chat", () => {
+    /* never respond: the turn hangs until the watchdog stops it */
+  });
+  await openChat(page);
+  await page.clock.install();
+  await send(page, "ユーフォ");
+  await expect(page.locator(".chat-typing")).toBeVisible();
+  await page.clock.fastForward(61_000);
+  await expect(page.getByText(states.d5Message)).toBeVisible();
+  await expect(page.getByRole("button", { name: states.d5Retry })).toBeVisible();
+});
+
+test("D6 validation rejection apologises without leaking technical detail", async ({ page }) => {
+  await routeChatStream(page, patchFinalFrame(chatStreamRecording("search"), failedEnvelope("output_validation_failed")));
+  await openChat(page);
+  await send(page, "ユーフォ");
+  await expect(page.getByText(states.d6Message)).toBeVisible();
+  await expect(page.getByRole("button", { name: states.d6Retry })).toBeVisible();
+  await expect(page.getByText(/ModelRetry|output_validator/)).toHaveCount(0);
+});
+
+test("D8 session expiry preserves the conversation and resumes in place", async ({ page }) => {
+  await page.route("**/v1/chat", (route) => route.fulfill({ status: 401, body: "" }));
+  await openChat(page);
+  await send(page, "こんにちは");
+  await expect(page.getByText(states.d8Message)).toBeVisible();
+  await expect(page.getByText("こんにちは")).toBeVisible();
+  await expect(page.getByRole("button", { name: states.d8Login })).toBeVisible();
+  await expect(page.getByRole("button", { name: states.d8Resume })).toBeVisible();
+});
+
+test("D9 scene image 404 degrades to a gradient placeholder with the episode label", async ({ page }) => {
+  await page.route("**/broken/scene.webp", (route) => route.fulfill({ status: 404, body: "" }));
+  await routeChatStream(page, patchFinalFrame(chatStreamRecording("search"), brokenScene));
+  await openChat(page);
+  await send(page, "ユーフォ");
+  await expect(page.getByText("第8話")).toBeVisible();
+  await expect(page.locator("img.chat-scene-thumb")).toHaveCount(0);
+});


### PR DESCRIPTION
Frontend half of #272 (S1.6): every one of the nine defined exception/edge-case states now renders its prescribed in-character fallback — never a bare stack trace, HTTP code, or blank screen. The backend error-boundary hook + prompt patches are the separate half.

## What's in here

### 1. Error classifier — `apps/web/src/lib/chat/errorClassifier.ts` (pure, unit-tested)
`classifyFailure(signal)` maps raw client observations onto the D-state enum:

| Signal | Mapping |
|---|---|
| `http` status | 401/403 → **D8** · 408/504 → **D5** · other ≥400 → **D4** |
| `stream-abort` (fetch abort / network drop) | **D4** |
| `timeout` (60s turn watchdog) | **D5** |
| `envelope` (settled `data-response`) | failed intent/`success:false` + not-found-family code (`not_found`/`no_bangumi`/`invalid_station`) → **D1** · timeout-family code → **D5** · any other failure → **D6** · search with 0 rows → **D2** · route with 0 points → **D2** · route with 1-2 points → **D3** |
| `image` | `map` → **D7** · `scene` → **D9** |

### 2. ErrorStates components — `apps/web/src/features/chat/components/ErrorStates/`
- `StreamInterruption` (D4/D5): inline retry strip on error tokens; input stays usable.
- `SessionExpired` (D8): warning-tone banner, LoginModal opens **in place** (chat never unmounts), resume button.
- `EnvelopeFallback` (D1/D2/D5/D6): apology cards with fox subtitle, hints, suggestion chips; copy comes exclusively from the dictionary — wire error details never reach the DOM.
- `ShortRouteNotice` (D3): spot cards stay rendered, advisory + 「近くの別作品も足す?」 chip below.
- `MapFallback` (D7): inline SVG doodle + 地図アプリで開く external link — never a broken map.
- `SceneThumb` (D9): scene still that degrades to a gradient placeholder + episode label on 404; wired into spot rows.
- Chips/retries flow through a `ChatActions` context (no >2-level prop drilling).
- The raw-detail-leaking `ErrorCard` is retired; `error`/`unknown` envelopes route through the classifier before the intent registry, and a failed intent never wears a skeleton.

### 3. Recovery semantics (P6 merge-blocking gate)
D4/D5/D8 recovery **never resumes the broken AI-SDK stream**: with a known session id the client calls `GET /v1/conversations/{id}/messages` and replaces the transcript with the session's final state (prior conversation preserved — no message loss); with nothing persisted yet it falls back to `regenerate()`. D8 additionally drops the cached auth token first. The session tracker now records each chat response's HTTP status (401 → D8 classification) and exposes the captured session id.

Stream failures render inline D-strips; the A5 top banner is now healthz-only.

### 4. i18n
`ChatDict.errorStates` — all nine states in **ja/zh/en**, feature-local (`apps/web/src/features/chat/i18n.ts`). Tests pin: 9-state coverage per locale, ja copy contains Japanese script (a ja user never sees leaked English), and **zero** `ModelRetry`/`output_validator`/technical vocabulary in any string.

### 5. Design
Animal Island semantic tokens only (`--color-error-bg`/`--color-error-strong` AA pair for strips, gold `--color-warning-fg` accent for D8, primary-gradient D9 placeholder mirroring the mood card) — night-theme aware via the token layer, no raw palette values.

## Tests

| Layer | Coverage |
|---|---|
| Browser (Playwright, `e2e/web-chat-error-states.spec.ts`, 9 cases) | D1/D2/D6 patched failure envelopes over the real stream recordings · D3 from the recorded 2-point route · D4 abort **incl. before-first-chunk retry entry (no stuck spinner)** · D4 recovery via `GET .../messages` with prior conversation intact · D5 via Playwright clock (61s fast-forward) · D8 401 banner preserving the conversation · D9 genuinely 404ing scene still |
| Unit (vitest + MSW recordings, 84 new tests) | classifier table tests · i18n nine-state/ja-script/leak-free assertions · every ErrorStates component incl. interactions · watchdog with mocked clock · recovery hook incl. failure path + auth-token drop · page-level D1/D2/D3/D6/D9 envelope flows and D4/D8 transport flows |

Gate: `pnpm lint:oxlint` + `pnpm typecheck` + `pnpm test` all green — 732 unit tests / 133 files, coverage 99.03% stmts / 95.35% branches / 99.59% fns / 99.85% lines (floors stay at the owner-signed 90). `pnpm run test:web` (404 + 9 D-states) 10/10 green against the dev server.

## Flags for the reviewer / backend half
- **D7 has no live trigger in the chat flow yet** — no map card renders there (C3 map card is future work). `MapFallback` ships unit-covered with the classifier mapping; the browser case lands with the chat map card.
- **D1/D6 failure-envelope shapes are anticipated** (`intent:"error"` + `errors[].code`), derived by patching the real recordings — the same discipline as the existing `patchSessionId`/`corruptFinalFrame` helpers. When the backend error-boundary hook ships real D-state recordings, only `tests/msw/chat-handlers.ts` + `e2e/fixtures/chat-stream.ts` need re-pointing.
- On a mid-stream error the AI SDK removes the errored turn's partial assistant message by contract (its regenerate semantics); what is preserved is the user message + all prior turns, and P6 recovery immediately restores the server's completed truth — asserted in both unit and browser suites.
- Scope: `apps/web/**` + `e2e/**` only; no `apps/agent/**` files touched.

Closes the frontend AC set of #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)