### PR TITLE
feat(agent): S1.6 SD-18 error-boundary hook + SD-17 prompt patches + token-budget CI check

### DIFF
--- a/.github/workflows/_python-ci.yml
+++ b/.github/workflows/_python-ci.yml
@@ -46,13 +46,10 @@ jobs:
           working-directory: apps/${{ inputs.app }}
 
       - name: Ruff format check
-        run: uv run ruff format --check agent/ scripts/
+        run: uv run ruff format --check agent/
 
       - name: Type check (mypy strict)
         run: uv run mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/
-
-      - name: Prompt token budget (SD-17)
-        run: uv run python scripts/check_prompt_token_budget.py
 
       - name: Dead code (vulture)
         run: uv run vulture agent/ vulture_whitelist.py

--- a/.github/workflows/_python-ci.yml
+++ b/.github/workflows/_python-ci.yml
@@ -46,10 +46,13 @@ jobs:
           working-directory: apps/${{ inputs.app }}
 
       - name: Ruff format check
-        run: uv run ruff format --check agent/
+        run: uv run ruff format --check agent/ scripts/
 
       - name: Type check (mypy strict)
         run: uv run mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/
+
+      - name: Prompt token budget (SD-17)
+        run: uv run python scripts/check_prompt_token_budget.py
 
       - name: Dead code (vulture)
         run: uv run vulture agent/ vulture_whitelist.py

--- a/Makefile
+++ b/Makefile
@@ -76,12 +76,12 @@ test-eval-fullstack:
 	cd apps/agent && EVAL_FULLSTACK=1 EVAL_MAX_CASES=$${EVAL_MAX_CASES:-50} $(PYTHON) -m agent.tests.eval.run_agent_eval
 
 lint:
-	cd apps/agent && uv run ruff check agent/
-	cd apps/agent && uv run ruff format --check agent/
+	cd apps/agent && uv run ruff check agent/ scripts/
+	cd apps/agent && uv run ruff format --check agent/ scripts/
 
 format:
-	cd apps/agent && uv run ruff format agent/
-	cd apps/agent && uv run ruff check --fix agent/
+	cd apps/agent && uv run ruff format agent/ scripts/
+	cd apps/agent && uv run ruff check --fix agent/ scripts/
 
 typecheck:
 	cd apps/agent && uv run mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/ agent/tests/eval/

--- a/apps/agent/agent/agents/animichi_agent.py
+++ b/apps/agent/agent/agents/animichi_agent.py
@@ -8,7 +8,9 @@ import os
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import NoReturn, cast
+from zoneinfo import ZoneInfo
 
 from logfire.variables import ResolvedVariable
 from pydantic_ai import Agent, ModelRetry, RunContext
@@ -28,6 +30,7 @@ from pydantic_ai_harness.memory import Memory, MemoryStore
 from agent.agents.agent_result import ProducedRoute, ProducedSearch, StepRecord
 from agent.agents.animichi_tools import TOOLS as ANIMICHI_TOOLS
 from agent.agents.base import resolve_model
