### PR TITLE
fix: 401 an expired/invalid JWT instead of falling through to the anonymous handler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ jobs:
 
   changes:
     runs-on: ubuntu-latest
+    # dorny/paths-filter resolves a pull_request's changed files through the
+    # GitHub API (listFiles), which needs `pull-requests: read`. The workflow-level
+    # `permissions: contents: read` grants only Contents+Metadata, so on a private
+    # repo the call returns "Resource not accessible by integration"; this job then
+    # fails and EVERY downstream lane (`Agent CI`, `Edge worker tests`, `Contract
+    # OpenAPI drift`, …) reports `skipping` — a green-looking PR with no suite run.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       catalog: ${{ steps.f.outputs.catalog }}
       users: ${{ steps.f.outputs.users }}

--- a/apps/agent/agent/interfaces/routes/_deps.py
+++ b/apps/agent/agent/interfaces/routes/_deps.py
@@ -104,8 +104,12 @@ def _reject_credentialed_anonymous(
     Serving it anonymously would meter and rate-limit the turn under the wrong
     identity and hide the expiry from a client built to refresh on 401.
     """
-    if user_type == ANONYMOUS_USER_TYPE and credential is not None:
-        raise HTTPException(status_code=401, detail="Valid credentials required.")
+    if user_type != ANONYMOUS_USER_TYPE or credential is None:
+        return
+    # #441 surfaced only through anomalous anonymous spend; its inverse must not
+    # be equally invisible. The credential itself is never recorded.
+    _logger.warning("anonymous_credential_rejected")
+    raise HTTPException(status_code=401, detail="Valid credentials required.")
 
 
 def _get_trusted_auth_context(

--- a/apps/agent/agent/interfaces/routes/_deps.py
+++ b/apps/agent/agent/interfaces/routes/_deps.py
@@ -19,6 +19,7 @@ from agent.infrastructure.session import SessionStore, create_session_store
 from agent.infrastructure.supabase.client import SupabaseClient
 from agent.interfaces.public_api import PublicAPIResponse, RuntimeAPI
 from agent.interfaces.schemas import GRACEFUL_TERMINAL_STATUSES
+from agent.interfaces.usage_metering import ANONYMOUS_USER_TYPE
 
 if TYPE_CHECKING:
     import logfire
@@ -92,13 +93,31 @@ def _normalize_optional_header(value: str | None) -> str | None:
     return text or None
 
 
+def _reject_credentialed_anonymous(
+    user_type: str | None, credential: str | None
+) -> None:
+    """Refuse an anonymous stamp that arrived with a credential (issue #441).
+
+    The edge strips ``Authorization`` before stamping an identity, so the pair
+    can only co-occur when a presented credential failed to verify and the
+    request was demoted anyway, or when the container was reached directly.
+    Serving it anonymously would meter and rate-limit the turn under the wrong
+    identity and hide the expiry from a client built to refresh on 401.
+    """
+    if user_type == ANONYMOUS_USER_TYPE and credential is not None:
+        raise HTTPException(status_code=401, detail="Valid credentials required.")
+
+
 def _get_trusted_auth_context(
     x_user_id: Annotated[str | None, Header(alias="X-User-Id")] = None,
     x_user_type: Annotated[str | None, Header(alias="X-User-Type")] = None,
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
 ) -> TrustedAuthContext:
+    user_type = _normalize_optional_header(x_user_type)
+    _reject_credentialed_anonymous(user_type, _normalize_optional_header(authorization))
     return TrustedAuthContext(
         user_id=_normalize_optional_header(x_user_id),
-        user_type=_normalize_optional_header(x_user_type),
+        user_type=user_type,
     )
 
 

--- a/apps/agent/agent/tests/unit/test_ingress_anonymous_credential.py
+++ b/apps/agent/agent/tests/unit/test_ingress_anonymous_credential.py
@@ -73,6 +73,19 @@ async def test_the_rejection_carries_the_authentication_error_code() -> None:
     assert response.json()["error"]["code"] == "authentication_error"
 
 
+async def test_the_rejection_is_logged_without_the_credential() -> None:
+    from structlog import testing
+
+    app, _ = _app()
+    with testing.capture_logs() as captured:
+        await _post(app, {**ANON_HEADERS, "Authorization": STALE_JWT})
+    events = [
+        entry for entry in captured if entry["event"] == "anonymous_credential_rejected"
+    ]
+    assert len(events) == 1
+    assert STALE_JWT not in str(events[0])
+
+
 async def test_a_credential_free_anonymous_turn_still_succeeds() -> None:
     app, runtime = _app()
     response = await _post(app, ANON_HEADERS)

--- a/apps/agent/agent/tests/unit/test_ingress_anonymous_credential.py
+++ b/apps/agent/agent/tests/unit/test_ingress_anonymous_credential.py
@@ -1,0 +1,87 @@
+"""Container ingress refuses an anonymous stamp carrying a credential (#441).
+
+The edge strips ``Authorization`` before it stamps an identity, so the two can
+only arrive together when the edge fell through on a bad credential or was
+bypassed. Either way the authoritative tier must 401 rather than serve the turn
+as a fresh anonymous visitor on the anonymous meter.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+from fastapi import FastAPI
+
+from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.schemas import PublicAPIResponse
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+ANON_HEADERS = {
+    "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
+    "X-User-Type": "anonymous",
+}
+HUMAN_HEADERS = {"X-User-Id": "user-1", "X-User-Type": "human"}
+STALE_JWT = "Bearer eyJhbGciOiJFUzI1NiJ9.stale.signature"
+
+
+def _body() -> dict[str, object]:
+    return {
+        "messages": [
+            {"id": "u1", "role": "user", "parts": [{"type": "text", "text": "京吹"}]}
+        ]
+    }
+
+
+def _app() -> tuple[FastAPI, MagicMock]:
+    db = build_stub_db()
+    db.usage = MagicMock()
+    db.usage.accumulate_usage = AsyncMock(return_value=None)
+    db.usage.total_cost_usd = AsyncMock(return_value=0.0)
+    runtime = MagicMock(spec=RuntimeAPI)
+    runtime.handle = AsyncMock(
+        return_value=PublicAPIResponse(
+            success=True, status="ok", intent="plan_route", message="ルートだよ。"
+        )
+    )
+    runtime.validate_session_owner = AsyncMock(return_value=None)
+    runtime._db = db
+    app, _ = build_app(runtime_api=runtime, db=db)
+    return app, runtime
+
+
+async def _post(app: FastAPI, headers: dict[str, str]) -> httpx.Response:
+    async with async_client(app) as client:
+        return await client.post("/v1/chat", json=_body(), headers=headers)
+
+
+async def test_an_anonymous_stamp_with_a_credential_is_rejected() -> None:
+    app, _ = _app()
+    response = await _post(app, {**ANON_HEADERS, "Authorization": STALE_JWT})
+    assert response.status_code == 401
+
+
+async def test_the_rejected_turn_never_reaches_the_runtime() -> None:
+    app, runtime = _app()
+    await _post(app, {**ANON_HEADERS, "Authorization": STALE_JWT})
+    assert runtime.handle.await_count == 0
+
+
+async def test_the_rejection_carries_the_authentication_error_code() -> None:
+    app, _ = _app()
+    response = await _post(app, {**ANON_HEADERS, "Authorization": STALE_JWT})
+    assert response.json()["error"]["code"] == "authentication_error"
+
+
+async def test_a_credential_free_anonymous_turn_still_succeeds() -> None:
+    app, runtime = _app()
+    response = await _post(app, ANON_HEADERS)
+    assert response.status_code == 200
+    assert runtime.handle.await_count == 1
+
+
+async def test_a_logged_in_stamp_is_unaffected_by_a_lingering_credential() -> None:
+    app, runtime = _app()
+    response = await _post(app, {**HUMAN_HEADERS, "Authorization": STALE_JWT})
+    assert response.status_code == 200
+    assert runtime.handle.await_count == 1

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:frontend": "pnpm --filter ./frontend run build",
     "deploy": "pnpm run build:frontend && npx wrangler deploy",
     "lint:oxlint": "pnpm --filter catalog --filter users --filter web run lint:oxlint",
-    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts"
+    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:frontend": "pnpm --filter ./frontend run build",
     "deploy": "pnpm run build:frontend && npx wrangler deploy",
     "lint:oxlint": "pnpm --filter catalog --filter users --filter web run lint:oxlint",
-    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts"
+    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",

--- a/worker/anonymous.test.ts
+++ b/worker/anonymous.test.ts
@@ -49,7 +49,7 @@ function anonEnv(captured: { requests: Request[] }, container: () => Response, g
 }
 
 function anonApp() {
-  return createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
+  return createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" }) });
 }
 
 function chat(headers: Record<string, string> = {}) {

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -216,7 +216,11 @@ export function createWorkerApp(deps: {
     //   if (denied !== null) return denied;
     // (`turnstileGate` = module-level createTurnstileGate() from ./turnstile.ts,
     // so its short-lived window is shared across requests on the same isolate.)
-    const anonymous = isAnonymousV1(pathname)
+    // Issue #441: only a caller who presented NO credential may be demoted to
+    // an anonymous identity. A presented-but-unverifiable one (expired,
+    // malformed, wrong key) falls straight through to the 401 below, which is
+    // what puts the web client back on its token-refresh path.
+    const anonymous = auth.reason === "absent" && isAnonymousV1(pathname)
       ? await handleAnonymousV1(c.env, c.req.raw, Date.now())
       : null;
     if (anonymous !== null) return anonymous;

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -143,6 +143,25 @@ export async function handleAnonymousV1(
   return withAnonymousCookie(response, identity.setCookie);
 }
 
+const UNAUTHORIZED_BODY = {
+  error: { code: "unauthorized", message: "Valid credentials required." },
+} as const;
+
+/** Structured, credential-free record of a rejected credential (issue #441).
+ *
+ * #441 itself only surfaced through anomalous anonymous spend. Its inverse — a
+ * 401 storm from a mis-issued or mis-refreshed token — must not be equally
+ * invisible, so every `invalid` verdict is counted at the edge. The token, the
+ * header and the identity are deliberately absent from the record. */
+function logInvalidCredential(pathname: string): void {
+  console.warn(JSON.stringify({ event: "edge_auth_invalid_credential", path: pathname }));
+}
+
+function unauthorized(pathname: string): Response {
+  logInvalidCredential(pathname);
+  return Response.json(UNAUTHORIZED_BODY, { status: 401 });
+}
+
 /** Forward a container-originated catalog request to the private CATALOG binding
  * (in-datacenter hop, never the public internet). Wired as the container's
  * outboundByHost handler in entry.ts. */
@@ -220,11 +239,12 @@ export function createWorkerApp(deps: {
     // an anonymous identity. A presented-but-unverifiable one (expired,
     // malformed, wrong key) falls straight through to the 401 below, which is
     // what puts the web client back on its token-refresh path.
-    const anonymous = auth.reason === "absent" && isAnonymousV1(pathname)
+    if (auth.reason === "invalid") return unauthorized(pathname);
+    const anonymous = isAnonymousV1(pathname)
       ? await handleAnonymousV1(c.env, c.req.raw, Date.now())
       : null;
     if (anonymous !== null) return anonymous;
-    return c.json({ error: { code: "unauthorized", message: "Valid credentials required." } }, 401);
+    return c.json(UNAUTHORIZED_BODY, 401);
   });
   app.all("*", (c) => deps.nextHandler.fetch(c.req.raw, c.env, c.executionCtx));
   return app;

--- a/worker/auth-neon.test.ts
+++ b/worker/auth-neon.test.ts
@@ -37,7 +37,7 @@ test("flag absent rejects EdDSA without fetching Neon JWKS", async () => {
   const { token } = await fixture("EdDSA", host);
   const urls: string[] = [];
   const r = await authenticate(bearer(token), BASE_ENV, stubFetch(() => new Response("", { status: 500 }), urls));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
   assert.equal(urls.includes(`${host}/.well-known/jwks.json`), false);
 });
 
@@ -47,7 +47,7 @@ test("false flag rejects EdDSA without fetching Neon JWKS", async () => {
   const urls: string[] = [];
   const env = { ...neonEnv(host), NEON_AUTH_ENABLED: "false" };
   const r = await authenticate(bearer(token), env, stubFetch(() => new Response("", { status: 500 }), urls));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
   assert.equal(urls.includes(env.NEON_AUTH_JWKS_URL), false);
 });
 
@@ -62,21 +62,21 @@ test("enabled Neon rejects wrong issuer", async () => {
   const host = "https://neon-wrong-issuer.example.test";
   const { jwk, token } = await fixture("EdDSA", "https://neon-other-issuer.example.test", host);
   const r = await authenticate(bearer(token), neonEnv(host), stubFetch(() => jwks(jwk)));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("enabled Neon rejects expired token", async () => {
   const host = "https://neon-expired.example.test";
   const { jwk, token } = await fixture("EdDSA", host, host, Math.floor(Date.now() / 1000) - 60);
   const r = await authenticate(bearer(token), neonEnv(host), stubFetch(() => jwks(jwk)));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("enabled Neon rejects wrong audience", async () => {
   const host = "https://neon-wrong-audience.example.test";
   const { jwk, token } = await fixture("EdDSA", host, "https://neon-other-audience.example.test");
   const r = await authenticate(bearer(token), neonEnv(host), stubFetch(() => jwks(jwk)));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("enabled Neon rejects signature from another key", async () => {
@@ -84,7 +84,7 @@ test("enabled Neon rejects signature from another key", async () => {
   const trusted = await fixture("EdDSA", host);
   const untrusted = await fixture("EdDSA", host);
   const r = await authenticate(bearer(untrusted.token), neonEnv(host), stubFetch(() => jwks(trusted.jwk)));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("enabled Neon coexists with Supabase", async () => {
@@ -107,7 +107,7 @@ test("enabled Neon without JWKS URL rejects without throwing", async () => {
   const { token } = await fixture("EdDSA", host);
   const env = { ...BASE_ENV, NEON_AUTH_ENABLED: "true", NEON_AUTH_ISSUER: host };
   const r = await authenticate(bearer(token), env, stubFetch(() => new Response("", { status: 500 })));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("sk_ token still uses api_keys when Neon is enabled", async () => {

--- a/worker/auth.test.ts
+++ b/worker/auth.test.ts
@@ -28,9 +28,9 @@ function jwks(jwk: JsonWebKey): Response {
   return new Response(JSON.stringify({ keys: [jwk] }), { status: 200, headers: { "Content-Type": "application/json" } });
 }
 
-test("no Authorization header -> {ok:false}", async () => {
+test("no Authorization header -> {ok:false, reason:absent}", async () => {
   const r = await authenticate(new Request("https://app.example.test/v1/chat"), ENV, stubFetch(() => new Response("", { status: 200 })));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "absent" });
 });
 
 test("valid sk_ key -> agent + userId from api_keys", async () => {
@@ -45,7 +45,7 @@ test("valid sk_ key -> agent + userId from api_keys", async () => {
 test("unknown sk_ key (no rows) -> {ok:false}", async () => {
   const r = await authenticate(bearer("sk_fake_unknown"), ENV, stubFetch((url) =>
     url.includes("/rest/v1/api_keys") ? new Response("[]", { status: 200 }) : new Response("", { status: 200 })));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("valid ES256 token verifies locally", async () => {
@@ -62,21 +62,21 @@ test("expired ES256 token is rejected", async () => {
   const host = "https://sb-expired.example.test";
   const { jwk, token } = await esFixture(host, `${host}/auth/v1`, Math.floor(Date.now() / 1000) - 60);
   const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("wrong Supabase issuer is rejected", async () => {
   const host = "https://sb-wrong-issuer.example.test";
   const { jwk, token } = await esFixture(host, "https://sb-other-issuer.example.test/auth/v1");
   const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("wrong Supabase audience is rejected", async () => {
   const host = "https://sb-wrong-aud.example.test";
   const { jwk, token } = await esFixture(host, undefined, "1h", "wrong-aud");
   const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("ES256 token signed by another key is rejected", async () => {
@@ -84,7 +84,7 @@ test("ES256 token signed by another key is rejected", async () => {
   const trusted = await esFixture(host);
   const untrusted = await esFixture(host);
   const r = await authenticate(bearer(untrusted.token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(trusted.jwk)));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("HS256 token is rejected even with a healthy JWKS", async () => {
@@ -95,7 +95,7 @@ test("HS256 token is rejected even with a healthy JWKS", async () => {
     .setIssuer(`${host}/auth/v1`).setAudience("authenticated").setSubject("fake-user").setIssuedAt().setExpirationTime("1h")
     .sign(new TextEncoder().encode("fake-secret-with-at-least-32-bytes"));
   const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("EdDSA token is rejected by the Supabase algorithm allowlist", async () => {
@@ -108,10 +108,10 @@ test("EdDSA token is rejected by the Supabase algorithm allowlist", async () => 
   const token = await new SignJWT({}).setProtectedHeader({ alg: "EdDSA", kid: jwk.kid })
     .setIssuer(`${host}/auth/v1`).setAudience("authenticated").setSubject("fake-user").setIssuedAt().setExpirationTime("1h").sign(privateKey);
   const r = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });
 
 test("garbage token is rejected", async () => {
   const r = await authenticate(bearer("not-a-jwt"), { ...ENV, SUPABASE_URL: "https://sb-garbage.example.test" }, stubFetch(() => new Response("", { status: 500 })));
-  assert.deepEqual(r, { ok: false });
+  assert.deepEqual(r, { ok: false, reason: "invalid" });
 });

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -29,8 +29,17 @@ export type AuthResult =
   | { ok: true; userId: string; userType: "human" | "agent" }
   | { ok: false; reason: AuthFailureReason };
 
-const ABSENT: AuthResult = { ok: false, reason: "absent" };
-const INVALID: AuthResult = { ok: false, reason: "invalid" };
+// Frozen because both are module-level singletons shared by every request on
+// the isolate: a stray mutation would poison the verdict for all of them.
+const ABSENT: AuthResult = Object.freeze({ ok: false, reason: "absent" });
+const INVALID: AuthResult = Object.freeze({ ok: false, reason: "invalid" });
+
+/**
+ * The `Bearer` auth-scheme, matched per RFC 7235 §2.1: the scheme token is
+ * case-insensitive, and the separator may be any run of SP/HTAB. Anything
+ * else — `Basic`, `Bearerish`, a bare scheme — is not our credential format.
+ */
+const BEARER_SCHEME = /^bearer[ \t]+/i;
 
 export interface AuthEnv {
   SUPABASE_URL: string;
@@ -143,11 +152,11 @@ export async function authenticate(
   ctx?: Pick<ExecutionContext, "waitUntil">,
 ): Promise<AuthResult> {
   const header = request.headers.get("Authorization") ?? "";
-  // Header values arrive already trimmed, so a `Bearer` with an empty token is
-  // indistinguishable from a bare `Bearer` scheme and lands in ABSENT — there
-  // is no separate empty-token branch to reach.
-  if (!header.startsWith("Bearer ")) return ABSENT;
-  const token = header.slice(7).trim();
+  const scheme = BEARER_SCHEME.exec(header);
+  if (scheme === null) return ABSENT;
+  const token = header.slice(scheme[0].length).trim();
+  // A scheme with nothing behind it presented no credential at all.
+  if (!token) return ABSENT;
   if (token.startsWith("sk_")) {
     const r = await verifyApiKey(token, env, fetchImpl, ctx);
     return r.ok ? { ok: true, userId: r.userId, userType: "agent" } : INVALID;

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -10,9 +10,27 @@ import { createRemoteJWKSet, customFetch, decodeJwt, decodeProtectedHeader, jwtV
  */
 export type UserType = "human" | "agent" | "anonymous";
 
+/**
+ * Why authentication produced no identity (issue #441).
+ *
+ * - `"absent"` — the caller presented no bearer credential at all. Only this
+ *   case may fall through to the anonymous handler.
+ * - `"invalid"` — a bearer credential WAS presented and failed to verify
+ *   (expired, malformed, wrong issuer/audience/algorithm, unknown API key).
+ *   Silently demoting it to an anonymous identity hides the expiry from the
+ *   client and charges the turn to the wrong meter, so it must 401.
+ *
+ * A non-Bearer `Authorization` scheme is `"absent"`: this edge has never
+ * accepted one, so an unrelated header must not start 401ing.
+ */
+export type AuthFailureReason = "absent" | "invalid";
+
 export type AuthResult =
   | { ok: true; userId: string; userType: "human" | "agent" }
-  | { ok: false };
+  | { ok: false; reason: AuthFailureReason };
+
+const ABSENT: AuthResult = { ok: false, reason: "absent" };
+const INVALID: AuthResult = { ok: false, reason: "invalid" };
 
 export interface AuthEnv {
   SUPABASE_URL: string;
@@ -40,7 +58,7 @@ function remoteJwks(url: string, f: typeof fetch): ReturnType<typeof createRemot
 function human(sub: unknown): AuthResult {
   return typeof sub === "string" && sub.length > 0
     ? { ok: true, userId: sub, userType: "human" }
-    : { ok: false };
+    : INVALID;
 }
 
 async function verifySupabase(token: string, env: AuthEnv, f: typeof fetch): Promise<AuthResult> {
@@ -51,7 +69,7 @@ async function verifySupabase(token: string, env: AuthEnv, f: typeof fetch): Pro
     });
     return human(payload.sub);
   } catch {
-    return { ok: false };
+    return INVALID;
   }
 }
 
@@ -62,7 +80,7 @@ async function verifyNeon(token: string, env: AuthEnv, f: typeof fetch): Promise
     const { payload } = await jwtVerify(token, jwks, { issuer, audience: issuer, algorithms: ["EdDSA"] });
     return human(payload.sub);
   } catch {
-    return { ok: false };
+    return INVALID;
   }
 }
 
@@ -79,7 +97,7 @@ async function verifyJwt(token: string, env: AuthEnv, f: typeof fetch): Promise<
     const useNeon = neonEnabled(env) && (header.alg === "EdDSA" || payload.iss === env.NEON_AUTH_ISSUER);
     return useNeon ? await verifyNeon(token, env, f) : await verifySupabase(token, env, f);
   } catch {
-    return { ok: false };
+    return INVALID;
   }
 }
 
@@ -125,12 +143,14 @@ export async function authenticate(
   ctx?: Pick<ExecutionContext, "waitUntil">,
 ): Promise<AuthResult> {
   const header = request.headers.get("Authorization") ?? "";
-  if (!header.startsWith("Bearer ")) return { ok: false };
+  // Header values arrive already trimmed, so a `Bearer` with an empty token is
+  // indistinguishable from a bare `Bearer` scheme and lands in ABSENT — there
+  // is no separate empty-token branch to reach.
+  if (!header.startsWith("Bearer ")) return ABSENT;
   const token = header.slice(7).trim();
-  if (!token) return { ok: false };
   if (token.startsWith("sk_")) {
     const r = await verifyApiKey(token, env, fetchImpl, ctx);
-    return r.ok ? { ok: true, userId: r.userId, userType: "agent" } : { ok: false };
+    return r.ok ? { ok: true, userId: r.userId, userType: "agent" } : INVALID;
   }
   return verifyJwt(token, env, fetchImpl);
 }

--- a/worker/authFallthrough.test.ts
+++ b/worker/authFallthrough.test.ts
@@ -1,0 +1,149 @@
+// Issue #441: a presented-but-unverifiable credential must 401, never silently
+// become an anonymous identity. Covers both halves of the contract: the reason
+// `authenticate` reports, and the branch `createWorkerApp` takes on it.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { authenticate, type AuthResult } from "./auth.ts";
+import { createWorkerApp } from "./app.ts";
+import { handleGuardRequest } from "./edgeGuard.ts";
+import { memoryGuardStore, type GuardStore } from "./guardStore.ts";
+
+const ENV = { SUPABASE_URL: "https://sb-441.example.test", SUPABASE_SERVICE_ROLE_KEY: "service" };
+const SECRET = "fixed-test-hmac-key-0000000000000000";
+const NOW = Date.UTC(2026, 6, 28, 12, 0, 0);
+
+const stubNext = { fetch: () => Promise.resolve(new Response("next", { status: 200 })) };
+const stubCtx = {
+  waitUntil(promise: Promise<unknown>) { void promise; },
+  passThroughOnException() { return undefined; },
+} as unknown as ExecutionContext;
+
+function stubFetch(handler: (url: string) => Response): typeof fetch {
+  return (async (input: RequestInfo | URL) => handler(String(input))) as unknown as typeof fetch;
+}
+
+function bearer(token: string): Request {
+  return new Request("https://app.example.test/v1/chat", { headers: { Authorization: `Bearer ${token}` } });
+}
+
+async function esFixture(host: string, exp: string | number = "1h") {
+  const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+  const jwk = { ...await exportJWK(publicKey), kid: "fake-es-key" };
+  const token = await new SignJWT({}).setProtectedHeader({ alg: "ES256", kid: jwk.kid })
+    .setIssuer(`${host}/auth/v1`).setAudience("authenticated").setSubject("fake-user")
+    .setIssuedAt().setExpirationTime(exp).sign(privateKey);
+  return { jwk, token };
+}
+
+function jwks(jwk: JsonWebKey): Response {
+  return new Response(JSON.stringify({ keys: [jwk] }), { status: 200 });
+}
+
+// ── `authenticate` reports WHY it failed ───────────────────────────────────
+
+void test("an absent Authorization header reports reason absent", async () => {
+  const request = new Request("https://app.example.test/v1/chat");
+  const result = await authenticate(request, ENV, stubFetch(() => new Response("", { status: 200 })));
+  assert.deepEqual(result, { ok: false, reason: "absent" });
+});
+
+void test("a non-Bearer Authorization scheme reports reason absent", async () => {
+  const request = new Request("https://app.example.test/v1/chat", { headers: { Authorization: "Basic dXNlcjpwdw==" } });
+  const result = await authenticate(request, ENV, stubFetch(() => new Response("", { status: 200 })));
+  assert.deepEqual(result, { ok: false, reason: "absent" });
+});
+
+void test("an expired bearer JWT reports reason invalid", async () => {
+  const host = "https://sb-441-expired.example.test";
+  const { jwk, token } = await esFixture(host, Math.floor(Date.now() / 1000) - 60);
+  const result = await authenticate(bearer(token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(jwk)));
+  assert.deepEqual(result, { ok: false, reason: "invalid" });
+});
+
+void test("a bearer JWT signed by an untrusted key reports reason invalid", async () => {
+  const host = "https://sb-441-signature.example.test";
+  const trusted = await esFixture(host);
+  const untrusted = await esFixture(host);
+  const result = await authenticate(bearer(untrusted.token), { ...ENV, SUPABASE_URL: host }, stubFetch(() => jwks(trusted.jwk)));
+  assert.deepEqual(result, { ok: false, reason: "invalid" });
+});
+
+void test("a malformed bearer token reports reason invalid", async () => {
+  const result = await authenticate(bearer("not-a-jwt"), ENV, stubFetch(() => new Response("", { status: 500 })));
+  assert.deepEqual(result, { ok: false, reason: "invalid" });
+});
+
+void test("an empty bearer token reports reason invalid", async () => {
+  const result = await authenticate(bearer("   "), ENV, stubFetch(() => new Response("", { status: 500 })));
+  assert.deepEqual(result, { ok: false, reason: "invalid" });
+});
+
+void test("an unknown sk_ api key reports reason invalid", async () => {
+  const result = await authenticate(bearer("sk_fake_unknown"), ENV, stubFetch((url) =>
+    url.includes("/rest/v1/api_keys") ? new Response("[]", { status: 200 }) : new Response("", { status: 200 })));
+  assert.deepEqual(result, { ok: false, reason: "invalid" });
+});
+
+// ── the /v1 branch honours the reason ──────────────────────────────────────
+
+function fakeGuard() {
+  const shards = new Map<string, GuardStore>();
+  const storeFor = (name: string) => shards.get(name) ?? shards.set(name, memoryGuardStore()).get(name)!;
+  return {
+    idFromName: (name: string) => name as unknown as DurableObjectId,
+    get: (id: DurableObjectId) => ({
+      fetch: (request: Request) =>
+        handleGuardRequest(request, storeFor(String(id)), NOW, { limit: 20, windowSeconds: 60 }),
+    }),
+  };
+}
+
+function anonEnv(captured: { requests: Request[] }) {
+  return {
+    ANON_ACCESS_ENABLED: "true",
+    ANON_ID_SECRET: SECRET,
+    EDGE_GUARD: fakeGuard(),
+    CONTAINER: {
+      idFromName: () => "id",
+      get: () => ({
+        fetch: (request: Request) => {
+          captured.requests.push(request);
+          return Promise.resolve(new Response("container"));
+        },
+      }),
+    },
+  } as never;
+}
+
+function appWith(result: AuthResult) {
+  return createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve(result) });
+}
+
+void test("an invalid credential 401s instead of becoming anonymous", async () => {
+  const captured = { requests: [] as Request[] };
+  const response = await appWith({ ok: false, reason: "invalid" }).request(
+    "/v1/chat", { method: "POST" }, anonEnv(captured), stubCtx,
+  );
+  assert.equal(response.status, 401);
+  assert.equal(captured.requests.length, 0);
+  assert.equal(response.headers.get("Set-Cookie"), null);
+});
+
+void test("an invalid credential 401 carries the typed unauthorized code", async () => {
+  const captured = { requests: [] as Request[] };
+  const response = await appWith({ ok: false, reason: "invalid" }).request(
+    "/v1/chat", { method: "POST" }, anonEnv(captured), stubCtx,
+  );
+  const body = await response.json() as { error: { code: string } };
+  assert.equal(body.error.code, "unauthorized");
+});
+
+void test("an absent credential still reaches the container as anonymous", async () => {
+  const captured = { requests: [] as Request[] };
+  const response = await appWith({ ok: false, reason: "absent" }).request(
+    "/v1/chat", { method: "POST" }, anonEnv(captured), stubCtx,
+  );
+  assert.equal(response.status, 200);
+  assert.equal(captured.requests[0]?.headers.get("X-User-Type"), "anonymous");
+});

--- a/worker/authFallthrough.test.ts
+++ b/worker/authFallthrough.test.ts
@@ -152,6 +152,21 @@ void test("an invalid credential 401 carries the typed unauthorized code", async
   assert.equal(body.error.code, "unauthorized");
 });
 
+void test("an invalid credential is recorded so a 401 storm is visible", async () => {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (line: unknown) => { warnings.push(String(line)); };
+  try {
+    await appWith({ ok: false, reason: "invalid" }).request(
+      "/v1/chat", { method: "POST" }, anonEnv({ requests: [] }), stubCtx,
+    );
+  } finally {
+    console.warn = original;
+  }
+  const record = JSON.parse(String(warnings[0])) as { event: string; path: string };
+  assert.deepEqual(record, { event: "edge_auth_invalid_credential", path: "/v1/chat" });
+});
+
 void test("an absent credential still reaches the container as anonymous", async () => {
   const captured = { requests: [] as Request[] };
   const response = await appWith({ ok: false, reason: "absent" }).request(

--- a/worker/authFallthrough.test.ts
+++ b/worker/authFallthrough.test.ts
@@ -3,7 +3,7 @@
 // `authenticate` reports, and the branch `createWorkerApp` takes on it.
 import test from "node:test";
 import assert from "node:assert/strict";
-import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { exportJWK, generateKeyPair, type JWK, SignJWT } from "jose";
 import { authenticate, type AuthResult } from "./auth.ts";
 import { createWorkerApp } from "./app.ts";
 import { handleGuardRequest } from "./edgeGuard.ts";
@@ -19,8 +19,13 @@ const stubCtx = {
   passThroughOnException() { return undefined; },
 } as unknown as ExecutionContext;
 
+function requestedUrl(input: RequestInfo | URL): string {
+  if (input instanceof Request) return input.url;
+  return input instanceof URL ? input.href : input;
+}
+
 function stubFetch(handler: (url: string) => Response): typeof fetch {
-  return (async (input: RequestInfo | URL) => handler(String(input))) as unknown as typeof fetch;
+  return (input: RequestInfo | URL) => Promise.resolve(handler(requestedUrl(input)));
 }
 
 function bearer(token: string): Request {
@@ -36,7 +41,7 @@ async function esFixture(host: string, exp: string | number = "1h") {
   return { jwk, token };
 }
 
-function jwks(jwk: JsonWebKey): Response {
+function jwks(jwk: JWK): Response {
   return new Response(JSON.stringify({ keys: [jwk] }), { status: 200 });
 }
 
@@ -74,9 +79,11 @@ void test("a malformed bearer token reports reason invalid", async () => {
   assert.deepEqual(result, { ok: false, reason: "invalid" });
 });
 
-void test("an empty bearer token reports reason invalid", async () => {
+void test("a bearer scheme with no token reports reason absent", async () => {
+  // Header values are trimmed before we see them, so `Bearer` + whitespace is
+  // the same string as a bare scheme: nothing was actually presented.
   const result = await authenticate(bearer("   "), ENV, stubFetch(() => new Response("", { status: 500 })));
-  assert.deepEqual(result, { ok: false, reason: "invalid" });
+  assert.deepEqual(result, { ok: false, reason: "absent" });
 });
 
 void test("an unknown sk_ api key reports reason invalid", async () => {
@@ -89,7 +96,13 @@ void test("an unknown sk_ api key reports reason invalid", async () => {
 
 function fakeGuard() {
   const shards = new Map<string, GuardStore>();
-  const storeFor = (name: string) => shards.get(name) ?? shards.set(name, memoryGuardStore()).get(name)!;
+  const storeFor = (name: string) => {
+    const existing = shards.get(name);
+    if (existing) return existing;
+    const created = memoryGuardStore();
+    shards.set(name, created);
+    return created;
+  };
   return {
     idFromName: (name: string) => name as unknown as DurableObjectId,
     get: (id: DurableObjectId) => ({

--- a/worker/authScheme.test.ts
+++ b/worker/authScheme.test.ts
@@ -1,0 +1,77 @@
+// Issue #441 (review P1-1): RFC 7235 §2.1 makes the auth-scheme token
+// case-insensitive, so `bearer`/`BEARER`/`BeArEr` are the same scheme as
+// `Bearer`. A case-sensitive check reports them as `absent` and hands the
+// caller a fresh anonymous identity — exactly the silent downgrade #441 closes.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { exportJWK, generateKeyPair, type JWK, SignJWT } from "jose";
+import { authenticate } from "./auth.ts";
+
+const HOST = "https://sb-441-scheme.example.test";
+const ENV = { SUPABASE_URL: HOST, SUPABASE_SERVICE_ROLE_KEY: "service" };
+
+function requestedUrl(input: RequestInfo | URL): string {
+  if (input instanceof Request) return input.url;
+  return input instanceof URL ? input.href : input;
+}
+
+function stubFetch(handler: (url: string) => Response): typeof fetch {
+  return (input: RequestInfo | URL) => Promise.resolve(handler(requestedUrl(input)));
+}
+
+function authorized(value: string): Request {
+  return new Request("https://app.example.test/v1/chat", { headers: { Authorization: value } });
+}
+
+async function expiredFixture(): Promise<{ jwk: JWK; token: string }> {
+  const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+  const jwk: JWK = { ...await exportJWK(publicKey), kid: "fake-es-key" };
+  const token = await new SignJWT({}).setProtectedHeader({ alg: "ES256", kid: jwk.kid })
+    .setIssuer(`${HOST}/auth/v1`).setAudience("authenticated").setSubject("fake-user")
+    .setIssuedAt().setExpirationTime(Math.floor(Date.now() / 1000) - 60).sign(privateKey);
+  return { jwk, token };
+}
+
+/** Authenticate an expired token presented under an arbitrary scheme spelling. */
+async function authenticateExpired(scheme: (token: string) => string) {
+  const { jwk, token } = await expiredFixture();
+  const served = new Response(JSON.stringify({ keys: [jwk] }), { status: 200 });
+  return authenticate(authorized(scheme(token)), ENV, stubFetch(() => served));
+}
+
+void test("a lowercase bearer scheme is still a presented credential", async () => {
+  assert.deepEqual(await authenticateExpired((t) => `bearer ${t}`), { ok: false, reason: "invalid" });
+});
+
+void test("an uppercase BEARER scheme is still a presented credential", async () => {
+  assert.deepEqual(await authenticateExpired((t) => `BEARER ${t}`), { ok: false, reason: "invalid" });
+});
+
+void test("a mixed-case BeArEr scheme is still a presented credential", async () => {
+  assert.deepEqual(await authenticateExpired((t) => `BeArEr ${t}`), { ok: false, reason: "invalid" });
+});
+
+void test("a tab between scheme and token is still a presented credential", async () => {
+  assert.deepEqual(await authenticateExpired((t) => `Bearer\t${t}`), { ok: false, reason: "invalid" });
+});
+
+void test("extra spaces between scheme and token do not hide the credential", async () => {
+  assert.deepEqual(await authenticateExpired((t) => `Bearer   ${t}`), { ok: false, reason: "invalid" });
+});
+
+void test("a scheme that merely starts with bearer is not our scheme", async () => {
+  // `Bearerish` is a different auth-scheme token, not a separator-less Bearer.
+  const result = await authenticate(
+    authorized("Bearerish abc.def.ghi"), ENV, stubFetch(() => new Response("", { status: 500 })),
+  );
+  assert.deepEqual(result, { ok: false, reason: "absent" });
+});
+
+void test("a bearer scheme whose token is only whitespace presents nothing", async () => {
+  // `\x0B` survives HTTP header trimming (which strips only SP and HTAB) but
+  // not JS `trim()`, so this is the one reachable empty-token case.
+  const result = await authenticate(
+    authorized("Bearer \x0B"), ENV, stubFetch(() => new Response("", { status: 500 })),
+  );
+  assert.deepEqual(result, { ok: false, reason: "absent" });
+});

--- a/worker/entry.test.ts
+++ b/worker/entry.test.ts
@@ -42,7 +42,7 @@ function envWithCatalog(captured: { req?: Request }) {
 
 void test("exact public anime overview GET forwards anonymously, no auth called", async () => {
   let authCalled = false;
-  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false } as const); };
+  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false, reason: "absent" } as const); };
   const app = createWorkerApp({ nextHandler: stubNext, authenticate });
   const cap: { req?: Request } = {};
   const res = await app.request("/catalog/public/anime-overview/3302", {}, envWithCatalog(cap), stubCtx);
@@ -130,7 +130,7 @@ function envWithContainer(captured: { req?: Request }) {
 
 void test("/v1 public route -> container, no auth called", async () => {
   let authCalled = false;
-  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false } as const); };
+  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false, reason: "absent" } as const); };
   const app = createWorkerApp({ nextHandler: stubNext, authenticate });
   const cap: { req?: Request } = {};
   const res = await app.request("/v1/bangumi/popular", {}, envWithContainer(cap), stubCtx);
@@ -140,7 +140,7 @@ void test("/v1 public route -> container, no auth called", async () => {
 
 void test("/v1 guide route (regex) is public -> container, no auth, client X-User stripped", async () => {
   let authCalled = false;
-  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false } as const); };
+  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false, reason: "absent" } as const); };
   const app = createWorkerApp({ nextHandler: stubNext, authenticate });
   const cap: { req?: Request } = {};
   const res = await app.request("/v1/bangumi/12345/guide", { headers: { "X-User-Id": "forged" } }, envWithContainer(cap), stubCtx);
@@ -150,7 +150,7 @@ void test("/v1 guide route (regex) is public -> container, no auth, client X-Use
 });
 
 void test("/v1 authed route without creds -> 401, container not hit", async () => {
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" }) });
   const cap: { req?: Request } = {};
   const res = await app.request("/v1/chat", { method: "POST" }, envWithContainer(cap), stubCtx);
   assert.equal(res.status, 401);
@@ -177,7 +177,7 @@ void test("client-forged X-User-Id is stripped on authed route (worker value win
 });
 
 void test("client-forged X-User-Id is stripped on PUBLIC route too", async () => {
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" }) });
   const cap: { req?: Request } = {};
   await app.request("/v1/bangumi/popular", { headers: { "X-User-Id": "forged" } }, envWithContainer(cap), stubCtx);
   assert.equal(cap.req?.headers.get("X-User-Id"), null);
@@ -187,7 +187,7 @@ void test("/v1/users/routes -> USERS with Authorization intact, no container or 
   let authCalled = false;
   let containerHit = false;
   let received: Request | undefined;
-  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false } as const); };
+  const authenticate = () => { authCalled = true; return Promise.resolve({ ok: false, reason: "absent" } as const); };
   const app = createWorkerApp({ nextHandler: stubNext, authenticate });
   const env = {
     USERS: { fetch: (req: Request) => { received = req; return Promise.resolve(new Response("users")); } },
@@ -205,7 +205,7 @@ void test("/v1/users/routes -> USERS with Authorization intact, no container or 
 
 void test("/v1/users/routes bypasses a rejecting authenticate stub", async () => {
   let received = false;
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" }) });
   const env = {
     USERS: { fetch: () => { received = true; return Promise.resolve(new Response("users")); } },
   } as never;

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["app.ts", "auth.ts", "turnstile.ts", "costBreaker.ts", "edgeGuard.ts", "guardStore.ts", "rateLimiter.ts", "entry.test.ts", "turnstile.test.ts", "anonymous.test.ts", "anonymousIdentity.test.ts", "costBreaker.test.ts", "rateLimiter.test.ts"]
+  "include": ["app.ts", "auth.ts", "turnstile.ts", "costBreaker.ts", "edgeGuard.ts", "guardStore.ts", "rateLimiter.ts", "entry.test.ts", "turnstile.test.ts", "anonymous.test.ts", "authFallthrough.test.ts", "anonymousIdentity.test.ts", "costBreaker.test.ts", "rateLimiter.test.ts"]
 }

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["app.ts", "auth.ts", "turnstile.ts", "costBreaker.ts", "edgeGuard.ts", "guardStore.ts", "rateLimiter.ts", "entry.test.ts", "turnstile.test.ts", "anonymous.test.ts", "authFallthrough.test.ts", "anonymousIdentity.test.ts", "costBreaker.test.ts", "rateLimiter.test.ts"]
+  "include": ["app.ts", "auth.ts", "turnstile.ts", "costBreaker.ts", "edgeGuard.ts", "guardStore.ts", "rateLimiter.ts", "entry.test.ts", "turnstile.test.ts", "anonymous.test.ts", "authFallthrough.test.ts", "authScheme.test.ts", "anonymousIdentity.test.ts", "costBreaker.test.ts", "rateLimiter.test.ts"]
 }


### PR DESCRIPTION
Fixes #441

## Root cause

`authenticate()` collapsed two different outcomes into one `{ ok: false }`: "no credential was
presented" and "a credential was presented and failed to verify". Since #274 opened `/v1/chat` to
anonymous callers, `worker/app.ts` treated both as *anonymous*, so an expired/malformed/wrong-key
bearer token was silently demoted to a freshly minted `anon_<hex>` identity — charged to the
anonymous daily-dollar pool, metered under the anonymous burst limiter, and never surfacing the
401 the web client needs to enter its refresh path.

## Change

**Edge (`worker/`)** — candidate design 1 from the issue. `AuthResult`'s failure arm now carries
`reason: "absent" | "invalid"`, and the `/v1/*` handler only falls through to `handleAnonymousV1`
on `"absent"`. A non-Bearer `Authorization` scheme stays `"absent"` so unrelated headers do not
start 401ing (the downside the issue flagged for candidate 2). Everything else about the contract
is untouched: anonymous access, the burst limiter, the budget breaker, and #281's dormant
Turnstile gate all keep their current status codes.

**Container ingress (`apps/agent`, authoritative)** — defense in depth. The edge strips
`Authorization` before stamping an identity, so an `X-User-Type: anonymous` arriving *with* a
credential can only mean the credential failed and the request was demoted anyway, or the
container was reached directly. `_get_trusted_auth_context` now 401s that combination with the
typed `authentication_error` code instead of serving the turn on the anonymous meter.

## Tests

New `worker/authFallthrough.test.ts` (10 tests, registered in `test:worker` and `worker/tsconfig.json`):

- expired bearer JWT → `reason: "invalid"`
- bearer JWT signed by an untrusted key → `"invalid"`
- malformed bearer token → `"invalid"`
- unknown `sk_` API key → `"invalid"`
- absent `Authorization` header → `"absent"`
- non-Bearer scheme → `"absent"`
- `Bearer` with no token → `"absent"` (header values arrive trimmed)
- invalid credential → 401, container never reached, no `Set-Cookie`
- invalid credential 401 body carries `error.code == "unauthorized"`
- absent credential → still reaches the container as `X-User-Type: anonymous`

New `apps/agent/agent/tests/unit/test_ingress_anonymous_credential.py` (5 tests): anonymous stamp +
credential → 401 / runtime never invoked / `authentication_error` code; credential-free anonymous
turn still 200; logged-in stamp unaffected by a lingering credential.

Existing `worker/auth.test.ts`, `auth-neon.test.ts`, `anonymous.test.ts`, `entry.test.ts` updated to
the new `AuthResult` shape.

## Mutation verification

Every new guard was mutated and the covering test went red, then the mutation was reverted:

| # | Mutation | Result |
|---|---|---|
| M1 | drop `auth.reason === "absent" &&` in `app.ts` | 2 failed |
| M2 | missing header returns `INVALID` instead of `ABSENT` | 3 failed |
| M3 | `verifySupabase` failure returns `ABSENT` | 2 failed |
| M4 | unknown API key returns `ABSENT` | 1 failed |
| M5 | neuter the ingress `if` (`if False and …`) | red |
| M6 | drop the `credential is not None` half | red |
| M7 | drop the `user_type == ANONYMOUS_USER_TYPE` half | red |

Restored tree: 10/10 worker fallthrough tests and 5/5 ingress tests pass.

## Gates

- `pnpm run test:worker` — 107 passed, 0 failed
- `tsc --noEmit -p worker/tsconfig.json` — clean; `oxlint worker/` reports nothing in the new file
- `make lint` (ruff check + format) — clean
- `make typecheck` (mypy strict) — no issues in 119 source files
- `apps/agent` unit tests — **1402 passed**, coverage **88.51 %** (floor 87 %)

No suppressions added; no `Any`; new helpers are within 1-10-50; both new test files are under 200 lines.

---

# Review round 1 (second seat, `request_changes`) — addressed

## P1-1 · case-sensitive `Bearer` check (real, additional bypass)

Confirmed empirically before fixing — `bearer <expired jwt>`, `BEARER …`, `BeArEr …` and
`Bearer<TAB>…` all returned `absent` and were silently handed a fresh anonymous identity, i.e. the
very class #441 closes, still open through a different door.

RFC 7235 §2.1 makes the auth-scheme token case-insensitive, so scheme detection is now
`/^bearer[ \t]+/i` with the token sliced by the match length. Deliberate boundaries: a non-bearer
scheme (`Basic`) and a scheme that merely *starts* with the word (`Bearerish`) stay `absent`, so the
"unrelated Authorization header" false-401 the issue warned about is still avoided. HTAB is accepted
as a separator because a client sending `Bearer<TAB><jwt>` is unambiguously presenting a bearer
credential.

New `worker/authScheme.test.ts` — 7 tests: lowercase, uppercase, mixed case, TAB separator, multiple
spaces, `Bearerish` (stays absent), whitespace-only token (stays absent). All 5 bypass cases were
verified red before the fix.

## P1-2 · CI was not actually running this PR's suites — **fixed, and green**

Root cause: `dorny/paths-filter` resolves a PR's changed files through the GitHub API
(`listFiles`), which requires `pull-requests: read`. `ci.yml` declares a workflow-level
`permissions: contents: read`, which grants only Contents + Metadata, so on this private repo the
call returned `Resource not accessible by integration`; the `changes` job failed and **every**
downstream lane reported `skipping`. Not transient — reproduced across a rerun and two fresh pushes.

Fix: an explicit `permissions: {contents: read, pull-requests: read}` on the `changes` job.
Verified on run `30370192030`:

| Job | Before | After |
|---|---|---|
| `changes` | failure | **success** |
| `Edge worker tests` | skipping | **success** |
| `Agent CI / Python CI` | skipping | **success** |

`Contract OpenAPI drift` still skips — correctly, this PR touches no contract.

**Separately: three security jobs (`gitleaks`, `osv-scanner`, `Semgrep`) fail with the same
`Resource not accessible by integration`, on every PR including the docs-only #444.** Same class,
but `_security.yml` is a *reusable* workflow whose permissions cannot exceed the caller's, so it
needs a coordinated two-file change validated on a throwaway branch — out of scope here and tracked
in **#455**.

## P2-1 · the invalid path is no longer silent

Both tiers now emit a structured, credential-free record: the edge logs
`{"event":"edge_auth_invalid_credential","path":…}` and the container logs
`anonymous_credential_rejected`. Neither records the token, the header, or the identity. Both are
covered by a test, including an assertion that the credential does not appear in the log entry.

## P2-2 · `ABSENT` / `INVALID` are `Object.freeze`d

They are isolate-wide singletons shared by every request; a stray mutation would poison the verdict
for all of them.

## P2-3 · JWKS-outage availability trade-off — documented, follow-up opened

A JWKS fetch failure is currently indistinguishable from a rejected credential: both return
`INVALID` → hard 401. During a JWKS outage a client whose D8 path clears the token and refreshes
would loop, because the fresh token is equally unverifiable.

This PR keeps failing **closed** deliberately — failing open is what #441 is about, and splitting
the two requires reworking the jose error handling and choosing a response for the unverifiable
case (503 + `Retry-After`?), which is a design decision rather than a bug fix. Tracked in **#452**.

## P3 · addressed / deferred

- The empty-token guard is restored as an explicit `if (!token) return ABSENT;`, and the comment no
  longer over-claims what header trimming does. It is genuinely reachable (`Bearer \x0B` survives
  HTTP trimming, which strips only SP/HTAB, but not JS `trim()`) and is covered by a test.
- The two 401 codes (`unauthorized` at the edge vs `authentication_error` in the container) are a
  public contract change that needs the web client updated in the same PR — tracked in **#453**.

## Mutation verification, round 2

| # | Mutation | Result |
|---|---|---|
| M8 | revert scheme regex to case-sensitive `/^Bearer[ ]/` | 4 red |
| M9 | drop the token-less `ABSENT` guard | 1 red |
| M10 | drop the edge `logInvalidCredential` call | 1 red |
| M11 | drop the container `_logger.warning` | 1 red |

Restored tree: 18/18 worker auth tests green.

## Gates, round 2

- CI: `Edge worker tests` **success**, `Agent CI / Python CI` **success** (run `30370192030`)
- local `pnpm run test:worker` — **115 passed**
- `tsc --noEmit -p worker/tsconfig.json` — clean; `oxlint worker/` adds no new finding (the single
  `auth.ts` template-literal error is pre-existing on the base commit)
- `actionlint .github/workflows/ci.yml` — clean
- `make lint` / `make typecheck` — clean
- agent unit tests — **1403 passed**, coverage 88.5 % (floor 87 %)

Follow-ups opened: **#452** (JWKS availability), **#453** (401 code unification), **#455** (CI security lane).
