### PR TITLE
fix(web): disable wrangler keepNames so SSR hydration stops crashing every route

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "lint:oxlint": "oxlint --type-aware --deny-warnings .",
+    "routes:generate": "node tests/setup/generate-route-tree.ts",
+    "lint:oxlint": "pnpm run routes:generate && oxlint --type-aware --deny-warnings .",
     "test": "vitest run --config vitest.config.ts --coverage",
     "test:integration": "vitest run --config vitest.integration.config.ts",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "pnpm run routes:generate && tsc --noEmit",
     "preview": "wrangler dev"
   },
   "dependencies": {
@@ -43,6 +44,7 @@
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-istanbul": "4.1.10",
     "jsdom": "^29.1.1",
+    "jsonc-parser": "^3.3.1",
     "msw": "2.15.0",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",

--- a/apps/web/tests/integration/build-output.test.ts
+++ b/apps/web/tests/integration/build-output.test.ts
@@ -1,12 +1,40 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parse } from "jsonc-parser";
 import { describe, expect, it } from "vitest";
 
 const packageRoot = fileURLToPath(new URL("../../", import.meta.url));
 const serverEntry = new URL("../../.output/server/index.mjs", import.meta.url);
 const publicDir = new URL("../../.output/public", import.meta.url);
 const wranglerConfigPath = new URL("../../wrangler.jsonc", import.meta.url);