+from agent.agents.error_boundary import error_boundary_hooks
 from agent.agents.history_compaction import native_history_compaction
 from agent.agents.runtime_deps import RuntimeDeps
 from agent.agents.runtime_models import (
@@ -49,7 +52,7 @@ from agent.utils.language import locale_name, resolve_reply_language
 MANAGED_PROMPT_NAME = "animichi-instructions"
 MANAGED_PROMPT_LABEL = "production"
 _LOCAL_PROMPT_VERSION = (
-    "sha256:06a56c060214574d0cc0b18c4a76a18e9656c100b710cf06e21f78d80f67f33a"
+    "sha256:d6941015e532fc2f240f64bc4ef056c8e7986044f7d6c0e5d773639030252cd5"
 )
 _PROMPT_RESOLUTION_DEADLINE_SECONDS = 2.0
 _PROMPT_RESOLUTION_EXECUTOR = ThreadPoolExecutor(
@@ -94,6 +97,7 @@ Never fabricate locations, coordinates, routes, candidate identity, or catalog d
 - search_nearby or plan_route upstream_unavailable: emit qa_response asking the user to retry.
 - plan_route ok: emit route_response; stale_ref means re-run the relevant search.
 - plan_route pending_sync: emit search_response explaining that catalog data is still syncing and route planning can be retried shortly.
+- Any tool result shaped `{"error": true, "message": ...}`: emit qa_response using that message, asking the user to retry.
 Never infer ambiguity from query length. Branch only on typed tool outcomes.
 
 ## Convergence rules
@@ -113,6 +117,18 @@ Never infer ambiguity from query length. Branch only on typed tool outcomes.
 - last_result_ref is an anaphora hint, never an implicit plan_route argument.
 - A greeting followed by a real query follows the real search or route path.
 - A standalone greeting, thanks, farewell, or capability question emits greeting_response.
+
+## Worked examples
+- Dual-intent ("小林家的龙女仆的圣地，然后帮我规划路线"): call resolve_anime once,
+  then search_bangumi, then plan_route with the new result_ref in the same
+  turn — do not ask the user to split this into two turns.
+- Sequel vs. original ("鬼滅の刃 無限列車編" vs "鬼滅の刃"): call resolve_anime with
+  the title exactly as written; trust its outcome as authoritative for that
+  string. A different season or movie title the user names later is a new,
+  distinct resolve_anime call, never a retry of the same one.
+- Mixed-CJK input ("我要看K-On!轻音少女的聖地"): the reply language follows the
+  current turn's dominant script (zh here), not an embedded English or
+  Japanese proper noun.
 
 ## Compact output
 Write a natural message sized to the response. For search, route, and clarify,
@@ -167,7 +183,10 @@ class _AnimichiManagedPrompt(ManagedPrompt[RuntimeDeps]):
             base = (
                 resolved.value if _prompt_failure(resolved) is None else _INSTRUCTIONS
             )
-            return f"{base.rstrip()}\n\n{_current_turn_language(_ctx)}"
+            return (
+                f"{base.rstrip()}\n\n{_current_turn_language(_ctx)}\n\n"
+                f"{_current_datetime_context(_ctx)}"
+            )
 
         return instructions
 
@@ -407,6 +426,21 @@ def _current_turn_language(ctx: RunContext[RuntimeDeps]) -> str:
     )
 
 
+_JST = ZoneInfo("Asia/Tokyo")
+
+
+def _format_jst_context(moment: datetime) -> str:
+    return (
+        f"Current date/time (JST): {moment.strftime('%Y-%m-%d %H:%M')}. Use "
+        "this for relative-time phrases like today or this afternoon "
+        "(きょう/午後)."
+    )
+
+
+def _current_datetime_context(_ctx: RunContext[RuntimeDeps]) -> str:
+    return _format_jst_context(datetime.now(_JST))
+
+
 def trusted_session_context(deps: RuntimeDeps) -> str:
     """Serialize volatile typed state into a trusted user-turn part."""
     session = deps.tool_state.session
@@ -498,6 +532,11 @@ def _modern_capabilities(
     memory: Memory[RuntimeDeps] | None,
 ) -> list[AgentCapability[RuntimeDeps]]:
     capabilities = _history_capabilities()
+    # error_boundary_hooks() precedes _modern_hooks() here so that on
+    # on_run_error, the reversed CombinedCapability traversal tries
+    # _modern_hooks()'s telemetry-then-reraise FIRST (unchanged behavior),
+    # falling through to the SD-18 typed conversion only after it re-raises.
+    capabilities.append(error_boundary_hooks())
     capabilities.append(_modern_hooks())
     if memory is not None:
         capabilities.append(memory)
@@ -513,7 +552,9 @@ def build_animichi_agent(
     managed_prompt = _managed_prompt_capability()
     _record_missing_managed_prompt_token()
     instructions: AgentInstructions[RuntimeDeps] = (
-        [_INSTRUCTIONS, _current_turn_language] if managed_prompt is None else None
+        [_INSTRUCTIONS, _current_turn_language, _current_datetime_context]
+        if managed_prompt is None
+        else None
     )
     agent: Agent[RuntimeDeps, RuntimeOutput] = Agent(
         resolve_model(None),

--- a/apps/agent/agent/agents/animichi_runner.py
+++ b/apps/agent/agent/agents/animichi_runner.py
@@ -209,7 +209,10 @@ async def run_animichi_agent(
     raw_output = run_result.output
     if isinstance(raw_output, ClarifyResponseModel):
         await _record_terminal_clarify(deps, raw_output)
-    else:
+    elif not isinstance(raw_output, ErrorResponseModel):
+        # SD-18 P2-2: a recovered error is transient — a retry needs the same
+        # pending clarification/geocode staging the failed attempt saw, not a
+        # wiped one that turns the retry into a cold, un-contextualized query.
         deps.tool_state.session.pending_clarification = None
         deps.tool_state.session.geocode_staging = None
     status, success_override = _terminal_status(raw_output)

--- a/apps/agent/agent/agents/animichi_runner.py
+++ b/apps/agent/agent/agents/animichi_runner.py
@@ -36,6 +36,7 @@ from agent.agents.runtime_models import (
     AgentResultOutput,
     BlockedResponseModel,
     ClarifyResponseModel,
+    ErrorResponseModel,
     GreetingResponseModel,
     PartialResponseModel,
     QAResponseModel,
@@ -66,6 +67,7 @@ _STAGE_BY_OUTPUT: dict[type[AgentResultOutput], str] = {
     QAResponseModel: "general_qa",
     PartialResponseModel: "partial",
     BlockedResponseModel: "blocked",
+    ErrorResponseModel: "error",
 }
 
 _PARTIAL_MESSAGES = {
@@ -145,6 +147,13 @@ def _seed_tool_state(deps: RuntimeDeps, context: dict[str, object] | None) -> No
     )
 
 
+def _terminal_status(raw_output: AgentResultOutput) -> tuple[str | None, bool | None]:
+    """SD-18: the error-boundary hook's recovered output is a terminal failure."""
+    if isinstance(raw_output, ErrorResponseModel):
+        return "error", False
+    return None, None
+
+
 async def run_animichi_agent(
     *,
     text: str,
@@ -203,6 +212,7 @@ async def run_animichi_agent(
     else:
         deps.tool_state.session.pending_clarification = None
         deps.tool_state.session.geocode_staging = None
+    status, success_override = _terminal_status(raw_output)
     result = AgentResult(
         output=raw_output,
         intent=runtime_stage(raw_output, deps.steps),
@@ -211,6 +221,8 @@ async def run_animichi_agent(
         tool_state=deps.tool_state.to_legacy_dict(),
         new_messages=list(run_result.new_messages()),
         usage=run_usage,
+        status=status,
+        success_override=success_override,
     )
     logger.info(
         "animichi_agent_complete",

--- a/apps/agent/agent/agents/animichi_tools.py
+++ b/apps/agent/agent/agents/animichi_tools.py
@@ -41,6 +41,9 @@ async def resolve_anime(
     candidate IDs. For `not_found`, emit `clarify_response` asking for a corrected
     title. For `upstream_unavailable`, emit `qa_response` asking the user to retry.
     Never infer ambiguity from query length.
+
+    Do not call this again once an anime is already resolved this turn or
+    session — call `search_bangumi` directly with the known bangumi_id instead.
     """
     call_id = _call_id(ctx, "resolve_anime")
     await _emit(ctx, call_id, "resolve_anime", "running", {})
@@ -53,7 +56,11 @@ async def search_bangumi(
     ctx: RunContext[RuntimeDeps],
     bangumi_id: Annotated[str, Field(pattern=r"^\d+$")],
 ) -> SearchToolResult:
-    """Fetch points by work ID; upstream_unavailable means ask the user to retry."""
+    """Fetch points by work ID; upstream_unavailable means ask the user to retry.
+
+    Do not call this for a location-only query (use `search_nearby` instead),
+    and do not call it before `resolve_anime` has produced a bangumi_id.
+    """
     call_id = _call_id(ctx, "search_bangumi")
     await _emit(ctx, call_id, "search_bangumi", "running", {})
     result = await run_work_search(ctx, ctx.deps.catalog, bangumi_id)
@@ -113,7 +120,10 @@ TOOLS: list[Tool[RuntimeDeps] | ToolFuncEither[RuntimeDeps]] = [
         description=(
             "Plan a walking route over the exact registry result named by "
             "search_result_ref. The ref is required and has no session default. "
-            "Optional pacing is chill, normal, or packed."
+            "Optional pacing is chill, normal, or packed. Do not call this for "
+            "a request that only asks for a search, not a route, and never "
+            "invent a search_result_ref — it must come from a prior "
+            "search_bangumi or search_nearby outcome."
         ),
         docstring_format="google",
         timeout=CATALOG_TOOL_TIMEOUT_SECONDS,

--- a/apps/agent/agent/agents/error_boundary.py
+++ b/apps/agent/agent/agents/error_boundary.py
@@ -1,0 +1,92 @@
+"""SD-18 error-boundary hook: the 5th agent-composition hook.
+
+Uniformly maps tool-execution exceptions and agent-loop exceptions onto one
+typed, localized payload (``ErrorResponseModel``) instead of each call site
+erroring ad hoc. Reuses ``error_messages.build_error_message`` for
+localization rather than duplicating the catalog-error -> string mapping.
+
+Composes alongside the four existing hooks (compaction / output_validator /
+@instructions / Logfire) — it does not modify any of them. ``UsageLimitExceeded``,
+``UnexpectedModelBehavior``, ``ContentFilterError``, ``ModelHTTPError``,
+``FallbackExceptionGroup``, and ``httpx.HTTPError`` already get specific,
+tailored handling in ``animichi_runner`` / ``interfaces.public_api``, so this
+hook re-raises them unchanged and only converts genuinely unclassified failures.
+"""
+
+from __future__ import annotations
+
+import httpx
+from pydantic_ai import RunContext
+from pydantic_ai.agent import AgentRunResult
+from pydantic_ai.capabilities import Hooks
+from pydantic_ai.exceptions import (
+    ContentFilterError,
+    FallbackExceptionGroup,
+    ModelHTTPError,
+    UnexpectedModelBehavior,
+    UsageLimitExceeded,
+)
+from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.tools import ToolDefinition
+
+from agent.agents.error_messages import build_error_message
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.runtime_models import ErrorResponseModel
+
+_GENERIC_FALLBACK = {
+    "en": "Something went wrong on our side. Please try again later.",
+    "ja": "サーバー側で問題が発生しました。しばらくしてからもう一度お試しください。",
+    "zh": "我们这边出了点问题，请稍后再试。",
+}
+
+_ALREADY_HANDLED_ELSEWHERE: tuple[type[BaseException], ...] = (
+    UsageLimitExceeded,
+    UnexpectedModelBehavior,
+    ContentFilterError,
+    ModelHTTPError,
+    FallbackExceptionGroup,
+    httpx.HTTPError,
+)
+
+
+def map_exception_to_error_response(
+    error: Exception, locale: str
+) -> ErrorResponseModel:
+    """The one function every tool and agent-loop exception flows through."""
+    fallback = _GENERIC_FALLBACK.get(locale, _GENERIC_FALLBACK["en"])
+    message = build_error_message(error, locale, fallback=fallback)
+    return ErrorResponseModel(message=message)
+
+
+async def _on_tool_execute_error(
+    ctx: RunContext[RuntimeDeps],
+    *,
+    call: ToolCallPart,
+    tool_def: ToolDefinition,
+    args: object,
+    error: Exception,
+) -> dict[str, object]:
+    """Convert an unhandled tool exception into a result the model can react to."""
+    del call, tool_def, args
+    payload = map_exception_to_error_response(error, ctx.deps.locale)
+    return payload.model_dump()
+
+
+async def _on_run_error(
+    ctx: RunContext[RuntimeDeps], *, error: BaseException
+) -> AgentRunResult[ErrorResponseModel]:
+    """Convert a genuinely unclassified agent-loop exception into a clean result."""
+    if isinstance(error, _ALREADY_HANDLED_ELSEWHERE) or not isinstance(
+        error, Exception
+    ):
+        raise error
+    payload = map_exception_to_error_response(error, ctx.deps.locale)
+    return AgentRunResult(output=payload)
+
+
+def error_boundary_hooks() -> Hooks[RuntimeDeps]:
+    """Build the 5th agent-composition hook, additive alongside the other four."""
+    hooks = Hooks[RuntimeDeps]()
+    hooks.on.tool_execute_error(_on_tool_execute_error)
+    hooks.on.run_error(_on_run_error)
+    return hooks

--- a/apps/agent/agent/agents/error_boundary.py
+++ b/apps/agent/agent/agents/error_boundary.py
@@ -16,6 +16,7 @@ hook re-raises them unchanged and only converts genuinely unclassified failures.
 from __future__ import annotations
 
 import httpx
+import structlog
 from pydantic_ai import RunContext
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.capabilities import Hooks
@@ -32,6 +33,8 @@ from pydantic_ai.tools import ToolDefinition
 from agent.agents.error_messages import build_error_message
 from agent.agents.runtime_deps import RuntimeDeps
 from agent.agents.runtime_models import ErrorResponseModel
+
+logger = structlog.get_logger(__name__)
 
 _GENERIC_FALLBACK = {
     "en": "Something went wrong on our side. Please try again later.",
@@ -65,11 +68,16 @@ async def _on_tool_execute_error(
     tool_def: ToolDefinition,
     args: object,
     error: Exception,
-) -> dict[str, object]:
+) -> ErrorResponseModel:
     """Convert an unhandled tool exception into a result the model can react to."""
-    del call, tool_def, args
-    payload = map_exception_to_error_response(error, ctx.deps.locale)
-    return payload.model_dump()
+    del tool_def, args
+    logger.warning(
+        "animichi_tool_execute_error",
+        tool=call.tool_name,
+        error_type=type(error).__name__,
+        error=str(error),
+    )
+    return map_exception_to_error_response(error, ctx.deps.locale)
 
 
 async def _on_run_error(

--- a/apps/agent/agent/agents/runtime_models.py
+++ b/apps/agent/agent/agents/runtime_models.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
+from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from agent.agents.session_state import ClarificationReason
 
@@ -14,26 +15,68 @@ class _CompactOutput(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    message: str
+    message: str = Field(description="The natural-language reply shown to the user.")
 
 
 class SearchResponseModel(_CompactOutput):
     """Brief prose wrapper for a registry-backed search response."""
 
+    message: str = Field(
+        description=(
+            "Brief 1-2 sentence wrapper around a completed search; the app "
+            "renders results from typed SessionState, so never re-type points, "
+            "counts, or titles here."
+        )
+    )
+
 
 class RouteResponseModel(_CompactOutput):
     """Brief prose wrapper for a registry-backed route response."""
+
+    message: str = Field(
+        description=(
+            "Brief 1-2 sentence wrapper around a completed route; the app "
+            "renders the route from typed SessionState, so never re-type stops, "
+            "legs, or times here."
+        )
+    )
 
 
 class GreetingResponseModel(_CompactOutput):
     """Brief greeting, thanks, farewell, or capability introduction."""
 
+    message: str = Field(
+        description=(
+            "A standalone greeting, thanks, farewell, or capability-"
+            "introduction reply; there is no search or route data to summarize."
+        )
+    )
+
 
 class ClarifyResponseModel(_CompactOutput):
     """Terminal clarification output with stable candidate identity only."""
 
-    reason: ClarificationReason
-    candidate_ids: list[str]
+    message: str = Field(
+        description=(
+            "Brief 1-2 sentence prompt asking the user to disambiguate; the "
+            "app renders candidate names from candidate_ids, so never restate "
+            "them here."
+        )
+    )
+    reason: ClarificationReason = Field(
+        description=(
+            "The disambiguation reason; must exactly match the pending tool "
+            "outcome's own reason (anime_ambiguity, place_ambiguity, "
+            "place_too_broad, unknown_place, missing_location, or "
+            "anime_not_found)."
+        )
+    )
+    candidate_ids: list[str] = Field(
+        description=(
+            "Candidate identifiers in the exact order the pending tool outcome "
+            "supplied; never invented, reordered, or partially copied."
+        )
+    )
 
     @field_validator("candidate_ids", mode="before")
     @classmethod
@@ -50,6 +93,13 @@ class ClarifyResponseModel(_CompactOutput):
 class QAResponseModel(_CompactOutput):
     """Full prose answer; the message intentionally has no length cap."""
 
+    message: str = Field(
+        description=(
+            "A full, appropriately-long general-QA answer; the prose IS the "
+            "content, so never truncate it to one line."
+        )
+    )
+
 
 class PartialResponseModel(_CompactOutput):
     """Runner-authored notice for a graceful incomplete result."""
@@ -57,6 +107,19 @@ class PartialResponseModel(_CompactOutput):
 
 class BlockedResponseModel(_CompactOutput):
     """Runner-authored refusal for a blocked user prompt."""
+
+
+class ErrorResponseModel(_CompactOutput):
+    """Runner-authored notice for an unexpected tool or agent-loop failure.
+
+    SD-18: the uniform payload the error-boundary hook maps every otherwise
+    unhandled exception onto. Never one of the model's own output_type choices.
+    """
+
+    error: Literal[True] = Field(
+        default=True,
+        description="Discriminator marking this as a uniform error payload.",
+    )
 
 
 RuntimeStageOutput = (
@@ -67,4 +130,9 @@ RuntimeStageOutput = (
     | QAResponseModel
 )
 
-AgentResultOutput = RuntimeStageOutput | PartialResponseModel | BlockedResponseModel
+AgentResultOutput = (
+    RuntimeStageOutput
+    | PartialResponseModel
+    | BlockedResponseModel
+    | ErrorResponseModel
+)

--- a/apps/agent/agent/interfaces/response_builder.py
+++ b/apps/agent/agent/interfaces/response_builder.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import asdict
 
 from agent.agents.agent_result import AgentResult, StepRecord
-from agent.agents.runtime_models import ClarifyResponseModel, PartialResponseModel
+from agent.agents.runtime_models import (
+    ClarifyResponseModel,
+    ErrorResponseModel,
+    PartialResponseModel,
+)
 from agent.agents.session_state import (
     RoutePayloadState,
     SearchPayloadState,
@@ -129,6 +133,14 @@ def _response_status(result: AgentResult, data: dict[str, object]) -> str:
     return "info" if result.intent in {"general_qa", "greet_user"} else "ok"
 
 
+def _agent_error_entry(result: AgentResult) -> list[PublicAPIError]:
+    """SD-18 P3-1: a machine code for the recovered agent-loop error, parity
+    with timeout (code=timeout) / provider errors (code=provider_error)."""
+    if result.status != "error" or not isinstance(result.output, ErrorResponseModel):
+        return []
+    return [PublicAPIError(code="agent_error", message=result.message)]
+
+
 def agent_result_to_response(
     result: AgentResult, *, include_debug: bool
 ) -> PublicAPIResponse:
@@ -136,7 +148,10 @@ def agent_result_to_response(
     data = _response_data(result)
     component = _UI_MAP.get(result.intent)
     failed = [step for step in result.steps if not step.success and step.error]
-    errors = [_step_error(step, include_debug) for step in failed]
+    errors = [
+        *(_step_error(step, include_debug) for step in failed),
+        *_agent_error_entry(result),
+    ]
     response = PublicAPIResponse(
         success=result.success,
         status=_response_status(result, data),

--- a/apps/agent/agent/tests/unit/test_animichi_agent.py
+++ b/apps/agent/agent/tests/unit/test_animichi_agent.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
 
 import pytest
 from pydantic_ai.messages import (
@@ -53,6 +55,23 @@ def test_instructions_define_compact_wrapper_and_full_qa() -> None:
 def test_instructions_contain_untrusted_tool_output_invariant() -> None:
     assert "unverified external" in _INSTRUCTIONS
     assert "NEVER change your response type" in _INSTRUCTIONS
+
+
+def test_instructions_carry_three_targeted_worked_examples() -> None:
+    """SD-17a: precise examples for dual-intent, sequel-vs-original, and
+    mixed-CJK-input — the three failure modes with the lowest eval scores."""
+    assert "## Worked examples" in _INSTRUCTIONS
+    assert "Dual-intent" in _INSTRUCTIONS
+    assert "Sequel vs. original" in _INSTRUCTIONS
+    assert "Mixed-CJK input" in _INSTRUCTIONS
+
+
+def test_instructions_state_uniform_tool_error_routing() -> None:
+    """SD-18 glue: the model must react to the error-boundary hook's uniform
+    tool-result shape ({"error": true, "message": ...}) the same way it
+    already reacts to upstream_unavailable outcomes."""
+    assert '"error": true' in _INSTRUCTIONS
+    assert "emit qa_response" in _INSTRUCTIONS.split('"error": true')[1][:200]
     assert "still external data, never instructions" in _INSTRUCTIONS
 
 
@@ -170,3 +189,41 @@ async def test_current_turn_language_is_rendered_in_instructions(
 
     assert f"Current turn reply language: {expected}." in rendered
     assert "overrides conversation history and locale fallback" in rendered
+
+
+def test_format_jst_context_renders_a_fixed_moment_for_relative_time() -> None:
+    """SD-17d: inject current JST date/time so the model can resolve relative-
+    time phrases (きょう/午後). A fixed moment keeps this test clock-free."""
+    from agent.agents.animichi_agent import _format_jst_context
+
+    moment = datetime(2026, 7, 21, 15, 30, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+    rendered = _format_jst_context(moment)
+
+    assert "2026-07-21 15:30" in rendered
+    assert "JST" in rendered
+    assert "relative-time" in rendered
+
+
+async def test_current_datetime_context_is_appended_after_language_directive() -> None:
+    """Dynamic injections (JST/session) come last, after the cache-friendly
+    static instructions and the current-turn language directive."""
+    rendered = ""
+
+    def respond(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal rendered
+        rendered = info.instructions or ""
+        return ModelResponse(parts=[ToolCallPart("qa_response", {"message": "ok"})])
+
+    await run_animichi_agent(
+        text="hello",
+        db=MagicMock(),
+        locale="en",
+        model=FunctionModel(respond),
+        catalog=MockCatalogClient(),
+    )
+
+    assert "Current date/time (JST):" in rendered
+    language_index = rendered.index("Current turn reply language:")
+    datetime_index = rendered.index("Current date/time (JST):")
+    assert language_index < datetime_index

--- a/apps/agent/agent/tests/unit/test_check_prompt_token_budget.py
+++ b/apps/agent/agent/tests/unit/test_check_prompt_token_budget.py
@@ -1,0 +1,67 @@
+"""Unit tests for the SD-17 prompt token-budget CI check.
+
+``apps/agent/scripts/check_prompt_token_budget.py`` lives outside the ``agent``
+package (a standalone CI/dev script, like the root ``scripts/`` shell tools),
+so it is loaded here via its file path rather than a normal package import.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "check_prompt_token_budget.py"
+)
+_INSTRUCTIONS_PATH = (
+    Path(__file__).resolve().parents[2] / "agents" / "animichi_agent.py"
+)
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "check_prompt_token_budget", _SCRIPT_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_MODULE = _load_script()
+
+
+def test_count_tokens_grows_with_more_text() -> None:
+    short = _MODULE.count_tokens("hello")
+    longer = _MODULE.count_tokens("hello " * 50)
+    assert 0 < short < longer
+
+
+def test_check_budget_accepts_at_or_under_the_ceiling() -> None:
+    assert _MODULE.check_budget(2000, budget=2000) is True
+    assert _MODULE.check_budget(100, budget=2000) is True
+
+
+def test_check_budget_rejects_over_the_ceiling() -> None:
+    assert _MODULE.check_budget(2001, budget=2000) is False
+
+
+def test_extract_static_instructions_pulls_the_literal_block() -> None:
+    # Mirrors animichi_agent.py's own backslash-newline continuation right
+    # after the opening triple-quote, which a raw substring slice would
+    # miscount (the backslash-newline must be suppressed, not counted).
+    source = 'x = 1\n_INSTRUCTIONS = """\\\nhello\nworld"""\ny = 2\n'
+    assert _MODULE.extract_static_instructions(source) == "hello\nworld"
+
+
+def test_current_static_prompt_fits_within_the_sd17_budget() -> None:
+    source = _INSTRUCTIONS_PATH.read_text(encoding="utf-8")
+    instructions = _MODULE.extract_static_instructions(source)
+    token_count = _MODULE.count_tokens(instructions)
+    assert _MODULE.check_budget(token_count) is True
+
+
+def test_main_returns_zero_for_the_checked_in_prompt() -> None:
+    assert _MODULE.main() == 0

--- a/apps/agent/agent/tests/unit/test_check_prompt_token_budget.py
+++ b/apps/agent/agent/tests/unit/test_check_prompt_token_budget.py
@@ -11,6 +11,8 @@ import importlib.util
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 _SCRIPT_PATH = (
     Path(__file__).resolve().parents[3] / "scripts" / "check_prompt_token_budget.py"
 )
@@ -65,3 +67,16 @@ def test_current_static_prompt_fits_within_the_sd17_budget() -> None:
 
 def test_main_returns_zero_for_the_checked_in_prompt() -> None:
     assert _MODULE.main() == 0
+
+
+def test_main_fails_loudly_when_over_budget(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(_MODULE, "check_budget", lambda *_args, **_kwargs: False)
+
+    exit_code = _MODULE.main()
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "EXCEEDS budget" in captured.err

--- a/apps/agent/agent/tests/unit/test_error_boundary.py
+++ b/apps/agent/agent/tests/unit/test_error_boundary.py
@@ -139,3 +139,28 @@ async def test_tool_execution_exception_is_converted_end_to_end() -> None:
     tool_return = _tool_returned(result.new_messages, "resolve_anime")
     assert tool_return is not None
     assert "サーバー側で問題が発生しました" in tool_return
+
+
+async def test_agent_loop_exception_is_a_terminal_error_result_end_to_end() -> None:
+    """Goes through run_animichi_agent (not build_animichi_agent().run()
+    directly), so this also proves the recovered ErrorResponseModel reaches
+    the runner's own _terminal_status/AgentResult construction, marking the
+    turn as a failed, non-retryable result (status/success), not just that
+    the underlying agent run recovers."""
+
+    def fail(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        raise RuntimeError("the model backend misbehaved")
+
+    result = await run_animichi_agent(
+        text="hello",
+        db=MagicMock(),
+        locale="zh",
+        catalog=MockCatalogClient(),
+        model=FunctionModel(fail),
+    )
+
+    assert isinstance(result.output, ErrorResponseModel)
+    assert result.output.message == "我们这边出了点问题，请稍后再试。"
+    assert result.status == "error"
+    assert result.success is False
+    assert result.intent == "error"

--- a/apps/agent/agent/tests/unit/test_error_boundary.py
+++ b/apps/agent/agent/tests/unit/test_error_boundary.py
@@ -1,0 +1,141 @@
+"""Unit tests for the SD-18 error-boundary hook.
+
+The hook unifies tool-execution exceptions and agent-loop exceptions onto one
+typed, localized payload (``ErrorResponseModel``) instead of each call site
+erroring ad hoc. It reuses ``error_messages.build_error_message`` for
+localization rather than duplicating the catalog-error -> string mapping.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_ai import RunContext
+from pydantic_ai.agent import AgentRunResult
+from pydantic_ai.exceptions import UsageLimitExceeded
+from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import ToolDefinition
+from pydantic_ai.usage import RunUsage
+
+from agent.agents import error_boundary
+from agent.agents.animichi_runner import run_animichi_agent
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.runtime_models import ErrorResponseModel, QAResponseModel
+from agent.clients.catalog_client import ResolveNotFound, ResolveResolved
+from agent.clients.catalog_errors import WorkNotFoundData, WorkNotFoundError
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+
+def _deps(locale: str = "ja") -> RuntimeDeps:
+    return RuntimeDeps(
+        db=MagicMock(), locale=locale, query="q", catalog=MockCatalogClient()
+    )
+
+
+def _ctx(locale: str = "ja") -> RunContext[RuntimeDeps]:
+    return RunContext(deps=_deps(locale), model=TestModel(), usage=RunUsage())
+
+
+def _tool_returned(messages: list[ModelMessage], tool_name: str) -> str | None:
+    from pydantic_ai.messages import ToolReturnPart
+
+    for message in messages:
+        for part in getattr(message, "parts", []):
+            if isinstance(part, ToolReturnPart) and part.tool_name == tool_name:
+                return str(part.content)
+    return None
+
+
+def test_map_exception_reuses_error_messages_for_catalog_errors() -> None:
+    exc = WorkNotFoundError(WorkNotFoundData(bangumi_id="8000"))
+
+    payload = error_boundary.map_exception_to_error_response(exc, "en")
+
+    assert payload.message == (
+        "No pilgrimage spots found for this work. Try a different anime."
+    )
+    assert payload.error is True
+
+
+def test_map_exception_falls_back_per_locale_for_generic_exceptions() -> None:
+    exc = ValueError("some internal bug")
+
+    en = error_boundary.map_exception_to_error_response(exc, "en")
+    zh = error_boundary.map_exception_to_error_response(exc, "zh")
+
+    assert en.message == "Something went wrong on our side. Please try again later."
+    assert zh.message == "我们这边出了点问题，请稍后再试。"
+
+
+async def test_tool_and_run_errors_flow_through_the_one_mapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[Exception] = []
+    original = error_boundary.map_exception_to_error_response
+
+    def spy(error: Exception, locale: str) -> ErrorResponseModel:
+        calls.append(error)
+        return original(error, locale)
+
+    monkeypatch.setattr(error_boundary, "map_exception_to_error_response", spy)
+
+    tool_error = ValueError("catalog client returned a malformed response")
+    tool_result = await error_boundary._on_tool_execute_error(
+        _ctx("zh"),
+        call=ToolCallPart("resolve_anime", {"title": "x"}),
+        tool_def=ToolDefinition(name="resolve_anime"),
+        args={"title": "x"},
+        error=tool_error,
+    )
+
+    loop_error = RuntimeError("the model backend misbehaved")
+    run_result = await error_boundary._on_run_error(_ctx("zh"), error=loop_error)
+
+    assert calls == [tool_error, loop_error]
+    assert tool_result == {"message": "我们这边出了点问题，请稍后再试。", "error": True}
+    assert isinstance(run_result, AgentRunResult)
+    assert isinstance(run_result.output, ErrorResponseModel)
+    assert run_result.output.message == "我们这边出了点问题，请稍后再试。"
+
+
+async def test_on_run_error_reraises_exception_types_already_handled_elsewhere() -> (
+    None
+):
+    already_handled = UsageLimitExceeded("request limit reached")
+
+    with pytest.raises(UsageLimitExceeded):
+        await error_boundary._on_run_error(_ctx(), error=already_handled)
+
+
+async def test_on_run_error_reraises_base_exceptions() -> None:
+    with pytest.raises(KeyboardInterrupt):
+        await error_boundary._on_run_error(_ctx(), error=KeyboardInterrupt())
+
+
+async def test_tool_execution_exception_is_converted_end_to_end() -> None:
+    class _RaisingCatalog(MockCatalogClient):
+        async def resolve(self, query: str) -> ResolveResolved | ResolveNotFound:
+            raise ValueError("catalog client returned a malformed response")
+
+    def respond(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        if _tool_returned(messages, "resolve_anime") is None:
+            return ModelResponse(
+                parts=[ToolCallPart("resolve_anime", {"title": "test"})]
+            )
+        return ModelResponse(parts=[ToolCallPart("qa_response", {"message": "ok"})])
+
+    result = await run_animichi_agent(
+        text="test anime",
+        db=MagicMock(),
+        locale="ja",
+        catalog=_RaisingCatalog(),
+        model=FunctionModel(respond),
+    )
+
+    assert isinstance(result.output, QAResponseModel)
+    tool_return = _tool_returned(result.new_messages, "resolve_anime")
+    assert tool_return is not None
+    assert "サーバー側で問題が発生しました" in tool_return

--- a/apps/agent/agent/tests/unit/test_error_boundary.py
+++ b/apps/agent/agent/tests/unit/test_error_boundary.py
@@ -24,6 +24,12 @@ from agent.agents import error_boundary
 from agent.agents.animichi_runner import run_animichi_agent
 from agent.agents.runtime_deps import RuntimeDeps
 from agent.agents.runtime_models import ErrorResponseModel, QAResponseModel
+from agent.agents.session_state import (
+    GeocodeStaging,
+    OrderedCandidate,
+    PendingClarification,
+    SessionState,
+)
 from agent.clients.catalog_client import ResolveNotFound, ResolveResolved
 from agent.clients.catalog_errors import WorkNotFoundData, WorkNotFoundError
 from agent.tests.eval.mock_catalog_client import MockCatalogClient
@@ -95,10 +101,38 @@ async def test_tool_and_run_errors_flow_through_the_one_mapper(
     run_result = await error_boundary._on_run_error(_ctx("zh"), error=loop_error)
 
     assert calls == [tool_error, loop_error]
-    assert tool_result == {"message": "我们这边出了点问题，请稍后再试。", "error": True}
+    assert isinstance(tool_result, ErrorResponseModel)
+    assert tool_result.message == "我们这边出了点问题，请稍后再试。"
+    assert tool_result.error is True
     assert isinstance(run_result, AgentRunResult)
     assert isinstance(run_result.output, ErrorResponseModel)
     assert run_result.output.message == "我们这边出了点问题，请稍后再试。"
+
+
+async def test_tool_execute_error_logs_before_converting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """P2-1: a swallowed tool exception must still leave a trace — pre-PR this
+    logged pipeline_unhandled_exception at ERROR; the hook must not silently
+    convert to "please retry" with zero observability."""
+    from structlog import testing
+
+    error = ValueError("catalog client returned a malformed response")
+
+    with testing.capture_logs() as captured:
+        await error_boundary._on_tool_execute_error(
+            _ctx("en"),
+            call=ToolCallPart("resolve_anime", {"title": "x"}),
+            tool_def=ToolDefinition(name="resolve_anime"),
+            args={"title": "x"},
+            error=error,
+        )
+
+    [event] = captured
+    assert event["event"] == "animichi_tool_execute_error"
+    assert event["tool"] == "resolve_anime"
+    assert event["error_type"] == "ValueError"
+    assert event["log_level"] == "warning"
 
 
 async def test_on_run_error_reraises_exception_types_already_handled_elsewhere() -> (
@@ -164,3 +198,36 @@ async def test_agent_loop_exception_is_a_terminal_error_result_end_to_end() -> N
     assert result.status == "error"
     assert result.success is False
     assert result.intent == "error"
+
+
+async def test_recovered_error_preserves_pending_clarification_for_retry() -> None:
+    """P2-2: user answers a disambiguation card, hits a transient error, and
+    retries — the retry must still see the pending clarification/geocode
+    staging the failed attempt saw, not a cold, un-contextualized query."""
+    pending = PendingClarification(
+        reason="anime_ambiguity",
+        candidate_ids=["1", "2"],
+        ordered_candidates=[
+            OrderedCandidate(id="1", title="Anime A"),
+            OrderedCandidate(id="2", title="Anime B"),
+        ],
+        revision=1,
+    )
+    staging = GeocodeStaging(candidates=[OrderedCandidate(id="p1", title="Place")])
+    state = SessionState(pending_clarification=pending, geocode_staging=staging)
+
+    def fail(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        raise RuntimeError("transient backend hiccup")
+
+    result = await run_animichi_agent(
+        text="1番目",
+        db=MagicMock(),
+        locale="ja",
+        catalog=MockCatalogClient(),
+        model=FunctionModel(fail),
+        context={"session_state_v2": state.model_dump(mode="json")},
+    )
+
+    assert isinstance(result.output, ErrorResponseModel)
+    assert result.session_state.pending_clarification == pending
+    assert result.session_state.geocode_staging == staging

--- a/apps/agent/agent/tests/unit/test_managed_prompt.py
+++ b/apps/agent/agent/tests/unit/test_managed_prompt.py
@@ -165,6 +165,24 @@ async def test_managed_prompt_appends_current_turn_language(
     )
 
 
+async def test_managed_prompt_appends_current_datetime_after_language(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """P3-4: _AnimichiManagedPrompt.get_instructions() builds its own
+    instructions() closure, separate from the default (non-managed) path —
+    prove the JST datetime context is appended there too, dynamic-last after
+    the language directive, not just on the default path."""
+    monkeypatch.setenv("ANIMICHI_MANAGED_PROMPT", "1")
+    _patch_resolution(monkeypatch, value=_INSTRUCTIONS)
+
+    rendered = await _run_and_capture_instructions()
+
+    assert "Current date/time (JST):" in rendered
+    assert rendered.index("Current turn reply language") < rendered.index(
+        "Current date/time (JST)"
+    )
+
+
 async def test_remote_content_drift_falls_back_to_checked_in_prompt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/agent/agent/tests/unit/test_managed_prompt_gates.py
+++ b/apps/agent/agent/tests/unit/test_managed_prompt_gates.py
@@ -4,6 +4,7 @@ import pytest
 
 from agent.agents.animichi_agent import (
     _INSTRUCTIONS,
+    _current_datetime_context,
     _current_turn_language,
     build_animichi_agent,
 )
@@ -19,6 +20,6 @@ def test_default_and_kill_switch_keep_construction_equal(
     monkeypatch.setenv("LOGFIRE_API_KEY", "api-key")
     killed_agent = build_animichi_agent()
 
-    expected = [_INSTRUCTIONS, _current_turn_language]
+    expected = [_INSTRUCTIONS, _current_turn_language, _current_datetime_context]
     assert default_agent._instructions == killed_agent._instructions == expected
     assert repr(default_agent._root_capability) == repr(killed_agent._root_capability)

--- a/apps/agent/agent/tests/unit/test_modern_capabilities.py
+++ b/apps/agent/agent/tests/unit/test_modern_capabilities.py
@@ -16,6 +16,7 @@ from pydantic_ai.profiles import ModelProfile
 
 from agent.agents.animichi_agent import build_animichi_agent
 from agent.agents.runtime_deps import RuntimeDeps, TitleTranslator, WebSearcher
+from agent.agents.runtime_models import ErrorResponseModel
 from agent.agents.translation import TranslationResult
 from agent.tests.eval.mock_catalog_client import MockCatalogClient
 from agent.tests.eval.mock_web import MockWebSearcher
@@ -97,9 +98,14 @@ async def test_instructions_remain_cache_neutral_across_output_retry() -> None:
     assert all("Current session state" not in text for text in instructions)
 
 
-async def test_run_error_hook_records_and_reraises(
+async def test_run_error_hook_records_then_sd18_boundary_converts_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The pre-SD-18 contract was "record telemetry, then re-raise" — proven by
+    letting a bare RuntimeError blow up the whole run. SD-18 adds a 5th hook
+    (error_boundary) composed alongside this one: telemetry recording is
+    UNCHANGED (still happens exactly once), but the run now recovers with a
+    typed ErrorResponseModel instead of propagating the raw exception."""
     recorded: list[BaseException] = []
     monkeypatch.setattr(
         "agent.agents.animichi_agent.record_agent_run_error", recorded.append
@@ -108,8 +114,10 @@ async def test_run_error_hook_records_and_reraises(
     def fail(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
         raise RuntimeError("model failed")
 
-    with pytest.raises(RuntimeError, match="model failed"):
-        await build_animichi_agent().run(
-            "fail", deps=_deps(), model=FunctionModel(fail)
-        )
+    result = await build_animichi_agent().run(
+        "fail", deps=_deps(), model=FunctionModel(fail)
+    )
+
     assert len(recorded) == 1
+    assert isinstance(recorded[0], RuntimeError)
+    assert isinstance(result.output, ErrorResponseModel)

--- a/apps/agent/agent/tests/unit/test_response_builder.py
+++ b/apps/agent/agent/tests/unit/test_response_builder.py
@@ -11,6 +11,7 @@ from agent.agents.agent_result import (
 )
 from agent.agents.runtime_models import (
     ClarifyResponseModel,
+    ErrorResponseModel,
     QAResponseModel,
     RouteResponseModel,
     SearchResponseModel,
@@ -189,6 +190,31 @@ def test_unknown_intent_has_no_compatibility_fallback() -> None:
     response = agent_result_to_response(result, include_debug=False)
     assert response.intent == "unknown_new_stage"
     assert response.ui is None
+
+
+def test_agent_error_result_carries_a_machine_code() -> None:
+    """SD-18 P3-1: parity with timeout (code=timeout) / provider errors
+    (code=provider_error) — a code-less error defaults to D6 on the frontend."""
+    result = AgentResult(
+        output=ErrorResponseModel(message="Something went wrong."),
+        intent="error",
+        session_state=SessionState(),
+        status="error",
+        success_override=False,
+    )
+    response = agent_result_to_response(result, include_debug=False)
+    assert response.success is False
+    assert response.status == "error"
+    assert len(response.errors) == 1
+    assert response.errors[0].code == "agent_error"
+    assert response.errors[0].message == "Something went wrong."
+
+
+def test_non_error_status_never_synthesizes_an_agent_error_entry() -> None:
+    response = agent_result_to_response(
+        _result("search_bangumi", _search_state()), include_debug=False
+    )
+    assert response.errors == []
 
 
 def test_application_error_response_and_step_serialization() -> None:

--- a/apps/agent/agent/tests/unit/test_runtime_models.py
+++ b/apps/agent/agent/tests/unit/test_runtime_models.py
@@ -1,0 +1,68 @@
+"""Unit tests for response-model field descriptions (SD-17d) and ErrorResponseModel (SD-18)."""
+
+from __future__ import annotations
+
+from agent.agents.runtime_models import (
+    AgentResultOutput,
+    ClarifyResponseModel,
+    ErrorResponseModel,
+    GreetingResponseModel,
+    QAResponseModel,
+    RouteResponseModel,
+    SearchResponseModel,
+)
+
+_FIVE_RESPONSE_MODELS = (
+    SearchResponseModel,
+    RouteResponseModel,
+    GreetingResponseModel,
+    ClarifyResponseModel,
+    QAResponseModel,
+)
+
+
+def test_every_field_on_the_five_response_models_has_a_description() -> None:
+    for model in _FIVE_RESPONSE_MODELS:
+        schema = model.model_json_schema()
+        for name, field_schema in schema["properties"].items():
+            assert field_schema.get("description"), (
+                f"{model.__name__}.{name} is missing a Field(description=...)"
+            )
+
+
+def test_message_descriptions_are_specific_per_response_type() -> None:
+    descriptions = {
+        model.__name__: model.model_json_schema()["properties"]["message"][
+            "description"
+        ]
+        for model in _FIVE_RESPONSE_MODELS
+    }
+    assert len(set(descriptions.values())) == len(descriptions)
+
+
+def test_qa_message_description_forbids_truncation() -> None:
+    schema = QAResponseModel.model_json_schema()
+    assert "never" in schema["properties"]["message"]["description"].lower()
+
+
+def test_clarify_candidate_ids_description_states_ordering_contract() -> None:
+    schema = ClarifyResponseModel.model_json_schema()
+    description = schema["properties"]["candidate_ids"]["description"].lower()
+    assert "order" in description
+
+
+def test_error_response_model_is_runner_only_never_a_model_output() -> None:
+    assert ErrorResponseModel not in (
+        SearchResponseModel,
+        RouteResponseModel,
+        GreetingResponseModel,
+        ClarifyResponseModel,
+        QAResponseModel,
+    )
+    assert ErrorResponseModel in AgentResultOutput.__args__
+
+
+def test_error_response_model_marks_the_uniform_error_discriminator() -> None:
+    payload = ErrorResponseModel(message="something failed")
+    assert payload.error is True
+    assert payload.model_dump() == {"message": "something failed", "error": True}

--- a/apps/agent/agent/tests/unit/test_tools_catalog_wiring.py
+++ b/apps/agent/agent/tests/unit/test_tools_catalog_wiring.py
@@ -75,6 +75,39 @@ def test_plan_route_tool_definition_requires_explicit_ref_and_optional_pacing() 
     assert "no session default" in definition.description
 
 
+def _description(tool_name: str) -> str:
+    tool = next(t for t in ANIMICHI_TOOLS if t.tool_def.name == tool_name)
+    description = tool.tool_def.description
+    assert description is not None
+    return description
+
+
+def test_resolve_anime_docstring_states_when_not_to_call_it() -> None:
+    description = _description("resolve_anime")
+    assert "Do not call this again" in description
+    assert "search_bangumi" in description.split("Do not call this again")[1]
+
+
+def test_search_bangumi_docstring_states_when_not_to_call_it() -> None:
+    description = _description("search_bangumi")
+    assert "Do not call this" in description
+    assert "search_nearby" in description
+
+
+def test_plan_route_description_states_when_not_to_call_it() -> None:
+    description = _description("plan_route")
+    assert "Do not call this" in description
+    assert "only asks for a search" in description
+
+
+def test_web_search_docstring_already_states_when_not_to_use_it() -> None:
+    """SD-17b audit: web_search already carries a counter-example — unchanged."""
+    tool = next(t for t in WEB_TOOLS if _name(t) == "web_search")
+    doc = tool.__doc__
+    assert doc is not None
+    assert "Do not use this tool to find pilgrimage locations" in doc
+
+
 def test_agent_registers_tools_at_construction() -> None:
     path = Path(__file__).parents[2] / "agents" / "animichi_agent.py"
     calls = [

--- a/apps/agent/scripts/check_prompt_token_budget.py
+++ b/apps/agent/scripts/check_prompt_token_budget.py
@@ -1,0 +1,80 @@
+"""SD-17 length governance: fail when the static prompt section exceeds budget.
+
+Counts tokens in the literal ``_INSTRUCTIONS`` string in ``animichi_agent.py``
+(the static, cache-friendly prompt segment — dynamic per-turn injections like
+the current-turn language and JST date/time are appended separately and are
+not part of this budget). Parsed via ``ast`` rather than imported, so this
+stays a lightweight, secret-free CI check with no ``Settings()``/env-var
+dependency. Uses ``tiktoken``, a hard transitive dependency of this project's
+own ``pydantic-ai`` (via ``pydantic-ai-slim[openai]``), so no extra
+dependency is declared for it.
+
+Usage: uv run python scripts/check_prompt_token_budget.py
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import tiktoken
+
+TOKEN_BUDGET = 2000
+_INSTRUCTIONS_NAME = "_INSTRUCTIONS"
+_ENCODING_NAME = "cl100k_base"
+_INSTRUCTIONS_PATH = (
+    Path(__file__).resolve().parent.parent / "agent" / "agents" / "animichi_agent.py"
+)
+
+
+def count_tokens(text: str) -> int:
+    """Count tokens with the same encoding family the runtime models use."""
+    encoding = tiktoken.get_encoding(_ENCODING_NAME)
+    return len(encoding.encode(text))
+
+
+def extract_static_instructions(source: str) -> str:
+    """Return the literal ``_INSTRUCTIONS`` value exactly as Python evaluates it."""
+    assignment = _find_instructions_assignment(ast.parse(source))
+    value: object = ast.literal_eval(assignment.value)
+    if not isinstance(value, str):
+        raise TypeError(f"{_INSTRUCTIONS_NAME} must be a string literal")
+    return value
+
+
+def _find_instructions_assignment(tree: ast.Module) -> ast.Assign:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and _assigns_instructions(node):
+            return node
+    raise ValueError(f"No `{_INSTRUCTIONS_NAME} = ...` assignment found")
+
+
+def _assigns_instructions(node: ast.Assign) -> bool:
+    return any(
+        isinstance(target, ast.Name) and target.id == _INSTRUCTIONS_NAME
+        for target in node.targets
+    )
+
+
+def check_budget(token_count: int, budget: int = TOKEN_BUDGET) -> bool:
+    """Return whether the static prompt fits within the SD-17 token budget."""
+    return token_count <= budget
+
+
+def main() -> int:
+    source = _INSTRUCTIONS_PATH.read_text(encoding="utf-8")
+    instructions = extract_static_instructions(source)
+    token_count = count_tokens(instructions)
+    if check_budget(token_count):
+        print(f"prompt_token_budget: {token_count}/{TOKEN_BUDGET} tokens (OK)")
+        return 0
+    print(
+        f"prompt_token_budget: {token_count}/{TOKEN_BUDGET} tokens EXCEEDS budget",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Backend half of #272 (S1.6). Frontend D1-D9 UI is a separate in-flight PR; `apps/web/**` is untouched here.

- **SD-18 error-boundary hook** (`apps/agent/agent/agents/error_boundary.py`, new): a 5th agent-composition hook, alongside the four existing ones (compaction / output_validator / @instructions / Logfire — none modified). One shared `map_exception_to_error_response()` maps both tool-execution exceptions (`on_tool_execute_error`) and agent-loop exceptions (`on_run_error`) onto a typed, localized `ErrorResponseModel`, reusing `error_messages.py` instead of duplicating its catalog-error localization. Exception types with existing tailored handling (`UsageLimitExceeded`, `UnexpectedModelBehavior`, `ContentFilterError`, `ModelHTTPError`, `FallbackExceptionGroup`, `httpx.HTTPError`) are deliberately excluded so this hook only converts genuinely unclassified failures — verified by keeping every pre-existing exception-path test green.
- **SD-17 prompt patches**, audited item by item against the current tree (much had already evolved past the original spec):
  - (a) **Few-shot examples**: the "generic 8" the spec described no longer exists in `_INSTRUCTIONS` (zero examples were present) — added 3 precise ones targeting dual-intent, sequel-vs-original, and mixed-CJK-input.
  - (b) **Tool docstring counter-examples**: `web_search` already had one (verified, left unchanged, now regression-locked by a test). Added "when not to use this" notes to `resolve_anime`, `search_bangumi`, and `plan_route` (the latter via its `Tool(description=...)` override, which is what the model actually sees — its function docstring is discarded).
  - (c) **Language-disambiguation rule**: already implemented in `resolve_reply_language`/`detect_language` (current-turn script priority + Unicode fallback) — verified, no change.
  - (d) **`Field(description=...)`** added to all 5 response models (previously zero field descriptions on the LLM-facing schema) + current JST date/time injected as a dynamic, cache-safe instruction (after the language directive) for relative-time phrases.
  - Static prompt: 1208/2000 tokens, well within the SD-17 length ceiling.
  - The `pydantic-ai-guardrails` dead-dependency item is confirmed moot (already removed in #327; no `guardrails.py` ever existed on this tree).
- **Prompt token-budget check** (`apps/agent/scripts/check_prompt_token_budget.py`, new): counts `_INSTRUCTIONS` via `ast.literal_eval` (not import, to stay secret-free; not substring-slicing, to correctly handle the `"""\` line-continuation) and fails at >2000 tokens.

## CI wiring note

The token-budget check's CI wiring is the pytest unit test (`test_check_prompt_token_budget.py`), which already runs inside the existing required "Unit tests" step. A dedicated named CI step was written but had to be dropped: the push credential available to this agent lacks the GitHub OAuth `workflow` scope needed to update `.github/workflows/*.yml`, and granting it requires an interactive device-code approval. `make lint`/`make format` locally still cover the new `scripts/` directory. A maintainer with the `workflow` scope can add the standalone step as a follow-up for extra CI visibility — see the "chore" commit in this PR for the exact diff that was reverted.

## Eval note

This PR touches `apps/agent/agent/agents/**`, so it will auto-trigger the L0 smoke eval gate (`Agent Eval (L0 smoke, ~80 cases)`) required on this path per SD-30 — that's the first regression signal (zero-errored + trajectory thrash gates). No live eval was run in the worktree (no MIMO key, per instructions). The full stratified-bootstrap L0 comparison (SD-30) still needs an owner run via the gate/nightly L1 before final sign-off; prompt changes were kept conservative (3 short examples, 1 routing line, field descriptions, dynamic JST) specifically to minimize that regression risk.

## Test plan

- [x] `make lint` — ruff check + format, clean (`agent/` + `scripts/`)
- [x] `make typecheck` — mypy strict, 111 files, no issues
- [x] `make test` — 1265 unit tests, 88.01% coverage (floor 82%, not lowered)
- [x] `uv run python scripts/check_prompt_token_budget.py` — 1208/2000 tokens, exit 0
- [x] `make test-integration` attempted; blocked by a pre-existing environment gap unrelated to this change (globally-installed Atlas CLI v1.2.4 vs. the project's pinned v0.30.0) — no DB/migration files are touched by this PR
- [ ] L0 smoke eval gate (runs automatically on this PR via CI)
- [ ] Full L1 eval comparison + owner sign-off (SD-30, separate from this PR per the card)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>