### PR TITLE
feat(web): localized in-character tool step badges with unknown-tool fallback

### DIFF
--- a/apps/web/src/features/chat/components/MessageList.tsx
+++ b/apps/web/src/features/chat/components/MessageList.tsx
@@ -23,8 +23,8 @@ function partKey(messageId: string, part: Part, index: number): string {
   return `${messageId}:${part.type}:${String(index)}`;
 }
 
-function ToolBadges({ parts }: Readonly<{ parts: readonly ToolPart[] }>) {
-  return parts.map((part) => <ToolStepBadge key={part.toolCallId} type={part.type} state={part.state} />);
+function ToolBadges({ parts, dict }: Readonly<{ parts: readonly ToolPart[]; dict: ChatDict }>) {
+  return parts.map((part) => <ToolStepBadge key={part.toolCallId} type={part.type} state={part.state} dict={dict} />);
 }
 
 type PipelineProps = Readonly<{
@@ -36,7 +36,7 @@ type PipelineProps = Readonly<{
 
 function Pipeline({ parts, settled, elapsedLabel, dict }: PipelineProps) {
   if (parts.length === 0) return null;
-  const badges = <ToolBadges parts={parts} />;
+  const badges = <ToolBadges parts={parts} dict={dict} />;
   if (!settled) return badges;
   return <SettledFootprint elapsedLabel={elapsedLabel} dict={dict}>{badges}</SettledFootprint>;
 }

--- a/apps/web/src/features/chat/components/ToolStepBadge.tsx
+++ b/apps/web/src/features/chat/components/ToolStepBadge.tsx
@@ -1,3 +1,6 @@
+import { HIDDEN_TOOL_STEPS, toolStepLabel } from "../i18n";
+import type { ChatDict } from "../i18n";
+
 export type StepStatus = "done" | "error" | "running";
 
 /** Tool-part `state` machine → badge status (spec S1.1: step badges ← tool parts). */
@@ -7,13 +10,14 @@ export function stepStatus(state: string): StepStatus {
   return "running";
 }
 
-type Props = Readonly<{ type: string; state: string }>;
+type Props = Readonly<{ type: string; state: string; dict: ChatDict }>;
 
-export function ToolStepBadge({ type, state }: Props) {
+export function ToolStepBadge({ type, state, dict }: Props) {
   const name = type.replace(/^tool-/, "");
+  if (HIDDEN_TOOL_STEPS.has(name)) return null;
   return (
     <span className="chat-step" data-status={stepStatus(state)} data-tool={name}>
-      {name}
+      {toolStepLabel(dict, name)}
     </span>
   );
 }

--- a/apps/web/src/features/chat/i18n.ts
+++ b/apps/web/src/features/chat/i18n.ts
@@ -23,6 +23,34 @@ export interface ChatErrorStatesDict {
   readonly d9Episode: string;
 }
 
+/** Tools whose step badges surface to the user as localized progress copy. */
+export const TOOL_STEP_KEYS = [
+  "resolve_anime",
+  "search_bangumi",
+  "search_nearby",
+  "plan_route",
+  "plan_selected",
+  "plan_multi",
+  "web_search",
+] as const;
+
+export type ToolStepKey = (typeof TOOL_STEP_KEYS)[number];
+
+/**
+ * Explicit deny-list: internal agent mechanics that must never appear in the
+ * badge stream. `translate_anime_title` is plumbing (the agent translating a
+ * title to query the catalog), not user-visible progress.
+ */
+export const HIDDEN_TOOL_STEPS: ReadonlySet<string> = new Set([
+  "translate_anime_title",
+]);
+
+/** In-character progress copy for tool step badges. */
+export interface ChatToolStepsDict {
+  readonly labels: Readonly<Record<ToolStepKey, string>>;
+  readonly fallback: string;
+}
+
 /** Chat-page copy, kept feature-local to avoid the shared dictionary hot file. */
 export interface ChatDict {
   readonly greeting: string;
@@ -40,7 +68,47 @@ export interface ChatDict {
   readonly waitingSubtitle: string;
   readonly footprintDetails: string;
   readonly errorStates: ChatErrorStatesDict;
+  readonly toolSteps: ChatToolStepsDict;
 }
+
+const jaToolSteps: ChatToolStepsDict = {
+  labels: {
+    resolve_anime: "作品をしらべてるよ…",
+    search_bangumi: "聖地をさがしてるよ…",
+    search_nearby: "近くの聖地をさがしてるよ…",
+    plan_route: "ルートを組んでるよ…",
+    plan_selected: "えらんだ場所でルートを組んでるよ…",
+    plan_multi: "まとめてルートを組んでるよ…",
+    web_search: "ネットでしらべてるよ…",
+  },
+  fallback: "じゅんびしてるよ…",
+};
+
+const zhToolSteps: ChatToolStepsDict = {
+  labels: {
+    resolve_anime: "在查这部作品…",
+    search_bangumi: "在找圣地…",
+    search_nearby: "在找附近的圣地…",
+    plan_route: "在规划路线…",
+    plan_selected: "在按你选的地点排路线…",
+    plan_multi: "在把路线排到一起…",
+    web_search: "在网上查一查…",
+  },
+  fallback: "在准备中…",
+};
+
+const enToolSteps: ChatToolStepsDict = {
+  labels: {
+    resolve_anime: "Looking up the title…",
+    search_bangumi: "Finding the spots…",
+    search_nearby: "Searching nearby…",
+    plan_route: "Planning the route…",
+    plan_selected: "Routing your picks…",
+    plan_multi: "Weaving routes together…",
+    web_search: "Searching the web…",
+  },
+  fallback: "Working on it…",
+};
 
 const jaErrorStates: ChatErrorStatesDict = {
   d1Title: "ごめんね、その作品が見つからなかった…",
@@ -128,6 +196,7 @@ const ja: ChatDict = {
   waitingSubtitle: "いま さがしてるよ…",
   footprintDetails: "詳細を見る",
   errorStates: jaErrorStates,
+  toolSteps: jaToolSteps,
 };
 
 const zh: ChatDict = {
@@ -146,6 +215,7 @@ const zh: ChatDict = {
   waitingSubtitle: "正在帮你找…",
   footprintDetails: "查看详情",
   errorStates: zhErrorStates,
+  toolSteps: zhToolSteps,
 };
 
 const en: ChatDict = {
@@ -168,10 +238,20 @@ const en: ChatDict = {
   waitingSubtitle: "Looking that up…",
   footprintDetails: "View details",
   errorStates: enErrorStates,
+  toolSteps: enToolSteps,
 };
 
 const CHAT_DICTIONARIES: Record<Locale, ChatDict> = { ja, zh, en };
 
 export function chatDictFor(locale: Locale): ChatDict {
   return CHAT_DICTIONARIES[locale];
+}
+
+function isToolStepKey(name: string): name is ToolStepKey {
+  return (TOOL_STEP_KEYS as readonly string[]).includes(name);
+}
+
+export function toolStepLabel(dict: ChatDict, name: string): string {
+  if (isToolStepKey(name)) return dict.toolSteps.labels[name];
+  return dict.toolSteps.fallback;
 }

--- a/apps/web/tests/unit/chat/chat-page-stream.test.tsx
+++ b/apps/web/tests/unit/chat/chat-page-stream.test.tsx
@@ -28,7 +28,9 @@ describe("send flow over the recorded search stream", () => {
     expect(await screen.findByText("ユーフォ")).toBeTruthy();
     await screen.findByText("宇治の聖地を2件、徒歩ルートにまとめました。");
     for (const tool of ["resolve_anime", "search_bangumi", "plan_route"]) {
-      expect(screen.getByText(tool).getAttribute("data-status")).toBe("done");
+      const badge = document.querySelector(`.chat-step[data-tool="${tool}"]`);
+      expect(badge?.getAttribute("data-status")).toBe("done");
+      expect(badge?.textContent).not.toBe(tool);
     }
     expect(screen.getByText("宇治橋")).toBeTruthy();
     const card = document.querySelector('[data-intent="plan_route"]');

--- a/apps/web/tests/unit/chat/message-list.test.tsx
+++ b/apps/web/tests/unit/chat/message-list.test.tsx
@@ -39,6 +39,7 @@ describe("MessageList pipeline collapse", () => {
   it("keeps the pipeline inline while the turn is still streaming", () => {
     render(<MessageList messages={[toolMessage()]} dict={ja} status="streaming" />);
     expect(document.querySelector(".chat-settled")).toBeNull();
-    expect(screen.getByText("resolve_anime")).toBeTruthy();
+    const badge = screen.getByText(ja.toolSteps.labels.resolve_anime);
+    expect(badge.getAttribute("data-tool")).toBe("resolve_anime");
   });
 });

--- a/apps/web/tests/unit/chat/tool-step-badge.test.tsx
+++ b/apps/web/tests/unit/chat/tool-step-badge.test.tsx
@@ -7,6 +7,8 @@ import {
   ToolStepBadge,
   stepStatus,
 } from "../../../src/features/chat/components/ToolStepBadge";
+import { TOOL_STEP_KEYS, chatDictFor } from "../../../src/features/chat/i18n";
+import { LOCALES } from "../../../src/i18n/locales";
 
 describe("stepStatus", () => {
   it("maps output-available to done", () => {
@@ -17,21 +19,71 @@ describe("stepStatus", () => {
     expect(stepStatus("output-error")).toBe("error");
   });
 
+  it("maps output-denied to error", () => {
+    expect(stepStatus("output-denied")).toBe("error");
+  });
+
   it("maps in-flight states to running", () => {
     expect(stepStatus("input-streaming")).toBe("running");
     expect(stepStatus("input-available")).toBe("running");
   });
 });
 
-describe("ToolStepBadge", () => {
-  it("shows the bare tool name with its status", () => {
-    render(<ToolStepBadge type="tool-resolve_anime" state="output-available" />);
-    const badge = screen.getByText("resolve_anime");
+describe("ToolStepBadge localized copy", () => {
+  it.each(LOCALES)("renders the %s label for every mapped tool, never the raw id", (locale) => {
+    const dict = chatDictFor(locale);
+    for (const key of TOOL_STEP_KEYS) {
+      const { unmount } = render(
+        <ToolStepBadge type={`tool-${key}`} state="output-available" dict={dict} />,
+      );
+      const badge = screen.getByText(dict.toolSteps.labels[key]);
+      expect(badge.textContent).not.toBe(key);
+      unmount();
+    }
+  });
+
+  it("keeps the raw identifier in data-tool while showing localized text", () => {
+    const dict = chatDictFor("ja");
+    render(<ToolStepBadge type="tool-search_bangumi" state="output-available" dict={dict} />);
+    const badge = screen.getByText(dict.toolSteps.labels.search_bangumi);
+    expect(badge.getAttribute("data-tool")).toBe("search_bangumi");
     expect(badge.getAttribute("data-status")).toBe("done");
   });
 
   it("marks running steps", () => {
-    render(<ToolStepBadge type="tool-plan_route" state="input-streaming" />);
-    expect(screen.getByText("plan_route").getAttribute("data-status")).toBe("running");
+    const dict = chatDictFor("ja");
+    render(<ToolStepBadge type="tool-plan_route" state="input-streaming" dict={dict} />);
+    const badge = screen.getByText(dict.toolSteps.labels.plan_route);
+    expect(badge.getAttribute("data-status")).toBe("running");
+  });
+});
+
+describe("ToolStepBadge unknown-tool degradation", () => {
+  it.each(LOCALES)("renders the %s fallback label for an unmapped tool", (locale) => {
+    const dict = chatDictFor(locale);
+    render(<ToolStepBadge type="tool-brand_new_tool" state="input-available" dict={dict} />);
+    const badge = screen.getByText(dict.toolSteps.fallback);
+    expect(badge.textContent).not.toBe("brand_new_tool");
+    expect(badge.textContent.length).toBeGreaterThan(0);
+  });
+
+  it("keeps the raw identifier in data-tool for unmapped tools", () => {
+    const dict = chatDictFor("en");
+    const { container } = render(
+      <ToolStepBadge type="tool-brand_new_tool" state="input-available" dict={dict} />,
+    );
+    const badge = container.querySelector(".chat-step");
+    expect(badge?.getAttribute("data-tool")).toBe("brand_new_tool");
+    expect(badge?.textContent).toBe(dict.toolSteps.fallback);
+  });
+});
+
+describe("ToolStepBadge hidden tools", () => {
+  it("suppresses translate_anime_title from the badge stream", () => {
+    const dict = chatDictFor("ja");
+    const { container } = render(
+      <ToolStepBadge type="tool-translate_anime_title" state="output-available" dict={dict} />,
+    );
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/apps/web/tests/unit/chat/tool-step-i18n.test.ts
+++ b/apps/web/tests/unit/chat/tool-step-i18n.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  HIDDEN_TOOL_STEPS,
+  TOOL_STEP_KEYS,
+  chatDictFor,
+  toolStepLabel,
+} from "../../../src/features/chat/i18n";
+import { LOCALES } from "../../../src/i18n/locales";
+
+const JAPANESE_SCRIPT = /[぀-ヿ一-鿿]/u;
+
+describe("tool-step dictionary coverage", () => {
+  it.each(LOCALES)("has non-empty %s copy for every tool key and the fallback", (locale) => {
+    const steps = chatDictFor(locale).toolSteps;
+    for (const key of TOOL_STEP_KEYS) {
+      expect(steps.labels[key].length, `${locale} toolSteps.labels.${key}`).toBeGreaterThan(0);
+    }
+    expect(steps.fallback.length).toBeGreaterThan(0);
+  });
+
+  it("writes the ja step copy in Japanese so a ja user never sees leaked English", () => {
+    const steps = chatDictFor("ja").toolSteps;
+    for (const key of TOOL_STEP_KEYS) {
+      expect(JAPANESE_SCRIPT.test(steps.labels[key]), `ja toolSteps.labels.${key}`).toBe(true);
+    }
+    expect(JAPANESE_SCRIPT.test(steps.fallback)).toBe(true);
+  });
+
+  it.each(LOCALES)("keeps raw snake_case identifiers out of every %s label", (locale) => {
+    const steps = chatDictFor(locale).toolSteps;
+    for (const key of TOOL_STEP_KEYS) {
+      expect(steps.labels[key], `${locale} toolSteps.labels.${key}`).not.toContain("_");
+    }
+    expect(steps.fallback).not.toContain("_");
+  });
+});
+
+describe("toolStepLabel", () => {
+  it("returns the mapped label for a known tool", () => {
+    const dict = chatDictFor("en");
+    expect(toolStepLabel(dict, "web_search")).toBe(dict.toolSteps.labels.web_search);
+  });
+
+  it("returns the fallback for an unknown tool", () => {
+    const dict = chatDictFor("en");
+    expect(toolStepLabel(dict, "never_registered")).toBe(dict.toolSteps.fallback);
+  });
+});
+
+describe("hidden tool list", () => {
+  it("hides translate_anime_title and never a surfaced tool", () => {
+    expect(HIDDEN_TOOL_STEPS.has("translate_anime_title")).toBe(true);
+    for (const key of TOOL_STEP_KEYS) {
+      expect(HIDDEN_TOOL_STEPS.has(key), `surfaced tool ${key} must not be hidden`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`ToolStepBadge` rendered the raw tool identifier (`search_bangumi`, `plan_route`, …) straight to the user as the progress label, and `features/chat/i18n.ts` had no tool copy at all. With C1 in flight, `web_search` and `translate_anime_title` were about to join that raw-identifier stream.

## What changed

- **`ChatDict.toolSteps`** (`apps/web/src/features/chat/i18n.ts`): short, in-character ja/zh/en labels for every tool that can surface as a step badge, plus a per-locale `fallback`. Tool list verified read-only against the backend registrations (`apps/agent/agent/agents/animichi_tools.py`, `web_tools.py`, `selected_route.py`, `selection.py`).
- **Graceful degradation (core requirement)**: `toolStepLabel()` narrows via a `TOOL_STEP_KEYS` type guard; any unmapped tool renders the locale's generic fallback ("じゅんびしてるよ… / 在准备中… / Working on it…") — never `undefined`, never empty, never the raw id.
- **Explicit deny-list**: `HIDDEN_TOOL_STEPS = {"translate_anime_title"}` with a comment; `ToolStepBadge` returns `null` for hidden tools. Not a silent render-logic filter.
- **`data-tool` keeps the raw identifier** for tests/telemetry; only the visible text is localized. `stepStatus` state machine untouched. No visual changes — same `chat-step` styling and tokens.

## Tool → copy mapping (ja / zh / en)

| Tool | ja | zh | en |
|---|---|---|---|
| `resolve_anime` | 作品をしらべてるよ… | 在查这部作品… | Looking up the title… |
| `search_bangumi` | 聖地をさがしてるよ… | 在找圣地… | Finding the spots… |
| `search_nearby` | 近くの聖地をさがしてるよ… | 在找附近的圣地… | Searching nearby… |
| `plan_route` | ルートを組んでるよ… | 在规划路线… | Planning the route… |
| `plan_selected` | えらんだ場所でルートを組んでるよ… | 在按你选的地点排路线… | Routing your picks… |
| `plan_multi` | まとめてルートを組んでるよ… | 在把路线排到一起… | Weaving routes together… |
| `web_search` | ネットでしらべてるよ… | 在网上查一查… | Searching the web… |
| *(unknown)* | じゅんびしてるよ… | 在准备中… | Working on it… |

## UX decision: `translate_anime_title` is suppressed

The tool is agent plumbing — translating a title so the agent can query the catalog. To the user this is an implementation detail of "looking up the title": it always occurs adjacent to `resolve_anime`/`web_search`, which already carry visible copy, so hiding it loses no perceived progress. Showing it would either duplicate the resolve label (noise) or expose an internal mechanic users can't act on (confusion). Suppression is implemented as the explicit `HIDDEN_TOOL_STEPS` allow/deny list so reversing the call is a one-line change.

## Tests (unit)

- Each mapped tool renders its localized label in all three locales; raw id never shown.
- Unknown tool renders the fallback (non-empty, not the raw id) and still carries `data-tool`.
- `translate_anime_title` renders nothing.
- `stepStatus` machine unchanged (incl. `output-denied` → error).
- i18n completeness (`tool-step-i18n.test.ts`, mirrors the `errorStates` suite): every key non-empty in ja/zh/en, ja copy contains Japanese script, no snake_case leaks, hidden set never overlaps surfaced keys.
- Two pre-existing tests that asserted the raw identifier as *visible text* (the defect) were updated to assert via `data-tool` + localized label.

## Verification

`pnpm run lint:oxlint` clean · `pnpm exec tsc --noEmit` clean · `pnpm run test`: **134 files / 754 tests passed**; coverage Stmts 99.04% / Branch 95.39% / Funcs 99.59% / Lines 99.85% (floor 90/90/90/90 intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)