### PR TITLE
fix(ci): add SUPABASE_DB_URL dummy binding to the agent-eval-smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,9 @@ jobs:
           MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
           EVAL_SMOKE: "1"
           EVAL_MAX_CASES: "80"
+          # Settings requires presence; the trajectory tier uses NullDatabase and
+          # never opens this endpoint (mirrors the python-integration job).
+          SUPABASE_DB_URL: postgresql://test:test@localhost:5432/test
 
   # ── Neon test infrastructure (non-gating during calibration) ──
 

--- a/apps/agent/agent/tests/unit/test_ci_eval_gate_workflow.py
+++ b/apps/agent/agent/tests/unit/test_ci_eval_gate_workflow.py
@@ -99,6 +99,16 @@ def test_smoke_job_has_no_kill_switch_and_wires_the_zero_error_direct_gate() -> 
     assert "test_translation.py" not in job  # translation stays L1-only (nightly)
 
 
+def test_smoke_job_sets_supabase_db_url_so_settings_import_succeeds() -> None:
+    """Regression: settings require SUPABASE_DB_URL at import time (NullDatabase
+    never opens it), mirroring the dummy value python-integration already sets."""
+    job = _named_workflow_job(
+        _CI_WORKFLOW.read_text(encoding="utf-8"), "agent-eval-smoke"
+    )
+
+    assert "SUPABASE_DB_URL" in job
+
+
 def test_no_disabled_eval_gate_remains_in_ci() -> None:
     """Regression tripwire: the always-off `&& false` gate must never return."""
     assert "&& false" not in _CI_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## What

The L0 smoke eval gate (added in #417) fails at **pytest collection** on every PR that touches `agent_behavior` paths — before a single eval case runs. Root cause: the agent's Pydantic `Settings` requires `SUPABASE_DB_URL` to be present at import time, and the smoke job's `env:` block never set it. Its sibling job `python-integration` already carries a dummy value for exactly this reason.

One line:
```yaml
SUPABASE_DB_URL: postgresql://test:test@localhost:5432/test
```
The trajectory tier runs on `NullDatabase` and never opens this endpoint — the value only satisfies settings validation.

## Why this matters

Observed live on **#422** and again on **#423** (which touched `config/settings.py`, correctly matching the `agent_behavior` path filter): the gate triggered exactly as designed, then failed for a configuration reason unrelated to code quality. A gate that is always red trains everyone to ignore it — worse than having no gate.

## Test

`test_ci_eval_gate_workflow.py::test_smoke_job_sets_supabase_db_url_so_settings_import_succeeds` asserts the binding is present in the smoke job env, so this cannot silently regress.

## Verification

`actionlint .github/workflows/ci.yml` clean · `test_ci_eval_gate_workflow.py` 6 passed · rebased onto current `feat/frontend-rebuild` (0 behind).

> Note: this fix sat un-pushable for a while — pushing `.github/workflows/**` requires the `workflow` OAuth scope, which the token lacked. Resolved via `gh auth refresh -s workflow`.