### PR TITLE
feat(web): S1.5 route card — TimedItinerary, map promotion, Walk seam, E1 supersession (#271)

### DIFF
--- a/apps/web/src/features/chat/components/DataPartCard.tsx
+++ b/apps/web/src/features/chat/components/DataPartCard.tsx
@@ -8,8 +8,8 @@ import { intentRegistry } from "../registry";
 import { EnvelopeFallback } from "./ErrorStates/EnvelopeFallback";
 import { ShortRouteNotice } from "./ErrorStates/ShortRouteNotice";
 
-type CardProps = Readonly<{ data: unknown; dict: ChatDict }>;
-type PartProps = Readonly<{ part: ChatDataPart; dict: ChatDict }>;
+type CardProps = Readonly<{ data: unknown; dict: ChatDict; superseded?: boolean }>;
+type PartProps = Readonly<{ part: ChatDataPart; dict: ChatDict; superseded?: boolean }>;
 type IntentProps = PartProps & Readonly<{ appendix?: ReactNode }>;
 
 function FallbackCard({ dict }: Readonly<{ dict: ChatDict }>) {
@@ -24,11 +24,26 @@ function SkeletonCard({ part, dict }: PartProps) {
   );
 }
 
-function IntentCard({ part, dict, appendix }: IntentProps) {
+/** E1: a superseded living-document card dims and wears the version badge. */
+function cardClass(superseded: boolean | undefined): string {
+  return superseded === true ? "chat-card chat-card--superseded" : "chat-card";
+}
+
+function VersionBadge({ dict }: Readonly<{ dict: ChatDict }>) {
+  return <span className="chat-card__version-badge">{dict.previousVersion}</span>;
+}
+
+function CardMessage({ part }: Readonly<{ part: ChatDataPart }>) {
+  if (!part.message) return null;
+  return <p className="chat-card__message">{part.message}</p>;
+}
+
+function IntentCard({ part, dict, appendix, superseded }: IntentProps) {
   const Body = intentRegistry[part.intent];
   return (
-    <article className="chat-card" data-intent={part.intent}>
-      {part.message ? <p className="chat-card__message">{part.message}</p> : null}
+    <article className={cardClass(superseded)} data-intent={part.intent}>
+      {superseded === true ? <VersionBadge dict={dict} /> : null}
+      <CardMessage part={part} />
       <Body part={part} dict={dict} />
       {appendix}
     </article>
@@ -41,10 +56,10 @@ type SettledProps = PartProps & Readonly<{ state: ChatErrorState | undefined }>;
  * Settled envelopes classify first (issue #272 §D): a D-state renders its
  * in-character fallback instead of — or for D3, alongside — the intent card.
  */
-function SettledCard({ part, dict, state }: SettledProps) {
-  if (state === "D3") return <IntentCard part={part} dict={dict} appendix={<ShortRouteNotice dict={dict} />} />;
-  if (state !== undefined) return <EnvelopeFallback state={state} dict={dict} />;
-  return <IntentCard part={part} dict={dict} />;
+function SettledCard({ part, dict, state, superseded }: SettledProps) {
+  const d3 = state === "D3" ? <ShortRouteNotice dict={dict} /> : undefined;
+  if (state !== undefined && state !== "D3") return <EnvelopeFallback state={state} dict={dict} />;
+  return <IntentCard part={part} dict={dict} appendix={d3} superseded={superseded} />;
 }
 
 /**
@@ -53,10 +68,10 @@ function SettledCard({ part, dict, state }: SettledProps) {
  * classify then render. A skeleton covers intent-first frames — except failed
  * intents, whose fallback shows immediately (an error never wears a skeleton).
  */
-export function DataPartCard({ data, dict }: CardProps) {
+export function DataPartCard({ data, dict, superseded }: CardProps) {
   const part = parseChatDataPart(data);
   if (!part) return <FallbackCard dict={dict} />;
   const state = classifyFailure({ kind: "envelope", part });
   if (isIntentOnly(part) && state === undefined) return <SkeletonCard part={part} dict={dict} />;
-  return <SettledCard part={part} dict={dict} state={state} />;
+  return <SettledCard part={part} dict={dict} state={state} superseded={superseded} />;
 }

--- a/apps/web/src/features/chat/components/DataPartCard.tsx
+++ b/apps/web/src/features/chat/components/DataPartCard.tsx
@@ -38,14 +38,18 @@ function CardMessage({ part }: Readonly<{ part: ChatDataPart }>) {
   return <p className="chat-card__message">{part.message}</p>;
 }
 
+function CardBadge({ dict, superseded }: Readonly<{ dict: ChatDict; superseded?: boolean }>) {
+  if (superseded !== true) return null;
+  return <VersionBadge dict={dict} />;
+}
+
 function IntentCard({ part, dict, appendix, superseded }: IntentProps) {
   const Body = intentRegistry[part.intent];
   return (
     <article className={cardClass(superseded)} data-intent={part.intent}>
-      {superseded === true ? <VersionBadge dict={dict} /> : null}
+      <CardBadge dict={dict} superseded={superseded} />
       <CardMessage part={part} />
-      <Body part={part} dict={dict} />
-      {appendix}
+      <Body part={part} dict={dict} />{appendix}
     </article>
   );
 }

--- a/apps/web/src/features/chat/components/MessageList.tsx
+++ b/apps/web/src/features/chat/components/MessageList.tsx
@@ -1,4 +1,5 @@
 import type { ChatStatus, UIMessage } from "ai";
+import { routeDocumentKey, supersededFlags } from "../../../lib/chat/supersession";
 import type { ChatDict } from "../i18n";
 import { formatElapsed } from "../telemetry";
 import { statusedSteps } from "../tool-steps";
@@ -8,20 +9,48 @@ import { ToolStepBadge } from "./ToolStepBadge";
 
 type Part = UIMessage["parts"][number];
 type ToolPart = Extract<Part, { toolCallId: string }>;
-type PartProps = Readonly<{ part: Part; dict: ChatDict }>;
+type PartProps = Readonly<{ part: Part; dict: ChatDict; superseded: boolean }>;
 
 function isToolPart(part: Part): part is ToolPart {
   return part.type.startsWith("tool-") || part.type === "dynamic-tool";
 }
 
-function MessagePart({ part, dict }: PartProps) {
+function nonToolParts(message: UIMessage): readonly Part[] {
+  return message.parts.filter((part) => !isToolPart(part));
+}
+
+function MessagePart({ part, dict, superseded }: PartProps) {
   if (part.type === "text") return <p className="chat-bubble">{part.text}</p>;
-  if (part.type === "data-response") return <DataPartCard data={part.data} dict={dict} />;
+  if (part.type === "data-response") return <DataPartCard data={part.data} dict={dict} superseded={superseded} />;
   return null;
 }
 
 function partKey(messageId: string, part: Part, index: number): string {
   return `${messageId}:${part.type}:${String(index)}`;
+}
+
+interface DataPartRef {
+  readonly key: string;
+  readonly data: unknown;
+}
+
+function messageDataParts(message: UIMessage): readonly DataPartRef[] {
+  const refs: DataPartRef[] = [];
+  for (const [index, part] of nonToolParts(message).entries()) {
+    if (part.type === "data-response") refs.push({ key: partKey(message.id, part, index), data: part.data });
+  }
+  return refs;
+}
+
+/**
+ * E1 living-document pass (issue #271, generalized for #273): collect every
+ * streamed data part in conversation order and flag the ones a newer card of
+ * the same document supersedes. Route cards are the first keyed document.
+ */
+function supersededPartKeys(messages: readonly UIMessage[]): ReadonlySet<string> {
+  const refs = messages.flatMap(messageDataParts);
+  const flags = supersededFlags(refs.map((ref) => routeDocumentKey(ref.data)));
+  return new Set(refs.filter((_, index) => flags[index] === true).map((ref) => ref.key));
 }
 
 function ToolBadges({ parts, dict }: Readonly<{ parts: readonly ToolPart[]; dict: ChatDict }>) {
@@ -44,10 +73,18 @@ function Pipeline({ parts, settled, elapsedLabel, dict }: PipelineProps) {
   return <SettledFootprint elapsedLabel={elapsedLabel} dict={dict}>{badges}</SettledFootprint>;
 }
 
-function MessageBody({ parts, messageId, dict }: Readonly<{ parts: readonly Part[]; messageId: string; dict: ChatDict }>) {
-  return parts.map((part, index) => (
-    <MessagePart key={partKey(messageId, part, index)} part={part} dict={dict} />
-  ));
+type BodyProps = Readonly<{
+  parts: readonly Part[];
+  messageId: string;
+  dict: ChatDict;
+  supersededKeys: ReadonlySet<string>;
+}>;
+
+function MessageBody({ parts, messageId, dict, supersededKeys }: BodyProps) {
+  return parts.map((part, index) => {
+    const key = partKey(messageId, part, index);
+    return <MessagePart key={key} part={part} dict={dict} superseded={supersededKeys.has(key)} />;
+  });
 }
 
 type ItemProps = Readonly<{
@@ -55,15 +92,15 @@ type ItemProps = Readonly<{
   dict: ChatDict;
   settled: boolean;
   elapsedLabel?: string;
+  supersededKeys: ReadonlySet<string>;
 }>;
 
-function MessageItem({ message, dict, settled, elapsedLabel }: ItemProps) {
+function MessageItem({ message, dict, settled, elapsedLabel, supersededKeys }: ItemProps) {
   const tools = message.parts.filter(isToolPart);
-  const rest = message.parts.filter((part) => !isToolPart(part));
   return (
     <li className={`chat-message chat-message--${message.role}`}>
       <Pipeline parts={tools} settled={settled} elapsedLabel={elapsedLabel} dict={dict} />
-      <MessageBody parts={rest} messageId={message.id} dict={dict} />
+      <MessageBody parts={nonToolParts(message)} messageId={message.id} dict={dict} supersededKeys={supersededKeys} />
     </li>
   );
 }
@@ -83,12 +120,13 @@ type RowProps = Readonly<{
   dict: ChatDict;
   status: ChatStatus;
   settledDurationMs?: number;
+  supersededKeys: ReadonlySet<string>;
 }>;
 
-function MessageRow({ message, isLast, dict, status, settledDurationMs }: RowProps) {
+function MessageRow({ message, isLast, dict, status, settledDurationMs, supersededKeys }: RowProps) {
   const settled = !(isLast && isActive(status));
   return (
-    <MessageItem message={message} dict={dict} settled={settled} elapsedLabel={elapsedFor(isLast, settledDurationMs)} />
+    <MessageItem message={message} dict={dict} settled={settled} elapsedLabel={elapsedFor(isLast, settledDurationMs)} supersededKeys={supersededKeys} />
   );
 }
 
@@ -102,8 +140,9 @@ type ListProps = Readonly<{
 export function MessageList({ messages, dict, status, settledDurationMs }: ListProps) {
   if (messages.length === 0) return null;
   const lastIndex = messages.length - 1;
+  const supersededKeys = supersededPartKeys(messages);
   const items = messages.map((message, index) => (
-    <MessageRow key={message.id} message={message} isLast={index === lastIndex} dict={dict} status={status} settledDurationMs={settledDurationMs} />
+    <MessageRow key={message.id} message={message} isLast={index === lastIndex} dict={dict} status={status} settledDurationMs={settledDurationMs} supersededKeys={supersededKeys} />
   ));
   return <ol className="chat-messages">{items}</ol>;
 }

--- a/apps/web/src/features/chat/components/RouteCard.tsx
+++ b/apps/web/src/features/chat/components/RouteCard.tsx
@@ -5,21 +5,18 @@ import type { LocatedSpot } from "../../../lib/chat/spotClusters";
 import type { ChatDict } from "../i18n";
 import { resultsOf, routeOf, routeSpotsOf, SpotList } from "./cards";
 import type { IntentCardProps } from "./cards";
+import { routeStatsCopy } from "../route-copy";
 import { RouteTrailMap } from "./RouteTrailMap";
 import type { AttachBasemap } from "./SearchMap";
 import { TimedItinerary } from "./TimedItinerary";
 
-type PartProps = Readonly<{ part: ChatDataPart }>;
 type RouteCardProps = IntentCardProps & Readonly<{ attach?: AttachBasemap }>;
 
-function RouteStats({ part }: PartProps) {
+function RouteStats({ part, dict }: Readonly<{ part: ChatDataPart; dict: ChatDict }>) {
   const route = routeOf(part);
   if (!route) return null;
-  return (
-    <p className="chat-card__stats">
-      {route.point_count ?? 0} spots · {route.total_walk_minutes ?? "?"} min
-    </p>
-  );
+  const copy = routeStatsCopy(dict, route.point_count ?? 0, route.total_walk_minutes ?? undefined);
+  return <p className="chat-card__stats">{copy}</p>;
 }
 
 type GateProps = Readonly<{ itinerary: TimedItineraryModel | undefined; dict: ChatDict }>;
@@ -56,7 +53,7 @@ function TrailMapGate({ part, dict, attach }: MapGateProps) {
 export function RouteCard({ part, dict, attach }: RouteCardProps) {
   return (
     <div className="chat-card__body">
-      <RouteStats part={part} />
+      <RouteStats part={part} dict={dict} />
       <ItineraryGate itinerary={routeOf(part)?.timed_itinerary} dict={dict} />
       <TrailMapGate part={part} dict={dict} attach={attach} />
       <SpotList part={part} dict={dict} />

--- a/apps/web/src/features/chat/components/RouteCard.tsx
+++ b/apps/web/src/features/chat/components/RouteCard.tsx
@@ -1,0 +1,65 @@
+import type { ChatDataPart, TimedItinerary as TimedItineraryModel } from "@seichijunrei/contract";
+import { itineraryView } from "../../../lib/chat/itinerary";
+import { locatedSpots, toSearchSpots } from "../../../lib/chat/spotClusters";
+import type { LocatedSpot } from "../../../lib/chat/spotClusters";
+import type { ChatDict } from "../i18n";
+import { resultsOf, routeOf, routeSpotsOf, SpotList } from "./cards";
+import type { IntentCardProps } from "./cards";
+import { RouteTrailMap } from "./RouteTrailMap";
+import type { AttachBasemap } from "./SearchMap";
+import { TimedItinerary } from "./TimedItinerary";
+
+type PartProps = Readonly<{ part: ChatDataPart }>;
+type RouteCardProps = IntentCardProps & Readonly<{ attach?: AttachBasemap }>;
+
+function RouteStats({ part }: PartProps) {
+  const route = routeOf(part);
+  if (!route) return null;
+  return (
+    <p className="chat-card__stats">
+      {route.point_count ?? 0} spots · {route.total_walk_minutes ?? "?"} min
+    </p>
+  );
+}
+
+type GateProps = Readonly<{ itinerary: TimedItineraryModel | undefined; dict: ChatDict }>;
+
+function ItineraryGate({ itinerary, dict }: GateProps) {
+  if (!itinerary || itinerary.stops.length === 0) return null;
+  return <TimedItinerary view={itineraryView(itinerary)} dict={dict} />;
+}
+
+/** Route spots in walking order, restricted to rows the map can place. */
+function routeStations(part: ChatDataPart): readonly LocatedSpot[] {
+  return locatedSpots(toSearchSpots(routeSpotsOf(part)));
+}
+
+/** Located result spots that the planner left off the route; they dim. */
+function offRouteSpots(part: ChatDataPart, stations: readonly LocatedSpot[]): readonly LocatedSpot[] {
+  const onRoute = new Set(stations.map((spot) => spot.id));
+  const rows = resultsOf(part)?.rows ?? [];
+  return locatedSpots(toSearchSpots(rows)).filter((spot) => !onRoute.has(spot.id));
+}
+
+type MapGateProps = IntentCardProps & Readonly<{ attach?: AttachBasemap }>;
+
+function TrailMapGate({ part, dict, attach }: MapGateProps) {
+  const stations = routeStations(part);
+  if (stations.length === 0) return null;
+  return <RouteTrailMap stations={stations} dimmed={offRouteSpots(part, stations)} dict={dict} attach={attach} />;
+}
+
+/**
+ * S1.5 route card (issue #271): summary stats, the timed itinerary, the
+ * promoted trail map, and the spot strip (whose stills degrade per D9).
+ */
+export function RouteCard({ part, dict, attach }: RouteCardProps) {
+  return (
+    <div className="chat-card__body">
+      <RouteStats part={part} />
+      <ItineraryGate itinerary={routeOf(part)?.timed_itinerary} dict={dict} />
+      <TrailMapGate part={part} dict={dict} attach={attach} />
+      <SpotList part={part} dict={dict} />
+    </div>
+  );
+}

--- a/apps/web/src/features/chat/components/RouteTrailMap.tsx
+++ b/apps/web/src/features/chat/components/RouteTrailMap.tsx
@@ -42,19 +42,19 @@ function TrackLine({ placements }: Readonly<{ placements: readonly PointPlacemen
   );
 }
 
-function DimmedPins({ spots, placements }: Readonly<{ spots: readonly LocatedSpot[]; placements: readonly PointPlacement[] }>) {
+type PinsProps = Readonly<{ placements: readonly PointPlacement[] }>;
+
+// Position-keyed (like ClusterBubble): the whole overlay recomputes from the
+// coordinate array, so index identity is stable within a placement set.
+function DimmedPins({ placements }: PinsProps) {
   return placements.map((placement, index) => (
-    <span
-      key={spots[index]?.id ?? String(index)}
-      className="chat-map-pin chat-map-pin--dimmed"
-      style={percentStyle(placement)}
-    />
+    <span key={index} className="chat-map-pin chat-map-pin--dimmed" style={percentStyle(placement)} />
   ));
 }
 
-function OrderedPins({ spots, placements }: Readonly<{ spots: readonly LocatedSpot[]; placements: readonly PointPlacement[] }>) {
+function OrderedPins({ placements }: PinsProps) {
   return placements.map((placement, index) => (
-    <span key={spots[index]?.id ?? String(index)} className="chat-route-pin" style={percentStyle(placement)}>
+    <span key={index} className="chat-route-pin" style={percentStyle(placement)}>
       {index + 1}
     </span>
   ));
@@ -66,8 +66,8 @@ function TrailOverlay(props: SpotsProps) {
   return (
     <div className="chat-search-map__overlay" aria-hidden="true">
       <TrackLine placements={route} />
-      <DimmedPins spots={props.dimmed} placements={rest} />
-      <OrderedPins spots={props.stations} placements={route} />
+      <DimmedPins placements={rest} />
+      <OrderedPins placements={route} />
     </div>
   );
 }

--- a/apps/web/src/features/chat/components/RouteTrailMap.tsx
+++ b/apps/web/src/features/chat/components/RouteTrailMap.tsx
@@ -1,0 +1,98 @@
+import type { LocatedSpot } from "../../../lib/chat/spotClusters";
+import { pointPlacements } from "../../bubble-map/bubbleGeometry";
+import type { PointPlacement } from "../../bubble-map/bubbleGeometry";
+import { attachBasemap } from "../../bubble-map/bubbleMapController";
+import type { ChatDict } from "../i18n";
+import { MapFallback } from "./ErrorStates/MapFallback";
+import { MapFrame, percentStyle, useBasemap } from "./SearchMap";
+import type { AttachBasemap } from "./SearchMap";
+
+type TrailProps = Readonly<{
+  /** Route spots in walking order — pin numbers follow this order. */
+  stations: readonly LocatedSpot[];
+  /** Located result spots that did not make the route; rendered dimmed. */
+  dimmed: readonly LocatedSpot[];
+  dict: ChatDict;
+  attach?: AttachBasemap;
+}>;
+
+type SpotsProps = Readonly<{ stations: readonly LocatedSpot[]; dimmed: readonly LocatedSpot[] }>;
+
+interface TrailPlacements {
+  readonly route: readonly PointPlacement[];
+  readonly rest: readonly PointPlacement[];
+}
+
+/** Route and off-route spots project into ONE percent space so they align. */
+function trailPlacements({ stations, dimmed }: SpotsProps): TrailPlacements {
+  const all = [...stations, ...dimmed].map((spot) => spot.coord);
+  const placements = pointPlacements(all);
+  return { route: placements.slice(0, stations.length), rest: placements.slice(stations.length) };
+}
+
+function trackPoints(placements: readonly PointPlacement[]): string {
+  return placements.map((placement) => `${String(placement.leftPct)},${String(placement.topPct)}`).join(" ");
+}
+
+function TrackLine({ placements }: Readonly<{ placements: readonly PointPlacement[] }>) {
+  return (
+    <svg className="chat-route-map__track" viewBox="0 0 100 100" preserveAspectRatio="none">
+      <polyline className="chat-route-map__line" points={trackPoints(placements)} />
+    </svg>
+  );
+}
+
+function DimmedPins({ spots, placements }: Readonly<{ spots: readonly LocatedSpot[]; placements: readonly PointPlacement[] }>) {
+  return placements.map((placement, index) => (
+    <span
+      key={spots[index]?.id ?? String(index)}
+      className="chat-map-pin chat-map-pin--dimmed"
+      style={percentStyle(placement)}
+    />
+  ));
+}
+
+function OrderedPins({ spots, placements }: Readonly<{ spots: readonly LocatedSpot[]; placements: readonly PointPlacement[] }>) {
+  return placements.map((placement, index) => (
+    <span key={spots[index]?.id ?? String(index)} className="chat-route-pin" style={percentStyle(placement)}>
+      {index + 1}
+    </span>
+  ));
+}
+
+/** Decorative overlay; the timeline list is the accessible walking order. */
+function TrailOverlay(props: SpotsProps) {
+  const { route, rest } = trailPlacements(props);
+  return (
+    <div className="chat-search-map__overlay" aria-hidden="true">
+      <TrackLine placements={route} />
+      <DimmedPins spots={props.dimmed} placements={rest} />
+      <OrderedPins spots={props.stations} placements={route} />
+    </div>
+  );
+}
+
+function allCoords({ stations, dimmed }: SpotsProps) {
+  return [...stations, ...dimmed].map((spot) => spot.coord);
+}
+
+function TrailFallback({ stations, dict }: Readonly<{ stations: readonly LocatedSpot[]; dict: ChatDict }>) {
+  const first = stations[0];
+  return <MapFallback dict={dict} lat={first?.coord.lat} lng={first?.coord.lng} />;
+}
+
+/**
+ * S1.5 map promotion: after route generation the map draws the gold track,
+ * renumbers pins in walking order, dims off-route spots, and shows the gold
+ * route pill. Tile failure degrades to D7 like every other basemap surface.
+ */
+export function RouteTrailMap({ stations, dimmed, dict, attach = attachBasemap }: TrailProps) {
+  const basemap = useBasemap(allCoords({ stations, dimmed }), attach);
+  if (basemap.status === "fallback") return <TrailFallback stations={stations} dict={dict} />;
+  return (
+    <MapFrame basemap={basemap} role="img" label={dict.route.mapLabel}>
+      <TrailOverlay stations={stations} dimmed={dimmed} />
+      <span className="chat-route-pill">{dict.route.routePill}</span>
+    </MapFrame>
+  );
+}

--- a/apps/web/src/features/chat/components/SearchMap.tsx
+++ b/apps/web/src/features/chat/components/SearchMap.tsx
@@ -12,7 +12,7 @@ import { MapFallback } from "./ErrorStates/MapFallback";
 /** Injectable mount so tests (and D7 simulations) never touch WebGL. */
 export type AttachBasemap = (options: MountBasemapOptions) => () => void;
 
-interface Basemap {
+export interface Basemap {
   readonly ref: RefObject<HTMLDivElement | null>;
   readonly status: BasemapStatus;
 }
@@ -45,7 +45,7 @@ function useStablePoints(points: readonly LatLng[]): readonly LatLng[] {
   return held.current.points;
 }
 
-function useBasemap(points: readonly LatLng[], attach: AttachBasemap): Basemap {
+export function useBasemap(points: readonly LatLng[], attach: AttachBasemap): Basemap {
   const ref = useRef<HTMLDivElement>(null);
   const [status, setStatus] = useState<BasemapStatus>("loading");
   const stable = useStablePoints(points);
@@ -60,7 +60,7 @@ type FrameProps = Readonly<{
   children: ReactNode;
 }>;
 
-function MapFrame({ basemap, role, label, children }: FrameProps) {
+export function MapFrame({ basemap, role, label, children }: FrameProps) {
   return (
     <div className="chat-search-map" role={role} aria-label={label}>
       <div ref={basemap.ref} className="chat-search-map__gl" aria-hidden />
@@ -69,7 +69,7 @@ function MapFrame({ basemap, role, label, children }: FrameProps) {
   );
 }
 
-function percentStyle(placement: PointPlacement): CSSProperties {
+export function percentStyle(placement: PointPlacement): CSSProperties {
   return { left: `${String(placement.leftPct)}%`, top: `${String(placement.topPct)}%` };
 }
 

--- a/apps/web/src/features/chat/components/TimedItinerary.tsx
+++ b/apps/web/src/features/chat/components/TimedItinerary.tsx
@@ -1,0 +1,112 @@
+import type { ItineraryLeg, ItineraryStation, ItineraryView } from "../../../lib/chat/itinerary";
+import type { ChatDict } from "../i18n";
+import { legCapsule } from "../route-copy";
+
+type DictProps = Readonly<{ dict: ChatDict }>;
+type ViewProps = Readonly<{ view: ItineraryView; dict: ChatDict }>;
+
+/** Colour alone never carries the highlight: the star names itself for AT. */
+function GoldStar({ dict }: DictProps) {
+  return (
+    <span className="chat-itinerary__star" role="img" aria-label={dict.route.highlight}>
+      ★
+    </span>
+  );
+}
+
+function stationTimes(station: ItineraryStation): string | undefined {
+  if (station.arrive === undefined) return station.depart;
+  if (station.depart === undefined || station.depart === station.arrive) return station.arrive;
+  return `${station.arrive}–${station.depart}`;
+}
+
+function stopClass(station: ItineraryStation): string {
+  return station.highlighted ? "chat-itinerary__stop chat-itinerary__stop--highlight" : "chat-itinerary__stop";
+}
+
+function StationRow({ station, dict }: Readonly<{ station: ItineraryStation; dict: ChatDict }>) {
+  const times = stationTimes(station);
+  return (
+    <li className={stopClass(station)}>
+      {times !== undefined ? <time className="chat-itinerary__time">{times}</time> : null}
+      <span className="chat-itinerary__name">{station.name}</span>
+      {station.highlighted ? <GoldStar dict={dict} /> : null}
+    </li>
+  );
+}
+
+function LegRow({ leg, dict }: Readonly<{ leg: ItineraryLeg; dict: ChatDict }>) {
+  return (
+    <li className="chat-itinerary__leg" data-mode={leg.mode}>
+      <span className="chat-itinerary__capsule">{legCapsule(dict, leg)}</span>
+    </li>
+  );
+}
+
+function TimelineItems({ view, dict }: ViewProps) {
+  return view.stations.flatMap((station, index) => {
+    const leg = view.legs[index];
+    const rows = [<StationRow key={`stop-${station.id}`} station={station} dict={dict} />];
+    if (leg) rows.push(<LegRow key={`leg-${station.id}`} leg={leg} dict={dict} />);
+    return rows;
+  });
+}
+
+function PacingPill({ view, dict }: ViewProps) {
+  if (view.pacing === undefined) return null;
+  return (
+    <span className="chat-pacing-pill" data-pacing={view.pacing}>
+      {dict.route.pacing[view.pacing]}
+    </span>
+  );
+}
+
+function MapsCta({ view, dict }: ViewProps) {
+  if (view.mapsUrl === undefined) return null;
+  return (
+    <a className="chat-chip" data-tone="explore" href={view.mapsUrl} target="_blank" rel="noreferrer">
+      {dict.route.openMaps}
+    </a>
+  );
+}
+
+/** Reserved Walk-mode entry point (issue #271): a disabled seam, not a mode. */
+function WalkCtaSlot({ dict }: DictProps) {
+  return (
+    <button type="button" className="chat-chip" data-tone="walk" data-cta="walk-mode" disabled>
+      {dict.route.walkCta}
+    </button>
+  );
+}
+
+function CtaRow({ view, dict }: ViewProps) {
+  return (
+    <div className="chat-cta-row">
+      <MapsCta view={view} dict={dict} />
+      <WalkCtaSlot dict={dict} />
+    </div>
+  );
+}
+
+function Timeline({ view, dict }: ViewProps) {
+  return (
+    <ol className="chat-itinerary__timeline" aria-label={dict.route.timelineLabel}>
+      <TimelineItems view={view} dict={dict} />
+    </ol>
+  );
+}
+
+/**
+ * S1.5 route timeline: station-granularity HH:MM rows, one gold-star highlight,
+ * walk capsules between stations, pacing pill, and the CTA row. The labelled
+ * list doubles as the non-visual equivalent of the promoted map's track order.
+ */
+export function TimedItinerary({ view, dict }: ViewProps) {
+  return (
+    <div className="chat-itinerary">
+      <PacingPill view={view} dict={dict} />
+      <Timeline view={view} dict={dict} />
+      <CtaRow view={view} dict={dict} />
+    </div>
+  );
+}

--- a/apps/web/src/features/chat/components/cards.tsx
+++ b/apps/web/src/features/chat/components/cards.tsx
@@ -12,12 +12,12 @@ function dataOf(part: ChatDataPart): PartData | undefined {
   return part.data;
 }
 
-function resultsOf(part: ChatDataPart) {
+export function resultsOf(part: ChatDataPart) {
   const data = dataOf(part);
   return data && "results" in data ? data.results : undefined;
 }
 
-function routeOf(part: ChatDataPart) {
+export function routeOf(part: ChatDataPart) {
   const data = dataOf(part);
   return data && "route" in data ? data.route : undefined;
 }
@@ -27,7 +27,7 @@ function candidatesOf(part: ChatDataPart) {
   return data && "candidates" in data ? (data.candidates ?? []) : [];
 }
 
-type SpotRow = Readonly<{
+export type SpotRow = Readonly<{
   id?: string;
   name?: string;
   screenshot_url?: string;
@@ -41,7 +41,7 @@ type SpotRow = Readonly<{
 }>;
 
 /** Streamed routes may carry spots only as `route.ordered_points` objects. */
-function routeSpotsOf(part: ChatDataPart): SpotRow[] {
+export function routeSpotsOf(part: ChatDataPart): SpotRow[] {
   const points = routeOf(part)?.ordered_points ?? [];
   const spots: SpotRow[] = [];
   for (const point of points) {
@@ -55,8 +55,10 @@ function spotsOf(part: ChatDataPart): SpotRow[] {
   return rows.length > 0 ? rows : routeSpotsOf(part);
 }
 
+/** Upstream sends `-1` as the unknown-episode sentinel, never an omission. */
 function epOf(row: SpotRow): number | undefined {
-  return row.ep ?? row.episode;
+  const raw = row.ep ?? row.episode;
+  return raw !== undefined && raw >= 0 ? raw : undefined;
 }
 
 /** The thumb renders only for rows that carry a still; D9 degrades it. */
@@ -69,7 +71,7 @@ function SpotItem({ row, dict }: Readonly<{ row: SpotRow; dict: ChatDict }>) {
   );
 }
 
-function SpotList({ part, dict }: IntentCardProps) {
+export function SpotList({ part, dict }: IntentCardProps) {
   const rows = spotsOf(part);
   if (rows.length === 0) return null;
   const items = rows.map((row) => <SpotItem key={row.id ?? row.name} row={row} dict={dict} />);
@@ -83,25 +85,6 @@ export function SearchCard({ part, dict }: IntentCardProps) {
     <div className="chat-card__body">
       {results?.title ? <p className="chat-card__title">{results.title}</p> : null}
       <SearchResult spots={toSearchSpots(spotsOf(part))} dict={dict} />
-    </div>
-  );
-}
-
-function RouteStats({ part }: Readonly<{ part: ChatDataPart }>) {
-  const route = routeOf(part);
-  if (!route) return null;
-  return (
-    <p className="chat-card__stats">
-      {route.point_count ?? 0} spots · {route.total_walk_minutes ?? "?"} min
-    </p>
-  );
-}
-
-export function RouteCard({ part, dict }: IntentCardProps) {
-  return (
-    <div className="chat-card__body">
-      <RouteStats part={part} />
-      <SpotList part={part} dict={dict} />
     </div>
   );
 }

--- a/apps/web/src/features/chat/i18n.ts
+++ b/apps/web/src/features/chat/i18n.ts
@@ -1,4 +1,11 @@
 import type { Locale } from "../../i18n/locales";
+import { enRoute, jaRoute, zhRoute } from "./route-i18n";
+import type { ChatRouteDict } from "./route-i18n";
+import { enSearch, jaSearch, zhSearch } from "./search-i18n";
+import type { ChatSearchDict } from "./search-i18n";
+
+export type { ChatRouteDict } from "./route-i18n";
+export type { ChatSearchDict } from "./search-i18n";
 
 /** In-character copy for the nine D1-D9 fallback states (issue #272 S1.6). */
 export interface ChatErrorStatesDict {
@@ -21,14 +28,6 @@ export interface ChatErrorStatesDict {
   readonly d8Login: string;
   readonly d8Resume: string;
   readonly d9Episode: string;
-}
-
-/** Copy for the C3a/C3b search result cards and static map (issue #261 S1.4). */
-export interface ChatSearchDict {
-  readonly select: string;
-  readonly spotCount: string;
-  readonly areaFallback: string;
-  readonly mapLabel: string;
 }
 
 /** Tools whose step badges surface to the user as localized progress copy. */
@@ -103,32 +102,14 @@ export interface ChatDict {
   readonly thinking: string;
   readonly waitingSubtitle: string;
   readonly footprintDetails: string;
+  /** E1 badge on a superseded living-document card (issues #271/#273). */
+  readonly previousVersion: string;
   readonly errorStates: ChatErrorStatesDict;
   readonly toolSteps: ChatToolStepsDict;
   readonly search: ChatSearchDict;
   readonly turnstile: ChatTurnstileDict;
+  readonly route: ChatRouteDict;
 }
-
-const jaSearch: ChatSearchDict = {
-  select: "この聖地をえらぶ",
-  spotCount: "{count}件",
-  areaFallback: "エリア{n}",
-  mapLabel: "聖地マップ",
-};
-
-const zhSearch: ChatSearchDict = {
-  select: "选择这个圣地",
-  spotCount: "{count} 处",
-  areaFallback: "区域{n}",
-  mapLabel: "圣地地图",
-};
-
-const enSearch: ChatSearchDict = {
-  select: "Select this spot",
-  spotCount: "{count} spots",
-  areaFallback: "Area {n}",
-  mapLabel: "Spot map",
-};
 
 const jaToolSteps: ChatToolStepsDict = {
   labels: {
@@ -257,10 +238,12 @@ const ja: ChatDict = {
   thinking: "考え中…",
   waitingSubtitle: "いま さがしてるよ…",
   footprintDetails: "詳細を見る",
+  previousVersion: "以前の版",
   errorStates: jaErrorStates,
   toolSteps: jaToolSteps,
   search: jaSearch,
   turnstile: jaTurnstile,
+  route: jaRoute,
 };
 
 const zh: ChatDict = {
@@ -278,10 +261,12 @@ const zh: ChatDict = {
   thinking: "思考中…",
   waitingSubtitle: "正在帮你找…",
   footprintDetails: "查看详情",
+  previousVersion: "旧版本",
   errorStates: zhErrorStates,
   toolSteps: zhToolSteps,
   search: zhSearch,
   turnstile: zhTurnstile,
+  route: zhRoute,
 };
 
 const en: ChatDict = {
@@ -303,10 +288,12 @@ const en: ChatDict = {
   thinking: "Thinking…",
   waitingSubtitle: "Looking that up…",
   footprintDetails: "View details",
+  previousVersion: "Previous version",
   errorStates: enErrorStates,
   toolSteps: enToolSteps,
   search: enSearch,
   turnstile: enTurnstile,
+  route: enRoute,
 };
 
 const CHAT_DICTIONARIES: Record<Locale, ChatDict> = { ja, zh, en };

--- a/apps/web/src/features/chat/registry.ts
+++ b/apps/web/src/features/chat/registry.ts
@@ -1,7 +1,8 @@
 import type { ChatDataPart } from "@seichijunrei/contract";
 import type { ComponentType } from "react";
-import { ClarifyCard, ProseCard, RouteCard, SearchCard } from "./components/cards";
+import { ClarifyCard, ProseCard, SearchCard } from "./components/cards";
 import type { IntentCardProps } from "./components/cards";
+import { RouteCard } from "./components/RouteCard";
 
 /**
  * intent → card body. Later chat cards extend this map, not the renderer.

--- a/apps/web/src/features/chat/route-copy.ts
+++ b/apps/web/src/features/chat/route-copy.ts
@@ -1,0 +1,8 @@
+import type { ItineraryLeg } from "../../lib/chat/itinerary";
+import type { ChatDict } from "./i18n";
+
+/** Localized capsule copy for a between-station leg (issue #271 S1.5). */
+export function legCapsule(dict: ChatDict, leg: ItineraryLeg): string {
+  const template = leg.mode === "walk" ? dict.route.walkCapsule : dict.route.transitCapsule;
+  return template.replace("{min}", String(leg.minutes));
+}

--- a/apps/web/src/features/chat/route-copy.ts
+++ b/apps/web/src/features/chat/route-copy.ts
@@ -6,3 +6,12 @@ export function legCapsule(dict: ChatDict, leg: ItineraryLeg): string {
   const template = leg.mode === "walk" ? dict.route.walkCapsule : dict.route.transitCapsule;
   return template.replace("{min}", String(leg.minutes));
 }
+
+/** Localized headline stats for the route card (issue #271 S1.5). Absent
+ * walking minutes render as an em dash rather than a bare "?" so the line
+ * reads as copy in every locale. */
+export function routeStatsCopy(dict: ChatDict, spots: number, minutes: number | undefined): string {
+  return dict.route.stats
+    .replace("{spots}", String(spots))
+    .replace("{min}", minutes === undefined ? "—" : String(minutes));
+}

--- a/apps/web/src/features/chat/route-i18n.ts
+++ b/apps/web/src/features/chat/route-i18n.ts
@@ -1,0 +1,50 @@
+import type { Pacing } from "@seichijunrei/contract";
+
+/** Copy for the S1.5 route card: pacing pill, capsules, CTA row (issue #271). */
+export interface ChatRouteDict {
+  readonly pacing: Readonly<Record<Pacing, string>>;
+  readonly walkCapsule: string;
+  readonly transitCapsule: string;
+  readonly highlight: string;
+  readonly routePill: string;
+  readonly walkCta: string;
+  readonly openMaps: string;
+  readonly timelineLabel: string;
+  readonly mapLabel: string;
+}
+
+export const jaRoute: ChatRouteDict = {
+  pacing: { chill: "ゆったり", normal: "適中", packed: "緊張" },
+  walkCapsule: "徒歩{min}分",
+  transitCapsule: "移動{min}分",
+  highlight: "名場面スポット",
+  routePill: "ルート",
+  walkCta: "歩きモード(準備中)",
+  openMaps: "Googleマップで開く",
+  timelineLabel: "ルートのタイムライン",
+  mapLabel: "ルートマップ",
+};
+
+export const zhRoute: ChatRouteDict = {
+  pacing: { chill: "悠闲", normal: "适中", packed: "紧凑" },
+  walkCapsule: "步行{min}分钟",
+  transitCapsule: "乘车{min}分钟",
+  highlight: "名场面地点",
+  routePill: "路线",
+  walkCta: "步行模式(即将上线)",
+  openMaps: "在 Google 地图打开",
+  timelineLabel: "路线时间轴",
+  mapLabel: "路线地图",
+};
+
+export const enRoute: ChatRouteDict = {
+  pacing: { chill: "Chill", normal: "Balanced", packed: "Packed" },
+  walkCapsule: "Walk {min} min",
+  transitCapsule: "Transit {min} min",
+  highlight: "Highlight scene",
+  routePill: "Route",
+  walkCta: "Walk mode (coming soon)",
+  openMaps: "Open in Google Maps",
+  timelineLabel: "Route timeline",
+  mapLabel: "Route map",
+};

--- a/apps/web/src/features/chat/route-i18n.ts
+++ b/apps/web/src/features/chat/route-i18n.ts
@@ -3,6 +3,8 @@ import type { Pacing } from "@seichijunrei/contract";
 /** Copy for the S1.5 route card: pacing pill, capsules, CTA row (issue #271). */
 export interface ChatRouteDict {
   readonly pacing: Readonly<Record<Pacing, string>>;
+  /** `{spots}` spots and `{min}` total walking minutes. */
+  readonly stats: string;
   readonly walkCapsule: string;
   readonly transitCapsule: string;
   readonly highlight: string;
@@ -15,6 +17,7 @@ export interface ChatRouteDict {
 
 export const jaRoute: ChatRouteDict = {
   pacing: { chill: "ゆったり", normal: "適中", packed: "緊張" },
+  stats: "{spots}スポット・徒歩{min}分",
   walkCapsule: "徒歩{min}分",
   transitCapsule: "移動{min}分",
   highlight: "名場面スポット",
@@ -27,6 +30,7 @@ export const jaRoute: ChatRouteDict = {
 
 export const zhRoute: ChatRouteDict = {
   pacing: { chill: "悠闲", normal: "适中", packed: "紧凑" },
+  stats: "{spots} 个地点・步行 {min} 分钟",
   walkCapsule: "步行{min}分钟",
   transitCapsule: "乘车{min}分钟",
   highlight: "名场面地点",
@@ -39,6 +43,7 @@ export const zhRoute: ChatRouteDict = {
 
 export const enRoute: ChatRouteDict = {
   pacing: { chill: "Chill", normal: "Balanced", packed: "Packed" },
+  stats: "{spots} spots · {min} min walking",
   walkCapsule: "Walk {min} min",
   transitCapsule: "Transit {min} min",
   highlight: "Highlight scene",

--- a/apps/web/src/features/chat/search-i18n.ts
+++ b/apps/web/src/features/chat/search-i18n.ts
@@ -1,0 +1,28 @@
+/** Copy for the C3a/C3b search result cards and static map (issue #261 S1.4). */
+export interface ChatSearchDict {
+  readonly select: string;
+  readonly spotCount: string;
+  readonly areaFallback: string;
+  readonly mapLabel: string;
+}
+
+export const jaSearch: ChatSearchDict = {
+  select: "この聖地をえらぶ",
+  spotCount: "{count}件",
+  areaFallback: "エリア{n}",
+  mapLabel: "聖地マップ",
+};
+
+export const zhSearch: ChatSearchDict = {
+  select: "选择这个圣地",
+  spotCount: "{count} 处",
+  areaFallback: "区域{n}",
+  mapLabel: "圣地地图",
+};
+
+export const enSearch: ChatSearchDict = {
+  select: "Select this spot",
+  spotCount: "{count} spots",
+  areaFallback: "Area {n}",
+  mapLabel: "Spot map",
+};

--- a/apps/web/src/lib/chat/itinerary.ts
+++ b/apps/web/src/lib/chat/itinerary.ts
@@ -1,0 +1,77 @@
+import type { Pacing, TimedItinerary, TimedStop, TransitLeg } from "@seichijunrei/contract";
+
+/** One station row on the S1.5 route timeline (issue #271 AC: HH:MM granularity). */
+export interface ItineraryStation {
+  readonly id: string;
+  readonly name: string;
+  readonly arrive?: string;
+  readonly depart?: string;
+  readonly highlighted: boolean;
+}
+
+/** A between-station leg rendered as a walk capsule or transit chip. */
+export interface ItineraryLeg {
+  readonly mode: "walk" | "transit";
+  readonly minutes: number;
+}
+
+/** View model for the timed-itinerary card; `legs[i]` sits after `stations[i]`. */
+export interface ItineraryView {
+  readonly stations: readonly ItineraryStation[];
+  readonly legs: readonly (ItineraryLeg | undefined)[];
+  readonly pacing?: Pacing;
+  readonly mapsUrl?: string;
+}
+
+/** Upstream sends sentinels, not omissions: `""` marks a missing HH:MM string. */
+function timeOf(value: string): string | undefined {
+  return value === "" ? undefined : value;
+}
+
+/** The gold star sits on the most-photographed station (first among ties). */
+function highlightIndex(stops: readonly TimedStop[]): number {
+  let best = 0;
+  for (const [index, stop] of stops.entries()) {
+    if (stop.photo_count > (stops[best]?.photo_count ?? 0)) best = index;
+  }
+  return best;
+}
+
+function toStation(stop: TimedStop, highlighted: boolean): ItineraryStation {
+  return {
+    id: stop.cluster_id,
+    name: stop.name,
+    arrive: timeOf(stop.arrive),
+    depart: timeOf(stop.depart),
+    highlighted,
+  };
+}
+
+function legBetween(legs: readonly TransitLeg[], fromId: string, toId: string): ItineraryLeg | undefined {
+  const leg = legs.find((candidate) => candidate.from_id === fromId && candidate.to_id === toId);
+  if (!leg) return undefined;
+  return { mode: leg.mode, minutes: leg.duration_minutes };
+}
+
+function pairLegs(stops: readonly TimedStop[], legs: readonly TransitLeg[]): readonly (ItineraryLeg | undefined)[] {
+  return stops.slice(1).map((next, index) => {
+    const prev = stops[index];
+    return prev ? legBetween(legs, prev.cluster_id, next.cluster_id) : undefined;
+  });
+}
+
+/** The sentinel for a missing export link is `""`, which `??` passes through. */
+function firstMapsUrl(urls: readonly string[] | undefined): string | undefined {
+  return urls?.find((url) => url !== "");
+}
+
+export function itineraryView(itinerary: TimedItinerary): ItineraryView {
+  const stops = itinerary.stops;
+  const star = highlightIndex(stops);
+  return {
+    stations: stops.map((stop, index) => toStation(stop, index === star)),
+    legs: pairLegs(stops, itinerary.legs),
+    pacing: itinerary.pacing,
+    mapsUrl: firstMapsUrl(itinerary.export_google_maps_url),
+  };
+}

--- a/apps/web/src/lib/chat/itinerary.ts
+++ b/apps/web/src/lib/chat/itinerary.ts
@@ -31,8 +31,9 @@ function timeOf(value: string): string | undefined {
 /** The gold star sits on the most-photographed station (first among ties). */
 function highlightIndex(stops: readonly TimedStop[]): number {
   let best = 0;
+  let bestPhotos = Number.NEGATIVE_INFINITY;
   for (const [index, stop] of stops.entries()) {
-    if (stop.photo_count > (stops[best]?.photo_count ?? 0)) best = index;
+    if (stop.photo_count > bestPhotos) [best, bestPhotos] = [index, stop.photo_count];
   }
   return best;
 }
@@ -54,10 +55,13 @@ function legBetween(legs: readonly TransitLeg[], fromId: string, toId: string): 
 }
 
 function pairLegs(stops: readonly TimedStop[], legs: readonly TransitLeg[]): readonly (ItineraryLeg | undefined)[] {
-  return stops.slice(1).map((next, index) => {
-    const prev = stops[index];
-    return prev ? legBetween(legs, prev.cluster_id, next.cluster_id) : undefined;
-  });
+  const pairs: (ItineraryLeg | undefined)[] = [];
+  let prev: TimedStop | undefined;
+  for (const stop of stops) {
+    if (prev) pairs.push(legBetween(legs, prev.cluster_id, stop.cluster_id));
+    prev = stop;
+  }
+  return pairs;
 }
 
 /** The sentinel for a missing export link is `""`, which `??` passes through. */

--- a/apps/web/src/lib/chat/supersession.ts
+++ b/apps/web/src/lib/chat/supersession.ts
@@ -1,0 +1,47 @@
+/**
+ * E1 living-document rule (spec-chat-page-states §E1): within one conversation,
+ * only the newest card of a given document is current; every earlier card that
+ * shares its document key dims to a "previous version". `supersededFlags` is
+ * generic over the key so other living documents (issue #273 S1.7) reuse it by
+ * supplying their own key producer — `routeDocumentKey` below is the route
+ * card's (issue #271 S1.5), the first such producer.
+ */
+export function supersededFlags(keys: readonly (string | undefined)[]): readonly boolean[] {
+  const lastIndex = new Map<string, number>();
+  keys.forEach((key, index) => {
+    if (key !== undefined) lastIndex.set(key, index);
+  });
+  return keys.map((key, index) => key !== undefined && lastIndex.get(key) !== index);
+}
+
+const ROUTE_INTENTS: ReadonlySet<string> = new Set([
+  "plan_route",
+  "plan_selected",
+  "plan_multi",
+  "partial",
+]);
+
+function intentOf(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null || !("intent" in data)) return undefined;
+  const { intent } = data;
+  return typeof intent === "string" ? intent : undefined;
+}
+
+/** Only frames that actually carry a route are versions of the document. */
+function hasRoute(data: unknown): boolean {
+  if (typeof data !== "object" || data === null || !("data" in data)) return false;
+  const inner = data.data;
+  if (typeof inner !== "object" || inner === null || !("route" in inner)) return false;
+  return inner.route !== undefined && inner.route !== null;
+}
+
+/**
+ * Document key for a streamed `data-response` payload: route-family cards that
+ * carry a route form one living document per conversation. Intent-only frames
+ * and non-route intents are keyless — they never dim, and never dim others.
+ */
+export function routeDocumentKey(data: unknown): string | undefined {
+  const intent = intentOf(data);
+  if (intent === undefined || !ROUTE_INTENTS.has(intent)) return undefined;
+  return hasRoute(data) ? "route" : undefined;
+}

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -591,3 +591,142 @@
   font-size: 0.8125rem;
   color: var(--color-primary-fg);
 }
+
+/* --- S1.5 route card: timed itinerary (issue #271) --- */
+
+.chat-itinerary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chat-pacing-pill {
+  align-self: flex-start;
+  padding: 0.125rem 0.625rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-muted);
+  color: var(--color-fg);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.chat-itinerary__timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.chat-itinerary__stop {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.chat-itinerary__time {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.8125rem;
+  color: var(--color-muted-fg);
+}
+
+.chat-itinerary__stop--highlight .chat-itinerary__name {
+  font-weight: 700;
+}
+
+.chat-itinerary__star {
+  color: var(--color-gold);
+}
+
+.chat-itinerary__leg {
+  display: flex;
+  padding-left: 1.5rem;
+}
+
+.chat-itinerary__capsule {
+  padding: 0.125rem 0.625rem;
+  border-radius: 999px;
+  background: var(--color-walk-bg);
+  color: var(--color-walk-fg);
+  font-size: 0.75rem;
+}
+
+.chat-itinerary__leg[data-mode="transit"] .chat-itinerary__capsule {
+  background: var(--color-explore-bg);
+  color: var(--color-explore-fg);
+}
+
+.chat-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+/* --- S1.5 promoted route map --- */
+
+.chat-route-map__track {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.chat-route-map__line {
+  fill: none;
+  stroke: var(--color-gold);
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 6 4;
+  vector-effect: non-scaling-stroke;
+}
+
+.chat-route-pin {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.125rem;
+  height: 1.125rem;
+  transform: translate(-50%, -50%);
+  border: 2px solid var(--color-bg);
+  border-radius: 50%;
+  background: var(--color-map-pin-teal);
+  color: var(--color-primary-fg);
+  font-size: 0.625rem;
+  font-weight: 700;
+}
+
+.chat-map-pin--dimmed {
+  opacity: 0.35;
+}
+
+.chat-route-pill {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.125rem 0.625rem;
+  border: 1px solid var(--color-gold);
+  border-radius: 999px;
+  background: var(--color-gold-soft);
+  color: var(--color-gold-fg);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+/* --- E1 living document: superseded cards (issues #271/#273) --- */
+
+.chat-card--superseded {
+  opacity: 0.55;
+}
+
+.chat-card__version-badge {
+  align-self: flex-start;
+  padding: 0.0625rem 0.5rem;
+  border-radius: 999px;
+  background: var(--color-muted);
+  color: var(--color-muted-fg);
+  font-size: 0.6875rem;
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -36,6 +36,10 @@
   --color-map-pin-green: #4caf50;
   --color-map-pin-orange: #ff9800;
   --color-map-pin-brand: #c1440e;
+  /* Route-card gold (issue #271 S1.5): star, track, and the route pill. */
+  --color-gold: #f5c31c;
+  --color-gold-soft: #fbf0cf;
+  --color-gold-fg: #6b5200;
   --shadow-3d: #bdaea0;
   --shadow-press: 0 5px 0 0 var(--shadow-3d);
   --app-font-display: "Noto Serif JP", "Hiragino Mincho ProN", Georgia, serif;
@@ -205,6 +209,8 @@ h1 {
   --color-explore-fg: #7fdcd2;
   --color-walk-bg: #1c3320;
   --color-walk-fg: #a8d5ab;
+  --color-gold-soft: #3a3117;
+  --color-gold-fg: #f0d98a;
   /* Press shadow follows via var(--shadow-3d) in :root. */
   --shadow-3d: #120d07;
 }

--- a/apps/web/tests/unit/chat/_route-fixtures.ts
+++ b/apps/web/tests/unit/chat/_route-fixtures.ts
@@ -1,0 +1,72 @@
+import { ChatResponseDataPart } from "@seichijunrei/contract";
+import type { ChatDataPart, TimedItinerary, TimedStop, TransitLeg } from "@seichijunrei/contract";
+
+/** Contract-validated fixtures for the S1.5 route card tests (issue #271). */
+
+export function stopAt(id: string, name: string, arrive: string, depart: string, photos: number, lat: number, lng: number): TimedStop {
+  return { cluster_id: id, name, arrive, depart, dwell_minutes: 20, lat, lng, photo_count: photos };
+}
+
+export function walkLeg(fromId: string, toId: string, minutes: number): TransitLeg {
+  return { from_id: fromId, to_id: toId, mode: "walk", duration_minutes: minutes, distance_m: minutes * 62 };
+}
+
+/** Three Uji stops; 京阪宇治駅 carries the most photos, so it wears the star. */
+export function ujiItinerary(): TimedItinerary {
+  return {
+    stops: [
+      stopAt("a", "宇治橋", "10:00", "10:20", 2, 34.891, 135.807),
+      stopAt("b", "京阪宇治駅", "10:32", "10:52", 9, 34.911, 135.806),
+      stopAt("c", "宇治神社", "11:00", "11:20", 4, 34.9, 135.81),
+    ],
+    legs: [walkLeg("a", "b", 12), { ...walkLeg("b", "c", 8), mode: "transit" }],
+    total_minutes: 80,
+    total_distance_m: 1500,
+    pacing: "chill",
+    start_time: "10:00",
+    export_google_maps_url: ["https://maps.example/route"],
+  };
+}
+
+export interface RoutePointSpec {
+  readonly id: string;
+  readonly name: string;
+  readonly lat?: number;
+  readonly lng?: number;
+  readonly screenshot?: string;
+  readonly episode?: number;
+}
+
+/** Upstream never omits stills/episodes — it sends "" and -1 sentinels. */
+export function routePoint(spec: RoutePointSpec): Record<string, unknown> {
+  return {
+    id: spec.id,
+    name: spec.name,
+    latitude: spec.lat,
+    longitude: spec.lng,
+    screenshot_url: spec.screenshot ?? "",
+    episode: spec.episode ?? -1,
+  };
+}
+
+export function routePartRaw(points: readonly Record<string, unknown>[], extras: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    intent: "plan_route",
+    success: true,
+    status: "ok",
+    data: { route: { ordered_points: points, point_count: points.length, ...extras } },
+  };
+}
+
+/** Every fixture crosses the REAL contract schema before a test renders it. */
+export function parsedPart(raw: unknown): ChatDataPart {
+  return ChatResponseDataPart.parse(raw);
+}
+
+export function ujiPoints(): readonly Record<string, unknown>[] {
+  return [
+    routePoint({ id: "a", name: "宇治橋", lat: 34.891, lng: 135.807, screenshot: "/scene-a.webp", episode: 8 }),
+    routePoint({ id: "b", name: "京阪宇治駅", lat: 34.911, lng: 135.806 }),
+    routePoint({ id: "c", name: "宇治神社", lat: 34.9, lng: 135.81 }),
+  ];
+}

--- a/apps/web/tests/unit/chat/itinerary.test.ts
+++ b/apps/web/tests/unit/chat/itinerary.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { itineraryView } from "../../../src/lib/chat/itinerary";
+import { stopAt, ujiItinerary, walkLeg } from "./_route-fixtures";
+
+describe("itineraryView stations (AC1: HH:MM timeline + gold-star highlight)", () => {
+  it("keeps walking order and HH:MM strings from the contract payload", () => {
+    const view = itineraryView(ujiItinerary());
+    expect(view.stations.map((station) => station.name)).toEqual(["宇治橋", "京阪宇治駅", "宇治神社"]);
+    expect(view.stations.map((station) => station.arrive)).toEqual(["10:00", "10:32", "11:00"]);
+    expect(view.stations.map((station) => station.depart)).toEqual(["10:20", "10:52", "11:20"]);
+  });
+
+  it("highlights exactly the most-photographed station", () => {
+    const view = itineraryView(ujiItinerary());
+    expect(view.stations.map((station) => station.highlighted)).toEqual([false, true, false]);
+  });
+
+  it("highlights the first station when every photo count ties", () => {
+    const stops = [stopAt("a", "A", "10:00", "10:10", 0, 34.9, 135.8), stopAt("b", "B", "10:20", "10:30", 0, 34.91, 135.8)];
+    const view = itineraryView({ stops, legs: [], total_minutes: 30, total_distance_m: 500 });
+    expect(view.stations.map((station) => station.highlighted)).toEqual([true, false]);
+  });
+
+  it("normalizes the empty-string time sentinel to undefined", () => {
+    const stops = [stopAt("a", "A", "", "", 1, 34.9, 135.8)];
+    const view = itineraryView({ stops, legs: [], total_minutes: 0, total_distance_m: 0 });
+    expect(view.stations[0]?.arrive).toBeUndefined();
+    expect(view.stations[0]?.depart).toBeUndefined();
+  });
+});
+
+describe("itineraryView legs (AC1: walk capsule between stations)", () => {
+  it("pairs each leg with the station it follows, keeping mode and minutes", () => {
+    const view = itineraryView(ujiItinerary());
+    expect(view.legs).toEqual([
+      { mode: "walk", minutes: 12 },
+      { mode: "transit", minutes: 8 },
+    ]);
+  });
+
+  it("leaves a gap undefined when no leg connects two adjacent stations", () => {
+    const stops = [stopAt("a", "A", "10:00", "10:10", 1, 34.9, 135.8), stopAt("b", "B", "10:20", "10:30", 0, 34.91, 135.8)];
+    const view = itineraryView({ stops, legs: [walkLeg("x", "y", 5)], total_minutes: 30, total_distance_m: 500 });
+    expect(view.legs).toEqual([undefined]);
+  });
+});
+
+describe("itineraryView extras (pacing pill + maps CTA)", () => {
+  it("carries pacing through and picks the first non-empty export URL", () => {
+    const view = itineraryView({ ...ujiItinerary(), export_google_maps_url: ["", "https://maps.example/second"] });
+    expect(view.pacing).toBe("chill");
+    expect(view.mapsUrl).toBe("https://maps.example/second");
+  });
+
+  it("returns no maps URL when the export list is absent", () => {
+    const view = itineraryView({ ...ujiItinerary(), export_google_maps_url: undefined });
+    expect(view.mapsUrl).toBeUndefined();
+  });
+});

--- a/apps/web/tests/unit/chat/route-card.test.tsx
+++ b/apps/web/tests/unit/chat/route-card.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatActionsProvider } from "../../../src/features/chat/chat-actions";
+import { DataPartCard } from "../../../src/features/chat/components/DataPartCard";
+import { RouteCard } from "../../../src/features/chat/components/RouteCard";
+import type { AttachBasemap } from "../../../src/features/chat/components/SearchMap";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { parsedPart, routePartRaw, routePoint, ujiItinerary, ujiPoints } from "./_route-fixtures";
+
+afterEach(cleanup);
+
+const dict = chatDictFor("ja");
+const attachReady: AttachBasemap = ({ onStatus }) => {
+  onStatus("ready");
+  return () => undefined;
+};
+
+function fullRouteRaw() {
+  const offRoute = { id: "x", name: "平等院", latitude: 34.889, longitude: 135.808, screenshot_url: "", episode: -1 };
+  return {
+    ...routePartRaw(ujiPoints().slice(), { timed_itinerary: ujiItinerary() }),
+    data: {
+      results: { rows: [...ujiPoints(), offRoute] },
+      route: { ordered_points: ujiPoints().slice(), point_count: 3, timed_itinerary: ujiItinerary() },
+    },
+  };
+}
+
+function renderRouteCard(raw: unknown = fullRouteRaw()) {
+  return render(<RouteCard part={parsedPart(raw)} dict={dict} attach={attachReady} />);
+}
+
+describe("route card composition (S1.5 replaces the stats-only card)", () => {
+  it("renders the timeline, the promoted map, and the spot strip together", () => {
+    renderRouteCard();
+    expect(screen.getByRole("list", { name: dict.route.timelineLabel })).toBeTruthy();
+    expect(screen.getByRole("img", { name: dict.route.mapLabel })).toBeTruthy();
+    expect(document.querySelector(".chat-card__spots")).toBeTruthy();
+  });
+
+  it("dims exactly the located result spots the planner left off the route", () => {
+    renderRouteCard();
+    expect(document.querySelectorAll(".chat-route-pin")).toHaveLength(3);
+    expect(document.querySelectorAll(".chat-map-pin--dimmed")).toHaveLength(1);
+  });
+
+  it("renders no timeline and no map when the route carries neither", () => {
+    renderRouteCard(routePartRaw([{ id: "a", name: "宇治橋" }]));
+    expect(screen.queryByRole("list", { name: dict.route.timelineLabel })).toBeNull();
+    expect(document.querySelector(".chat-search-map")).toBeNull();
+    expect(screen.getByText("宇治橋")).toBeTruthy();
+  });
+});
+
+describe("AC5: a 404'd scene still degrades to the D9 placeholder", () => {
+  it("swaps the broken img for the gradient placeholder with episode text", () => {
+    renderRouteCard();
+    const img = document.querySelector("img.chat-scene-thumb");
+    expect(img).toBeTruthy();
+    fireEvent.error(img as HTMLImageElement);
+    expect(document.querySelector("img.chat-scene-thumb")).toBeNull();
+    expect(screen.getByText("第8話").className).toContain("chat-scene-thumb--fallback");
+  });
+
+  it("never renders a thumb or a leaked -1 episode for sentinel rows", () => {
+    renderRouteCard();
+    expect(document.querySelectorAll("img.chat-scene-thumb")).toHaveLength(1);
+    expect(screen.queryByText(/第-1話/)).toBeNull();
+  });
+
+  it("keeps the -1 episode sentinel out of the D9 placeholder label", () => {
+    renderRouteCard(routePartRaw([routePoint({ id: "a", name: "宇治橋", screenshot: "/broken.webp" })]));
+    fireEvent.error(document.querySelector("img.chat-scene-thumb") as HTMLImageElement);
+    const placeholder = document.querySelector(".chat-scene-thumb--fallback");
+    expect(placeholder?.textContent).toBe("");
+  });
+});
+
+describe("AC4: a short route still renders the card plus the D3 note", () => {
+  it("keeps the timeline and appends the explanatory notice for <3 spots", () => {
+    const short = {
+      ...routePartRaw(ujiPoints().slice(0, 2)),
+      data: { route: { ordered_points: ujiPoints().slice(0, 2), point_count: 2, timed_itinerary: { ...ujiItinerary(), stops: ujiItinerary().stops.slice(0, 2), legs: ujiItinerary().legs.slice(0, 1) } } },
+    };
+    render(
+      <ChatActionsProvider actions={{ send: vi.fn(), regenerate: vi.fn() }}>
+        <DataPartCard data={short} dict={dict} />
+      </ChatActionsProvider>,
+    );
+    expect(screen.getByText(dict.errorStates.d3Notice)).toBeTruthy();
+    expect(screen.getByRole("button", { name: dict.errorStates.d3Chip })).toBeTruthy();
+    expect(screen.getByText("10:00–10:20")).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/chat/route-card.test.tsx
+++ b/apps/web/tests/unit/chat/route-card.test.tsx
@@ -73,7 +73,7 @@ describe("AC5: a 404'd scene still degrades to the D9 placeholder", () => {
 
   it("keeps the -1 episode sentinel out of the D9 placeholder label", () => {
     renderRouteCard(routePartRaw([routePoint({ id: "a", name: "宇治橋", screenshot: "/broken.webp" })]));
-    fireEvent.error(document.querySelector("img.chat-scene-thumb") as HTMLImageElement);
+    fireEvent.error(screen.getByRole("img"));
     const placeholder = document.querySelector(".chat-scene-thumb--fallback");
     expect(placeholder?.textContent).toBe("");
   });

--- a/apps/web/tests/unit/chat/route-i18n.test.ts
+++ b/apps/web/tests/unit/chat/route-i18n.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { chatDictFor } from "../../../src/features/chat/i18n";
-import { legCapsule } from "../../../src/features/chat/route-copy";
+import { legCapsule, routeStatsCopy } from "../../../src/features/chat/route-copy";
 import { LOCALES } from "../../../src/i18n/locales";
 
 const PACINGS = ["chill", "normal", "packed"] as const;
@@ -34,5 +34,24 @@ describe("legCapsule templating", () => {
     expect(legCapsule(dict, { mode: "walk", minutes: 12 })).toContain("12");
     expect(legCapsule(dict, { mode: "transit", minutes: 8 })).toContain("8");
     expect(legCapsule(dict, { mode: "walk", minutes: 12 })).not.toContain("{min}");
+  });
+});
+
+// The card's headline was hardcoded English ("N spots · M min") and rendered
+// that way to ja and zh users on the flagship deliverable of this story.
+describe("route headline stats", () => {
+  it("renders both numbers through localized copy in every locale", () => {
+    const rendered = LOCALES.map((locale) => routeStatsCopy(chatDictFor(locale), 4, 25));
+    for (const line of rendered) {
+      expect(line).toContain("4");
+      expect(line).toContain("25");
+    }
+    expect(new Set(rendered).size).toBe(LOCALES.length);
+  });
+
+  it("renders an em dash, not a bare question mark, when walking minutes are absent", () => {
+    const line = routeStatsCopy(chatDictFor("ja"), 4, undefined);
+    expect(line).toContain("—");
+    expect(line).not.toContain("?");
   });
 });

--- a/apps/web/tests/unit/chat/route-i18n.test.ts
+++ b/apps/web/tests/unit/chat/route-i18n.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { legCapsule } from "../../../src/features/chat/route-copy";
+import { LOCALES } from "../../../src/i18n/locales";
+
+const PACINGS = ["chill", "normal", "packed"] as const;
+
+describe("AC6: route dictionary coverage per locale", () => {
+  it.each(LOCALES)("defines every pacing label and CTA string for %s", (locale) => {
+    const route = chatDictFor(locale).route;
+    for (const pacing of PACINGS) expect(route.pacing[pacing].length).toBeGreaterThan(0);
+    for (const copy of [route.walkCta, route.openMaps, route.routePill, route.highlight]) {
+      expect(copy.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("pins the ja pacing trio to the specced copy", () => {
+    expect(chatDictFor("ja").route.pacing).toEqual({ chill: "ゆったり", normal: "適中", packed: "緊張" });
+  });
+
+  it("keeps each locale's pacing copy distinct from English", () => {
+    expect(chatDictFor("ja").route.pacing.chill).not.toBe(chatDictFor("en").route.pacing.chill);
+    expect(chatDictFor("zh").route.pacing.packed).not.toBe(chatDictFor("en").route.pacing.packed);
+  });
+
+  it.each(LOCALES)("localizes the E1 previous-version badge for %s", (locale) => {
+    expect(chatDictFor(locale).previousVersion.length).toBeGreaterThan(0);
+  });
+});
+
+describe("legCapsule templating", () => {
+  it.each(LOCALES)("substitutes minutes into the %s walk and transit capsules", (locale) => {
+    const dict = chatDictFor(locale);
+    expect(legCapsule(dict, { mode: "walk", minutes: 12 })).toContain("12");
+    expect(legCapsule(dict, { mode: "transit", minutes: 8 })).toContain("8");
+    expect(legCapsule(dict, { mode: "walk", minutes: 12 })).not.toContain("{min}");
+  });
+});

--- a/apps/web/tests/unit/chat/route-supersession.test.tsx
+++ b/apps/web/tests/unit/chat/route-supersession.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { UIMessage } from "ai";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatActionsProvider } from "../../../src/features/chat/chat-actions";
+import { MessageList } from "../../../src/features/chat/components/MessageList";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import chatCss from "../../../src/styles/chat.css?raw";
+import { ruleDeclaration } from "../_token-helpers";
+import { routePartRaw, ujiPoints } from "./_route-fixtures";
+
+afterEach(cleanup);
+
+const ja = chatDictFor("ja");
+
+function assistantMessage(id: string, data: unknown): UIMessage {
+  const part = { type: "data-response", id: "response", data };
+  return { id, role: "assistant", parts: [part] as unknown as UIMessage["parts"] };
+}
+
+function renderList(messages: readonly UIMessage[]) {
+  return render(
+    <ChatActionsProvider actions={{ send: vi.fn(), regenerate: vi.fn() }}>
+      <MessageList messages={messages} dict={ja} status="ready" />
+    </ChatActionsProvider>,
+  );
+}
+
+function routeCards(): readonly Element[] {
+  return [...document.querySelectorAll('article[data-intent="plan_route"]')];
+}
+
+describe("AC7: regenerating the route replaces the card per the E1 rule", () => {
+  it("dims the old card with the previous-version badge and keeps the new one last", () => {
+    renderList([
+      assistantMessage("a1", routePartRaw(ujiPoints().slice())),
+      assistantMessage("a2", routePartRaw(ujiPoints().slice(0, 3))),
+    ]);
+    const [oldCard, newCard] = routeCards();
+    expect(oldCard?.className).toBe("chat-card chat-card--superseded");
+    expect(oldCard?.querySelector(".chat-card__version-badge")?.textContent).toBe(ja.previousVersion);
+    expect(newCard?.className).toBe("chat-card");
+    expect(newCard?.querySelector(".chat-card__version-badge")).toBeNull();
+  });
+
+  it("dims every older version once a third regeneration lands", () => {
+    renderList([
+      assistantMessage("a1", routePartRaw(ujiPoints().slice())),
+      assistantMessage("a2", routePartRaw(ujiPoints().slice())),
+      assistantMessage("a3", routePartRaw(ujiPoints().slice())),
+    ]);
+    const flags = routeCards().map((card) => card.className.includes("chat-card--superseded"));
+    expect(flags).toEqual([true, true, false]);
+  });
+
+  it("pins the E1 dim to opacity .55 in the stylesheet", () => {
+    expect(ruleDeclaration(chatCss, ".chat-card--superseded", "opacity")).toBe("0.55");
+  });
+});
+
+describe("E1 scoping: only newer versions of the same document supersede", () => {
+  it("never dims the route card for an unrelated later search card", () => {
+    const search = { intent: "search_bangumi", success: true, status: "ok", data: { results: { rows: [{ id: "p1", name: "宇治橋" }] } } };
+    renderList([
+      assistantMessage("a1", routePartRaw(ujiPoints().slice())),
+      assistantMessage("a2", search),
+    ]);
+    expect(routeCards()[0]?.className).toBe("chat-card");
+  });
+
+  it("keeps the old card current while the regenerated route is still a skeleton", () => {
+    renderList([
+      assistantMessage("a1", routePartRaw(ujiPoints().slice())),
+      assistantMessage("a2", { intent: "plan_route" }),
+    ]);
+    expect(routeCards()[0]?.className).toBe("chat-card");
+    expect(screen.getByRole("status").getAttribute("data-intent")).toBe("plan_route");
+  });
+});

--- a/apps/web/tests/unit/chat/route-trail-map.test.tsx
+++ b/apps/web/tests/unit/chat/route-trail-map.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { RouteTrailMap } from "../../../src/features/chat/components/RouteTrailMap";
 import type { AttachBasemap } from "../../../src/features/chat/components/SearchMap";
 import { chatDictFor } from "../../../src/features/chat/i18n";
+import { pointPlacements } from "../../../src/features/bubble-map/bubbleGeometry";
 import type { LocatedSpot } from "../../../src/lib/chat/spotClusters";
 import { ruleDeclaration } from "../_token-helpers";
 import chatCss from "../../../src/styles/chat.css?raw";
@@ -44,6 +45,23 @@ describe("AC2: map promotion after route generation", () => {
     renderTrail();
     const pins = [...document.querySelectorAll(".chat-route-pin")];
     expect(pins.map((pin) => pin.textContent)).toEqual(["1", "2", "3"]);
+  });
+
+  // Labels alone do not pin the ordering: reversing the placements keeps the
+  // labels "1","2","3" present and leaves the polyline shape identical, so the
+  // assertion above survives that mutation. Bind each label to the position its
+  // station actually projects to.
+  it("puts pin N at station N's own position, not merely somewhere on the map", () => {
+    renderTrail();
+    const expected = pointPlacements([...STATIONS, ...OFF_ROUTE].map((s) => s.coord));
+    const pins = [...document.querySelectorAll<HTMLElement>(".chat-route-pin")];
+    const actual = pins.map((pin) => [pin.style.left, pin.style.top]);
+    expect(actual).toEqual(
+      STATIONS.map((_, index) => [
+        `${String(expected[index]?.leftPct)}%`,
+        `${String(expected[index]?.topPct)}%`,
+      ]),
+    );
   });
 
   it("dims spots that did not make the route", () => {

--- a/apps/web/tests/unit/chat/route-trail-map.test.tsx
+++ b/apps/web/tests/unit/chat/route-trail-map.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { RouteTrailMap } from "../../../src/features/chat/components/RouteTrailMap";
+import type { AttachBasemap } from "../../../src/features/chat/components/SearchMap";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import type { LocatedSpot } from "../../../src/lib/chat/spotClusters";
+import { ruleDeclaration } from "../_token-helpers";
+import chatCss from "../../../src/styles/chat.css?raw";
+
+afterEach(cleanup);
+
+const dict = chatDictFor("ja");
+const attachReady: AttachBasemap = ({ onStatus }) => {
+  onStatus("ready");
+  return () => undefined;
+};
+const attachFailing: AttachBasemap = ({ onStatus }) => {
+  onStatus("fallback");
+  return () => undefined;
+};
+
+function spot(id: string, name: string, lat: number, lng: number): LocatedSpot {
+  return { id, name, coord: { lat, lng } };
+}
+
+const STATIONS = [spot("a", "宇治橋", 34.891, 135.807), spot("b", "京阪宇治駅", 34.911, 135.806), spot("c", "宇治神社", 34.9, 135.81)];
+const OFF_ROUTE = [spot("x", "平等院", 34.889, 135.808)];
+
+function renderTrail(attach: AttachBasemap = attachReady) {
+  return render(<RouteTrailMap stations={STATIONS} dimmed={OFF_ROUTE} dict={dict} attach={attach} />);
+}
+
+describe("AC2: map promotion after route generation", () => {
+  it("draws one track polyline through every route station", () => {
+    renderTrail();
+    const line = document.querySelector(".chat-route-map__line");
+    expect(line?.getAttribute("points")?.split(" ")).toHaveLength(3);
+  });
+
+  it("renumbers pins in walking order", () => {
+    renderTrail();
+    const pins = [...document.querySelectorAll(".chat-route-pin")];
+    expect(pins.map((pin) => pin.textContent)).toEqual(["1", "2", "3"]);
+  });
+
+  it("dims spots that did not make the route", () => {
+    renderTrail();
+    expect(document.querySelectorAll(".chat-map-pin--dimmed")).toHaveLength(1);
+    expect(ruleDeclaration(chatCss, ".chat-map-pin--dimmed", "opacity")).toBe("0.35");
+  });
+
+  it("shows the gold route pill in the frame corner, styled by gold tokens", () => {
+    renderTrail();
+    expect(screen.getByText(dict.route.routePill).className).toBe("chat-route-pill");
+    expect(ruleDeclaration(chatCss, ".chat-route-pill", "background")).toBe("var(--color-gold-soft)");
+    expect(ruleDeclaration(chatCss, ".chat-route-map__line", "stroke")).toBe("var(--color-gold)");
+  });
+});
+
+describe("accessibility of the promoted map", () => {
+  it("labels the frame and hides the decorative overlay from AT", () => {
+    renderTrail();
+    expect(screen.getByRole("img", { name: dict.route.mapLabel })).toBeTruthy();
+    const overlay = document.querySelector(".chat-search-map__overlay");
+    expect(overlay?.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+describe("degradation", () => {
+  it("falls back to the D7 doodle when the basemap fails", () => {
+    renderTrail(attachFailing);
+    expect(screen.getByText(dict.errorStates.d7Message)).toBeTruthy();
+    expect(document.querySelector(".chat-route-pin")).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/chat/supersession.test.ts
+++ b/apps/web/tests/unit/chat/supersession.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { routeDocumentKey, supersededFlags } from "../../../src/lib/chat/supersession";
+import { parsedPart, routePartRaw, ujiPoints } from "./_route-fixtures";
+
+describe("supersededFlags (E1 rule, shared with issue #273)", () => {
+  it("dims every earlier card of a key, keeping only the newest current", () => {
+    expect(supersededFlags(["route", undefined, "route", "route"])).toEqual([true, false, true, false]);
+  });
+
+  it("tracks keys independently so different documents never dim each other", () => {
+    expect(supersededFlags(["route", "shiori", "route"])).toEqual([true, false, false]);
+  });
+
+  it("never dims keyless entries", () => {
+    expect(supersededFlags([undefined, undefined])).toEqual([false, false]);
+  });
+});
+
+describe("routeDocumentKey (route cards as the first living document)", () => {
+  it("keys every route-family intent that carries a route", () => {
+    const intents = ["plan_route", "plan_selected", "plan_multi", "partial"];
+    const keys = intents.map((intent) => routeDocumentKey({ ...routePartRaw(ujiPoints().slice()), intent }));
+    expect(keys).toEqual(["route", "route", "route", "route"]);
+  });
+
+  it("accepts the exact shape the contract schema emits", () => {
+    expect(routeDocumentKey(parsedPart(routePartRaw(ujiPoints().slice())))).toBe("route");
+  });
+
+  it("leaves intent-only frames keyless so a streaming skeleton never dims the old card", () => {
+    expect(routeDocumentKey({ intent: "plan_route" })).toBeUndefined();
+  });
+
+  it("leaves non-route intents and malformed payloads keyless", () => {
+    expect(routeDocumentKey({ intent: "search_bangumi", data: { results: {} } })).toBeUndefined();
+    expect(routeDocumentKey({ intent: "plan_route", data: { route: null } })).toBeUndefined();
+    expect(routeDocumentKey({ intent: "plan_route", data: { route: undefined } })).toBeUndefined();
+    expect(routeDocumentKey({ intent: 42, data: {} })).toBeUndefined();
+    expect(routeDocumentKey("not-an-object")).toBeUndefined();
+  });
+});

--- a/apps/web/tests/unit/chat/timed-itinerary.test.tsx
+++ b/apps/web/tests/unit/chat/timed-itinerary.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TimedItinerary } from "../../../src/features/chat/components/TimedItinerary";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { itineraryView } from "../../../src/lib/chat/itinerary";
+import { ujiItinerary } from "./_route-fixtures";
+
+afterEach(cleanup);
+
+const ja = chatDictFor("ja");
+
+function renderTimeline(locale: "ja" | "zh" | "en" = "ja") {
+  const dict = chatDictFor(locale);
+  return { dict, ...render(<TimedItinerary view={itineraryView(ujiItinerary())} dict={dict} />) };
+}
+
+describe("AC1: station-granularity HH:MM timeline", () => {
+  it("renders each station with its labelled HH:MM arrive–depart window", () => {
+    renderTimeline();
+    const timeline = screen.getByRole("list", { name: ja.route.timelineLabel });
+    expect(timeline.querySelectorAll(".chat-itinerary__stop")).toHaveLength(3);
+    expect(screen.getByText("10:00–10:20")).toBeTruthy();
+    expect(screen.getByText("10:32–10:52")).toBeTruthy();
+  });
+
+  it("gold-stars exactly one station — the most-photographed — with an AT name", () => {
+    renderTimeline();
+    const star = screen.getByRole("img", { name: ja.route.highlight });
+    expect(star.closest(".chat-itinerary__stop--highlight")?.textContent).toContain("京阪宇治駅");
+    expect(document.querySelectorAll(".chat-itinerary__star")).toHaveLength(1);
+  });
+
+  it("renders a visible walk capsule and styles transit legs distinctly", () => {
+    renderTimeline();
+    expect(screen.getByText("徒歩12分").closest("li")?.getAttribute("data-mode")).toBe("walk");
+    expect(screen.getByText("移動8分").closest("li")?.getAttribute("data-mode")).toBe("transit");
+  });
+});
+
+describe("AC6: pacing pill and CTA row copy per locale", () => {
+  it("renders the ja pacing pill and CTA copy", () => {
+    renderTimeline("ja");
+    expect(screen.getByText("ゆったり").getAttribute("data-pacing")).toBe("chill");
+    expect(screen.getByRole("link", { name: ja.route.openMaps }).getAttribute("href")).toBe("https://maps.example/route");
+    expect(screen.getByRole("button", { name: ja.route.walkCta })).toBeTruthy();
+  });
+
+  it("renders the zh pacing pill and CTA copy", () => {
+    const { dict } = renderTimeline("zh");
+    expect(screen.getByText("悠闲")).toBeTruthy();
+    expect(screen.getByRole("button", { name: dict.route.walkCta })).toBeTruthy();
+    expect(screen.getByRole("link", { name: dict.route.openMaps })).toBeTruthy();
+  });
+
+  it("renders the en pacing pill and CTA copy", () => {
+    const { dict } = renderTimeline("en");
+    expect(screen.getByText("Chill")).toBeTruthy();
+    expect(screen.getByRole("button", { name: dict.route.walkCta })).toBeTruthy();
+  });
+});
+
+describe("reserved Walk-mode entry point", () => {
+  it("keeps the Walk CTA a disabled placeholder seam", () => {
+    renderTimeline();
+    const walk = screen.getByRole("button", { name: ja.route.walkCta });
+    expect(walk.getAttribute("data-cta")).toBe("walk-mode");
+    expect((walk as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe("sparse itineraries", () => {
+  it("omits pill, times, and maps link when the payload has none", () => {
+    const bare = { ...ujiItinerary(), pacing: undefined, export_google_maps_url: [], stops: ujiItinerary().stops.map((stop) => ({ ...stop, arrive: "", depart: "" })) };
+    render(<TimedItinerary view={itineraryView(bare)} dict={ja} />);
+    expect(document.querySelector(".chat-pacing-pill")).toBeNull();
+    expect(document.querySelector(".chat-itinerary__time")).toBeNull();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #271

S1.5: the route card becomes a real TimedItinerary — station-granularity HH:MM timeline, gold-star highlight, walk capsules, pacing pill, CTA row with a reserved Walk-mode seam — plus map promotion (gold track, walking-order pin numbers, dimmed off-route spots, gold route pill) and the E1 supersession rule for regenerated routes.

## AC → covering test

| AC | Status | Test |
|---|---|---|
| 1. HH:MM timeline + gold-star station + walk capsule (browser) | done | `tests/unit/chat/timed-itinerary.test.tsx` ("AC1: station-granularity HH:MM timeline") + `tests/unit/chat/itinerary.test.ts` |
| 2. Map promotion: track, renumbered pins, dimmed spots, gold pill (browser) | done | `tests/unit/chat/route-trail-map.test.tsx` ("AC2: map promotion after route generation") |
| 3. ×1.3 detour coefficient | **already shipped — untouched** | pre-existing regression test `workers/catalog/test/route.worker.test.ts:129` ("buildTimedItinerary — walking detour coefficient" pins ×1.3); verified present, no catalog file modified |
| 4. <3 spots still renders + D3 note (browser) | done | `tests/unit/chat/route-card.test.tsx` ("AC4: a short route still renders the card plus the D3 note") — reuses #420's `ShortRouteNotice`/classifier |
| 5. 404'd thumbnail → gradient placeholder + episode text (browser) | done | `tests/unit/chat/route-card.test.tsx` ("AC5: …D9 placeholder") — reuses #420's `SceneThumb`; includes a `-1` episode-sentinel guard |
| 6. Pacing pill ゆったり/適中/緊張 + CTA copy per locale (unit) | done | `tests/unit/chat/route-i18n.test.ts` + locale render cases in `timed-itinerary.test.tsx` |
| 7. E1 supersession: old card `opacity .55` + 「以前の版」 badge, new card last (integration) | done | `tests/unit/chat/route-supersession.test.tsx` (MessageList integration incl. CSS pin of `.chat-card--superseded { opacity: 0.55 }`) + `tests/unit/chat/supersession.test.ts` |

`ac_total == ac_with_test`: 6 implemented ACs each map to tests in this diff; AC3 was pre-shipped with its own regression test.

## How the E1 helper is scoped for #273

The rule lives in `apps/web/src/lib/chat/supersession.ts` as two pieces:

- `supersededFlags(keys)` — fully generic: given per-card document keys in conversation order, flags every card that a newer card of the same key supersedes. #273 reuses this untouched for other living documents by supplying its own key producer.
- `routeDocumentKey(data)` — the route card's key producer (route-family intents that actually carry a route; intent-only streaming frames are keyless so a skeleton never dims the current card).

`MessageList` runs one supersession pass over all `data-response` parts and passes a `superseded` flag down; `DataPartCard` renders the dim class + badge generically (`dict.previousVersion`), with zero route-specific logic in the card renderer.

## Reused from #435 / #420 (not forked)

- `useBasemap`/`useStablePoints`/`MapFrame`/`percentStyle` exported from `SearchMap.tsx` and reused by `RouteTrailMap` — the coordinate-keyed identity (no map remount per SSE chunk) is preserved.
- `MapFallback` (D7), `SceneThumb` (D9), `ShortRouteNotice` (D3), the error classifier — no second set built.
- Sentinel discipline from `spotClusters.ts`: new mappings normalize `""` screenshot / `""` HH:MM / `-1` episode with explicit comparisons (not `??`); fixtures are `ChatResponseDataPart.parse`d against the real contract.

## Notes

- New gold tokens (`--color-gold`, `--color-gold-soft`, `--color-gold-fg`) added to `globals.css` (light + night) — no fitting semantic token existed for the gold star/pill.
- `ChatSearchDict` moved to `search-i18n.ts` (verbatim) to keep `i18n.ts` under the 300-line file cap; `route-i18n.ts` added alongside.
- Accessibility: the timeline `<ol>` is labelled and is the non-visual equivalent of the promoted map (frame `role="img"` + label, overlay `aria-hidden`); the gold star carries `role="img"` + localized name, so the highlight is not colour-only.

## Gates

```
pnpm run typecheck   → exit 0
pnpm run lint:oxlint → exit 0 (--deny-warnings)
pnpm run test        → 147 files / 863 tests passed
Statements 98.92% · Branches 95.08% · Functions 99.65% · Lines 99.87%
(floors: 95/94/95/95)
```

Mutation checks (each mutated in source, covering test failed, then reverted): highlight selection, walk capsule, dimmed-pin class, `supersededFlags`, version badge, `-1` episode guard, ja pacing copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
