### PR TITLE
fix(agent): never resurrect a closed CatalogClient http client (#303)

### DIFF
--- a/apps/agent/agent/clients/catalog_client.py
+++ b/apps/agent/agent/clients/catalog_client.py
@@ -205,7 +205,16 @@ class CatalogClientProtocol(Protocol):
 
 
 class CatalogClient:
-    """Async client for the Catalog RPC methods over a shared httpx client."""
+    """Async client for the Catalog RPC methods over a shared httpx client.
+
+    Lifecycle: one ``httpx.AsyncClient`` is built on first use and reused by
+    every RPC, so the hot agent path keeps httpx's connection pool and
+    keep-alive instead of re-handshaking per call. The owner — the FastAPI
+    lifespan in ``fastapi_service._lifespan_build_runtime`` — calls
+    :meth:`aclose` at shutdown. A closed client is never rebuilt: resurrecting
+    one would leak a pool nobody closes, and rebuilding an injected
+    ``http_client`` would silently escape its transport seam onto the network.
+    """
 
     def __init__(
         self,
@@ -283,14 +292,17 @@ class CatalogClient:
         return IngestResult.model_validate(payload)
 
     async def aclose(self) -> None:
-        """Close the shared HTTP client (no-op when never used)."""
-        if self._client is not None and not self._client.is_closed:
-            await self._client.aclose()
-        self._client = None
+        """Close the shared HTTP client (idempotent; no-op when never used)."""
+        if self._client is None or self._client.is_closed:
+            return
+        await self._client.aclose()
 
     def _http(self) -> httpx.AsyncClient:
-        """Return the shared httpx client, creating it lazily."""
-        if self._client is None or self._client.is_closed:
+        """Return the shared httpx client, built exactly once on first use.
+
+        A closed client is deliberately never rebuilt — see ``aclose``.
+        """
+        if self._client is None:
             self._client = self._build_http_client()
         return self._client
 

--- a/apps/agent/agent/clients/catalog_client.py
+++ b/apps/agent/agent/clients/catalog_client.py
@@ -207,13 +207,10 @@ class CatalogClientProtocol(Protocol):
 class CatalogClient:
     """Async client for the Catalog RPC methods over a shared httpx client.
 
-    Lifecycle: one ``httpx.AsyncClient`` is built on first use and reused by
-    every RPC, so the hot agent path keeps httpx's connection pool and
-    keep-alive instead of re-handshaking per call. The owner — the FastAPI
-    lifespan in ``fastapi_service._lifespan_build_runtime`` — calls
-    :meth:`aclose` at shutdown. A closed client is never rebuilt: resurrecting
-    one would leak a pool nobody closes, and rebuilding an injected
-    ``http_client`` would silently escape its transport seam onto the network.
+    One client is built on first use and reused by every RPC, so the hot agent
+    path keeps httpx's pool and keep-alive. The FastAPI lifespan owns it and
+    calls :meth:`aclose` at shutdown; a closed client is never rebuilt, so a
+    late call raises instead of leaking a pool or escaping an injected seam.
     """
 
     def __init__(

--- a/apps/agent/agent/tests/unit/test_catalog_client_http.py
+++ b/apps/agent/agent/tests/unit/test_catalog_client_http.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import AsyncIterator, Callable
 from unittest.mock import AsyncMock, MagicMock
@@ -62,6 +63,35 @@ async def test_reuses_one_http_client_across_requests() -> None:
     assert client._http() is shared
     assert len(calls) == 2
     await client.aclose()
+
+
+async def test_concurrent_requests_share_lazy_http_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    barrier = asyncio.Barrier(2)
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        await barrier.wait()
+        return _response(request, 200, {"rows": [], "synced_at": ""})
+
+    constructor = MagicMock(return_value=httpx.MockTransport(handler))
+    monkeypatch.setattr(
+        "agent.clients.catalog_client.httpx.AsyncHTTPTransport", constructor
+    )
+    client = CatalogClient("https://catalog.test")
+
+    try:
+        results = await asyncio.gather(client.search("響け"), client.search("氷菓"))
+        shared = client._client
+
+        assert results == [[], []]
+        assert len(requests) == 2
+        assert shared is not None and client._http() is shared
+        constructor.assert_called_once()
+    finally:
+        await client.aclose()
 
 
 @pytest.mark.parametrize("status", [408, 429, 500, 503])

--- a/apps/agent/agent/tests/unit/test_catalog_client_http.py
+++ b/apps/agent/agent/tests/unit/test_catalog_client_http.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -15,6 +15,7 @@ from agent.clients.catalog_errors import WorkNotFoundError
 from agent.clients.errors import APIError, TransientAPIError
 
 Handler = Callable[[httpx.Request], httpx.Response]
+AsyncHandler = Callable[[httpx.Request], Awaitable[httpx.Response]]
 
 
 class _StreamingBody(httpx.AsyncByteStream):
@@ -34,7 +35,13 @@ def _response(request: httpx.Request, status: int, payload: object) -> httpx.Res
     )
 
 
-def _install_transport(monkeypatch: pytest.MonkeyPatch, handler: Handler) -> MagicMock:
+def _ok(request: httpx.Request) -> httpx.Response:
+    return _response(request, 200, {"rows": [], "synced_at": ""})
+
+
+def _install_transport(
+    monkeypatch: pytest.MonkeyPatch, handler: Handler | AsyncHandler
+) -> MagicMock:
     constructor = MagicMock(return_value=httpx.MockTransport(handler))
     monkeypatch.setattr(
         "agent.clients.catalog_client.httpx.AsyncHTTPTransport", constructor
@@ -49,19 +56,14 @@ def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
 
 
 async def test_reuses_one_http_client_across_requests() -> None:
-    calls: list[httpx.Request] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        calls.append(request)
-        return _response(request, 200, {"rows": [], "synced_at": ""})
-
+    handler = MagicMock(side_effect=_ok)
     shared = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     client = CatalogClient("https://catalog.test", http_client=shared)
     await client.search("響け")
     await client.search("氷菓")
 
     assert client._http() is shared
-    assert len(calls) == 2
+    assert handler.call_count == 2
     await client.aclose()
 
 
@@ -69,26 +71,19 @@ async def test_concurrent_requests_share_lazy_http_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     barrier = asyncio.Barrier(2)
-    requests: list[httpx.Request] = []
 
     async def handler(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
         await barrier.wait()
-        return _response(request, 200, {"rows": [], "synced_at": ""})
+        return _ok(request)
 
-    constructor = MagicMock(return_value=httpx.MockTransport(handler))
-    monkeypatch.setattr(
-        "agent.clients.catalog_client.httpx.AsyncHTTPTransport", constructor
-    )
+    constructor = _install_transport(monkeypatch, handler)
     client = CatalogClient("https://catalog.test")
 
     try:
         results = await asyncio.gather(client.search("響け"), client.search("氷菓"))
-        shared = client._client
 
         assert results == [[], []]
-        assert len(requests) == 2
-        assert shared is not None and client._http() is shared
+        assert client._client is not None
         constructor.assert_called_once()
     finally:
         await client.aclose()
@@ -170,10 +165,7 @@ async def test_streaming_503_retries_without_reading_transport_body(
 
 
 async def test_aclose_closes_shared_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    def handler(request: httpx.Request) -> httpx.Response:
-        return _response(request, 200, {"rows": [], "synced_at": ""})
-
-    _install_transport(monkeypatch, handler)
+    _install_transport(monkeypatch, _ok)
     client = CatalogClient("https://catalog.test")
     await client.search("響け")
     shared = client._client
@@ -181,7 +173,6 @@ async def test_aclose_closes_shared_client(monkeypatch: pytest.MonkeyPatch) -> N
     await client.aclose()
 
     assert shared is not None and shared.is_closed
-    assert client._client is None
 
 
 async def test_aclose_without_requests_is_noop() -> None:
@@ -190,3 +181,18 @@ async def test_aclose_without_requests_is_noop() -> None:
     await client.aclose()
 
     assert client._client is None
+
+
+async def test_closed_client_is_not_resurrected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After shutdown a request must fail loudly, not build a leaked pool."""
+    constructor = _install_transport(monkeypatch, _ok)
+    client = CatalogClient("https://catalog.test")
+    await client.search("響け")
+    await client.aclose()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        await client.search("氷菓")
+
+    constructor.assert_called_once()


### PR DESCRIPTION
Closes #303

## What I found first

Most of #303 was **already on `feat/frontend-rebuild`** via commit `eb056f16`
("wip: CatalogClient shared AsyncClient #303 (codex output, pre-verification)"),
which had landed unreviewed through an earlier merge. Present on base already:

- `CatalogClient` holds one `httpx.AsyncClient` (`_http()` lazy-build), with
  `httpx.Limits(max_connections=20, max_keepalive_connections=10, keepalive_expiry=30)`
- `AsyncTenacityTransport` retry wiring and timeouts intact
- FastAPI lifespan ownership: `_lifespan_build_runtime` builds the client and
  `await catalog_client.aclose()` in its `finally`
- Tests for reuse, `aclose`, retries, and lifespan-shutdown close

So this PR is **verification plus the residual holes**, not the original fix.

## Lifecycle owner

The FastAPI lifespan (`fastapi_service._lifespan_build_runtime`) — unchanged
from base, and the right owner: it is the only place that *constructs* the
catalog client (`build_catalog_client`), so construction and teardown sit in one
scope, and its `finally` runs on both clean and failed startup.

`_lifespan_with_runtime_api` (the injected-`runtime_api` test branch)
deliberately does **not** close the catalog client — it did not build it, and
closing a caller-owned client is not its business.

## The residual hole this PR closes

`_http()` rebuilt the client whenever `self._client.is_closed`, and `aclose()`
nulled `_client`. Together those meant **a closed client silently resurrects**:

1. Any call arriving after lifespan shutdown (in-flight request during graceful
   drain) builds a *fresh* pool that nobody will ever close — exactly the leak
   #303 is about, just moved later in the lifecycle.
2. Worse for testing: if an **injected** `http_client` is closed, `_http()`
   replaced it with a self-built `AsyncHTTPTransport` client — the transport
   test seam silently escalating to real network I/O. This is observable: the
   mutation run below shows unit tests performing live DNS lookups for
   `catalog.test`.

Now the client is built exactly once and never rebuilt; a late call raises
httpx's own `RuntimeError: Cannot send a request, as the client has been closed.`
`aclose()` is idempotent and keeps the closed instance rather than nulling it.

## Test seam preserved

Unchanged: tests patch `agent.clients.catalog_client.httpx.AsyncHTTPTransport`
with a `MagicMock` returning an `httpx.MockTransport` (`_install_transport`), so
the retry transport, timeouts, and error mapping all still run for real — only
the socket layer is stubbed. The `http_client=` constructor seam also still
works (`test_reuses_one_http_client_across_requests`). Doubling as the reuse
assertion, that `MagicMock` constructor is asserted `called_once`.

## Tests

Kept + tightened from base, plus:

- `test_concurrent_requests_share_lazy_http_client` — **inherited WIP, kept.**
  Two `search()` calls under `asyncio.gather`, rendezvousing on an
  `asyncio.Barrier` so both are genuinely in flight, then
  `constructor.assert_called_once()`. Rewritten to reuse `_install_transport`
  rather than re-patching inline.
- `test_closed_client_is_not_resurrected` — **new.** After `aclose()`, a further
  `search()` raises and the transport constructor is still `called_once`.

No timing assertions anywhere — reuse is proved by object/constructor identity.

## Mutation evidence

Reverted `_post_json` to build a client per request:

```python
async with self._build_http_client() as _c:
    response = await _c.post(url, json=body)
```

```
FAILED test_catalog_client_http.py::test_reuses_one_http_client_across_requests - agent.clients.errors.TransientAPIError: Transport failure for https://catal...
FAILED test_catalog_client_http.py::test_concurrent_requests_share_lazy_http_client - assert None is not None
FAILED test_catalog_client_http.py::test_aclose_closes_shared_client - assert (None is not None)
FAILED test_catalog_client_http.py::test_closed_client_is_not_resurrected - Failed: DID NOT RAISE RuntimeError
4 failed, 13 passed in 4.19s
```

Restored → `17 passed`.

## Gates

```
LINT=0   All checks passed! / 322 files already formatted
TC=0     Success: no issues found in 111 source files
TEST=0   1291 passed in 34.43s
         TOTAL 5695 550 1146 175 88%
         Required test coverage of 88% reached. Total coverage: 88.17%
```

## Notes

- **Coverage floor ratcheted 82 → 88** in `apps/agent/pytest.ini` (it was `82`,
  not `88` as assumed). Note `.github/workflows/_python-ci.yml` overrides with
  `--cov-fail-under=80`, so the CI floor is a separate, lower number — worth a
  follow-up to align the three.
- `make test` initially failed on `test_chat_wire_contract.py` with
  `ERR_MODULE_NOT_FOUND: tsx`. That was a **missing `node_modules`** — the
  worktree had none at all. `pnpm install --frozen-lockfile` fixed it; the wire
  format was not touched.
- Out of scope, left alone: `clients/python/seichijunrei_client.py`,
  `scripts/seed_http.py`, and `infrastructure/gateways/geocoding.py` still open a
  client per request. None is on the agent hot path and #303 names `CatalogClient`
  only.
- `catalog_client.py` is 425 lines, over the 300-line cap. Pre-existing; splitting
  it is a separate refactor and would have buried this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
