### PR TITLE
feat(agent): S1.6 message length + type ceiling (MESSAGE_MAX_CHARS)

### DIFF
--- a/apps/agent/agent/agents/error_messages.py
+++ b/apps/agent/agent/agents/error_messages.py
@@ -10,6 +10,8 @@ catalog service are never echoed to users — see
 
 from __future__ import annotations
 
+from typing import Literal
+
 from agent.clients.catalog_errors import (
     CatalogError,
     RouteTooManyClustersError,
@@ -17,7 +19,23 @@ from agent.clients.catalog_errors import (
     WorkNotFoundError,
 )
 
+InputError = Literal["message_too_long", "non_text_message"]
 _DEFAULT_LOCALE = "en"
+
+_INPUT_MESSAGES: dict[tuple[InputError, str], str] = {
+    (
+        "message_too_long",
+        "ja",
+    ): "メッセージが長すぎます。短くしてもう一度お試しください。",
+    ("message_too_long", "zh"): "消息太长了，请缩短后重试。",
+    (
+        "message_too_long",
+        "en",
+    ): "Your message is too long. Please shorten it and try again.",
+    ("non_text_message", "ja"): "テキストメッセージを入力してください。",
+    ("non_text_message", "zh"): "请输入文字消息。",
+    ("non_text_message", "en"): "Please enter a text message.",
+}
 
 _CODE_MESSAGES: dict[tuple[str, str], str] = {
     (
@@ -81,6 +99,14 @@ _CATEGORY_MESSAGES: dict[tuple[str, str], str] = {
     ("system", "zh"): "我们这边出了点问题，请稍后再试。",
     ("system", "en"): "Something went wrong on our side. Please try again later.",
 }
+
+
+def build_input_error_message(reason: InputError, locale: str) -> str:
+    """Return locally authored input-validation copy for one locale."""
+    message = _INPUT_MESSAGES.get((reason, locale))
+    return (
+        message if message is not None else _INPUT_MESSAGES[(reason, _DEFAULT_LOCALE)]
+    )
 
 
 def build_error_message(exc: Exception, locale: str, *, fallback: str) -> str:

--- a/apps/agent/agent/config/settings.py
+++ b/apps/agent/agent/config/settings.py
@@ -116,6 +116,9 @@ class Settings(BaseSettings):
     timeout_seconds: int = Field(
         default=120, description="API request timeout (reasoning models need longer)"
     )
+    message_max_chars: int = Field(
+        default=4000, gt=0, description="Maximum characters in one user message"
+    )
     agent_deadline: float = Field(
         default=100.0, gt=0, description="Whole-run agent deadline in seconds"
     )
@@ -274,6 +277,7 @@ class Settings(BaseSettings):
             "service_port": self.service_port,
             "max_retries": self.max_retries,
             "timeout_seconds": self.timeout_seconds,
+            "message_max_chars": self.message_max_chars,
             "agent_deadline": self.agent_deadline,
             "model_attempt_timeout": self.model_attempt_timeout,
             "cache_ttl_seconds": self.cache_ttl_seconds,

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -32,6 +32,7 @@ from agent.agents.base import (
     resolve_model,
     resolve_model_alias,
 )
+from agent.agents.error_messages import build_input_error_message
 from agent.agents.runtime_deps import OnStep, StepEvent, StepStatus, new_step_call_id
 from agent.agents.selected_route import execute_selected_route
 from agent.agents.selection import (
@@ -125,6 +126,23 @@ def default_catalog_client() -> CatalogClient:
     return CatalogClient(base_url=get_settings().catalog_api_url)
 
 
+def _input_error_response(
+    request: PublicAPIRequest, limit: int
+) -> PublicAPIResponse | None:
+    """Reject oversized text with safe localized copy."""
+    if len(request.text) <= limit:
+        return None
+    message = build_input_error_message("message_too_long", request.locale)
+    error = PublicAPIError(code=ErrorCode.INVALID_INPUT.value, message=message)
+    return PublicAPIResponse(
+        success=False,
+        status="invalid_request",
+        intent="unknown",
+        message=message,
+        errors=[error],
+    )
+
+
 class RuntimeAPI:
     """Thin interface-layer facade over the runtime agent."""
 
@@ -175,6 +193,9 @@ class RuntimeAPI:
         on_step: OnStep | None = None,
     ) -> PublicAPIResponse:
         """Execute the runtime pipeline and normalize its output."""
+        rejection = _input_error_response(request, self._settings.message_max_chars)
+        if rejection is not None:
+            return rejection
         session_id, is_new_session = await self._prepare_session(request, user_id)
         started_at = perf_counter()
         response: PublicAPIResponse | None = None

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import json
-from typing import Annotated, Literal, cast
+from typing import Annotated, Literal, Never, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from starlette.responses import Response, StreamingResponse
 
+from agent.agents.error_messages import InputError, build_input_error_message
 from agent.agents.runtime_deps import OnStep
 from agent.interfaces.routes._deps import (
     TrustedAuthContext,
     _get_runtime_api,
+    _get_settings_from_request,
     _require_trusted_user,
 )
 from agent.interfaces.routes.chat_stream import stream_chat
@@ -33,29 +35,42 @@ def _messages(body: dict[str, object]) -> list[object]:
     return value
 
 
-def _last_user_text(messages: list[object]) -> str:
+def _last_user_text(messages: list[object], locale: Locale, max_chars: int) -> str:
     for message in reversed(messages):
-        text = _user_message_text(message)
+        text = _user_message_text(message, locale, max_chars)
         if text is not None:
             return text
     return ""
 
 
-def _user_message_text(message: object) -> str | None:
+def _user_message_text(message: object, locale: Locale, max_chars: int) -> str | None:
     if not isinstance(message, dict) or message.get("role") != "user":
         return None
     parts = message.get("parts")
     if not isinstance(parts, list):
-        return None
-    values = [_text_part(part) for part in parts]
-    return "".join(value for value in values if value is not None)
+        _reject_input("non_text_message", locale)
+    values = [_text_part(part, locale) for part in parts]
+    return _checked_length("".join(values), max_chars, locale)
 
 
-def _text_part(part: object) -> str | None:
+def _text_part(part: object, locale: Locale) -> str:
     if not isinstance(part, dict) or part.get("type") != "text":
-        return None
+        _reject_input("non_text_message", locale)
     value = part.get("text")
-    return value if isinstance(value, str) else None
+    if not isinstance(value, str):
+        _reject_input("non_text_message", locale)
+    return value
+
+
+def _checked_length(text: str, max_chars: int, locale: Locale) -> str:
+    if len(text) > max_chars:
+        _reject_input("message_too_long", locale)
+    return text
+
+
+def _reject_input(reason: InputError, locale: Locale) -> Never:
+    message = build_input_error_message(reason, locale)
+    raise HTTPException(status_code=422, detail=message)
 
 
 def _optional_ids(body: dict[str, object], field: str) -> list[str] | None:
@@ -100,11 +115,14 @@ def _decode_body(raw: bytes) -> dict[str, object]:
     return value
 
 
-def _runtime_request(request: Request, body: dict[str, object]) -> PublicAPIRequest:
+def _runtime_request(
+    request: Request, body: dict[str, object], max_chars: int
+) -> PublicAPIRequest:
+    locale = _locale(request)
     return PublicAPIRequest(
-        text=_last_user_text(_messages(body)),
+        text=_last_user_text(_messages(body), locale, max_chars),
         session_id=request.headers.get("x-session-id"),
-        locale=_locale(request),
+        locale=locale,
         selected_point_ids=_optional_ids(body, "selected_point_ids"),
         selected_candidate_ids=_optional_ids(body, "selected_candidate_ids"),
         clarification_id=_clarification_id(body),
@@ -120,7 +138,9 @@ async def handle_chat(
     auth: Annotated[TrustedAuthContext, Depends(_require_trusted_user)],
 ) -> Response:
     """Stream chat as an AI SDK UI message stream with tool + data parts."""
-    api_request = _runtime_request(request, _decode_body(await request.body()))
+    settings = _get_settings_from_request(request)
+    body = _decode_body(await request.body())
+    api_request = _runtime_request(request, body, settings.message_max_chars)
     runtime_api = _get_runtime_api(request)
     await runtime_api.validate_session_owner(api_request.session_id, auth.user_id)
 

--- a/apps/agent/agent/interfaces/schemas.py
+++ b/apps/agent/agent/interfaces/schemas.py
@@ -77,8 +77,6 @@ class PublicAPIRequest(BaseModel):
     @model_validator(mode="after")
     def validate_request(self) -> PublicAPIRequest:
         self.text = self.text.strip()
-        if len(self.text) > 2000:
-            raise ValueError("text must be 2000 characters or fewer")
         if self.origin is not None:
             self.origin = self.origin.strip() or None
         self.selected_point_ids = _normalize_ids(self.selected_point_ids)

--- a/apps/agent/agent/tests/unit/test_chat_input_boundary.py
+++ b/apps/agent/agent/tests/unit/test_chat_input_boundary.py
@@ -1,0 +1,132 @@
+"""Unit tests for chat message type and length validation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from agent.config.settings import Settings
+from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.schemas import PublicAPIResponse
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+
+def _body(text: object) -> object:
+    return {"messages": [{"role": "user", "parts": [{"type": "text", "text": text}]}]}
+
+
+def _runtime() -> MagicMock:
+    runtime = MagicMock(spec=RuntimeAPI)
+    runtime.handle = AsyncMock(
+        return_value=PublicAPIResponse(
+            success=True, status="ok", intent="qa", message="ok"
+        )
+    )
+    runtime._db = build_stub_db()
+    return runtime
+
+
+async def _post(
+    client: httpx.AsyncClient, body: object, locale: str = "ja"
+) -> httpx.Response:
+    return await client.post(
+        "/v1/chat",
+        json=body,
+        headers={"X-User-Id": "user-1", "X-Locale": locale},
+    )
+
+
+def _error_message(response: httpx.Response) -> str:
+    payload: object = response.json()
+    if not isinstance(payload, dict):
+        raise AssertionError("expected an error object")
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        raise AssertionError("expected an error payload")
+    message = error.get("message")
+    if not isinstance(message, str):
+        raise AssertionError("expected an error message")
+    return message
+
+
+async def test_message_at_configured_limit_is_accepted() -> None:
+    runtime = _runtime()
+    app, _ = build_app(runtime_api=runtime, settings=Settings(message_max_chars=4))
+    async with async_client(app) as client:
+        response = await _post(client, _body("巡礼検索"))
+    assert response.status_code == 200
+    runtime.handle.assert_awaited_once()
+
+
+async def test_message_over_limit_is_rejected_before_runtime() -> None:
+    runtime = _runtime()
+    app, _ = build_app(runtime_api=runtime, settings=Settings(message_max_chars=4))
+    async with async_client(app) as client:
+        response = await _post(client, _body("巡礼検索!"))
+    assert response.status_code == 422
+    assert _error_message(response) == (
+        "メッセージが長すぎます。短くしてもう一度お試しください。"
+    )
+    runtime.handle.assert_not_awaited()
+
+
+async def test_non_text_message_is_rejected_before_runtime() -> None:
+    runtime = _runtime()
+    app, _ = build_app(runtime_api=runtime)
+    body = {"messages": [{"role": "user", "parts": [{"type": "image"}]}]}
+    async with async_client(app) as client:
+        response = await _post(client, body)
+    assert response.status_code == 422
+    assert _error_message(response) == "テキストメッセージを入力してください。"
+    runtime.handle.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("locale", "body", "expected"),
+    [
+        ("ja", _body("xx"), "メッセージが長すぎます。短くしてもう一度お試しください。"),
+        ("zh", _body("xx"), "消息太长了，请缩短后重试。"),
+        (
+            "en",
+            _body("xx"),
+            "Your message is too long. Please shorten it and try again.",
+        ),
+        (
+            "ja",
+            {"messages": [{"role": "user", "parts": [{"type": "image"}]}]},
+            "テキストメッセージを入力してください。",
+        ),
+        (
+            "zh",
+            {"messages": [{"role": "user", "parts": [{"type": "image"}]}]},
+            "请输入文字消息。",
+        ),
+        (
+            "en",
+            {"messages": [{"role": "user", "parts": [{"type": "image"}]}]},
+            "Please enter a text message.",
+        ),
+    ],
+)
+async def test_input_error_copy_is_localized_and_nontechnical(
+    locale: str, body: object, expected: str
+) -> None:
+    app, _ = build_app(runtime_api=_runtime(), settings=Settings(message_max_chars=1))
+    async with async_client(app) as client:
+        response = await _post(client, body, locale)
+    message = _error_message(response)
+    assert message == expected
+    assert "MESSAGE_MAX_CHARS" not in message
+    assert "4000" not in message
+
+
+def test_message_ceiling_defaults_to_4000(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MESSAGE_MAX_CHARS", raising=False)
+    assert Settings(_env_file=None).message_max_chars == 4000
+
+
+def test_message_ceiling_reads_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MESSAGE_MAX_CHARS", "17")
+    assert Settings(_env_file=None).message_max_chars == 17

--- a/apps/agent/agent/tests/unit/test_runtime_input_boundary.py
+++ b/apps/agent/agent/tests/unit/test_runtime_input_boundary.py
@@ -1,0 +1,109 @@
+"""Regression tests for the shared runtime input ceiling."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from agent.config.settings import Settings
+from agent.infrastructure.session.memory import InMemorySessionStore
+from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.schemas import (
+    JsonObject,
+    PublicAPIResponse,
+    as_json_object,
+)
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+
+def _runtime(settings: Settings) -> RuntimeAPI:
+    return RuntimeAPI(
+        build_stub_db(),
+        session_store=InMemorySessionStore(),
+        catalog=MagicMock(),
+        settings=settings,
+        model_http_client=MagicMock(),
+    )
+
+
+async def _post(
+    runtime: RuntimeAPI, settings: Settings, path: str, payload: object
+) -> httpx.Response:
+    app, _ = build_app(runtime_api=runtime, settings=settings)
+    async with async_client(app) as client:
+        return await asyncio.wait_for(client.post(path, json=payload), timeout=1)
+
+
+def _done_payload(response: httpx.Response) -> JsonObject:
+    encoded = response.text.split("event: done\ndata: ", 1)[1].split("\n\n", 1)[0]
+    return as_json_object(json.loads(encoded))
+
+
+def _assert_safe_error(response: httpx.Response, expected: str) -> None:
+    assert response.status_code == 400
+    assert response.json()["message"] == expected
+    assert response.json()["errors"] == [
+        {"code": "invalid_input", "message": expected, "details": {}}
+    ]
+    assert "MESSAGE_MAX_CHARS" not in response.text
+    assert "4000" not in response.text
+
+
+@pytest.mark.parametrize(
+    ("locale", "expected"),
+    [
+        ("ja", "メッセージが長すぎます。短くしてもう一度お試しください。"),
+        ("zh", "消息太长了，请缩短后重试。"),
+        ("en", "Your message is too long. Please shorten it and try again."),
+    ],
+)
+async def test_runtime_rejects_over_limit_before_agent_with_safe_copy(
+    locale: str, expected: str
+) -> None:
+    settings = Settings(message_max_chars=4000)
+    with patch(
+        "agent.interfaces.public_api.run_animichi_agent", new_callable=AsyncMock
+    ) as runner:
+        response = await _post(
+            _runtime(settings),
+            settings,
+            "/v1/runtime",
+            {"text": "x" * 4001, "locale": locale},
+        )
+    _assert_safe_error(response, expected)
+    runner.assert_not_awaited()
+
+
+async def test_runtime_stream_rejects_before_agent_and_terminates() -> None:
+    settings = Settings(message_max_chars=4)
+    with patch(
+        "agent.interfaces.public_api.run_animichi_agent", new_callable=AsyncMock
+    ) as runner:
+        response = await _post(
+            _runtime(settings),
+            settings,
+            "/v1/runtime/stream",
+            {"text": "12345"},
+        )
+    payload = _done_payload(response)
+    assert response.status_code == 200
+    assert payload["success"] is False
+    assert payload["status"] == "invalid_request"
+    assert response.text.endswith("\n\n")
+    runner.assert_not_awaited()
+
+
+@pytest.mark.parametrize("path", ["/v1/runtime", "/v1/runtime/stream"])
+async def test_runtime_routes_reject_non_text_before_runtime(path: str) -> None:
+    runtime = MagicMock(spec=RuntimeAPI)
+    runtime.handle = AsyncMock(
+        return_value=PublicAPIResponse(success=True, status="ok", intent="qa")
+    )
+    runtime._db = build_stub_db()
+    response = await _post(runtime, Settings(), path, {"text": ["not", "text"]})
+    assert response.status_code == 422
+    runtime.handle.assert_not_awaited()


### PR DESCRIPTION
## What

Closes the last open code item of #287 (S1.12/S1.6 `Message-length ceiling` AC, a merge-blocking gate): user input beyond a configured length ceiling, or of a non-text type, is rejected **before it ever reaches the agent**, with localized in-character copy.

- `MESSAGE_MAX_CHARS` (default **4000**) added to Pydantic `Settings` with a `gt=0` constraint — no ad-hoc `os.environ` reads.
- Rejection happens at the HTTP boundary (`interfaces/routes/chat.py`), returning **422** with a localized message. The spec's AC is literally "never sent to the agent", so this is deliberately at the route layer rather than an agent-internal `InputGuard` — the agent is never even constructed, costing zero tokens.
- Non-text message parts are rejected the same way.
- Copy is localized ja/zh/en via the existing `error_messages.py` mapper and asserted to leak no technical detail (no `MESSAGE_MAX_CHARS`, no `4000`).

## Audit note

While scoping #287, most of it turned out to be **already implemented**: the untrusted-content delimiting (`wrap_untrusted_web_results` + `<untrusted_web_result>` tags + `sanitize_untrusted` closing-tag forgery guard), tool-return injection detection, the architectural invariant in the system prompt, source tiering, and the G-1 injection eval set (23 cases). This PR closes the one genuinely missing piece. The Prompt Guard side-channel (Llama Prompt Guard 2 22M) is **deliberately not adopted** — the hard defenses are in place and a 22M model would cost container image size and cold start for log-only signal.

## Tests

`test_chat_input_boundary.py` — 7 tests:
- a message exactly at the limit is accepted (and `runtime.handle` **is** awaited)
- over the limit → 422, and `runtime.handle.assert_not_awaited()` proves the agent is never invoked
- non-text type → 422, same proof
- rejection copy exists and is correct in ja/zh/en, and contains no technical strings
- the ceiling defaults to 4000 and reads `MESSAGE_MAX_CHARS` from the environment

## Verification

`make lint` clean · `make typecheck` (mypy strict, 111 files) clean · `make test` **1282 passed, 88.10% coverage** (floor 82%, not lowered).

Implemented by Codex; independently re-verified (gates re-run and tests read, not taken on trust).