+
+interface WranglerConfig {
+  main: string;
+  assets: { directory: string; binding: string };
+}
+
+function readWranglerConfig(): WranglerConfig {
+  return parse(readFileSync(wranglerConfigPath, "utf8")) as WranglerConfig;
+}
+
+function bundleWorkerToTempDir(): string {
+  const outdir = mkdtempSync(join(tmpdir(), "animichi-web-bundle-"));
+  execFileSync("pnpm", ["exec", "wrangler", "deploy", "--dry-run", "--outdir", outdir], {
+    cwd: packageRoot,
+    stdio: "pipe",
+    timeout: 120_000,
+  });
+  return outdir;
+}
+
+function readBundledWorker(outdir: string): string {
+  const entry = readdirSync(outdir).find((name) => name.endsWith(".js"));
+  if (!entry) throw new Error(`no bundled worker emitted in ${outdir}`);
+  return readFileSync(join(outdir, entry), "utf8");
+}
 
 describe("build output", () => {
   it("emits the Cloudflare server entry and public assets", () => {
@@ -23,9 +51,7 @@ describe("build output", () => {
   });
 
   it("validates Wrangler output mapping", () => {
-    const wranglerConfig = JSON.parse(
-      readFileSync(wranglerConfigPath, "utf8"),
-    ) as { main: string; assets: { directory: string; binding: string } };
+    const wranglerConfig = readWranglerConfig();
 
     expect(wranglerConfig.main).toBe(".output/server/index.mjs");
     expect(wranglerConfig.assets.directory).toBe(".output/public");
@@ -38,6 +64,15 @@ describe("build output", () => {
       stdio: "pipe",
       timeout: 120_000,
     });
+  });
+
+  // Regression: esbuild `keepNames` wraps functions in `__name(...)`, and seroval serialises its
+  // stream helpers with Function.prototype.toString() into the inline `$tsr-stream-barrier` script,
+  // where `__name` is undefined — that ReferenceError blanked every SSR route (issue #426).
+  it("bundles the Worker without esbuild keepNames wrappers", () => {
+    const bundle = readBundledWorker(bundleWorkerToTempDir());
+
+    expect(bundle).not.toContain("__name(");
   });
 
   it("dry-runs the staging web Worker deployment", () => {

--- a/apps/web/tests/setup/generate-route-tree.ts
+++ b/apps/web/tests/setup/generate-route-tree.ts
@@ -4,11 +4,12 @@ import { Generator, getConfig } from "@tanstack/router-generator";
 const appRoot = fileURLToPath(new URL("../../", import.meta.url));
 
 /**
- * Vitest globalSetup: emit `src/routeTree.gen.ts` before the suite runs.
+ * Emit `src/routeTree.gen.ts`. Used as the vitest globalSetup and, via the
+ * `routes:generate` script, by `lint:oxlint` and `typecheck`.
  *
  * The TanStack Start vite plugin generates it during dev/build, but the unit
- * pool runs without that plugin, so `router.tsx` (now in the coverage sweep)
- * would fail to import the generated tree otherwise.
+ * pool runs without that plugin and a fresh checkout has never built, so both
+ * the suite and the type-aware gates would otherwise see an unresolved import.
  */
 export default async function setup(): Promise<void> {
   const config = getConfig(
@@ -21,3 +22,5 @@ export default async function setup(): Promise<void> {
   );
   await new Generator({ config, root: appRoot }).run();
 }
+
+if (import.meta.main) await setup();

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -4,6 +4,11 @@
   "main": ".output/server/index.mjs",
   "compatibility_date": "2026-06-01",
   "compatibility_flags": ["nodejs_compat"],
+  // Wrangler's esbuild pass defaults to keepNames, which rewrites functions as `__name(fn, "…")`.
+  // seroval serialises its SSR stream helpers with Function.prototype.toString(), so those wrappers
+  // land in the inline `$tsr-stream-barrier` script where `__name` does not exist — the resulting
+  // ReferenceError aborts hydration and blanks every route (issue #426).
+  "keep_names": false,
   "assets": {
     "directory": ".output/public",
     "binding": "ASSETS"

--- a/e2e/web-404.spec.ts
+++ b/e2e/web-404.spec.ts
@@ -1,8 +1,26 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 // E2E_WEB_BASE_URL targets the new apps/web app (dev :3000 / CI wrangler :8799); deliberately separate from E2E_BASE_URL in playwright.config.ts, which targets the legacy Next.js frontend on :3001 — both apps coexist until the S0.7 cutover.
 test.use({
   baseURL: process.env.E2E_WEB_BASE_URL ?? "http://localhost:3000",
+});
+
+// Issue #426: a hydration ReferenceError wiped the SSR DOM on every route, so asserting markup on
+// the 404 page alone is not enough — collect uncaught browser errors and require none.
+async function collectPageErrors(page: Page, path: string): Promise<string[]> {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.goto(path);
+  await page.waitForLoadState("networkidle");
+  return errors;
+}
+
+test("undefined route hydrates without uncaught errors", async ({ page }) => {
+  expect(await collectPageErrors(page, "/this-route-does-not-exist")).toEqual([]);
+});
+
+test("home route hydrates without uncaught errors", async ({ page }) => {
+  expect(await collectPageErrors(page, "/")).toEqual([]);
 });
 
 test("undefined route renders a branded 404", async ({ page }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       msw:
         specifier: 2.15.0
         version: 2.15.0(@types/node@26.1.1)(typescript@7.0.2)


### PR DESCRIPTION
Fixes #426.

## Reproduction (before)

`apps/web` production build + `wrangler dev --port 8799`. SSR HTML is perfect — `curl /this-route-does-not-exist` returns **404** with `<h1 id="not-found-title">404</h1>` — but the browser blanks the page while hydrating:

```
/                          status=200 bodyHTML=2726 h1Count=0 pageerrors=4
   pageerror: __name is not defined
   pageerror: Cannot read properties of undefined (reading 'return')
   pageerror: Invariant failed
   pageerror: Invariant failed
/this-route-does-not-exist status=404 bodyHTML=2687 h1Count=0 pageerrors=4
   (identical)
```

`playwright test web-404.spec.ts` failed with `getByRole('heading', { name: '404' })` — element not found, blank screenshot.

## Root cause — not an upstream TanStack packaging bug

The issue write-up guessed the `__name` artifacts were baked into the published `@tanstack/router-core` / `react-router-with-query` dist. They are not. Verified:

- `grep -rl '__name' node_modules/@tanstack/router-core/dist node_modules/seroval/dist` → **no matches**
- `grep -rl '__name' apps/web/.output/server` → **no matches**

So a dependency bump could not have fixed this. `__name` is injected **by wrangler**, downstream of our build:

1. `wrangler/wrangler-dist/cli.js`: `keepNames: config.keep_names ?? true` — wrangler's esbuild pass enables `keepNames` by default, rewriting every function as `/* @__PURE__ */ __name(fn, "name")`.
2. seroval (`1.5.5`) serialises its SSR stream helpers with `Function.prototype.toString()` — `xr.toString()`, `ee.toString()`, … — so it emits **post-esbuild source text**, `__name(...)` wrappers included.
3. TanStack Start embeds that text in the inline `<script id="$tsr-stream-barrier">`, where the `__name` helper does not exist.
4. `ReferenceError: __name is not defined` → the `dehydratedData.queryStream` handshake is corrupted → `Cannot read properties of undefined (reading 'return')` → React `Invariant failed` → the tree unmounts and the DOM is wiped, on **every** route.

## Fix

`apps/web/wrangler.jsonc`: `"keep_names": false` (a first-class wrangler option, not a workaround — it only affects `Function.name` in stack traces; minify is off here anyway). **No stopgap `__name` shim, no dependency bump, nothing to revert later.**

## Tests (both verified red before the fix, green after)

- **integration** `apps/web/tests/integration/build-output.test.ts` — bundles the Worker with `wrangler deploy --dry-run --outdir <tmp>` and asserts the emitted bundle contains no `__name(`. Fails on the pre-fix config with `expected 'var __defProp = Object.defineProperty…' not to contain '__name('`.
- **browser** `e2e/web-404.spec.ts` — two new tests assert **zero `pageerror`** on `/` **and** on `/this-route-does-not-exist`. The existing branded-404 test is untouched and unweakened. Flipping `keep_names` back to `true` makes all three fail with `+ "__name is not defined"` — this is not a vacuous assertion.

## After

```
/                          status=200 bodyHTML=7085 h1Count=1 pageerrors=0
/this-route-does-not-exist status=404 bodyHTML=296  h1Count=1 pageerrors=0
RESULT: clean hydration
```

```
✓ undefined route hydrates without uncaught errors (995ms)
✓ home route hydrates without uncaught errors (892ms)
✓ undefined route renders a branded 404 (220ms)
3 passed
```

`curl | grep -c __name` → 0 on both routes.

## Second bug in the issue: fresh checkout cannot pass its own gate

`src/routeTree.gen.ts` is gitignored and only emitted by a build, so on a clean clone `pnpm --filter web run lint:oxlint` died with ~30 `no-unsafe-call` / `no-unsafe-member-access` errors on an unresolved import. Small fix taken: the existing vitest `globalSetup` generator gained an `import.meta.main` self-run guard and is now exposed as `routes:generate`, which `lint:oxlint` and `typecheck` run first. No duplicated codegen logic. Verified by `rm -f src/routeTree.gen.ts && pnpm run lint:oxlint` → clean.

`jsonc-parser` added as a devDependency because `wrangler.jsonc` now carries the explanatory comment and the config test used `JSON.parse`. `pnpm-lock.yaml` is committed.

## Gate output

| Gate | Result |
|---|---|
| `pnpm run lint:oxlint` | exit 0, no findings |
| `pnpm exec tsc --noEmit` | `TypeScript: No errors found` |
| `pnpm run test` | **134 files, 754 tests passed**; coverage stmts 99.04 / branches 95.39 / fns 99.59 / lines 99.85 |
| `pnpm run test:integration` | 6 passed (was 5) |
| `playwright web-404.spec.ts` | 3 passed (was 1) |

No dependency versions bumped. `apps/agent/**` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)