### PR TITLE
fix(eval): stop the repeat tripwire from equating unrecorded tool params (#443)

### DIFF
--- a/apps/agent/agent/agents/agent_result.py
+++ b/apps/agent/agent/agents/agent_result.py
@@ -76,6 +76,10 @@ class StepRecord:
     provenance: StepProvenance | None = None
     error: str | None = None
     model_initiated: bool = True
+    # False when the call's arguments could not be projected (#443). Empty
+    # `params` then means "unknown", not "called with no arguments" — consumers
+    # that compare calls by arguments must not equate two unknowns.
+    params_recorded: bool = True
 
 
 @dataclass

--- a/apps/agent/agent/agents/tool_event_bridge.py
+++ b/apps/agent/agent/agents/tool_event_bridge.py
@@ -40,6 +40,9 @@ class ActiveToolCall:
 
     tool: str
     params: dict[str, JsonValue]
+    # See StepRecord.params_recorded (#443): an unprojectable or never-seen call
+    # carries empty params that must not be read as "no arguments".
+    params_recorded: bool = True
 
 
 @dataclass
@@ -50,11 +53,11 @@ class ToolLifecycleRegistry:
     provenance: dict[str, StepProvenance] = field(default_factory=dict)
     recovered_exceptions: set[str] = field(default_factory=set)
 
-    def start(self, call_id: str, tool: str, params: dict[str, JsonValue]) -> None:
-        self.active[call_id] = ActiveToolCall(tool, params)
+    def start(self, call_id: str, call: ActiveToolCall) -> None:
+        self.active[call_id] = call
 
     def finish(self, call_id: str, tool: str) -> ActiveToolCall:
-        return self.active.pop(call_id, ActiveToolCall(tool, {}))
+        return self.active.pop(call_id, ActiveToolCall(tool, {}, params_recorded=False))
 
     def register_provenance(self, call_id: str, provenance: StepProvenance) -> None:
         self.provenance[call_id] = provenance
@@ -109,23 +112,26 @@ def register_recovered_tool_exception(
     ctx.deps.tool_lifecycle.mark_recovered_exception(call_id)
 
 
-def _call_params(event: FunctionToolCallEvent) -> dict[str, JsonValue]:
+def _call_params(event: FunctionToolCallEvent) -> ActiveToolCall:
     """Never let an odd argument shape kill the run — the siblings all guard too.
 
     Malformed JSON already arrives as {"INVALID_JSON": raw} from pydantic-ai, so
     the model keeps its own retry path; the residual raiser is dict-typed args
     holding non-JSON values. Recording empty params is strictly better than
-    turning a retryable tool call into a terminal run error.
+    turning a retryable tool call into a terminal run error — but it is flagged
+    as unrecorded (#443) so no consumer mistakes the loss for "no arguments".
     """
+    tool = event.part.tool_name
     try:
-        return _OBJECT.validate_python(event.part.args_as_dict())
+        return ActiveToolCall(tool, _OBJECT.validate_python(event.part.args_as_dict()))
     except ValidationError:
-        return {}
+        return ActiveToolCall(tool, {}, params_recorded=False)
 
 
 async def _handle_call(deps: RuntimeDeps, event: FunctionToolCallEvent) -> None:
-    params = _call_params(event)
-    deps.tool_lifecycle.start(event.tool_call_id, event.part.tool_name, params)
+    call = _call_params(event)
+    deps.tool_lifecycle.start(event.tool_call_id, call)
+    params = call.params
     data = cast(StepData, params)
     await _emit(
         deps, StepEvent(event.part.tool_name, event.tool_call_id, "running", data)
@@ -206,7 +212,15 @@ def _record_terminal_return(
     params = cast(StepData, call.params)
     payload = cast(StepData | None, data)
     deps.steps.append(
-        StepRecord(call.tool, success, params, payload, provenance, error)
+        StepRecord(
+            call.tool,
+            success,
+            params,
+            payload,
+            provenance,
+            error,
+            params_recorded=call.params_recorded,
+        )
     )
 
 

--- a/apps/agent/agent/agents/tool_event_bridge.py
+++ b/apps/agent/agent/agents/tool_event_bridge.py
@@ -57,7 +57,11 @@ class ToolLifecycleRegistry:
         self.active[call_id] = call
 
     def finish(self, call_id: str, tool: str) -> ActiveToolCall:
-        return self.active.pop(call_id, ActiveToolCall(tool, {}, params_recorded=False))
+        active = self.active.pop(call_id, None)
+        if active is not None:
+            return active
+        logger.warning("tool_call_params_unrecorded", tool=tool, call_id=call_id)
+        return ActiveToolCall(tool, {}, params_recorded=False)
 
     def register_provenance(self, call_id: str, provenance: StepProvenance) -> None:
         self.provenance[call_id] = provenance
@@ -125,6 +129,9 @@ def _call_params(event: FunctionToolCallEvent) -> ActiveToolCall:
     try:
         return ActiveToolCall(tool, _OBJECT.validate_python(event.part.args_as_dict()))
     except ValidationError:
+        logger.warning(
+            "tool_call_params_unprojectable", tool=tool, call_id=event.tool_call_id
+        )
         return ActiveToolCall(tool, {}, params_recorded=False)
 
 
@@ -213,12 +220,12 @@ def _record_terminal_return(
     payload = cast(StepData | None, data)
     deps.steps.append(
         StepRecord(
-            call.tool,
-            success,
-            params,
-            payload,
-            provenance,
-            error,
+            tool=call.tool,
+            success=success,
+            params=params,
+            data=payload,
+            provenance=provenance,
+            error=error,
             params_recorded=call.params_recorded,
         )
     )

--- a/apps/agent/agent/tests/eval/direct_gates.py
+++ b/apps/agent/agent/tests/eval/direct_gates.py
@@ -15,14 +15,20 @@ from agent.agents.agent_result import AgentResult
 REQUEST_LIMIT = 12
 # Calibrated 2026-07-20: legitimate multi-step disambiguation (sequel/season
 # cases added by #304B) needs 7-8 tool calls; this cap only bounds runaway
-# breadth. NOTE: the repeated-identical detector below reads EXECUTED steps —
-# the runtime repeat-guard deflects identical re-calls before execution, so
-# post-guard this detector is a regression TRIPWIRE for the guard itself
-# (it firing means the guard broke), not a live thrash signal. That inference
-# holds only while recorded params are LOSSLESS: #443 fired on two nearby
-# searches with different locations because the rejected-search recording path
-# dropped its arguments, so both projected to "{}". Calls whose arguments were
-# not recorded are therefore excluded from the comparison, never equated.
+# breadth. NOTE: the repeated-identical detector below reads EXECUTED steps.
+# The runtime repeat-guard deflects identical re-calls before execution, so an
+# executed repeat is evidence the guard broke — but only ONE-WAY evidence. The
+# guard keys on VALIDATED arguments (defaults filled in) while these records
+# carry the model's RAW arguments, so the detector sees `{"location":"Uji"}` and
+# `{"location":"Uji","radius_m":null}` as different calls where the guard sees
+# one. It therefore promises no more than "identical RECORDED params never
+# execute twice"; guard breakage that survives that projection is invisible
+# here. Closing the fork by recording validated args is tracked separately.
+# The comparison is also only sound while records are lossless: #443 fired on
+# two nearby searches with different locations because the rejected-search
+# recording path dropped its arguments, so both projected to "{}". Calls whose
+# arguments were not recorded are excluded from the comparison and reported as
+# their own gate failure instead of being equated.
 TOOL_CALL_LIMIT = 10
 # Calibrated 2026-07-18 (#28): two stable full-655 official-v1 runs measured
 # request_p95 = 7 (baseline run observed 7-8). The original 6 would fail every
@@ -110,7 +116,24 @@ def _case_failures(case: TrajectoryCase) -> list[str]:
             f"exceeds limit={TOOL_CALL_LIMIT}"
         )
     failures.extend(_repeat_failures(case))
+    failures.extend(_unrecorded_failures(case))
     return failures
+
+
+def _unrecorded_failures(case: TrajectoryCase) -> list[str]:
+    """Lost arguments blind the tripwire, so they are a defect in their own right.
+
+    On every live path the bridge projects the model's own call arguments, so
+    this count is 0 in a healthy run; anything above 0 means a recording defect
+    reached the gate, not that the agent repeated itself.
+    """
+    unrecorded = _unrecorded_count(case)
+    if unrecorded == 0:
+        return []
+    return [
+        f"{case.case_id}: unrecorded_params={unrecorded} — tool arguments were "
+        "lost, so the repeat tripwire is blind for this case"
+    ]
 
 
 def _request_limit_passes(requests: int) -> bool:

--- a/apps/agent/agent/tests/eval/direct_gates.py
+++ b/apps/agent/agent/tests/eval/direct_gates.py
@@ -18,7 +18,11 @@ REQUEST_LIMIT = 12
 # breadth. NOTE: the repeated-identical detector below reads EXECUTED steps —
 # the runtime repeat-guard deflects identical re-calls before execution, so
 # post-guard this detector is a regression TRIPWIRE for the guard itself
-# (it firing means the guard broke), not a live thrash signal.
+# (it firing means the guard broke), not a live thrash signal. That inference
+# holds only while recorded params are LOSSLESS: #443 fired on two nearby
+# searches with different locations because the rejected-search recording path
+# dropped its arguments, so both projected to "{}". Calls whose arguments were
+# not recorded are therefore excluded from the comparison, never equated.
 TOOL_CALL_LIMIT = 10
 # Calibrated 2026-07-18 (#28): two stable full-655 official-v1 runs measured
 # request_p95 = 7 (baseline run observed 7-8). The original 6 would fail every
@@ -33,15 +37,19 @@ class RecordedToolCall:
 
     tool: str
     arguments: str
+    # #443: an unrecorded-argument step is an UNKNOWN call, not an empty one.
+    # Two unknowns are not evidence of a repeat, so they are excluded from the
+    # comparison instead of collapsing onto the same "{}" identity.
+    arguments_known: bool = True
 
     @classmethod
     def from_arguments(
-        cls, tool: str, arguments: Mapping[str, object]
+        cls, tool: str, arguments: Mapping[str, object], *, known: bool = True
     ) -> RecordedToolCall:
         encoded = json.dumps(
             arguments, ensure_ascii=False, sort_keys=True, separators=(",", ":")
         )
-        return cls(tool=tool, arguments=encoded)
+        return cls(tool=tool, arguments=encoded, arguments_known=known)
 
 
 @dataclass(frozen=True)
@@ -56,7 +64,9 @@ class TrajectoryCase:
     def from_result(cls, case_id: str, result: AgentResult) -> TrajectoryCase:
         requests = result.usage.requests if result.usage is not None else 0
         calls = tuple(
-            RecordedToolCall.from_arguments(step.tool, step.params)
+            RecordedToolCall.from_arguments(
+                step.tool, step.params, known=step.params_recorded
+            )
             for step in result.steps
             if step.model_initiated
         )
@@ -81,7 +91,8 @@ def print_direct_thrash_metrics(
     for case in cases:
         print(
             f"{case.case_id}: requests={case.requests} "
-            f"tool_calls={len(case.tool_calls)} repeats={_repeat_count(case)}"
+            f"tool_calls={len(case.tool_calls)} repeats={_repeat_count(case)} "
+            f"unrecorded_params={_unrecorded_count(case)}"
         )
     if include_p95:
         print(f"request_p95={_request_p95(cases)}")
@@ -124,7 +135,7 @@ def _request_context(requests: int) -> EvaluatorContext[object, object, object]:
 def _repeat_failures(case: TrajectoryCase) -> list[str]:
     seen: set[RecordedToolCall] = set()
     repeated: set[str] = set()
-    for call in case.tool_calls:
+    for call in _comparable_calls(case):
         if call in seen:
             repeated.add(call.tool)
         seen.add(call)
@@ -134,8 +145,17 @@ def _repeat_failures(case: TrajectoryCase) -> list[str]:
     ]
 
 
+def _comparable_calls(case: TrajectoryCase) -> tuple[RecordedToolCall, ...]:
+    return tuple(call for call in case.tool_calls if call.arguments_known)
+
+
 def _repeat_count(case: TrajectoryCase) -> int:
-    return len(case.tool_calls) - len(set(case.tool_calls))
+    comparable = _comparable_calls(case)
+    return len(comparable) - len(set(comparable))
+
+
+def _unrecorded_count(case: TrajectoryCase) -> int:
+    return len(case.tool_calls) - len(_comparable_calls(case))
 
 
 def _request_p95(cases: Sequence[TrajectoryCase]) -> int:

--- a/apps/agent/agent/tests/unit/test_eval_repeat_tripwire.py
+++ b/apps/agent/agent/tests/unit/test_eval_repeat_tripwire.py
@@ -47,10 +47,13 @@ def test_distinct_locations_never_read_as_a_repeated_call() -> None:
     assert direct_thrash_gate([trajectory]) == []
 
 
-def test_unrecorded_params_do_not_manufacture_a_repeat() -> None:
+def test_unrecorded_params_fail_as_a_recording_defect_not_as_a_repeat() -> None:
     trajectory = _trajectory(_unrecorded_nearby(), _unrecorded_nearby())
 
-    assert direct_thrash_gate([trajectory]) == []
+    assert direct_thrash_gate([trajectory]) == [
+        "C1_en_005: unrecorded_params=2 — tool arguments were lost, so the "
+        "repeat tripwire is blind for this case"
+    ]
 
 
 def test_identical_recorded_params_still_trip_the_guard_regression_wire() -> None:
@@ -69,6 +72,14 @@ def test_genuinely_empty_arguments_still_trip_the_wire() -> None:
     assert direct_thrash_gate([trajectory]) == [
         "C1_en_005: repeated identical tool call: search_nearby"
     ]
+
+
+def test_recorded_params_alone_keep_the_recording_gate_silent() -> None:
+    trajectory = _trajectory(_nearby("Uji"), _nearby("Kyoto"))
+
+    assert not any(
+        "unrecorded_params" in failure for failure in direct_thrash_gate([trajectory])
+    )
 
 
 def test_metrics_report_unrecorded_params_instead_of_hiding_them(

--- a/apps/agent/agent/tests/unit/test_eval_repeat_tripwire.py
+++ b/apps/agent/agent/tests/unit/test_eval_repeat_tripwire.py
@@ -1,0 +1,82 @@
+"""#443: the repeat tripwire may only fire on genuinely identical arguments.
+
+The runtime repeat-guard (`before_tool_execute`) deflects identical re-calls
+before execution, so an executed repeat means the guard broke. That inference is
+only sound while recorded params are lossless: when a step's arguments were not
+recorded, "same recorded params" no longer implies "same call", and the tripwire
+must abstain instead of inventing a repeat.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai.usage import RunUsage
+
+from agent.agents.agent_result import AgentResult, StepRecord
+from agent.agents.runtime_models import QAResponseModel
+from agent.agents.session_state import SessionState
+from agent.tests.eval.direct_gates import (
+    TrajectoryCase,
+    direct_thrash_gate,
+    print_direct_thrash_metrics,
+)
+
+
+def _trajectory(*steps: StepRecord) -> TrajectoryCase:
+    result = AgentResult(
+        output=QAResponseModel(message="answer"),
+        intent="general_qa",
+        session_state=SessionState(),
+        steps=list(steps),
+        usage=RunUsage(requests=2),
+    )
+    return TrajectoryCase.from_result("C1_en_005", result)
+
+
+def _nearby(location: str) -> StepRecord:
+    return StepRecord("search_nearby", True, params={"location": location})
+
+
+def _unrecorded_nearby() -> StepRecord:
+    return StepRecord("search_nearby", True, params={}, params_recorded=False)
+
+
+def test_distinct_locations_never_read_as_a_repeated_call() -> None:
+    trajectory = _trajectory(_nearby("Nishinomiya, Japan"), _nearby("西宮市"))
+
+    assert direct_thrash_gate([trajectory]) == []
+
+
+def test_unrecorded_params_do_not_manufacture_a_repeat() -> None:
+    trajectory = _trajectory(_unrecorded_nearby(), _unrecorded_nearby())
+
+    assert direct_thrash_gate([trajectory]) == []
+
+
+def test_identical_recorded_params_still_trip_the_guard_regression_wire() -> None:
+    trajectory = _trajectory(_nearby("Uji"), _nearby("Uji"))
+
+    assert direct_thrash_gate([trajectory]) == [
+        "C1_en_005: repeated identical tool call: search_nearby"
+    ]
+
+
+def test_genuinely_empty_arguments_still_trip_the_wire() -> None:
+    """A near-me search takes no arguments; repeating it is real thrash."""
+    empty = StepRecord("search_nearby", True, params={})
+    trajectory = _trajectory(empty, empty)
+
+    assert direct_thrash_gate([trajectory]) == [
+        "C1_en_005: repeated identical tool call: search_nearby"
+    ]
+
+
+def test_metrics_report_unrecorded_params_instead_of_hiding_them(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    trajectory = _trajectory(_unrecorded_nearby(), _nearby("Uji"))
+
+    print_direct_thrash_metrics([trajectory], include_p95=False, enforced=True)
+
+    report = capsys.readouterr().out
+    assert "C1_en_005: requests=2 tool_calls=2 repeats=0 unrecorded_params=1" in report

--- a/apps/agent/agent/tests/unit/test_tool_event_bridge_params.py
+++ b/apps/agent/agent/tests/unit/test_tool_event_bridge_params.py
@@ -1,0 +1,87 @@
+"""#443: recorded tool params must never silently degrade into empty args.
+
+The eval repeat tripwire compares recorded step params. A step whose params were
+lost must say so, otherwise two calls with *different* arguments both project to
+`{}` and read as one repeated identical call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock
+
+from pydantic_ai.messages import (
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    ToolCallPart,
+    ToolReturnPart,
+)
+
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.tool_event_bridge import tool_event_bridge
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+
+def _deps() -> RuntimeDeps:
+    return RuntimeDeps(MagicMock(), "en", "query", MockCatalogClient())
+
+
+async def _stream(*events: object) -> AsyncIterator[object]:
+    for event in events:
+        yield event
+
+
+async def _handle(deps: RuntimeDeps, *events: object) -> None:
+    await tool_event_bridge(MagicMock(deps=deps), _stream(*events))
+
+
+def _call(tool: str, call_id: str, args: object) -> FunctionToolCallEvent:
+    return FunctionToolCallEvent(ToolCallPart(tool, args, tool_call_id=call_id))
+
+
+def _result(tool: str, call_id: str) -> FunctionToolResultEvent:
+    part = ToolReturnPart(tool, {"outcome": "ok"}, tool_call_id=call_id)
+    return FunctionToolResultEvent(part)
+
+
+async def test_marks_params_recorded_when_arguments_are_projected() -> None:
+    deps = _deps()
+    await _handle(
+        deps,
+        _call("search_nearby", "c1", {"location": "Uji"}),
+        _result("search_nearby", "c1"),
+    )
+    assert deps.steps[0].params_recorded is True
+
+
+async def test_marks_params_unrecorded_when_no_call_event_was_seen() -> None:
+    """A return whose call event never arrived has no arguments to report."""
+    deps = _deps()
+    await _handle(deps, _result("search_nearby", "orphan"))
+    assert (deps.steps[0].params, deps.steps[0].params_recorded) == ({}, False)
+
+
+async def test_marks_params_unrecorded_when_arguments_are_not_projectable() -> None:
+    deps = _deps()
+    await _handle(
+        deps,
+        _call("search_nearby", "c2", {"radius_m": {"not", "json"}}),
+        _result("search_nearby", "c2"),
+    )
+    assert (deps.steps[0].params, deps.steps[0].params_recorded) == ({}, False)
+
+
+async def test_keeps_distinct_arguments_distinct_across_rejected_retries() -> None:
+    """The #443 trajectory: place resolution fails, the model retries a new spelling."""
+    deps = _deps()
+    await _handle(
+        deps,
+        _call("search_nearby", "a", {"location": "Nishinomiya, Japan"}),
+        _result("search_nearby", "a"),
+        _call("search_nearby", "b", {"location": "西宮市"}),
+        _result("search_nearby", "b"),
+    )
+    assert [step.params for step in deps.steps] == [
+        {"location": "Nishinomiya, Japan"},
+        {"location": "西宮市"},
+    ]

--- a/apps/agent/agent/tests/unit/test_tool_event_bridge_params.py
+++ b/apps/agent/agent/tests/unit/test_tool_event_bridge_params.py
@@ -16,6 +16,7 @@ from pydantic_ai.messages import (
     ToolCallPart,
     ToolReturnPart,
 )
+from structlog import testing
 
 from agent.agents.runtime_deps import RuntimeDeps
 from agent.agents.tool_event_bridge import tool_event_bridge
@@ -61,6 +62,13 @@ async def test_marks_params_unrecorded_when_no_call_event_was_seen() -> None:
     assert (deps.steps[0].params, deps.steps[0].params_recorded) == ({}, False)
 
 
+async def test_warns_in_production_when_no_call_event_was_seen() -> None:
+    deps = _deps()
+    with testing.capture_logs() as captured:
+        await _handle(deps, _result("search_nearby", "orphan"))
+    assert [entry["event"] for entry in captured] == ["tool_call_params_unrecorded"]
+
+
 async def test_marks_params_unrecorded_when_arguments_are_not_projectable() -> None:
     deps = _deps()
     await _handle(
@@ -69,6 +77,13 @@ async def test_marks_params_unrecorded_when_arguments_are_not_projectable() -> N
         _result("search_nearby", "c2"),
     )
     assert (deps.steps[0].params, deps.steps[0].params_recorded) == ({}, False)
+
+
+async def test_warns_in_production_when_arguments_are_not_projectable() -> None:
+    deps = _deps()
+    with testing.capture_logs() as captured:
+        await _handle(deps, _call("search_nearby", "c3", {"radius_m": {"x"}}))
+    assert [entry["event"] for entry in captured] == ["tool_call_params_unprojectable"]
 
 
 async def test_keeps_distinct_arguments_distinct_across_rejected_retries() -> None:


### PR DESCRIPTION
Fixes #443. Follow-up: #459.

## Diagnosis — explanation (1), decided with trajectories, not reasoning

I ran `C1_en_001` / `C1_en_005` in isolation against the live MiMo model on the trajectory tier (mock catalog, `NullDatabase`), capturing every executed step *and* the runtime guard's fingerprint ledger: **50 runs** on the first tree, **32 more** on the final tree — **82 runs, 0 repeat-guard hits, 0 errors, 0 unrecorded params** (0/82 → 95% one-sided upper bound **3.6%**; the first batch alone, 0/50, bounds it at 5.8%).

The runtime `before_tool_execute` repeat-guard is intact — not bypassed, no thrash regression.

What the model actually does, in **5/82 runs (6.1%, 95% CI 2.0%–13.7%)**, is retry `search_nearby` with a **different location spelling** after place resolution fails:

```
C1_en_005 (run 22)
  geocode        {"location": "Nishinomiya, Hyogo, Japan"}
  search_nearby  {"location": "Nishinomiya, Hyogo, Japan"}
  geocode        {"location": "西宮市, 兵庫県, 日本"}
  search_nearby  {"location": "西宮市, 兵庫県, 日本"}
  geocode        {"location": "Nishinomiya"}
  search_nearby  {"location": "Nishinomiya"}

C1_en_001 (run 1)
  search_nearby  {"location": "Uji, Kyoto, Japan"}
  search_nearby  {"location": "宇治市, 京都府, 日本"}
  search_nearby  {"location": "34.8862, 135.8002"}
```

Those arguments are plainly **not identical**, and the guard correctly let them through. The gate still failed because of how the calls were *recorded*. On the tree those CI runs used (pre-#430), a rejected nearby search was recorded with its arguments dropped:

```python
# apps/agent/agent/agents/catalog_tools.py @ 53271753^
if not isinstance(resolved, tuple):
    _record(ctx.deps, ToolName.SEARCH_NEARBY.value, {}, resolved.model_dump(), ...)
                                                    ^^ location thrown away
```

`direct_gates.RecordedToolCall` compares recorded `step.params`, so two or three *different* locations all projected onto the same `("search_nearby", "{}")` identity and read as one repeated identical call. That fully explains the report: intermittent (only when the model needs a geocode retry), independent of the branch diff, and passing on a plain re-run.

So this was never thrash and never a broken guard — the tripwire was reading a lossy projection. **The guard is not widened by one inch here.**

## Change

#430 already stopped dropping the arguments on that path. This turns the two surviving `{}` substitutions in the bridge into defense-in-depth that announces itself instead of lying, and gives the resulting signal a consumer:

- `StepRecord` / `ActiveToolCall` carry `params_recorded`. The event bridge sets it `False` for an unprojectable call and for a return whose call event was never seen — both previously became a silent `{}` — and logs a structlog warning (`tool_call_params_unprojectable` / `tool_call_params_unrecorded`) so the loss is visible in production, not only in an eval line.
- `direct_gates` excludes unknown-argument calls from the identical-call comparison (unknown ≠ identical) **and fails the gate on `unrecorded_params > 0`**. On every live path the bridge projects the model's own call arguments, so that count is 0 in a healthy run — anything above 0 is a recording defect, and a blind tripwire must not pass green.
- Identical **recorded** params still trip the wire — including a genuinely no-argument near-me search repeated, which is real thrash.
- The tripwire comment in `direct_gates.py` is narrowed to what the code supports: the guard keys on **validated** args while these records carry **raw** args, so it promises only "identical *recorded* params never execute twice" and cannot see guard breakage hiding in default normalization. Closing that fork is #459.
- `StepRecord` is constructed by keyword at the bridge site (8 fields, 6 optional).

## Gates

- `make lint` pass · `make typecheck` pass (mypy strict, 119 files) · `make test` **1409 passed, coverage 88.52%** (floor 87)
- **L0 smoke, cap 80 = the CI configuration** (`EVAL_SMOKE=1 EVAL_MAX_CASES=80`, live MiMo), run on the final tree — the selection contains the reported case `C1_en_001`:
  ```
  C1_en_001: requests=2 tool_calls=1 repeats=0 unrecorded_params=0
  C1_ja_007: requests=3 tool_calls=1 repeats=0 unrecorded_params=0
  80/80 evaluated, errored=0 → All gates passed.
  ```
  No case in the run reported a nonzero `repeats` or `unrecorded_params`.
- Targeted `C1_en_001` / `C1_en_005` batch on the final tree: 32 runs, **repeats=0, unrecorded_params=0**, including 3 runs that exercised the multi-attempt nearby/geocode retry path that used to false-positive.
- Mutation verification — **10/10 mutants killed**, baseline green:

| Mutant | Result |
|---|---|
| M1 unknown-argument calls back in the repeat comparison | KILLED |
| M2 `finish()` fallback: no warning, marked as recorded | KILLED |
| M3 `ValidationError` fallback: no warning, marked as recorded | KILLED |
| M4 `StepRecord` always claims recorded params | KILLED |
| M5 repeat detection disabled (tripwire removed) | KILLED |
| M6 `unrecorded_params` always counted as 0 | KILLED |
| M7 `unrecorded_params` gate never fails | KILLED |
| M8 `unrecorded_params` gate fails unconditionally | KILLED |
| M9 no production warning on an orphan return | KILLED |
| M10 no production warning on unprojectable args | KILLED |

CI's own `agent-eval-smoke` lane still needs the `changes`-job permission fix from #448 before it can run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
