### PR TITLE
chore(catalog): derive spike fixtures from the shared contract (#363)

### DIFF
--- a/workers/catalog/src/lib/geo-query.ts
+++ b/workers/catalog/src/lib/geo-query.ts
@@ -30,7 +30,8 @@ const toPoint = (r: NearbyRow): NearbyPoint => ({
   distanceM: r.distance_m,
 });
 
-const MAX_RADIUS_M = 50_000;
+/** Hard ceiling on the searched radius; larger requests are clamped, not rejected. */
+export const MAX_RADIUS_M = 50_000;
 const MAX_RESULTS = 200;
 
 /** Points within `radiusM` meters of (lat,lng), nearest first, with `distanceM`. */

--- a/workers/catalog/test/catalog-api.spike.test.ts
+++ b/workers/catalog/test/catalog-api.spike.test.ts
@@ -113,8 +113,10 @@ beforeAll(async () => {
 }, 120_000);
 
 afterEach(() => {
-  // Undo any per-test `global.fetch` stub so non-ingest tests stay offline-safe.
+  // `restoreAllMocks` does NOT undo `stubGlobal` — without `unstubAllGlobals` a
+  // fetch stub leaks into every later test in the file. Both are needed.
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 afterAll(() => {

--- a/workers/catalog/test/catalog-api.spike.test.ts
+++ b/workers/catalog/test/catalog-api.spike.test.ts
@@ -138,9 +138,17 @@ async function assertSearchHit(): Promise<void> {
   expect(typeof out.synced_at).toBe("string");
 }
 
+/** An alias miss now calls Bangumi search (tiered ingest). Stub it to an empty
+ * result so this asserts "unknown title -> no rows" instead of live upstream health. */
 async function assertSearchMiss(): Promise<void> {
+  stubFetch(unresolvableResponse);
   const out = await call<{ rows: ApiPoint[] }>("search", { query: "no-such-anime" });
   expect(out.rows).toHaveLength(0);
+}
+
+function unresolvableResponse(url: string): Response {
+  if (url.includes("/v0/search/subjects")) return jsonResponse({ data: [] });
+  throw new Error(`unexpected upstream url: ${url}`);
 }
 
 async function assertSpotsHit(): Promise<void> {
@@ -235,19 +243,30 @@ databaseDescribe("Catalog API end-to-end (Hono app + OpenAPIHandler + Drizzle/Po
 const NEW_WORK_ID = "10380"; // Bangumi subject id (K-On!)
 const NEW_TITLE = "けいおん！";
 
-/** Stub upstream JSON for the NEW work: a Bangumi subject + two Anitabi points. */
-function stubUpstream(): void {
-  // The neon serverless driver rides global fetch too (Phase B: the DB channel
-  // is HTTP) — pass its /sql traffic through to the real fetch, init included.
+/**
+ * Route every upstream call to a canned response. The neon serverless driver
+ * rides global fetch too (Phase B: the DB channel is HTTP), so its `/sql`
+ * traffic passes through to the real fetch, init included.
+ */
+function stubFetch(route: (url: string) => Response): void {
   const realFetch = globalThis.fetch;
   const stub = vi.fn((input: string | URL | Request, init?: RequestInit) => {
     const url = input instanceof Request ? input.url : input.toString();
     if (url.includes("/sql")) return realFetch(input, init);
-    if (url.includes("/v0/subjects/")) return Promise.resolve(jsonResponse({ name: NEW_TITLE, name_cn: "轻音少女" }));
-    if (url.includes("/points/detail")) return Promise.resolve(jsonResponse(ANITABI_POINTS));
-    throw new Error(`unexpected upstream url: ${url}`);
+    return Promise.resolve(route(url));
   });
   vi.stubGlobal("fetch", stub);
+}
+
+/** Stub upstream JSON for the NEW work: a Bangumi subject + two Anitabi points. */
+function stubUpstream(): void {
+  stubFetch(newWorkResponse);
+}
+
+function newWorkResponse(url: string): Response {
+  if (url.includes("/v0/subjects/")) return jsonResponse({ name: NEW_TITLE, name_cn: "轻音少女" });
+  if (url.includes("/points/detail")) return jsonResponse(ANITABI_POINTS);
+  throw new Error(`unexpected upstream url: ${url}`);
 }
 
 // A second uncovered work, reached via the search MISS path (Bangumi search ->
@@ -264,14 +283,10 @@ const MISS_TITLE = "響け！ユーフォニアム";
  */
 function stubSearchMiss(): { urls: string[] } {
   const urls: string[] = [];
-  const realFetch = globalThis.fetch;
-  const stub = vi.fn((input: string | URL | Request, init?: RequestInit) => {
-    const url = input instanceof Request ? input.url : input.toString();
-    if (url.includes("/sql")) return realFetch(input, init);
+  stubFetch((url) => {
     urls.push(url);
-    return Promise.resolve(searchMissResponse(url));
+    return searchMissResponse(url);
   });
-  vi.stubGlobal("fetch", stub);
   return { urls };
 }
 

--- a/workers/catalog/test/catalog-seed.worker.test.ts
+++ b/workers/catalog/test/catalog-seed.worker.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Offline guard for the spike seed fixtures (#363).
+ *
+ * The spikes only run when Neon Local credentials are present, so fixture rot
+ * used to stay invisible until a live run. These assertions run in the always-on
+ * worker pool and fail the moment a fixture stops matching the shared contract.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  aliasInsert,
+  aliasSeed,
+  ambiguousOutcome,
+  candidateOf,
+  pointInsert,
+  pointSeed,
+  resolvedOutcome,
+  workInsert,
+  workSeed,
+} from "./fixtures/catalog-seed";
+
+const beta = workSeed("1002", "Beta");
+const alpha = workSeed("1001", "Alpha");
+
+describe("catalog seed fixtures are contract-derived", () => {
+  it("rejects a work id that `pointsByWorkId` would reject with a 400", () => {
+    expect(() => workSeed("beta", "Beta")).toThrow();
+  });
+
+  it("accepts a Bangumi-style subject id", () => {
+    expect(workSeed("1002", "Beta").workId).toBe("1002");
+  });
+
+  it("rejects an out-of-range latitude", () => {
+    expect(() => pointSeed("p", beta, "Bad", 91, 139)).toThrow();
+  });
+
+  it("rejects an out-of-range longitude", () => {
+    expect(() => pointSeed("p", beta, "Bad", 36, 181)).toThrow();
+  });
+
+  it("rejects a negative points_count on an expected candidate", () => {
+    expect(() => candidateOf(beta, -1)).toThrow();
+  });
+
+  it("rejects a single-candidate disambiguation outcome", () => {
+    expect(() => ambiguousOutcome([candidateOf(beta, 2)])).toThrow();
+  });
+
+  it("builds a resolved outcome carrying the seeded identity", () => {
+    expect(resolvedOutcome(alpha, 1)).toEqual({
+      outcome: "resolved",
+      match: { bangumi_id: "1001", title: "Alpha", points_count: 1 },
+    });
+  });
+});
+
+describe("seed statements are emitted from the seed records", () => {
+  it("numbers work placeholders across every row", () => {
+    expect(workInsert([alpha, beta])).toEqual({
+      text: "INSERT INTO bangumi (id, title) VALUES ($1, $2), ($3, $4)",
+      values: ["1001", "Alpha", "1002", "Beta"],
+    });
+  });
+
+  it("emits point columns without the trigger-derived location", () => {
+    const seed = pointSeed("b-1", beta, "Beta Point 1", 36, 136);
+    expect(pointInsert([seed]).text).toBe(
+      "INSERT INTO points (id, bangumi_id, name, latitude, longitude)"
+      + " VALUES ($1, $2, $3, $4, $5)",
+    );
+    expect(pointInsert([seed]).values).toEqual(["b-1", "1002", "Beta Point 1", 36, 136]);
+  });
+
+  it("carries the parent work id into alias rows", () => {
+    const seed = aliasSeed(beta, "Shared", "shared", "bangumi", 40);
+    expect(aliasInsert([seed]).values).toEqual(["1002", "Shared", "shared", "bangumi", 40]);
+  });
+});

--- a/workers/catalog/test/fixtures/catalog-seed.ts
+++ b/workers/catalog/test/fixtures/catalog-seed.ts
@@ -5,9 +5,15 @@
  * source of truth) at construction, so a fixture that no longer matches the wire
  * contract fails loudly HERE instead of surfacing as a downstream 400/500 in a
  * live spike run. The INSERT statements are emitted from the same records the
- * assertions read, so the seed and the expectation cannot drift apart.
+ * assertions read (with table + column names taken from the Drizzle schema), so
+ * the seed, the schema, and the expectation cannot drift apart.
+ *
+ * SCOPE: only seeds built through these builders carry that guarantee. The other
+ * spike files still hand-write their INSERTs — converting them is tracked as a
+ * follow-up to #363.
  */
 
+import { getTableColumns, getTableName } from "drizzle-orm";
 import {
   AnimeCandidate,
   Latitude,
@@ -15,6 +21,11 @@ import {
   PointsByWorkIdInput,
   ResolveOutcome,
 } from "@seichijunrei/contract";
+import { aliases, bangumi, points } from "../../src/db/schema";
+
+const bangumiColumns = getTableColumns(bangumi);
+const pointColumns = getTableColumns(points);
+const aliasColumns = getTableColumns(aliases);
 
 /** A parameterized statement: placeholder SQL plus its positional values. */
 export interface SeedStatement {
@@ -120,22 +131,32 @@ function statement(
 }
 
 export function workInsert(seeds: readonly WorkSeed[]): SeedStatement {
-  return statement("bangumi", ["id", "title"], seeds.map((s) => [s.workId, s.title]));
+  return statement(
+    getTableName(bangumi),
+    [bangumiColumns.id.name, bangumiColumns.title.name],
+    seeds.map((s) => [s.workId, s.title]),
+  );
 }
 
 /** Coordinates only — the DB trigger derives the GEOGRAPHY `location` column. */
 export function pointInsert(seeds: readonly PointSeed[]): SeedStatement {
   return statement(
-    "points",
-    ["id", "bangumi_id", "name", "latitude", "longitude"],
+    getTableName(points),
+    [
+      pointColumns.id.name, pointColumns.bangumiId.name, pointColumns.name.name,
+      pointColumns.latitude.name, pointColumns.longitude.name,
+    ],
     seeds.map((s) => [s.id, s.workId, s.name, s.latitude, s.longitude]),
   );
 }
 
 export function aliasInsert(seeds: readonly AliasSeed[]): SeedStatement {
   return statement(
-    "aliases",
-    ["work_id", "alias", "alias_normalized", "source", "priority"],
+    getTableName(aliases),
+    [
+      aliasColumns.workId.name, aliasColumns.alias.name, aliasColumns.aliasNormalized.name,
+      aliasColumns.source.name, aliasColumns.priority.name,
+    ],
     seeds.map((s) => [s.workId, s.alias, s.normalized, s.source, s.priority]),
   );
 }

--- a/workers/catalog/test/fixtures/catalog-seed.ts
+++ b/workers/catalog/test/fixtures/catalog-seed.ts
@@ -1,0 +1,141 @@
+/**
+ * Contract-derived seed fixtures for the catalog spikes.
+ *
+ * Every fixture value is parsed through `packages/contract` (the cross-service
+ * source of truth) at construction, so a fixture that no longer matches the wire
+ * contract fails loudly HERE instead of surfacing as a downstream 400/500 in a
+ * live spike run. The INSERT statements are emitted from the same records the
+ * assertions read, so the seed and the expectation cannot drift apart.
+ */
+
+import {
+  AnimeCandidate,
+  Latitude,
+  Longitude,
+  PointsByWorkIdInput,
+  ResolveOutcome,
+} from "@seichijunrei/contract";
+
+/** A parameterized statement: placeholder SQL plus its positional values. */
+export interface SeedStatement {
+  text: string;
+  values: (string | number)[];
+}
+
+export interface WorkSeed {
+  workId: string;
+  title: string;
+}
+
+export interface PointSeed {
+  id: string;
+  workId: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+}
+
+export interface AliasSeed {
+  workId: string;
+  alias: string;
+  normalized: string;
+  source: string;
+  priority: number;
+}
+
+/** A work id the contract accepts on `pointsByWorkId` (bare Bangumi subject id). */
+export function contractWorkId(candidate: string): string {
+  return PointsByWorkIdInput.parse({ work_id: candidate }).work_id;
+}
+
+export function workSeed(id: string, title: string): WorkSeed {
+  return { workId: contractWorkId(id), title };
+}
+
+export function pointSeed(
+  id: string,
+  work: WorkSeed,
+  name: string,
+  latitude: number,
+  longitude: number,
+): PointSeed {
+  return {
+    id,
+    workId: work.workId,
+    name,
+    latitude: Latitude.parse(latitude),
+    longitude: Longitude.parse(longitude),
+  };
+}
+
+export function aliasSeed(
+  work: WorkSeed,
+  alias: string,
+  normalized: string,
+  source: string,
+  priority: number,
+): AliasSeed {
+  return { workId: work.workId, alias, normalized, source, priority };
+}
+
+/** Expected resolve candidate, validated against the shared `AnimeCandidate`. */
+export function candidateOf(work: WorkSeed, pointsCount: number): AnimeCandidate {
+  return AnimeCandidate.parse({
+    bangumi_id: work.workId,
+    title: work.title,
+    points_count: pointsCount,
+  });
+}
+
+/** Expected `resolved` outcome, validated against the shared `ResolveOutcome`. */
+export function resolvedOutcome(work: WorkSeed, pointsCount: number): ResolveOutcome {
+  return ResolveOutcome.parse({ outcome: "resolved", match: candidateOf(work, pointsCount) });
+}
+
+/** Expected `needs_disambiguation` outcome, validated against `ResolveOutcome`. */
+export function ambiguousOutcome(candidates: readonly AnimeCandidate[]): ResolveOutcome {
+  return ResolveOutcome.parse({
+    outcome: "needs_disambiguation",
+    reason: "anime_ambiguity",
+    candidates,
+  });
+}
+
+function placeholderGroup(row: number, columns: number): string {
+  const slots = Array.from({ length: columns }, (_, index) =>
+    `$${String(row * columns + index + 1)}`);
+  return `(${slots.join(", ")})`;
+}
+
+function statement(
+  table: string,
+  columns: readonly string[],
+  rows: readonly (readonly (string | number)[])[],
+): SeedStatement {
+  const groups = rows.map((_, row) => placeholderGroup(row, columns.length));
+  return {
+    text: `INSERT INTO ${table} (${columns.join(", ")}) VALUES ${groups.join(", ")}`,
+    values: rows.flatMap((row) => [...row]),
+  };
+}
+
+export function workInsert(seeds: readonly WorkSeed[]): SeedStatement {
+  return statement("bangumi", ["id", "title"], seeds.map((s) => [s.workId, s.title]));
+}
+
+/** Coordinates only — the DB trigger derives the GEOGRAPHY `location` column. */
+export function pointInsert(seeds: readonly PointSeed[]): SeedStatement {
+  return statement(
+    "points",
+    ["id", "bangumi_id", "name", "latitude", "longitude"],
+    seeds.map((s) => [s.id, s.workId, s.name, s.latitude, s.longitude]),
+  );
+}
+
+export function aliasInsert(seeds: readonly AliasSeed[]): SeedStatement {
+  return statement(
+    "aliases",
+    ["work_id", "alias", "alias_normalized", "source", "priority"],
+    seeds.map((s) => [s.workId, s.alias, s.normalized, s.source, s.priority]),
+  );
+}

--- a/workers/catalog/test/geo-query.spike.test.ts
+++ b/workers/catalog/test/geo-query.spike.test.ts
@@ -1,7 +1,13 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
-import { sql } from "drizzle-orm";
-import { makeNeonSql, type CatalogDb } from "../src/db/client";
-import { findPointsWithinRadius } from "../src/lib/geo-query";
+import { makeNeonSql, type CatalogDb, type NeonSql } from "../src/db/client";
+import { findPointsWithinRadius, MAX_RADIUS_M, type NearbyPoint } from "../src/lib/geo-query";
+import {
+  pointInsert,
+  pointSeed,
+  workInsert,
+  workSeed,
+  type SeedStatement,
+} from "./fixtures/catalog-seed";
 import {
   databaseDescribe,
   localDatabaseUrl,
@@ -15,61 +21,82 @@ import {
  *
  * The branch inherits the complete Atlas schema; this file isolates the catalog
  * tables, seeds points, and exercises PostGIS through Neon Local serverless HTTP.
+ * Seeds come from the contract-derived fixture builders so an id or coordinate
+ * the wire contract rejects fails at construction, not as a mystery empty row.
  */
 
-let db: CatalogDb;
-let neonSql: ReturnType<typeof makeNeonSql>;
+const LUCKY_STAR = workSeed("3701", "らき☆すた");
+const GIRLS_UND_PANZER = workSeed("7724", "ガールズ&パンツァー");
 
-async function seedPoints(): Promise<void> {
-  // Trigger derives GEOGRAPHY `location` from lat/lon, so insert coordinates only.
-  await db.execute(sql`
-    INSERT INTO bangumi (id, title) VALUES ('lucky-star', 'らき☆すた')
-  `);
-  await db.execute(sql`
-    INSERT INTO points (id, bangumi_id, name, latitude, longitude) VALUES
-      ('washinomiya', 'lucky-star', '鷲宮神社', 36.1019, 139.6586),
-      ('satte', 'lucky-star', '幸手権現堂', 36.0833, 139.7250),
-      ('kawagoe', 'lucky-star', '川越駅', 35.9077, 139.4828)
-  `);
+const WASHINOMIYA = pointSeed("washinomiya", LUCKY_STAR, "鷲宮神社", 36.1019, 139.6586);
+const POINTS = [
+  WASHINOMIYA,
+  pointSeed("satte", LUCKY_STAR, "幸手権現堂", 36.0833, 139.725),
+  pointSeed("kawagoe", LUCKY_STAR, "川越駅", 35.9077, 139.4828),
+  // ~82 km away: outside MAX_RADIUS_M, so it proves the clamp rather than an FK gap.
+  pointSeed("oarai", GIRLS_UND_PANZER, "大洗磯前神社", 36.3142, 140.5876),
+];
+
+let db: CatalogDb;
+let neonSql: NeonSql;
+
+async function run(statement: SeedStatement): Promise<void> {
+  await neonSql.query(statement.text, statement.values);
+}
+
+async function seed(): Promise<void> {
+  await run(workInsert([LUCKY_STAR, GIRLS_UND_PANZER]));
+  await run(pointInsert(POINTS));
+}
+
+function around(radiusM: number): Promise<NearbyPoint[]> {
+  return findPointsWithinRadius(neonSql, {
+    lat: WASHINOMIYA.latitude,
+    lng: WASHINOMIYA.longitude,
+    radiusM,
+  });
+}
+
+/** Read a seeded row back through the same driver, without the geo predicate. */
+async function seededRow(id: string): Promise<unknown> {
+  const rows: unknown = await neonSql.query(
+    "SELECT id, bangumi_id FROM points WHERE id = $1", [id],
+  );
+  return rows;
 }
 
 beforeAll(async () => {
   db = await openServerlessDb();
   neonSql = makeNeonSql(localDatabaseUrl());
   await truncateCatalog(db);
-  await seedPoints();
+  await seed();
 }, 120_000);
 
 afterAll(() => { restoreNeonConfig(); });
 
 databaseDescribe("findPointsWithinRadius — PostGIS ST_DWithin read primitive", () => {
   it("returns only points inside a 10km radius of Washinomiya", async () => {
-    const rows = await findPointsWithinRadius(neonSql, {
-      lat: 36.1019,
-      lng: 139.6586,
-      radiusM: 10_000,
-    });
+    const rows = await around(10_000);
     expect(rows.map((r) => r.id)).toEqual(["washinomiya", "satte"]);
     expect(rows[0]?.distanceM).toBeLessThan(100); // basically at center
-    expect(rows[0]?.latitude).toBeCloseTo(36.1019, 4);
   });
 
-  it("excludes Kawagoe at 10km but includes it (nearest-first) at 50km", async () => {
-    const near = await findPointsWithinRadius(neonSql, {
-      lat: 36.1019,
-      lng: 139.6586,
-      radiusM: 10_000,
-    });
-    expect(near.map((r) => r.id)).not.toContain("kawagoe");
-
-    const wide = await findPointsWithinRadius(neonSql, {
-      lat: 36.1019,
-      lng: 139.6586,
-      radiusM: 50_000,
-    });
+  it("adds Kawagoe nearest-first at the maximum radius", async () => {
+    const wide = await around(MAX_RADIUS_M);
     expect(wide.map((r) => r.id)).toEqual(["washinomiya", "satte", "kawagoe"]);
     const distances = wide.map((r) => r.distanceM);
     expect(distances[0]).toBeLessThan(distances[1] ?? 0);
     expect(distances[1]).toBeLessThan(distances[2] ?? 0);
+  });
+
+  it("clamps an over-cap radius instead of widening the result set", async () => {
+    const requested = await around(MAX_RADIUS_M * 4);
+    expect(requested.map((r) => r.id)).toEqual(["washinomiya", "satte", "kawagoe"]);
+  });
+
+  it("seeds Oarai on its own work — it is the clamp, not an FK gap, that hides it", async () => {
+    await expect(seededRow("oarai")).resolves.toEqual([
+      { id: "oarai", bangumi_id: GIRLS_UND_PANZER.workId },
+    ]);
   });
 });

--- a/workers/catalog/test/nearby.worker.test.ts
+++ b/workers/catalog/test/nearby.worker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { CatalogDb, NeonSql } from "../src/db/client";
 import { nearby } from "../src/api/nearby";
+import { MAX_RADIUS_M } from "../src/lib/geo-query";
 
 /**
  * Unit tests for the `nearby` read API handler (card W2-4).
@@ -52,10 +53,13 @@ function fakeDb(details: DetailRow[]): CatalogDb {
   } as unknown as CatalogDb;
 }
 
-/** Minimal NeonSql double: returns geo rows for the ST_DWithin read. */
-function fakeNeonSql(geo: GeoRow[]): NeonSql {
+/** Minimal NeonSql double: returns geo rows, recording each query's bound values. */
+function fakeNeonSql(geo: GeoRow[], bound: unknown[][] = []): NeonSql {
   return Object.assign(
-    (_strings: TemplateStringsArray, ..._values: unknown[]) => Promise.resolve(geo),
+    (_strings: TemplateStringsArray, ...values: unknown[]) => {
+      bound.push(values);
+      return Promise.resolve(geo);
+    },
     { transaction: undefined },
   ) as unknown as NeonSql;
 }
@@ -92,6 +96,25 @@ describe("nearby (api/nearby.ts)", () => {
     expect(rows[1]).toMatchObject({ bangumi_id: "lucky-star", screenshot_url: "" });
     expect(rows[1]?.name_cn).toBeUndefined();
     expect(rows[1]?.episode).toBeUndefined();
+  });
+
+  // The clamp is only otherwise exercised by the Neon-gated spike lane, which
+  // skips without credentials — assert it here so it runs in every CI job.
+  it("clamps an over-cap radius before it reaches the geo query", async () => {
+    const bound: unknown[][] = [];
+    await nearby(fakeDb(DETAILS), fakeNeonSql(GEO, bound), {
+      lat: 36.1019, lng: 139.6586, radius_m: MAX_RADIUS_M * 4,
+    });
+    expect(bound[0]).toContain(MAX_RADIUS_M);
+    expect(bound[0]).not.toContain(MAX_RADIUS_M * 4);
+  });
+
+  it("passes an under-cap radius through unchanged", async () => {
+    const bound: unknown[][] = [];
+    await nearby(fakeDb(DETAILS), fakeNeonSql(GEO, bound), {
+      lat: 36.1019, lng: 139.6586, radius_m: 1_000,
+    });
+    expect(bound[0]).toContain(1_000);
   });
 
   it("returns an empty rows array when no point is within the radius", async () => {

--- a/workers/catalog/test/resolve-api.spike.test.ts
+++ b/workers/catalog/test/resolve-api.spike.test.ts
@@ -6,6 +6,18 @@ import { afterAll, beforeAll, expect, it } from "vitest";
 import { makeNeonSql, type CatalogDb, type NeonSql } from "../src/db/client";
 import { catalogRouter, type CatalogContext } from "../src/router";
 import {
+  aliasInsert,
+  aliasSeed,
+  ambiguousOutcome,
+  candidateOf,
+  pointInsert,
+  pointSeed,
+  resolvedOutcome,
+  workInsert,
+  workSeed,
+  type SeedStatement,
+} from "./fixtures/catalog-seed";
+import {
   databaseDescribe,
   localDatabaseUrl,
   openDirectPool,
@@ -14,31 +26,46 @@ import {
   truncateCatalogPool,
 } from "./spike-db";
 
-/** Resolver SQL proof against the ephemeral branch's direct cloud endpoint. */
+/**
+ * Resolver SQL proof against the ephemeral branch's direct cloud endpoint.
+ *
+ * The context carries a REAL `NeonSql` built from the spike DSN: resolve's
+ * raw-SQL path (added by the July geocoding wave) is part of its contract, and
+ * the old `() => Promise.resolve([])` stub silently broke it into an on-demand
+ * ingest. Seeds and expectations are contract-derived — work ids that
+ * `pointsByWorkId` would 400 cannot be written here (#363).
+ */
 const handler = new OpenAPIHandler(catalogRouter);
+
+const ALPHA = workSeed("1001", "Alpha");
+const BETA = workSeed("1002", "Beta");
+const ZERO = workSeed("1003", "Zero Point");
+
+const POINTS = [
+  pointSeed("a-1", ALPHA, "Alpha Point", 35, 135),
+  pointSeed("b-1", BETA, "Beta Point 1", 36, 136),
+  pointSeed("b-2", BETA, "Beta Point 2", 37, 137),
+];
+
+const ALIASES = [
+  aliasSeed(ALPHA, "Shared", "shared", "bangumi", 40),
+  aliasSeed(ALPHA, "Shared", "shared", "manual", 40),
+  aliasSeed(BETA, "Shared", "shared", "bangumi", 40),
+  aliasSeed(ZERO, "Zero", "zero", "bangumi", 40),
+];
 
 let pool: pg.Pool;
 let db: CatalogDb;
 let neonSql: NeonSql;
 
-async function seedWorks(): Promise<void> {
-  await pool.query(`INSERT INTO bangumi (id, title) VALUES
-    ('1001', 'Alpha'), ('1002', 'Beta'), ('1003', 'Zero Point')`);
+async function run(statement: SeedStatement): Promise<void> {
+  await pool.query(statement.text, statement.values);
 }
 
-async function seedPoints(): Promise<void> {
-  await pool.query(`INSERT INTO points (id, bangumi_id, name, latitude, longitude) VALUES
-    ('a-1', '1001', 'Alpha Point', 35, 135),
-    ('b-1', '1002', 'Beta Point 1', 36, 136),
-    ('b-2', '1002', 'Beta Point 2', 37, 137)`);
-}
-
-async function seedAliases(): Promise<void> {
-  await pool.query(`INSERT INTO aliases (work_id, alias, alias_normalized, source, priority) VALUES
-    ('1001', 'Shared', 'shared', 'bangumi', 40),
-    ('1001', 'Shared', 'shared', 'manual', 40),
-    ('1002', 'Shared', 'shared', 'bangumi', 40),
-    ('1003', 'Zero', 'zero', 'bangumi', 40)`);
+async function seed(): Promise<void> {
+  await run(workInsert([ALPHA, BETA, ZERO]));
+  await run(pointInsert(POINTS));
+  await run(aliasInsert(ALIASES));
 }
 
 function context(): CatalogContext {
@@ -79,9 +106,7 @@ beforeAll(async () => {
   pool = await openDirectPool();
   db = drizzle(pool) as unknown as CatalogDb;
   await truncateCatalogPool(pool);
-  await seedWorks();
-  await seedPoints();
-  await seedAliases();
+  await seed();
 }, 120_000);
 
 afterAll(async () => {
@@ -91,24 +116,16 @@ afterAll(async () => {
 
 databaseDescribe("Phase 1a resolver SQL against Postgres", () => {
   it("deduplicates work ids and orders tied candidates by derived point count", async () => {
-    await expect(call("resolve", { query: "Shared" })).resolves.toEqual({
-      outcome: "needs_disambiguation", reason: "anime_ambiguity",
-      candidates: [
-        { bangumi_id: "1002", title: "Beta", points_count: 2 },
-        { bangumi_id: "1001", title: "Alpha", points_count: 1 },
-      ],
-    });
+    await expect(call("resolve", { query: "Shared" }))
+      .resolves.toEqual(ambiguousOutcome([candidateOf(BETA, 2), candidateOf(ALPHA, 1)]));
   });
 
   it("resolves a work with zero points instead of returning not_found", async () => {
-    await expect(call("resolve", { query: "Zero" })).resolves.toEqual({
-      outcome: "resolved",
-      match: { bangumi_id: "1003", title: "Zero Point", points_count: 0 },
-    });
+    await expect(call("resolve", { query: "Zero" })).resolves.toEqual(resolvedOutcome(ZERO, 0));
   });
 
   it("returns published rows through pointsByWorkId", async () => {
-    const result = await call("points-by-work-id", { work_id: "1002" });
-    expect(pointKeys(result)).toEqual(["1002:b-1", "1002:b-2"]);
+    const result = await call("points-by-work-id", { work_id: BETA.workId });
+    expect(pointKeys(result)).toEqual([`${BETA.workId}:b-1`, `${BETA.workId}:b-2`]);
   });
 });

--- a/workers/catalog/test/resolve-api.spike.test.ts
+++ b/workers/catalog/test/resolve-api.spike.test.ts
@@ -29,11 +29,14 @@ import {
 /**
  * Resolver SQL proof against the ephemeral branch's direct cloud endpoint.
  *
- * The context carries a REAL `NeonSql` built from the spike DSN: resolve's
- * raw-SQL path (added by the July geocoding wave) is part of its contract, and
- * the old `() => Promise.resolve([])` stub silently broke it into an on-demand
- * ingest. Seeds and expectations are contract-derived — work ids that
- * `pointsByWorkId` would 400 cannot be written here (#363).
+ * GUARD: the context must carry a REAL `NeonSql` built from the spike DSN.
+ * Resolve's raw-SQL path (the July geocoding wave) is part of its contract, so
+ * stubbing `neonSql` to something like `() => Promise.resolve([])` does not
+ * fail loudly — it silently turns every resolve into a miss and an on-demand
+ * ingest. Do not stub it.
+ *
+ * Seeds and expectations are built by `./fixtures/catalog-seed`, so a work id
+ * that `pointsByWorkId` would reject with a 400 cannot be written here (#363).
  */
 const handler = new OpenAPIHandler(catalogRouter);
 

--- a/workers/catalog/vitest.config.ts
+++ b/workers/catalog/vitest.config.ts
@@ -31,12 +31,13 @@ export default defineConfig({
       // pool, so they are excluded from this worker-runtime coverage scope.
       exclude: ["src/ingest/**", "src/enrich/**", "src/publish/**", "src/media/**"],
       reporter: ["text", "lcov"],
-      // Modest starting floor — ratchet UP as worker tests grow (never lower).
+      // Ratcheted to the measured floor (94.69/95.63/92.69/78.37). UP only —
+      // never lower these to make a change fit.
       thresholds: {
-        lines: 60,
-        functions: 60,
-        statements: 60,
-        branches: 50,
+        lines: 94,
+        functions: 95,
+        statements: 92,
+        branches: 78,
       },
     },
   },


### PR DESCRIPTION
Closes #363. Follow-up tracked in #456.

## The drift list (audited against current `src` + `packages/contract`)

| # | Fixture | Drifted from | Symptom |
|---|---|---|---|
| 1 | `resolve-api.spike.test.ts` seeds | `PointsByWorkIdInput` (`work_id: /^\d+$/`) | work ids `alpha`/`beta`/`zero` → 400 on `pointsByWorkId` |
| 2 | `geo-query.spike.test.ts` Oarai case | `MAX_RADIUS_M = 50_000` in `src/lib/geo-query.ts` | **not** an FK/seed gap as the issue suspected — the row lands fine (verified with a live direct query); the 200 km request is *clamped* to 50 km, so the ~82 km Oarai point is correctly excluded |
| 3 | `catalog-api.spike.test.ts` alias-miss (not in the issue — found by running the full live suite) | tiered miss path in `src/api/search.ts` | unstubbed → real Bangumi search → live 502 |
| 4 | `catalog-api.spike.test.ts` `afterEach` | `vi.stubGlobal` semantics | `restoreAllMocks()` does not undo `stubGlobal`; fetch stubs leaked between tests and only worked by chaining luck |

**Correction (review P1-1):** the `neonSql` stub the issue describes (`() => Promise.resolve([])`) is **not** on this PR's base. It was fixed by `8c56e225`, an unverified WIP already merged into `feat/frontend-rebuild`; base and this branch are byte-identical on that wiring. The spike's head comment is now written as a forward-looking guard ("do not stub `neonSql` — resolve's raw-SQL path needs a real one") rather than a claim about history a future reader cannot find.

## Approach — stop hand-copying snapshots

Rather than write a fresh snapshot that rots again, seeds and expectations are **derived from `packages/contract`** and the Drizzle schema:

- **`test/fixtures/catalog-seed.ts`** — every fixture value is `.parse()`d through the shared schemas at construction (`PointsByWorkIdInput`, `Latitude`, `Longitude`, `AnimeCandidate`, `ResolveOutcome`). Table and column names come from `getTableName` / `getTableColumns`, so a schema rename breaks the emitted SQL offline.
- **`test/catalog-seed.worker.test.ts`** — that guard runs in the always-on worker pool, so fixture rot is visible in CI *without* Neon credentials (the spikes skip when they are absent, which is how this rotted unseen).
- **`MAX_RADIUS_M` exported** from `src/lib/geo-query.ts`; the spike derives its boundaries from src, keeps the Oarai/ガルパン seed, and asserts both the clamp and the row's presence. `nearby.worker.test.ts` records the values bound into the geo query and asserts the clamp **in the offline pool** too, so this PR's only src behaviour change is not gated behind Neon.

**Scope of the guarantee (review P2-3):** "a contract-invalid work id cannot be written into a fixture" holds for seeds built through these builders — currently 2 of 16 spike files. The rest still hand-write INSERTs (`catalog-api.spike.test.ts` still seeds `'lucky-star'`, which `/^\d+$/` would reject; legal only because that file never calls `pointsByWorkId`). Converting them is #456, and the caveat is recorded in the fixture module's head comment.

No new `any`, no suppressions, 1-10-50 respected.

## Gates (all run in this branch)

- `pnpm run typecheck` (workers/catalog) — clean
- `pnpm run lint:oxlint` (type-aware, `--deny-warnings`) — clean
- `pnpm run test:worker` — **256 passed** (34 files)
- `pnpm run test:spike` **live against Neon Local** — **84 passed, 0 failed** (base was 83/1)
- Coverage floors ratcheted **60/60/60/50 → lines 94 / functions 95 / statements 92 / branches 78** (measured 94.69/95.63/92.69/78.37)
- **Mutation checks** (both fail for the right reason, green on restore):
  - replacing `Math.min(q.radiusM, MAX_RADIUS_M)` with `q.radiusM` → reddens the new `nearby.worker.test.ts` clamp test *and* the spike clamp test
  - renaming `points.bangumi_id` in `src/db/schema.ts` → reddens the offline fixture test

No contract package files changed, so no cross-package contract surface moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)