### PR TITLE
feat(web): S1.4 search content shapes + static map (C3a/C3b)

### DIFF
--- a/apps/web/src/features/bubble-map/BubbleMap.tsx
+++ b/apps/web/src/features/bubble-map/BubbleMap.tsx
@@ -1,7 +1,7 @@
 import type { AnimeOverviewCircle, AnimeScene } from "@seichijunrei/contract";
 import { type RefObject, useEffect, useRef, useState } from "react";
 import { BubbleMapPanel } from "./BubbleMapPanel";
-import { type BubbleMapStatus, attachBubbleMap } from "./bubbleMapController";
+import { type BasemapStatus, attachBubbleMap } from "./bubbleMapController";
 import type { BubbleMapCopy } from "./copy";
 
 type Props = Readonly<{
@@ -10,7 +10,7 @@ type Props = Readonly<{
   copy: BubbleMapCopy;
 }>;
 
-type StatusSetter = (status: BubbleMapStatus) => void;
+type StatusSetter = (status: BasemapStatus) => void;
 
 const attachToContainer = (
   container: HTMLDivElement | null,
@@ -32,7 +32,7 @@ function useBubbleMapMount(
 /** Feature entry: mounts the MapLibre basemap and renders the bubble overlay + sheet on top. */
 export function BubbleMap({ circles, scenes, copy }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [, setStatus] = useState<BubbleMapStatus>("loading");
+  const [, setStatus] = useState<BasemapStatus>("loading");
   useBubbleMapMount(containerRef, circles, setStatus);
   return <BubbleMapPanel circles={circles} scenes={scenes} copy={copy} mapContainerRef={containerRef} />;
 }

--- a/apps/web/src/features/bubble-map/bubbleGeometry.ts
+++ b/apps/web/src/features/bubble-map/bubbleGeometry.ts
@@ -61,3 +61,26 @@ export function bubblePlacements(circles: readonly AnimeOverviewCircle[]): reado
   const maxCount = circlesMaxCount(circles);
   return circles.map((circle) => toPlacement(circle, lat, lng, maxCount));
 }
+
+/** A located pin projected into overlay percent space (issue #261 C3a). */
+export interface PointPlacement {
+  readonly leftPct: number;
+  readonly topPct: number;
+}
+
+interface GeoPoint {
+  readonly lat: number;
+  readonly lng: number;
+}
+
+/** Project raw coordinates into the same inset percent space the bubbles use. */
+export function pointPlacements(points: readonly GeoPoint[]): readonly PointPlacement[] {
+  if (points.length === 0) return [];
+  const lat = extent(points.map((point) => point.lat));
+  const lng = extent(points.map((point) => point.lng));
+  return points.map((point) => ({
+    leftPct: projectAxis(point.lng, lng.min, lng.max),
+    // Latitude axis is inverted: the northernmost pin sits nearest the top.
+    topPct: projectAxis(point.lat, lat.max, lat.min),
+  }));
+}

--- a/apps/web/src/features/bubble-map/bubbleMapController.ts
+++ b/apps/web/src/features/bubble-map/bubbleMapController.ts
@@ -3,8 +3,7 @@ import type { AnimeOverviewCircle, LatLng } from "@seichijunrei/contract";
 import type { LngLatBoundsLike, Map as MapLibreMap } from "maplibre-gl";
 import { createMapStyle } from "../map-spike/mapStyle";
 
-export type BubbleMapStatus = "loading" | "ready" | "fallback";
-export type BasemapStatus = BubbleMapStatus;
+export type BasemapStatus = "loading" | "ready" | "fallback";
 
 /** Generic basemap mount: frame the tiles around a set of coordinates. */
 export type MountBasemapOptions = Readonly<{
@@ -18,7 +17,7 @@ export type MountBasemapOptions = Readonly<{
 export type MountBubbleMapOptions = Readonly<{
   container: HTMLElement;
   circles: readonly AnimeOverviewCircle[];
-  onStatus: (status: BubbleMapStatus) => void;
+  onStatus: (status: BasemapStatus) => void;
 }>;
 
 export type BubbleMapHandle = Readonly<{ destroy: () => void }>;

--- a/apps/web/src/features/bubble-map/bubbleMapController.ts
+++ b/apps/web/src/features/bubble-map/bubbleMapController.ts
@@ -1,9 +1,19 @@
 import "maplibre-gl/dist/maplibre-gl.css";
-import type { AnimeOverviewCircle } from "@seichijunrei/contract";
+import type { AnimeOverviewCircle, LatLng } from "@seichijunrei/contract";
 import type { LngLatBoundsLike, Map as MapLibreMap } from "maplibre-gl";
 import { createMapStyle } from "../map-spike/mapStyle";
 
 export type BubbleMapStatus = "loading" | "ready" | "fallback";
+export type BasemapStatus = BubbleMapStatus;
+
+/** Generic basemap mount: frame the tiles around a set of coordinates. */
+export type MountBasemapOptions = Readonly<{
+  container: HTMLElement;
+  points: readonly LatLng[];
+  onStatus: (status: BasemapStatus) => void;
+  /** Static-first surfaces (issue #261 C3a) mount the map non-interactive. */
+  interactive?: boolean;
+}>;
 
 export type MountBubbleMapOptions = Readonly<{
   container: HTMLElement;
@@ -22,39 +32,44 @@ const registerProtocol = async (gl: typeof import("maplibre-gl")): Promise<void>
   protocolReady = true;
 };
 
-const circlesBounds = (circles: readonly AnimeOverviewCircle[]): LngLatBoundsLike => {
-  const lngs = circles.map((c) => c.lng);
-  const lats = circles.map((c) => c.lat);
+const pointsBounds = (points: readonly LatLng[]): LngLatBoundsLike => {
+  const lngs = points.map((point) => point.lng);
+  const lats = points.map((point) => point.lat);
   return [
     [Math.min(...lngs), Math.min(...lats)],
     [Math.max(...lngs), Math.max(...lats)],
   ];
 };
 
-// Frame the tile basemap around the region cluster; the bubble overlay renders on top in React.
-const fitToCircles = (map: MapLibreMap, circles: readonly AnimeOverviewCircle[]): void => {
-  if (circles.length === 0) return;
-  map.fitBounds(circlesBounds(circles), { padding: 64, maxZoom: 12, animate: false });
+// Frame the tile basemap around the coordinates; any overlay renders on top in React.
+const fitToPoints = (map: MapLibreMap, points: readonly LatLng[]): void => {
+  if (points.length === 0) return;
+  map.fitBounds(pointsBounds(points), { padding: 64, maxZoom: 12, animate: false });
 };
 
-const createMap = (gl: typeof import("maplibre-gl"), container: HTMLElement): MapLibreMap => {
-  return new gl.Map({ container, style: createMapStyle("pmtiles"), attributionControl: { compact: true } });
+const createMap = (gl: typeof import("maplibre-gl"), options: MountBasemapOptions): MapLibreMap => {
+  return new gl.Map({
+    container: options.container,
+    style: createMapStyle("pmtiles"),
+    interactive: options.interactive ?? true,
+    attributionControl: { compact: true },
+  });
 };
 
-const onMapLoad = (map: MapLibreMap, options: MountBubbleMapOptions): void => {
-  fitToCircles(map, options.circles);
+const onMapLoad = (map: MapLibreMap, options: MountBasemapOptions): void => {
+  fitToPoints(map, options.points);
   options.onStatus("ready");
 };
 
-const wireEvents = (map: MapLibreMap, options: MountBubbleMapOptions): void => {
+const wireEvents = (map: MapLibreMap, options: MountBasemapOptions): void => {
   map.on("load", () => { onMapLoad(map, options); });
   map.on("error", () => { options.onStatus("fallback"); });
 };
 
-export const mountBubbleMap = async (options: MountBubbleMapOptions): Promise<BubbleMapHandle> => {
+export const mountBasemap = async (options: MountBasemapOptions): Promise<BubbleMapHandle> => {
   const gl = await import("maplibre-gl");
   await registerProtocol(gl);
-  const map = createMap(gl, options.container);
+  const map = createMap(gl, options);
   wireEvents(map, options);
   return { destroy: () => { map.remove(); } };
 };
@@ -72,12 +87,32 @@ const storeHandle = (attachment: Attachment, handle: BubbleMapHandle): void => {
   attachment.handle = handle;
 };
 
+// A failed mount (no WebGL context, import failure) degrades like a tile failure.
+const reportMountFailure = (attachment: Attachment, options: MountBasemapOptions): void => {
+  if (attachment.active) options.onStatus("fallback");
+};
+
 // Bridges the async mount into React's synchronous effect-cleanup contract.
-export const attachBubbleMap = (options: MountBubbleMapOptions): (() => void) => {
+export const attachBasemap = (options: MountBasemapOptions): (() => void) => {
   const attachment: Attachment = { handle: null, active: true };
-  void mountBubbleMap(options).then((handle) => { storeHandle(attachment, handle); });
+  void mountBasemap(options)
+    .then((handle) => { storeHandle(attachment, handle); })
+    .catch(() => { reportMountFailure(attachment, options); });
   return () => {
     attachment.active = false;
     attachment.handle?.destroy();
   };
+};
+
+const circlePoints = (circles: readonly AnimeOverviewCircle[]): readonly LatLng[] => {
+  return circles.map(({ lat, lng }) => ({ lat, lng }));
+};
+
+/** Bubble-map entry kept for BubbleMap.tsx: circles only frame the bounds. */
+export const attachBubbleMap = (options: MountBubbleMapOptions): (() => void) => {
+  return attachBasemap({
+    container: options.container,
+    points: circlePoints(options.circles),
+    onStatus: options.onStatus,
+  });
 };

--- a/apps/web/src/features/chat/components/SearchMap.tsx
+++ b/apps/web/src/features/chat/components/SearchMap.tsx
@@ -29,10 +29,27 @@ function attachTo(
   return attach({ container, points, onStatus, interactive: false });
 }
 
+function coordKey(points: readonly LatLng[]): string {
+  return points.map((point) => `${String(point.lat)},${String(point.lng)}`).join("|");
+}
+
+/** Callers build the point array inline, so it is a fresh reference on every
+ * render — and this card lives in the streaming chat surface, which re-renders
+ * per SSE chunk. Without this, each chunk would tear down and rebuild a MapLibre
+ * map (dynamic import + WebGL context + tile refetch); browsers cap live WebGL
+ * contexts around 16. Identity is keyed on the coordinates themselves. */
+function useStablePoints(points: readonly LatLng[]): readonly LatLng[] {
+  const key = coordKey(points);
+  const held = useRef({ key, points });
+  if (held.current.key !== key) held.current = { key, points };
+  return held.current.points;
+}
+
 function useBasemap(points: readonly LatLng[], attach: AttachBasemap): Basemap {
   const ref = useRef<HTMLDivElement>(null);
   const [status, setStatus] = useState<BasemapStatus>("loading");
-  useEffect(() => attachTo(ref.current, points, setStatus, attach), [points, attach]);
+  const stable = useStablePoints(points);
+  useEffect(() => attachTo(ref.current, stable, setStatus, attach), [stable, attach]);
   return { ref, status };
 }
 
@@ -125,7 +142,10 @@ function selectAt(clusters: readonly SpotCluster[], index: number, onSelect: (cl
 function BubbleOverlay({ clusters, dict, onSelect }: OverlayProps) {
   const circles = clusters.map((cluster, index) => toCircle(cluster, index, dict));
   const bubbles = bubblePlacements(circles).map((placement, index) => (
-    <ClusterBubble key={placement.region} placement={placement} dict={dict} onClick={() => { selectAt(clusters, index, onSelect); }} />
+    // Keyed by position, not by region name: two clusters >50km apart can share
+    // a city name (府中市 exists in both Tokyo and Hiroshima), and a duplicate
+    // key silently drops one bubble.
+    <ClusterBubble key={index} placement={placement} dict={dict} onClick={() => { selectAt(clusters, index, onSelect); }} />
   ));
   return <div className="chat-search-map__overlay chat-search-map__overlay--bubbles">{bubbles}</div>;
 }

--- a/apps/web/src/features/chat/components/SearchMap.tsx
+++ b/apps/web/src/features/chat/components/SearchMap.tsx
@@ -1,0 +1,143 @@
+import type { LatLng } from "@seichijunrei/contract";
+import { useEffect, useRef, useState } from "react";
+import type { CSSProperties, ReactNode, RefObject } from "react";
+import type { LocatedSpot, SpotCluster } from "../../../lib/chat/spotClusters";
+import { bubblePlacements, pointPlacements } from "../../bubble-map/bubbleGeometry";
+import type { BubblePlacement, PointPlacement } from "../../bubble-map/bubbleGeometry";
+import type { BasemapStatus, MountBasemapOptions } from "../../bubble-map/bubbleMapController";
+import { clusterName, spotCountBadge } from "../search-copy";
+import type { ChatDict } from "../i18n";
+import { MapFallback } from "./ErrorStates/MapFallback";
+
+/** Injectable mount so tests (and D7 simulations) never touch WebGL. */
+export type AttachBasemap = (options: MountBasemapOptions) => () => void;
+
+interface Basemap {
+  readonly ref: RefObject<HTMLDivElement | null>;
+  readonly status: BasemapStatus;
+}
+
+type StatusSetter = (status: BasemapStatus) => void;
+
+function attachTo(
+  container: HTMLDivElement | null,
+  points: readonly LatLng[],
+  onStatus: StatusSetter,
+  attach: AttachBasemap,
+): (() => void) | undefined {
+  if (!container || points.length === 0) return undefined;
+  return attach({ container, points, onStatus, interactive: false });
+}
+
+function useBasemap(points: readonly LatLng[], attach: AttachBasemap): Basemap {
+  const ref = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState<BasemapStatus>("loading");
+  useEffect(() => attachTo(ref.current, points, setStatus, attach), [points, attach]);
+  return { ref, status };
+}
+
+type FrameProps = Readonly<{
+  basemap: Basemap;
+  role: "img" | "group";
+  label: string;
+  children: ReactNode;
+}>;
+
+function MapFrame({ basemap, role, label, children }: FrameProps) {
+  return (
+    <div className="chat-search-map" role={role} aria-label={label}>
+      <div ref={basemap.ref} className="chat-search-map__gl" aria-hidden />
+      {children}
+    </div>
+  );
+}
+
+function percentStyle(placement: PointPlacement): CSSProperties {
+  return { left: `${String(placement.leftPct)}%`, top: `${String(placement.topPct)}%` };
+}
+
+function PinOverlay({ spots }: Readonly<{ spots: readonly LocatedSpot[] }>) {
+  const placements = pointPlacements(spots.map((spot) => spot.coord));
+  const pins = placements.map((placement, index) => (
+    <span key={spots[index]?.id ?? String(index)} className="chat-map-pin" style={percentStyle(placement)} />
+  ));
+  return <div className="chat-search-map__overlay">{pins}</div>;
+}
+
+type SpotMapProps = Readonly<{ spots: readonly LocatedSpot[]; dict: ChatDict; attach: AttachBasemap; maxPins: number }>;
+
+function SpotMapFallback({ spots, dict }: Readonly<{ spots: readonly LocatedSpot[]; dict: ChatDict }>) {
+  const first = spots[0];
+  return <MapFallback dict={dict} lat={first?.coord.lat} lng={first?.coord.lng} />;
+}
+
+/** C3a static map: framed basemap + ≤50 DOM pins; tile failure degrades to D7. */
+export function StaticSpotMap({ spots, dict, attach, maxPins }: SpotMapProps) {
+  const shown = spots.slice(0, maxPins);
+  const basemap = useBasemap(shown.map((spot) => spot.coord), attach);
+  if (basemap.status === "fallback") return <SpotMapFallback spots={spots} dict={dict} />;
+  return (
+    <MapFrame basemap={basemap} role="img" label={dict.search.mapLabel}>
+      <PinOverlay spots={shown} />
+    </MapFrame>
+  );
+}
+
+function bubbleStyle(placement: BubblePlacement): CSSProperties {
+  const size = placement.radius * 2;
+  return { width: size, height: size, ...percentStyle(placement) };
+}
+
+type BubbleProps = Readonly<{ placement: BubblePlacement; dict: ChatDict; onClick: () => void }>;
+
+function ClusterBubble({ placement, dict, onClick }: BubbleProps) {
+  return (
+    <button type="button" className="chat-map-bubble" style={bubbleStyle(placement)} onClick={onClick}>
+      <span className="chat-map-bubble__name">{placement.region}</span>
+      <span className="chat-map-bubble__count">{spotCountBadge(placement.count, dict)}</span>
+    </button>
+  );
+}
+
+type BubbleMapProps = Readonly<{
+  clusters: readonly SpotCluster[];
+  dict: ChatDict;
+  attach: AttachBasemap;
+  onSelect: (cluster: SpotCluster) => void;
+}>;
+
+type OverlayProps = Omit<BubbleMapProps, "attach">;
+
+function toCircle(cluster: SpotCluster, index: number, dict: ChatDict) {
+  return {
+    region: clusterName(cluster, index, dict),
+    count: cluster.spots.length,
+    lat: cluster.center.lat,
+    lng: cluster.center.lng,
+  };
+}
+
+function selectAt(clusters: readonly SpotCluster[], index: number, onSelect: (cluster: SpotCluster) => void): void {
+  const cluster = clusters[index];
+  if (cluster) onSelect(cluster);
+}
+
+function BubbleOverlay({ clusters, dict, onSelect }: OverlayProps) {
+  const circles = clusters.map((cluster, index) => toCircle(cluster, index, dict));
+  const bubbles = bubblePlacements(circles).map((placement, index) => (
+    <ClusterBubble key={placement.region} placement={placement} dict={dict} onClick={() => { selectAt(clusters, index, onSelect); }} />
+  ));
+  return <div className="chat-search-map__overlay chat-search-map__overlay--bubbles">{bubbles}</div>;
+}
+
+/** C3b overview: bubbles only (area ∝ count) — this zoom never draws pins. */
+export function ClusterBubbleMap({ clusters, dict, attach, onSelect }: BubbleMapProps) {
+  const basemap = useBasemap(clusters.map((cluster) => cluster.center), attach);
+  const first = clusters[0];
+  if (basemap.status === "fallback") return <MapFallback dict={dict} lat={first?.center.lat} lng={first?.center.lng} />;
+  return (
+    <MapFrame basemap={basemap} role="group" label={dict.search.mapLabel}>
+      <BubbleOverlay clusters={clusters} dict={dict} onSelect={onSelect} />
+    </MapFrame>
+  );
+}

--- a/apps/web/src/features/chat/components/SearchResult.tsx
+++ b/apps/web/src/features/chat/components/SearchResult.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { MAX_MAP_PINS, searchMapView, topSpots } from "../../../lib/chat/spotClusters";
+import type { SearchSpot, SpotCluster } from "../../../lib/chat/spotClusters";
+import { attachBasemap } from "../../bubble-map/bubbleMapController";
+import { episodeTag } from "../search-copy";
+import type { ChatDict } from "../i18n";
+import { EnvelopeFallback } from "./ErrorStates/EnvelopeFallback";
+import { SceneThumb } from "./ErrorStates/SceneThumb";
+import { ClusterBubbleMap, StaticSpotMap } from "./SearchMap";
+import type { AttachBasemap } from "./SearchMap";
+
+type SpotProps = Readonly<{ spot: SearchSpot; dict: ChatDict }>;
+type GridProps = Readonly<{ spots: readonly SearchSpot[]; dict: ChatDict }>;
+type ClusterProps = Readonly<{ cluster: SpotCluster; dict: ChatDict; attach: AttachBasemap }>;
+
+function SpotPick({ spot, dict }: SpotProps) {
+  return (
+    <label className="chat-spot-card__pick">
+      <input type="checkbox" className="chat-spot-card__check" aria-label={`${dict.search.select}: ${spot.name}`} />
+      <span className="chat-spot-card__name">{spot.name}</span>
+    </label>
+  );
+}
+
+/** C3a card: screenshot cover (D9-degrading) + episode tag + checkbox. */
+function SpotCard({ spot, dict }: SpotProps) {
+  const ep = episodeTag(dict, spot.ep);
+  return (
+    <li className="chat-spot-card">
+      <SceneThumb src={spot.screenshotUrl} alt={spot.name} ep={spot.ep} dict={dict} />
+      {ep ? <span className="chat-spot-card__ep">{ep}</span> : null}
+      <SpotPick spot={spot} dict={dict} />
+    </li>
+  );
+}
+
+export function SpotCardGrid({ spots, dict }: GridProps) {
+  return (
+    <ul className="chat-spot-grid">
+      {topSpots(spots).map((spot) => (
+        <SpotCard key={spot.id} spot={spot} dict={dict} />
+      ))}
+    </ul>
+  );
+}
+
+function SingleClusterView({ cluster, dict, attach }: ClusterProps) {
+  return (
+    <div className="chat-search-result">
+      <SpotCardGrid spots={cluster.spots} dict={dict} />
+      <StaticSpotMap spots={cluster.spots} dict={dict} attach={attach} maxPins={MAX_MAP_PINS} />
+    </div>
+  );
+}
+
+/** No locatable spot: the D2 state (issue #272 S1.6), never a silently empty map. */
+function EmptyMapState({ spots, dict }: GridProps) {
+  return (
+    <div className="chat-search-result">
+      {spots.length > 0 ? <SpotCardGrid spots={spots} dict={dict} /> : null}
+      <EnvelopeFallback state="D2" dict={dict} />
+    </div>
+  );
+}
+
+type SearchResultProps = Readonly<{ spots: readonly SearchSpot[]; dict: ChatDict; attach?: AttachBasemap }>;
+
+/**
+ * C3a/C3b search content shape (issue #261 S1.4): a single cluster renders the
+ * top-6 spot cards + a static pinned map; a multi-cluster (or >50km) result
+ * renders the bubble overview, and selecting a bubble drills into C3a.
+ */
+export function SearchResult({ spots, dict, attach = attachBasemap }: SearchResultProps) {
+  const view = searchMapView(spots);
+  const [drill, setDrill] = useState<SpotCluster | null>(null);
+  if (view.kind === "empty") return <EmptyMapState spots={spots} dict={dict} />;
+  if (view.kind === "single") return <SingleClusterView cluster={view.cluster} dict={dict} attach={attach} />;
+  if (drill !== null) return <SingleClusterView cluster={drill} dict={dict} attach={attach} />;
+  return <ClusterBubbleMap clusters={view.clusters} dict={dict} attach={attach} onSelect={setDrill} />;
+}

--- a/apps/web/src/features/chat/components/cards.tsx
+++ b/apps/web/src/features/chat/components/cards.tsx
@@ -1,6 +1,8 @@
 import type { ChatDataPart } from "@seichijunrei/contract";
+import { toSearchSpots } from "../../../lib/chat/spotClusters";
 import type { ChatDict } from "../i18n";
 import { SceneThumb } from "./ErrorStates/SceneThumb";
+import { SearchResult } from "./SearchResult";
 
 export type IntentCardProps = Readonly<{ part: ChatDataPart; dict: ChatDict }>;
 
@@ -31,6 +33,11 @@ type SpotRow = Readonly<{
   screenshot_url?: string;
   ep?: number;
   episode?: number;
+  lat?: number;
+  lng?: number;
+  latitude?: number;
+  longitude?: number;
+  city?: string;
 }>;
 
 /** Streamed routes may carry spots only as `route.ordered_points` objects. */
@@ -69,12 +76,13 @@ function SpotList({ part, dict }: IntentCardProps) {
   return <ul className="chat-card__spots">{items}</ul>;
 }
 
+/** C3a/C3b search shape (issue #261 S1.4): spot cards + static map / bubbles. */
 export function SearchCard({ part, dict }: IntentCardProps) {
   const results = resultsOf(part);
   return (
     <div className="chat-card__body">
       {results?.title ? <p className="chat-card__title">{results.title}</p> : null}
-      <SpotList part={part} dict={dict} />
+      <SearchResult spots={toSearchSpots(spotsOf(part))} dict={dict} />
     </div>
   );
 }

--- a/apps/web/src/features/chat/i18n.ts
+++ b/apps/web/src/features/chat/i18n.ts
@@ -23,6 +23,14 @@ export interface ChatErrorStatesDict {
   readonly d9Episode: string;
 }
 
+/** Copy for the C3a/C3b search result cards and static map (issue #261 S1.4). */
+export interface ChatSearchDict {
+  readonly select: string;
+  readonly spotCount: string;
+  readonly areaFallback: string;
+  readonly mapLabel: string;
+}
+
 /** Tools whose step badges surface to the user as localized progress copy. */
 export const TOOL_STEP_KEYS = [
   "resolve_anime",
@@ -71,7 +79,29 @@ export interface ChatDict {
   readonly footprintDetails: string;
   readonly errorStates: ChatErrorStatesDict;
   readonly toolSteps: ChatToolStepsDict;
+  readonly search: ChatSearchDict;
 }
+
+const jaSearch: ChatSearchDict = {
+  select: "この聖地をえらぶ",
+  spotCount: "{count}件",
+  areaFallback: "エリア{n}",
+  mapLabel: "聖地マップ",
+};
+
+const zhSearch: ChatSearchDict = {
+  select: "选择这个圣地",
+  spotCount: "{count} 处",
+  areaFallback: "区域{n}",
+  mapLabel: "圣地地图",
+};
+
+const enSearch: ChatSearchDict = {
+  select: "Select this spot",
+  spotCount: "{count} spots",
+  areaFallback: "Area {n}",
+  mapLabel: "Spot map",
+};
 
 const jaToolSteps: ChatToolStepsDict = {
   labels: {
@@ -202,6 +232,7 @@ const ja: ChatDict = {
   footprintDetails: "詳細を見る",
   errorStates: jaErrorStates,
   toolSteps: jaToolSteps,
+  search: jaSearch,
 };
 
 const zh: ChatDict = {
@@ -221,6 +252,7 @@ const zh: ChatDict = {
   footprintDetails: "查看详情",
   errorStates: zhErrorStates,
   toolSteps: zhToolSteps,
+  search: zhSearch,
 };
 
 const en: ChatDict = {
@@ -244,6 +276,7 @@ const en: ChatDict = {
   footprintDetails: "View details",
   errorStates: enErrorStates,
   toolSteps: enToolSteps,
+  search: enSearch,
 };
 
 const CHAT_DICTIONARIES: Record<Locale, ChatDict> = { ja, zh, en };

--- a/apps/web/src/features/chat/search-copy.ts
+++ b/apps/web/src/features/chat/search-copy.ts
@@ -1,0 +1,18 @@
+import type { SpotCluster } from "../../lib/chat/spotClusters";
+import type { ChatDict } from "./i18n";
+
+/** Cluster display name: the majority city, else a localized area fallback. */
+export function clusterName(cluster: SpotCluster, index: number, dict: ChatDict): string {
+  return cluster.city ?? dict.search.areaFallback.replace("{n}", String(index + 1));
+}
+
+/** Localized spot-count badge for a cluster bubble (C3b). */
+export function spotCountBadge(count: number, dict: ChatDict): string {
+  return dict.search.spotCount.replace("{count}", String(count));
+}
+
+/** Localized episode tag for a spot card (C3a); undefined when unknown. */
+export function episodeTag(dict: ChatDict, ep?: number): string | undefined {
+  if (ep === undefined) return undefined;
+  return dict.errorStates.d9Episode.replace("{ep}", String(ep));
+}

--- a/apps/web/src/lib/chat/spotClusters.ts
+++ b/apps/web/src/lib/chat/spotClusters.ts
@@ -56,14 +56,23 @@ function coordOf(row: SpotRowLike): LatLng | undefined {
   return { lat, lng };
 }
 
+/** Upstream never omits these fields — it sends sentinels. `screenshot_url` is a
+ * required string that the catalog worker fills with `""` when there is no image
+ * (`r.image ?? ""`), and `episode` carries pydantic's `-1` unknown-marker. Both
+ * arrive here via the agent's full `model_dump()`, so an `=== undefined` check
+ * would never fire in production even though it passes against hand-written
+ * fixtures. Normalize the sentinels to `undefined` once, here. */
 function toSearchSpot(row: SpotRowLike, index: number): SearchSpot {
   const id = row.id ?? row.name ?? `spot-${String(index)}`;
-  const ep = row.ep ?? row.episode;
-  return { id, name: row.name ?? "", screenshotUrl: row.screenshot_url, ep, city: row.city, coord: coordOf(row) };
+  const rawEp = row.ep ?? row.episode;
+  const ep = rawEp !== undefined && rawEp >= 0 ? rawEp : undefined;
+  // Not `??`: the sentinel is the empty string, which `??` passes straight through.
+  const screenshotUrl = row.screenshot_url === "" ? undefined : row.screenshot_url;
+  return { id, name: row.name ?? "", screenshotUrl, ep, city: row.city, coord: coordOf(row) };
 }
 
 export function toSearchSpots(rows: readonly SpotRowLike[]): readonly SearchSpot[] {
-  return rows.map(toSearchSpot);
+  return rows.map((row, index) => toSearchSpot(row, index));
 }
 
 export function locatedSpots(spots: readonly SearchSpot[]): readonly LocatedSpot[] {

--- a/apps/web/src/lib/chat/spotClusters.ts
+++ b/apps/web/src/lib/chat/spotClusters.ts
@@ -1,0 +1,158 @@
+import type { LatLng } from "@seichijunrei/contract";
+
+/** C3a shows at most this many spot cards (spec-chat-page-states §C3a). */
+export const TOP_SPOT_COUNT = 6;
+/** The static map never draws more pins than this (spec-chat-page-states §C3a). */
+export const MAX_MAP_PINS = 50;
+/** C3b threshold: cluster link distance and the max single-cluster envelope, in km. */
+export const CLUSTER_SPAN_KM = 50;
+
+/** One search result spot, normalized from a streamed row. */
+export interface SearchSpot {
+  readonly id: string;
+  readonly name: string;
+  readonly screenshotUrl?: string;
+  readonly ep?: number;
+  readonly city?: string;
+  readonly coord?: LatLng;
+}
+
+/** A spot that carries usable coordinates and can be placed on the map. */
+export interface LocatedSpot extends SearchSpot {
+  readonly coord: LatLng;
+}
+
+/** A geographic cluster of located spots with its centroid and majority city. */
+export interface SpotCluster {
+  readonly spots: readonly LocatedSpot[];
+  readonly center: LatLng;
+  readonly city?: string;
+}
+
+/** Which C3 shape the search result renders (spec-chat-page-states §C3a/C3b). */
+export type SearchMapView =
+  | { readonly kind: "empty" }
+  | { readonly kind: "single"; readonly cluster: SpotCluster }
+  | { readonly kind: "multi"; readonly clusters: readonly SpotCluster[] };
+
+/** Loose row shape as streamed: coordinates and episode arrive under two names. */
+export interface SpotRowLike {
+  readonly id?: string;
+  readonly name?: string;
+  readonly lat?: number;
+  readonly lng?: number;
+  readonly latitude?: number;
+  readonly longitude?: number;
+  readonly screenshot_url?: string;
+  readonly ep?: number;
+  readonly episode?: number;
+  readonly city?: string;
+}
+
+function coordOf(row: SpotRowLike): LatLng | undefined {
+  const lat = row.lat ?? row.latitude;
+  const lng = row.lng ?? row.longitude;
+  if (lat === undefined || lng === undefined) return undefined;
+  return { lat, lng };
+}
+
+function toSearchSpot(row: SpotRowLike, index: number): SearchSpot {
+  const id = row.id ?? row.name ?? `spot-${String(index)}`;
+  const ep = row.ep ?? row.episode;
+  return { id, name: row.name ?? "", screenshotUrl: row.screenshot_url, ep, city: row.city, coord: coordOf(row) };
+}
+
+export function toSearchSpots(rows: readonly SpotRowLike[]): readonly SearchSpot[] {
+  return rows.map(toSearchSpot);
+}
+
+export function locatedSpots(spots: readonly SearchSpot[]): readonly LocatedSpot[] {
+  return spots.flatMap((spot) => (spot.coord ? [{ ...spot, coord: spot.coord }] : []));
+}
+
+const EARTH_RADIUS_KM = 6371;
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+/** Great-circle (haversine) distance between two coordinates, in km. */
+export function distanceKm(a: LatLng, b: LatLng): number {
+  const sinLat = Math.sin(toRadians(b.lat - a.lat) / 2);
+  const sinLng = Math.sin(toRadians(b.lng - a.lng) / 2);
+  const h = sinLat * sinLat + Math.cos(toRadians(a.lat)) * Math.cos(toRadians(b.lat)) * sinLng * sinLng;
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h));
+}
+
+interface ClusterDraft {
+  spots: LocatedSpot[];
+  latSum: number;
+  lngSum: number;
+}
+
+function draftCenter(draft: ClusterDraft): LatLng {
+  const n = draft.spots.length;
+  return { lat: draft.latSum / n, lng: draft.lngSum / n };
+}
+
+function addToDraft(draft: ClusterDraft, spot: LocatedSpot): void {
+  draft.spots.push(spot);
+  draft.latSum += spot.coord.lat;
+  draft.lngSum += spot.coord.lng;
+}
+
+function placeSpot(drafts: ClusterDraft[], spot: LocatedSpot): void {
+  const near = drafts.find((draft) => distanceKm(draftCenter(draft), spot.coord) <= CLUSTER_SPAN_KM);
+  if (near) {
+    addToDraft(near, spot);
+    return;
+  }
+  drafts.push({ spots: [spot], latSum: spot.coord.lat, lngSum: spot.coord.lng });
+}
+
+function majorityCity(spots: readonly LocatedSpot[]): string | undefined {
+  const counts = new Map<string, number>();
+  for (const spot of spots) {
+    if (spot.city) counts.set(spot.city, (counts.get(spot.city) ?? 0) + 1);
+  }
+  const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  return ranked[0]?.[0];
+}
+
+function finishDraft(draft: ClusterDraft): SpotCluster {
+  return { spots: draft.spots, center: draftCenter(draft), city: majorityCity(draft.spots) };
+}
+
+/** Greedy centroid clustering: a spot joins the first cluster within 50km. */
+export function clusterSpots(spots: readonly LocatedSpot[]): readonly SpotCluster[] {
+  const drafts: ClusterDraft[] = [];
+  for (const spot of spots) placeSpot(drafts, spot);
+  return drafts.map(finishDraft);
+}
+
+/** Diagonal span of the bounding box around every located spot, in km. */
+export function envelopeKm(spots: readonly LocatedSpot[]): number {
+  const lats = spots.map((spot) => spot.coord.lat);
+  const lngs = spots.map((spot) => spot.coord.lng);
+  const southwest = { lat: Math.min(...lats), lng: Math.min(...lngs) };
+  const northeast = { lat: Math.max(...lats), lng: Math.max(...lngs) };
+  return distanceKm(southwest, northeast);
+}
+
+/** C3b when ≥2 clusters or a >50km envelope; otherwise C3a (spec §C3a/C3b). */
+export function searchMapView(spots: readonly SearchSpot[]): SearchMapView {
+  const located = locatedSpots(spots);
+  const [first, ...rest] = clusterSpots(located);
+  if (first === undefined) return { kind: "empty" };
+  if (rest.length > 0 || envelopeKm(located) > CLUSTER_SPAN_KM) return { kind: "multi", clusters: [first, ...rest] };
+  return { kind: "single", cluster: first };
+}
+
+function photoRank(spot: SearchSpot): number {
+  return spot.screenshotUrl === undefined ? 1 : 0;
+}
+
+/** Top-6 cards: photo-carrying spots first, upstream (relevance) order preserved. */
+export function topSpots(spots: readonly SearchSpot[]): readonly SearchSpot[] {
+  return [...spots].sort((a, b) => photoRank(a) - photoRank(b)).slice(0, TOP_SPOT_COUNT);
+}

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -475,3 +475,119 @@
     transform: translateY(-0.3rem);
   }
 }
+
+/* C3a/C3b search result shapes (issue #261 S1.4) */
+
+.chat-search-result {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chat-spot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.chat-spot-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-card);
+  box-shadow: 0 2px 0 var(--shadow-3d);
+}
+
+.chat-spot-card .chat-scene-thumb {
+  width: 100%;
+  height: 5rem;
+}
+
+.chat-spot-card__ep {
+  align-self: flex-start;
+  padding: 0 0.375rem;
+  border-radius: 6px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  background: var(--color-primary-soft);
+  color: var(--color-primary-strong);
+}
+
+.chat-spot-card__pick {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+  color: var(--color-fg);
+}
+
+.chat-spot-card__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-search-map {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  background: var(--color-muted);
+}
+
+.chat-search-map__gl {
+  position: absolute;
+  inset: 0;
+}
+
+.chat-search-map__overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.chat-map-pin {
+  position: absolute;
+  width: 0.75rem;
+  height: 0.75rem;
+  transform: translate(-50%, -100%);
+  border-radius: 50% 50% 50% 0;
+  background: var(--color-map-pin-teal);
+  border: 2px solid var(--color-bg);
+}
+
+.chat-map-bubble {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transform: translate(-50%, -50%);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: var(--color-primary-fg);
+  font-size: 0.625rem;
+  font-weight: 700;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.chat-map-bubble__name {
+  max-width: 90%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-map-bubble__count {
+  font-size: 0.8125rem;
+  color: var(--color-primary-fg);
+}

--- a/apps/web/tests/unit/chat/search-card-c3a.test.tsx
+++ b/apps/web/tests/unit/chat/search-card-c3a.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SearchResult } from "../../../src/features/chat/components/SearchResult";
+import type { AttachBasemap } from "../../../src/features/chat/components/SearchMap";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { toSearchSpots } from "../../../src/lib/chat/spotClusters";
+import type { SpotRowLike } from "../../../src/lib/chat/spotClusters";
+
+afterEach(cleanup);
+
+const dict = chatDictFor("ja");
+const attachReady: AttachBasemap = ({ onStatus }) => {
+  onStatus("ready");
+  return () => undefined;
+};
+
+function ujiRow(index: number, screenshot?: string): SpotRowLike {
+  return {
+    id: `p${String(index)}`,
+    name: `spot-${String(index)}`,
+    lat: 34.89 + index * 0.001,
+    lng: 135.8,
+    screenshot_url: screenshot,
+    ep: 8,
+  };
+}
+
+function renderSingle(rows: readonly SpotRowLike[]) {
+  return render(<SearchResult spots={toSearchSpots(rows)} dict={dict} attach={attachReady} />);
+}
+
+describe("C3a spot cards (AC: top-6 cards, cover + episode tag + checkbox)", () => {
+  it("renders at most six cards, photo-carrying spots first", () => {
+    const rows = [ujiRow(0), ...Array.from({ length: 7 }, (_, i) => ujiRow(i + 1, `/s${String(i + 1)}.webp`))];
+    renderSingle(rows);
+    expect(screen.getAllByRole("checkbox")).toHaveLength(6);
+    expect(screen.queryByText("spot-0")).toBeNull();
+    expect(screen.getByText("spot-1")).toBeTruthy();
+  });
+
+  it("shows the screenshot cover, episode tag, and a labelled checkbox on each card", () => {
+    renderSingle([ujiRow(1, "/s1.webp"), ujiRow(2, "/s2.webp")]);
+    expect(document.querySelectorAll("img.chat-scene-thumb")).toHaveLength(2);
+    expect(screen.getAllByText("第8話")).toHaveLength(2);
+    expect(screen.getByRole("checkbox", { name: `${dict.search.select}: spot-1` })).toBeTruthy();
+  });
+});
+
+describe("C3a static map (AC: static map with ≤50 pins)", () => {
+  it("mounts the basemap container with one pin per spot", () => {
+    renderSingle([ujiRow(1, "/s1.webp"), ujiRow(2, "/s2.webp"), ujiRow(3)]);
+    expect(document.querySelector(".chat-search-map__gl")).toBeTruthy();
+    expect(screen.getByRole("img", { name: dict.search.mapLabel })).toBeTruthy();
+    expect(document.querySelectorAll(".chat-map-pin")).toHaveLength(3);
+  });
+
+  it("never draws more than fifty pins even for a sixty-spot cluster", () => {
+    renderSingle(Array.from({ length: 60 }, (_, index) => ujiRow(index, "/s.webp")));
+    expect(document.querySelectorAll(".chat-map-pin")).toHaveLength(50);
+  });
+});

--- a/apps/web/tests/unit/chat/search-card-c3b.test.tsx
+++ b/apps/web/tests/unit/chat/search-card-c3b.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SearchResult } from "../../../src/features/chat/components/SearchResult";
+import type { AttachBasemap } from "../../../src/features/chat/components/SearchMap";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { toSearchSpots } from "../../../src/lib/chat/spotClusters";
+import type { SpotRowLike } from "../../../src/lib/chat/spotClusters";
+
+afterEach(cleanup);
+
+const dict = chatDictFor("ja");
+const attachReady: AttachBasemap = ({ onStatus }) => {
+  onStatus("ready");
+  return () => undefined;
+};
+
+function row(id: string, lat: number, lng: number, city: string): SpotRowLike {
+  return { id, name: id, lat, lng, city, screenshot_url: "/s.webp" };
+}
+
+const TWO_CLUSTERS: readonly SpotRowLike[] = [
+  row("u1", 34.89, 135.8, "宇治市"),
+  row("u2", 34.9, 135.81, "宇治市"),
+  row("u3", 34.91, 135.8, "宇治市"),
+  row("t1", 35.69, 139.7, "新宿区"),
+  row("t2", 35.7, 139.71, "新宿区"),
+];
+
+function renderMulti() {
+  return render(<SearchResult spots={toSearchSpots(TWO_CLUSTERS)} dict={dict} attach={attachReady} />);
+}
+
+function bubbleWidth(name: string): number {
+  const bubble = screen.getByRole("button", { name: new RegExp(name) });
+  return Number.parseFloat(bubble.style.width);
+}
+
+describe("C3b bubble overview (AC: bubbles only, area ∝ count, badge)", () => {
+  it("renders one bubble per cluster and never an individual pin", () => {
+    renderMulti();
+    expect(document.querySelectorAll(".chat-map-bubble")).toHaveLength(2);
+    expect(document.querySelectorAll(".chat-map-pin")).toHaveLength(0);
+    expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+  });
+
+  it("labels each bubble with its place name and localized count badge", () => {
+    renderMulti();
+    expect(screen.getByText("宇治市")).toBeTruthy();
+    expect(screen.getByText("新宿区")).toBeTruthy();
+    expect(screen.getByText("3件")).toBeTruthy();
+    expect(screen.getByText("2件")).toBeTruthy();
+  });
+
+  it("scales bubble size with spot count (area ∝ count)", () => {
+    renderMulti();
+    expect(bubbleWidth("宇治市")).toBeGreaterThan(bubbleWidth("新宿区"));
+  });
+
+  it("drills into the C3a single-cluster view when a bubble is selected", () => {
+    renderMulti();
+    fireEvent.click(screen.getByRole("button", { name: /宇治市/ }));
+    expect(document.querySelectorAll(".chat-map-bubble")).toHaveLength(0);
+    expect(screen.getAllByRole("checkbox")).toHaveLength(3);
+    expect(document.querySelectorAll(".chat-map-pin")).toHaveLength(3);
+  });
+});

--- a/apps/web/tests/unit/chat/search-copy-i18n.test.ts
+++ b/apps/web/tests/unit/chat/search-copy-i18n.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { clusterName, episodeTag, spotCountBadge } from "../../../src/features/chat/search-copy";
+import type { LocatedSpot, SpotCluster } from "../../../src/lib/chat/spotClusters";
+import { LOCALES } from "../../../src/i18n/locales";
+
+const CENTER = { lat: 34.89, lng: 135.8 };
+const NO_SPOTS: readonly LocatedSpot[] = [];
+
+function cluster(city?: string): SpotCluster {
+  return { spots: NO_SPOTS, center: CENTER, city };
+}
+
+function searchValuesOf(locale: (typeof LOCALES)[number]): readonly string[] {
+  const search = chatDictFor(locale).search;
+  return [search.select, search.spotCount, search.areaFallback, search.mapLabel];
+}
+
+describe("cluster names across locales (AC: i18n)", () => {
+  it.each(LOCALES)("passes the place name through untouched for %s", (locale) => {
+    expect(clusterName(cluster("宇治市"), 0, chatDictFor(locale))).toBe("宇治市");
+  });
+
+  it("localizes the nameless-area fallback per locale", () => {
+    expect(clusterName(cluster(), 0, chatDictFor("ja"))).toBe("エリア1");
+    expect(clusterName(cluster(), 0, chatDictFor("zh"))).toBe("区域1");
+    expect(clusterName(cluster(), 0, chatDictFor("en"))).toBe("Area 1");
+  });
+
+  it("numbers fallback areas from one, not zero", () => {
+    expect(clusterName(cluster(), 2, chatDictFor("en"))).toBe("Area 3");
+  });
+});
+
+describe("count badges across locales (AC: i18n)", () => {
+  it("localizes the spot-count badge per locale", () => {
+    expect(spotCountBadge(12, chatDictFor("ja"))).toBe("12件");
+    expect(spotCountBadge(12, chatDictFor("zh"))).toBe("12 处");
+    expect(spotCountBadge(12, chatDictFor("en"))).toBe("12 spots");
+  });
+
+  it.each(LOCALES)("keeps every %s search string non-empty", (locale) => {
+    for (const value of searchValuesOf(locale)) {
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("episode tags", () => {
+  it("localizes the episode tag via the shared d9 template", () => {
+    expect(episodeTag(chatDictFor("ja"), 8)).toBe("第8話");
+    expect(episodeTag(chatDictFor("en"), 8)).toBe("Ep. 8");
+  });
+
+  it("returns undefined when the episode is unknown", () => {
+    expect(episodeTag(chatDictFor("ja"))).toBeUndefined();
+  });
+});

--- a/apps/web/tests/unit/chat/search-map-fallbacks.test.tsx
+++ b/apps/web/tests/unit/chat/search-map-fallbacks.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatActionsProvider } from "../../../src/features/chat/chat-actions";
+import { SearchResult } from "../../../src/features/chat/components/SearchResult";
+import type { AttachBasemap } from "../../../src/features/chat/components/SearchMap";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { toSearchSpots } from "../../../src/lib/chat/spotClusters";
+import type { SpotRowLike } from "../../../src/lib/chat/spotClusters";
+
+afterEach(cleanup);
+
+const dict = chatDictFor("ja");
+const attachBroken: AttachBasemap = ({ onStatus }) => {
+  onStatus("fallback");
+  return () => undefined;
+};
+
+function renderResult(rows: readonly SpotRowLike[], attach?: AttachBasemap) {
+  return render(
+    <ChatActionsProvider actions={{ send: vi.fn(), regenerate: vi.fn() }}>
+      <SearchResult spots={toSearchSpots(rows)} dict={dict} attach={attach} />
+    </ChatActionsProvider>,
+  );
+}
+
+describe("empty map view (AC: D2 state, never a silently empty map)", () => {
+  it("renders the D2 zero-spots state when no spot carries coordinates", () => {
+    renderResult([{ id: "a", name: "無座標の聖地" }]);
+    expect(document.querySelector('[data-fallback="D2"]')).toBeTruthy();
+    expect(screen.getByText(dict.errorStates.d2Title)).toBeTruthy();
+    expect(document.querySelector(".chat-search-map")).toBeNull();
+  });
+
+  it("still lists the coordinate-less spots as cards next to the D2 state", () => {
+    renderResult([{ id: "a", name: "無座標の聖地" }]);
+    expect(screen.getByText("無座標の聖地")).toBeTruthy();
+  });
+});
+
+describe("map load failure (AC: D7 doodle + external map link)", () => {
+  const located = [
+    { id: "u1", name: "宇治橋", lat: 34.89, lng: 135.8 },
+    { id: "u2", name: "京阪宇治駅", lat: 34.9, lng: 135.81 },
+  ];
+
+  it("degrades the C3a static map to the D7 placeholder with the map-app link", () => {
+    renderResult(located, attachBroken);
+    expect(screen.getByText(dict.errorStates.d7Message)).toBeTruthy();
+    const link = screen.getByRole("link", { name: "地図アプリで開く" });
+    expect(link.getAttribute("href")).toContain("34.89,135.8");
+    expect(document.querySelector(".chat-search-map__gl")).toBeNull();
+    expect(document.querySelector(".chat-map-fallback__doodle")).toBeTruthy();
+  });
+
+  it("degrades the C3b bubble map the same way", () => {
+    renderResult([...located, { id: "t1", name: "須賀神社", lat: 35.69, lng: 139.7 }], attachBroken);
+    expect(screen.getByText(dict.errorStates.d7Message)).toBeTruthy();
+    expect(screen.getByRole("link", { name: dict.errorStates.d7Open })).toBeTruthy();
+    expect(document.querySelectorAll(".chat-map-bubble")).toHaveLength(0);
+  });
+});

--- a/apps/web/tests/unit/chat/spot-clusters.test.ts
+++ b/apps/web/tests/unit/chat/spot-clusters.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  clusterSpots,
+  distanceKm,
+  envelopeKm,
+  locatedSpots,
+  searchMapView,
+  toSearchSpots,
+  topSpots,
+} from "../../../src/lib/chat/spotClusters";
+import type { LocatedSpot } from "../../../src/lib/chat/spotClusters";
+
+const UJI = { lat: 34.89, lng: 135.8 };
+const TOKYO = { lat: 35.69, lng: 139.7 };
+
+function located(id: string, lat: number, lng: number, city?: string): LocatedSpot {
+  return { id, name: id, city, coord: { lat, lng } };
+}
+
+describe("toSearchSpots row normalization", () => {
+  it("reads coordinates and episode under both streamed field names", () => {
+    const spots = toSearchSpots([
+      { id: "a", name: "A", lat: 34.89, lng: 135.8, ep: 8 },
+      { id: "b", name: "B", latitude: 34.9, longitude: 135.81, episode: 3 },
+    ]);
+    expect(spots[0]?.coord).toEqual({ lat: 34.89, lng: 135.8 });
+    expect(spots[1]?.coord).toEqual({ lat: 34.9, lng: 135.81 });
+    expect(spots.map((spot) => spot.ep)).toEqual([8, 3]);
+  });
+
+  it("keeps coordinate-less rows but excludes them from located spots", () => {
+    const spots = toSearchSpots([{ id: "a", name: "A" }, { id: "b", name: "B", lat: 1, lng: 2 }]);
+    expect(spots).toHaveLength(2);
+    expect(locatedSpots(spots).map((spot) => spot.id)).toEqual(["b"]);
+  });
+});
+
+describe("distanceKm", () => {
+  it("measures Uji to Tokyo at roughly 365km", () => {
+    const km = distanceKm(UJI, TOKYO);
+    expect(km).toBeGreaterThan(340);
+    expect(km).toBeLessThan(390);
+  });
+});
+
+describe("clusterSpots", () => {
+  it("merges spots within 50km into one cluster with a majority city", () => {
+    const clusters = clusterSpots([
+      located("a", 34.89, 135.8, "宇治市"),
+      located("b", 34.9, 135.81, "宇治市"),
+      located("c", 34.95, 135.76, "京都市"),
+    ]);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]?.city).toBe("宇治市");
+    expect(clusters[0]?.spots).toHaveLength(3);
+  });
+
+  it("splits spots farther than 50km into separate clusters", () => {
+    const clusters = clusterSpots([located("a", UJI.lat, UJI.lng), located("b", TOKYO.lat, TOKYO.lng)]);
+    expect(clusters).toHaveLength(2);
+  });
+});
+
+describe("searchMapView", () => {
+  it("returns empty when no spot carries coordinates", () => {
+    expect(searchMapView(toSearchSpots([{ id: "a", name: "A" }])).kind).toBe("empty");
+  });
+
+  it("returns single for one tight cluster", () => {
+    const view = searchMapView([located("a", 34.89, 135.8), located("b", 34.9, 135.81)]);
+    expect(view.kind).toBe("single");
+  });
+
+  it("returns multi for two distant clusters", () => {
+    const view = searchMapView([located("a", UJI.lat, UJI.lng), located("b", TOKYO.lat, TOKYO.lng)]);
+    expect(view.kind).toBe("multi");
+  });
+
+  it("returns multi for a chained single cluster whose envelope exceeds 50km", () => {
+    const chain = [0, 0.2, 0.4, 0.5].map((step, index) => located(`c${String(index)}`, 34.5 + step, 135.8));
+    expect(clusterSpots(chain)).toHaveLength(1);
+    expect(envelopeKm(chain)).toBeGreaterThan(50);
+    expect(searchMapView(chain).kind).toBe("multi");
+  });
+});
+
+describe("topSpots", () => {
+  it("caps the cards at six", () => {
+    const spots = toSearchSpots(
+      Array.from({ length: 9 }, (_, index) => ({ id: `s${String(index)}`, name: `S${String(index)}`, screenshot_url: "/x.webp" })),
+    );
+    expect(topSpots(spots)).toHaveLength(6);
+  });
+
+  it("ranks photo-carrying spots first while preserving upstream order", () => {
+    const spots = toSearchSpots([
+      { id: "plain", name: "plain" },
+      { id: "p1", name: "p1", screenshot_url: "/1.webp" },
+      { id: "p2", name: "p2", screenshot_url: "/2.webp" },
+    ]);
+    expect(topSpots(spots).map((spot) => spot.id)).toEqual(["p1", "p2", "plain"]);
+  });
+});

--- a/apps/web/tests/unit/chat/spot-clusters.test.ts
+++ b/apps/web/tests/unit/chat/spot-clusters.test.ts
@@ -100,4 +100,36 @@ describe("topSpots", () => {
     ]);
     expect(topSpots(spots).map((spot) => spot.id)).toEqual(["p1", "p2", "plain"]);
   });
+
+  // Upstream never omits these fields. `screenshot_url` is required in the zod
+  // contract and the catalog worker fills it with "" when there is no image;
+  // `episode` carries pydantic's -1 unknown-marker. Fixtures that omit the keys
+  // let an `=== undefined` check pass while doing nothing in production.
+  it("ranks photo-first against the real contract shape, where absence is \"\" not undefined", () => {
+    const spots = toSearchSpots([
+      { id: "blank", name: "blank", screenshot_url: "" },
+      { id: "shot", name: "shot", screenshot_url: "/1.webp" },
+    ]);
+    expect(topSpots(spots).map((spot) => spot.id)).toEqual(["shot", "blank"]);
+  });
+});
+
+describe("toSearchSpots sentinel normalization", () => {
+  it("maps an empty screenshot_url to undefined so the card falls back to D9", () => {
+    const [spot] = toSearchSpots([{ id: "s", name: "s", screenshot_url: "" }]);
+    expect(spot?.screenshotUrl).toBeUndefined();
+  });
+
+  it("maps the -1 unknown-episode sentinel to undefined so no 第-1話 badge renders", () => {
+    const [spot] = toSearchSpots([{ id: "s", name: "s", screenshot_url: "/1.webp", episode: -1 }]);
+    expect(spot?.ep).toBeUndefined();
+  });
+
+  it("keeps a real episode number, including episode zero", () => {
+    const spots = toSearchSpots([
+      { id: "a", name: "a", screenshot_url: "/1.webp", episode: 0 },
+      { id: "b", name: "b", screenshot_url: "/1.webp", episode: 7 },
+    ]);
+    expect(spots.map((spot) => spot.ep)).toEqual([0, 7]);
+  });
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
         // as routes/_dev/map-spike.tsx.
         "src/features/bubble-map/BubbleMap.tsx",
       ],
-      thresholds: { statements: 90, branches: 90, functions: 90, lines: 90 },
+      thresholds: { statements: 95, branches: 94, functions: 95, lines: 95 },
     },
   },
 });


### PR DESCRIPTION
Closes #261

A single-cluster search result now renders the top-6 spot cards + a static MapLibre map; a multi-cluster result renders the nationwide bubble overview, and selecting a bubble drills into the single-cluster view.

## ACs and their tests (ac_total == ac_with_test == 5)

| AC | Test (all in `apps/web/tests/unit/chat/`) | Type |
|---|---|---|
| C3a: top-6 cards (popularity/photo-first, screenshot cover + episode tag + checkbox) + static map ≤50 pins | `search-card-c3a.test.tsx` — "renders at most six cards, photo-carrying spots first", "shows the screenshot cover, episode tag, and a labelled checkbox", "mounts the basemap container with one pin per spot", "never draws more than fifty pins even for a sixty-spot cluster" | browser (jsdom in-diff; live GL = Tester pass) |
| C3b: ≥2 clusters or >50km envelope → bubbles only (area ∝ count, numeric badge), never pins | `search-card-c3b.test.tsx` — "renders one bubble per cluster and never an individual pin", "scales bubble size with spot count", "labels each bubble…", plus drill-into-C3a click test | browser (jsdom in-diff; live GL = Tester pass) |
| Empty: 0 spots in view → D2 state, not a silently empty map | `search-map-fallbacks.test.tsx` — "renders the D2 zero-spots state when no spot carries coordinates" | browser (jsdom in-diff) |
| Error: tile/mount failure → D7 hand-drawn SVG + 「地図アプリで開く」 link | `search-map-fallbacks.test.tsx` — "degrades the C3a static map to the D7 placeholder with the map-app link" (+ C3b variant) | browser (jsdom in-diff) |
| i18n: cluster names + count badges under ja/zh/en | `search-copy-i18n.test.ts` (unit) | unit |

Also added: `spot-clusters.test.ts` (pure clustering/haversine/envelope/top-6 math).

## Reused vs written fresh

**Reused (promoted from spikes / #420):**
- `bubble-map/bubbleMapController.ts` — generalized from circles to `attachBasemap(points)` (already in the coverage exclude ledger as GL glue); `attachBubbleMap` kept as a thin wrapper so `BubbleMap.tsx` is untouched. Added: `interactive: false` for static-first mounts and a mount-failure `.catch` that degrades to D7 (previously an unhandled rejection).
- `bubble-map/bubbleGeometry.ts` — area∝count radius math reused as-is for C3b bubbles; added `pointPlacements` (same inset-percent projection) for C3a pins.
- `map-spike/mapStyle.ts` — Protomaps style reused via the controller, unchanged.
- #420 (S1.6) states reused directly, no forks: `EnvelopeFallback` (D2), `MapFallback` (D7 doodle + map-app link), `SceneThumb` (D9-degrading screenshot cover + shared `d9Episode` template for the episode tag).

**Written fresh:**
- `lib/chat/spotClusters.ts` — row normalization, haversine, greedy 50km centroid clustering, envelope span, C3a/C3b view decision, photo-first top-6.
- `features/chat/components/SearchResult.tsx` + `SearchMap.tsx` — spot card grid, static pin map, cluster bubble map, drill-down state.
- `features/chat/search-copy.ts` + `ChatSearchDict` (ja/zh/en) in `i18n.ts`; token-only styles in `chat.css`.

**Registry:** no change needed — `SearchCard` was already registered for `search_bangumi`/`search_nearby`; this PR upgrades its body (repo rule: register in `registry.ts` only, already satisfied).

## Gates

- `pnpm --filter web typecheck` — clean
- `pnpm --filter web lint:oxlint` — clean (`--type-aware --deny-warnings`)
- `pnpm --filter web test` — 140 files / 807 tests passed; coverage Stmts 99.06 / Branch 94.91 / Funcs 99.62 / Lines 99.86 (floor 90, no exclusions added, no suppressions anywhere)

## Notes / spec drift

- The card's "Files changed" paths (`components/chat/SpotCardGrid.tsx`, `components/map/StaticMap.tsx`, `components/chat/registry.ts`) predate the actual repo layout; implemented under `src/features/chat/` per current conventions.
- Rows carry no explicit popularity field in the stream contract; "popularity/photo availability" is implemented as photo-carrying spots first with upstream relevance order preserved (stable sort).
- "White numeric badge" uses `var(--color-primary-fg)` (white in the theme) — no hardcoded palette colors.
- jsdom cannot run WebGL, so the live MapLibre mount itself (tiles actually rendering) remains covered by the Tester browser pass, matching the S0.4/S5.2 precedent; everything else (pins, bubbles, D2/D7 degradation, i18n) is asserted in-diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)