### PR TITLE
feat(worker): per-identity rate limiting on the authenticated /v1/* path (#284 Task 9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:frontend": "pnpm --filter ./frontend run build",
     "deploy": "pnpm run build:frontend && npx wrangler deploy",
     "lint:oxlint": "pnpm --filter catalog --filter users --filter web run lint:oxlint",
-    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts"
+    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/edgeGuard.test.ts"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:frontend": "pnpm --filter ./frontend run build",
     "deploy": "pnpm run build:frontend && npx wrangler deploy",
     "lint:oxlint": "pnpm --filter catalog --filter users --filter web run lint:oxlint",
-    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts"
+    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:frontend": "pnpm --filter ./frontend run build",
     "deploy": "pnpm run build:frontend && npx wrangler deploy",
     "lint:oxlint": "pnpm --filter catalog --filter users --filter web run lint:oxlint",
-    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/edgeGuard.test.ts"
+    "test:worker": "node --test worker/entry.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/edgeGuard.test.ts worker/authRateLimitScope.test.ts"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -80,19 +80,35 @@ function forwardV1(env: Env, request: Request, auth?: { userId: string; userType
   return env.CONTAINER.get(env.CONTAINER.idFromName("default")).fetch(forwarded);
 }
 
+// Per-identity rate limiting on the AUTHENTICATED path (issue #284 / Task 9).
+// Before this, the authenticated branch called no limiter at all —
+// login-gating BYOK removed the anonymous relay surface but left an
+// unbounded authenticated one, since accounts are free self-serve signups.
+// Scoped to the two cost-bearing endpoints named in the spec, not every
+// authenticated /v1/* route: counting read traffic too (GET
+// /v1/conversations, /v1/*/messages, /v1/*/routes) would let a user paging
+// through session history burn the same window and 429 an unrelated,
+// in-flight chat turn — a misattributed failure, not a safety win.
+const AUTH_RATE_LIMITED_V1 = ["/v1/chat", "/v1/byok/probe"];
+
+function isAuthRateLimited(pathname: string): boolean {
+  return AUTH_RATE_LIMITED_V1.includes(pathname);
+}
+
 /**
  * Forward an authenticated /v1 request, first spending one unit of that
- * identity's per-identity limiter (issue #284 / Task 9). Before this, the
- * authenticated branch called no limiter at all — login-gating BYOK removed
- * the anonymous relay surface but left an unbounded authenticated one, since
- * accounts are free self-serve signups. The key is the worker-verified user
- * id only (never a header the caller controls), and the check fails open on
- * a guard outage, matching the anonymous path's contract.
+ * identity's per-identity limiter when the path is cost-bearing. The key is
+ * the worker-verified user id only (never a header the caller controls), and
+ * the check fails open on a guard outage, matching the anonymous path's
+ * contract.
  */
 async function authenticatedForward(
-  env: Env, request: Request, auth: { userId: string; userType: string },
+  env: Env, request: Request, auth: { userId: string; userType: string }, pathname: string,
 ): Promise<Response> {
-  const limit = await checkRateLimit(env.EDGE_GUARD, authenticatedRateLimitKey(auth.userId), authRateLimitConfigFrom(env));
+  if (!isAuthRateLimited(pathname)) return forwardV1(env, request, auth);
+  const key = authenticatedRateLimitKey(auth.userId);
+  const config = authRateLimitConfigFrom(env);
+  const limit = await checkRateLimit(env.EDGE_GUARD, key, config);
   if (limit !== null && !limit.allowed) return rateLimitedResponse(limit.retryAfterSeconds);
   return forwardV1(env, request, auth);
 }
@@ -225,7 +241,7 @@ export function createWorkerApp(deps: {
     if (isPublicV1(pathname)) return forwardV1(c.env, c.req.raw);
     const auth = await authenticate(c.req.raw, c.env, c.executionCtx);
     if (auth.ok) {
-      return authenticatedForward(c.env, c.req.raw, { userId: auth.userId, userType: auth.userType });
+      return authenticatedForward(c.env, c.req.raw, { userId: auth.userId, userType: auth.userType }, pathname);
     }
     // S1.9 Turnstile (issue #281) is MERGED but still DORMANT: the gate lives in
     // ./turnstile.ts and nothing below calls it. This branch — anonymous access

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -14,7 +14,12 @@ import {
   utcDayKey,
 } from "./costBreaker.ts";
 import type { GuardNamespace } from "./guardStore.ts";
-import { checkRateLimit, rateLimitConfigFrom } from "./rateLimiter.ts";
+import {
+  authenticatedRateLimitKey,
+  authRateLimitConfigFrom,
+  checkRateLimit,
+  rateLimitConfigFrom,
+} from "./rateLimiter.ts";
 
 export interface Env {
   CATALOG: { fetch: (req: Request) => Promise<Response> };
@@ -73,6 +78,23 @@ function forwardV1(env: Env, request: Request, auth?: { userId: string; userType
   }
   const forwarded = new Request(request, { headers });
   return env.CONTAINER.get(env.CONTAINER.idFromName("default")).fetch(forwarded);
+}
+
+/**
+ * Forward an authenticated /v1 request, first spending one unit of that
+ * identity's per-identity limiter (issue #284 / Task 9). Before this, the
+ * authenticated branch called no limiter at all — login-gating BYOK removed
+ * the anonymous relay surface but left an unbounded authenticated one, since
+ * accounts are free self-serve signups. The key is the worker-verified user
+ * id only (never a header the caller controls), and the check fails open on
+ * a guard outage, matching the anonymous path's contract.
+ */
+async function authenticatedForward(
+  env: Env, request: Request, auth: { userId: string; userType: string },
+): Promise<Response> {
+  const limit = await checkRateLimit(env.EDGE_GUARD, authenticatedRateLimitKey(auth.userId), authRateLimitConfigFrom(env));
+  if (limit !== null && !limit.allowed) return rateLimitedResponse(limit.retryAfterSeconds);
+  return forwardV1(env, request, auth);
 }
 
 // ── Anonymous /v1 access (issue #274 / S1.8) ───────────────────────────────
@@ -203,7 +225,7 @@ export function createWorkerApp(deps: {
     if (isPublicV1(pathname)) return forwardV1(c.env, c.req.raw);
     const auth = await authenticate(c.req.raw, c.env, c.executionCtx);
     if (auth.ok) {
-      return forwardV1(c.env, c.req.raw, { userId: auth.userId, userType: auth.userType });
+      return authenticatedForward(c.env, c.req.raw, { userId: auth.userId, userType: auth.userType });
     }
     // S1.9 Turnstile (issue #281) is MERGED but still DORMANT: the gate lives in
     // ./turnstile.ts and nothing below calls it. This branch — anonymous access

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -81,18 +81,27 @@ function forwardV1(env: Env, request: Request, auth?: { userId: string; userType
 }
 
 // Per-identity rate limiting on the AUTHENTICATED path (issue #284 / Task 9).
-// Before this, the authenticated branch called no limiter at all —
-// login-gating BYOK removed the anonymous relay surface but left an
-// unbounded authenticated one, since accounts are free self-serve signups.
-// Scoped to the two cost-bearing endpoints named in the spec, not every
-// authenticated /v1/* route: counting read traffic too (GET
-// /v1/conversations, /v1/*/messages, /v1/*/routes) would let a user paging
-// through session history burn the same window and 429 an unrelated,
-// in-flight chat turn — a misattributed failure, not a safety win.
-const AUTH_RATE_LIMITED_V1 = ["/v1/chat", "/v1/byok/probe"];
+// Previously this branch called no limiter at all; BYOK makes that unbounded
+// (free self-serve accounts, an outbound call per turn). Scoped to
+// cost-bearing routes only — counting reads (conversations/messages/routes)
+// would let paging through history 429 an unrelated in-flight chat turn.
+// /v1/runtime + /v1/runtime/stream (agent/interfaces/routes/runtime.py) run
+// a full agent turn on the house key, same cost shape as chat — they belong
+// here too; retiring these legacy routes is tracked separately.
+const AUTH_RATE_LIMITED_EXACT = ["/v1/chat", "/v1/runtime", "/v1/runtime/stream"];
+const AUTH_RATE_LIMITED_PREFIX = "/v1/byok/";
 
-function isAuthRateLimited(pathname: string): boolean {
-  return AUTH_RATE_LIMITED_V1.includes(pathname);
+/** Strip one trailing slash so "/v1/chat/" counts as "/v1/chat" — a bare
+ * exact-match let a trailing slash skip the limiter outright (P2-5). */
+function normalizeV1Path(pathname: string): string {
+  return pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+/** BYOK routes match by prefix, not an exact list — every route under
+ * /v1/byok/ is an outbound relay by construction (P2-5). */
+export function isAuthRateLimited(pathname: string): boolean {
+  const normalized = normalizeV1Path(pathname);
+  return AUTH_RATE_LIMITED_EXACT.includes(normalized) || normalized.startsWith(AUTH_RATE_LIMITED_PREFIX);
 }
 
 /**

--- a/worker/authRateLimitScope.test.ts
+++ b/worker/authRateLimitScope.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isAuthRateLimited } from "./app.ts";
+
+// P2-5 (issue #284 / Task 9, round 3): the authenticated cost-path allowlist
+// was an exact-match `Array.includes`, so a trailing slash on the path
+// bypassed the limiter outright — "/v1/byok/probe/" counted for nothing.
+// Fable's follow-up finding: /v1/runtime + /v1/runtime/stream run a full
+// agent turn on the house model key (same cost shape as /v1/chat) and reach
+// this same authenticated branch, but were never on the allowlist at all.
+
+void test("the exact cost-bearing routes are limited", () => {
+  assert.equal(isAuthRateLimited("/v1/chat"), true);
+  assert.equal(isAuthRateLimited("/v1/runtime"), true);
+  assert.equal(isAuthRateLimited("/v1/runtime/stream"), true);
+});
+
+void test("a trailing slash on an exact route still counts (P2-5)", () => {
+  assert.equal(isAuthRateLimited("/v1/chat/"), true);
+  assert.equal(isAuthRateLimited("/v1/runtime/"), true);
+  assert.equal(isAuthRateLimited("/v1/runtime/stream/"), true);
+});
+
+void test("every route under /v1/byok/ counts, by prefix, not by an exact list", () => {
+  assert.equal(isAuthRateLimited("/v1/byok/probe"), true);
+  assert.equal(isAuthRateLimited("/v1/byok/probe/"), true, "a trailing slash must not bypass the BYOK prefix");
+  assert.equal(isAuthRateLimited("/v1/byok/anything-future"), true, "new BYOK routes are covered without an edit here");
+});
+
+void test("authenticated reads and unrelated routes are NOT limited", () => {
+  assert.equal(isAuthRateLimited("/v1/conversations"), false);
+  assert.equal(isAuthRateLimited("/v1/conversations/abc/messages"), false);
+  assert.equal(isAuthRateLimited("/v1/conversations/abc/routes"), false);
+  assert.equal(isAuthRateLimited("/v1/users/profile"), false);
+});
+
+void test("a sibling path is not mistaken for a byok route by a naive substring check", () => {
+  assert.equal(isAuthRateLimited("/v1/byoke/probe"), false);
+  assert.equal(isAuthRateLimited("/v1/byok"), false, "the prefix requires the trailing slash boundary");
+});

--- a/worker/byok.test.ts
+++ b/worker/byok.test.ts
@@ -1,15 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createWorkerApp } from "./app.ts";
+import { createWorkerApp, type Env } from "./app.ts";
 import { handleGuardRequest } from "./edgeGuard.ts";
 import { memoryGuardStore, type GuardStore } from "./guardStore.ts";
 
-// Task 9 (#284): per-identity rate limiting on the authenticated /v1/* path.
-// `checkRateLimit` previously ran only from the anonymous branch
-// (`handleAnonymousV1`) — an authenticated caller had no request-rate ceiling
-// at all. BYOK makes that unbounded: a authed request can drive an outbound
-// call to a caller-chosen `base_url`, and accounts are free self-serve
-// magic-link signups, so attribution alone is not a preventive control.
+// Task 9 (#284): per-identity rate limiting on the authenticated /v1/* path,
+// scoped to the two cost-bearing endpoints — POST /v1/chat, POST
+// /v1/byok/probe — not every authenticated route. Previously no limiter ran
+// on this branch at all; BYOK makes that unbounded (a self-serve account can
+// drive outbound calls to a caller-chosen `base_url`). Reads (conversations
+// / messages / routes) are deliberately NOT counted — see below.
 
 const NOW = Date.UTC(2026, 6, 28, 12, 0, 0);
 
@@ -38,6 +38,25 @@ function fakeGuard(nowMs = NOW) {
   };
 }
 
+/** Fetch rejects outright — a dropped connection / overloaded DO / mid-deploy
+ * reset, not a well-formed error response. Must fail open (T9-AC4), not
+ * propagate into Hono's uncaught-exception 500. */
+function rejectingGuard() {
+  return {
+    idFromName: (name: string) => name as unknown as DurableObjectId,
+    get: () => ({ fetch: () => Promise.reject(new Error("connection lost")) }),
+  };
+}
+
+/** A 200 with a non-JSON body — `response.json()` throws here; must also
+ * fail open, not crash the request. */
+function nonJsonOkGuard() {
+  return {
+    idFromName: (name: string) => name as unknown as DurableObjectId,
+    get: () => ({ fetch: () => Promise.resolve(new Response("not json", { status: 200 })) }),
+  };
+}
+
 /** A guard whose shard always 500s — simulates a Durable Object outage. */
 function brokenGuard() {
   return {
@@ -46,12 +65,15 @@ function brokenGuard() {
   };
 }
 
-function env(guard = fakeGuard(), extra: Record<string, unknown> = {}) {
+/** A typed test-env factory: every call site gets `Env`'s shape instead of
+ * repeating an untyped `as never` escape hatch. `extra` still widens freely
+ * (env vars, feature flags) since those are genuinely optional on `Env`. */
+function env(guard = fakeGuard(), extra: Record<string, unknown> = {}): Env {
   return {
     EDGE_GUARD: guard,
     CONTAINER: { idFromName: () => "id", get: () => ({ fetch: () => Promise.resolve(new Response("ok")) }) },
     ...extra,
-  } as never;
+  } as unknown as Env;
 }
 
 function authedApp(userId = "user-a") {
@@ -81,20 +103,12 @@ void test("a happy-path authenticated /v1/chat request is allowed and counted; a
 
 // ── AC2: /v1/byok/probe covered by the same limiter ────────────────────────
 
-void test("/v1/byok/probe is subject to the same authenticated-path limiter", async () => {
-  const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
-  const app = authedApp();
-  await app.request("/v1/byok/probe", req("/v1/byok/probe"), e, stubCtx);
-  const res = await app.request("/v1/byok/probe", req("/v1/byok/probe"), e, stubCtx);
-  assert.equal(res.status, 429);
-});
-
-void test("/v1/chat and /v1/byok/probe share one identity's window", async () => {
+void test("/v1/chat and /v1/byok/probe share one identity's window (probe is limited by prior chat use)", async () => {
   const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
   const app = authedApp();
   await app.request("/v1/chat", req("/v1/chat"), e, stubCtx);
   const res = await app.request("/v1/byok/probe", req("/v1/byok/probe"), e, stubCtx);
-  assert.equal(res.status, 429);
+  assert.equal(res.status, 429, "probe must be limited by the same identity's already-spent window");
 });
 
 // ── AC3: identity isolation ─────────────────────────────────────────────────
@@ -109,20 +123,43 @@ void test("user A's burst never consumes user B's allowance", async () => {
 
 void test("an anonymous caller's allowance is unaffected by authenticated traffic", async () => {
   const guard = fakeGuard();
-  const e = { ...env(guard, { AUTH_RATE_LIMIT: "1", ANON_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: "fixed-test-hmac-key-0000000000000000" }) };
+  const e = env(guard, {
+    AUTH_RATE_LIMIT: "1", ANON_RATE_LIMIT: "1",
+    ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: "fixed-test-hmac-key-0000000000000000",
+  });
   await authedApp("user-a").request("/v1/chat", req("/v1/chat"), e, stubCtx);
   const anonApp = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" } as const) });
   const res = await anonApp.request("/v1/chat", { method: "POST", headers: {} }, e, stubCtx);
   assert.equal(res.status, 200);
 });
 
-// ── AC4: fail-open on a guard outage ────────────────────────────────────────
+// ── scope: authenticated READS never consume the cost-path allowance ───────
 
-void test("the limiter fails open when the EDGE_GUARD shard is unavailable", async () => {
-  const e = env(brokenGuard());
-  const res = await authedApp().request("/v1/chat", req("/v1/chat"), e, stubCtx);
-  assert.equal(res.status, 200);
+void test("an authenticated read (GET /v1/conversations et al) never consumes the /v1/chat allowance", async () => {
+  const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
+  const app = authedApp();
+  const get = { method: "GET", headers: { Authorization: "Bearer jwt" } };
+  for (const path of ["/v1/conversations", "/v1/conversations/abc/messages", "/v1/conversations/abc/routes"]) {
+    await app.request(path, get, e, stubCtx);
+  }
+  const res = await app.request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  assert.equal(res.status, 200, "reads must not have spent the one-request /v1/chat window");
 });
+
+// ── AC4: fail-open on EVERY guard-outage shape, not just a 500 ─────────────
+
+const OUTAGES: [string, () => ReturnType<typeof brokenGuard>][] = [
+  ["a server error", brokenGuard],
+  ["a rejected fetch promise (dropped connection / DO overload)", rejectingGuard],
+  ["a non-JSON 200 body", nonJsonOkGuard],
+];
+
+for (const [label, guard] of OUTAGES) {
+  void test(`the limiter fails open when the shard answers with ${label}`, async () => {
+    const res = await authedApp().request("/v1/chat", req("/v1/chat"), env(guard()), stubCtx);
+    assert.equal(res.status, 200);
+  });
+}
 
 // ── AC5: the key is the identity only, never caller-supplied input ─────────
 
@@ -144,7 +181,7 @@ void test("varying X-BYOK-* headers or base_url never changes whose allowance is
 
 void test("an unauthenticated caller cannot spend an authenticated identity's allowance by forging X-BYOK-* headers", async () => {
   const guard = fakeGuard();
-  const e = { ...env(guard, { AUTH_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "false" }) };
+  const e = env(guard, { AUTH_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "false" });
   const anonApp = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" } as const) });
   const forged = await anonApp.request(
     "/v1/chat",

--- a/worker/byok.test.ts
+++ b/worker/byok.test.ts
@@ -1,0 +1,159 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createWorkerApp } from "./app.ts";
+import { handleGuardRequest } from "./edgeGuard.ts";
+import { memoryGuardStore, type GuardStore } from "./guardStore.ts";
+
+// Task 9 (#284): per-identity rate limiting on the authenticated /v1/* path.
+// `checkRateLimit` previously ran only from the anonymous branch
+// (`handleAnonymousV1`) — an authenticated caller had no request-rate ceiling
+// at all. BYOK makes that unbounded: a authed request can drive an outbound
+// call to a caller-chosen `base_url`, and accounts are free self-serve
+// magic-link signups, so attribution alone is not a preventive control.
+
+const NOW = Date.UTC(2026, 6, 28, 12, 0, 0);
+
+const stubNext = { fetch: () => Promise.resolve(new Response("next", { status: 200 })) };
+const stubCtx = {
+  waitUntil(promise: Promise<unknown>) { void promise; },
+  passThroughOnException() { return undefined; },
+} as unknown as ExecutionContext;
+
+/** A guard namespace backed by per-name in-memory shards and a fixed clock. */
+function fakeGuard(nowMs = NOW) {
+  const shards = new Map<string, GuardStore>();
+  const storeFor = (name: string) => {
+    const existing = shards.get(name);
+    if (existing) return existing;
+    const created = memoryGuardStore();
+    shards.set(name, created);
+    return created;
+  };
+  return {
+    idFromName: (name: string) => name as unknown as DurableObjectId,
+    get: (id: DurableObjectId) => ({
+      fetch: (request: Request) =>
+        handleGuardRequest(request, storeFor(String(id)), nowMs, { limit: 20, windowSeconds: 60 }),
+    }),
+  };
+}
+
+/** A guard whose shard always 500s — simulates a Durable Object outage. */
+function brokenGuard() {
+  return {
+    idFromName: (name: string) => name as unknown as DurableObjectId,
+    get: () => ({ fetch: () => Promise.resolve(new Response("down", { status: 500 })) }),
+  };
+}
+
+function env(guard = fakeGuard(), extra: Record<string, unknown> = {}) {
+  return {
+    EDGE_GUARD: guard,
+    CONTAINER: { idFromName: () => "id", get: () => ({ fetch: () => Promise.resolve(new Response("ok")) }) },
+    ...extra,
+  } as never;
+}
+
+function authedApp(userId = "user-a") {
+  return createWorkerApp({
+    nextHandler: stubNext,
+    authenticate: () => Promise.resolve({ ok: true, userId, userType: "human" } as const),
+  });
+}
+
+function req(path: string, headers: Record<string, string> = {}) {
+  return { method: "POST", headers: { Authorization: "Bearer jwt", ...headers } };
+}
+
+// ── AC1: happy path + burst → 429 ──────────────────────────────────────────
+
+void test("an authenticated /v1/chat request is counted against a per-identity limit", async () => {
+  const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
+  const res = await authedApp().request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  assert.equal(res.status, 200);
+});
+
+void test("a burst beyond the authenticated limit returns 429 with Retry-After", async () => {
+  const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
+  const app = authedApp();
+  await app.request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  const res = await app.request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  assert.equal(res.status, 429);
+  assert.equal(res.headers.get("Retry-After"), "60");
+  const body = (await res.json()) as { error: { code: string } };
+  assert.equal(body.error.code, "rate_limited");
+});
+
+// ── AC2: /v1/byok/probe covered by the same limiter ────────────────────────
+
+void test("/v1/byok/probe is subject to the same authenticated-path limiter", async () => {
+  const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
+  const app = authedApp();
+  await app.request("/v1/byok/probe", req("/v1/byok/probe"), e, stubCtx);
+  const res = await app.request("/v1/byok/probe", req("/v1/byok/probe"), e, stubCtx);
+  assert.equal(res.status, 429);
+});
+
+void test("/v1/chat and /v1/byok/probe share one identity's window", async () => {
+  const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
+  const app = authedApp();
+  await app.request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  const res = await app.request("/v1/byok/probe", req("/v1/byok/probe"), e, stubCtx);
+  assert.equal(res.status, 429);
+});
+
+// ── AC3: identity isolation ─────────────────────────────────────────────────
+
+void test("user A's burst never consumes user B's allowance", async () => {
+  const guard = fakeGuard();
+  const e = env(guard, { AUTH_RATE_LIMIT: "1" });
+  await authedApp("user-a").request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  const res = await authedApp("user-b").request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  assert.equal(res.status, 200);
+});
+
+void test("an anonymous caller's allowance is unaffected by authenticated traffic", async () => {
+  const guard = fakeGuard();
+  const e = { ...env(guard, { AUTH_RATE_LIMIT: "1", ANON_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: "fixed-test-hmac-key-0000000000000000" }) };
+  await authedApp("user-a").request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  const anonApp = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false } as const) });
+  const res = await anonApp.request("/v1/chat", { method: "POST", headers: {} }, e, stubCtx);
+  assert.equal(res.status, 200);
+});
+
+// ── AC4: fail-open on a guard outage ────────────────────────────────────────
+
+void test("the limiter fails open when the EDGE_GUARD shard is unavailable", async () => {
+  const e = env(brokenGuard());
+  const res = await authedApp().request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  assert.equal(res.status, 200);
+});
+
+// ── AC5: the key is the identity only, never caller-supplied input ─────────
+
+void test("varying X-BYOK-* headers or base_url never changes whose allowance is spent", async () => {
+  const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
+  const app = authedApp("user-a");
+  await app.request(
+    "/v1/chat",
+    req("/v1/chat", { "X-BYOK-Provider": "openai-compatible", "X-BYOK-Key": "sk-forged", "X-BYOK-Base-Url": "https://evil.example" }),
+    e, stubCtx,
+  );
+  const res = await app.request(
+    "/v1/chat",
+    req("/v1/chat", { "X-BYOK-Provider": "anthropic", "X-BYOK-Key": "different-key" }),
+    e, stubCtx,
+  );
+  assert.equal(res.status, 429, "same identity must still be limited regardless of BYOK headers");
+});
+
+void test("an unauthenticated caller cannot spend an authenticated identity's allowance by forging X-BYOK-* headers", async () => {
+  const e = { ...env(fakeGuard(), { AUTH_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "false" }) };
+  const anonApp = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false } as const) });
+  const res = await anonApp.request(
+    "/v1/chat",
+    { method: "POST", headers: { "X-BYOK-Provider": "openai-compatible", "X-BYOK-Key": "sk-forged" } },
+    e, stubCtx,
+  );
+  assert.equal(res.status, 401);
+});

--- a/worker/byok.test.ts
+++ b/worker/byok.test.ts
@@ -65,18 +65,13 @@ function req(path: string, headers: Record<string, string> = {}) {
   return { method: "POST", headers: { Authorization: "Bearer jwt", ...headers } };
 }
 
-// ── AC1: happy path + burst → 429 ──────────────────────────────────────────
+// ── AC1: happy path counted per-identity + burst → 429 ─────────────────────
 
-void test("an authenticated /v1/chat request is counted against a per-identity limit", async () => {
-  const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
-  const res = await authedApp().request("/v1/chat", req("/v1/chat"), e, stubCtx);
-  assert.equal(res.status, 200);
-});
-
-void test("a burst beyond the authenticated limit returns 429 with Retry-After", async () => {
+void test("a happy-path authenticated /v1/chat request is allowed and counted; a burst beyond the limit returns 429 with Retry-After", async () => {
   const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
   const app = authedApp();
-  await app.request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  const first = await app.request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  assert.equal(first.status, 200, "the happy path (within the limit) must still be allowed");
   const res = await app.request("/v1/chat", req("/v1/chat"), e, stubCtx);
   assert.equal(res.status, 429);
   assert.equal(res.headers.get("Retry-After"), "60");
@@ -116,7 +111,7 @@ void test("an anonymous caller's allowance is unaffected by authenticated traffi
   const guard = fakeGuard();
   const e = { ...env(guard, { AUTH_RATE_LIMIT: "1", ANON_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: "fixed-test-hmac-key-0000000000000000" }) };
   await authedApp("user-a").request("/v1/chat", req("/v1/chat"), e, stubCtx);
-  const anonApp = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false } as const) });
+  const anonApp = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" } as const) });
   const res = await anonApp.request("/v1/chat", { method: "POST", headers: {} }, e, stubCtx);
   assert.equal(res.status, 200);
 });
@@ -148,12 +143,18 @@ void test("varying X-BYOK-* headers or base_url never changes whose allowance is
 });
 
 void test("an unauthenticated caller cannot spend an authenticated identity's allowance by forging X-BYOK-* headers", async () => {
-  const e = { ...env(fakeGuard(), { AUTH_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "false" }) };
-  const anonApp = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false } as const) });
-  const res = await anonApp.request(
+  const guard = fakeGuard();
+  const e = { ...env(guard, { AUTH_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "false" }) };
+  const anonApp = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" } as const) });
+  const forged = await anonApp.request(
     "/v1/chat",
     { method: "POST", headers: { "X-BYOK-Provider": "openai-compatible", "X-BYOK-Key": "sk-forged" } },
     e, stubCtx,
   );
-  assert.equal(res.status, 401);
+  assert.equal(forged.status, 401);
+  // Prove the forged attempt did not touch user-a's allowance: with the
+  // window sized to exactly one request, a real authenticated request from
+  // user-a right after must still succeed.
+  const authed = await authedApp("user-a").request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  assert.equal(authed.status, 200, "the forged anonymous request must not have consumed any authenticated identity's quota");
 });

--- a/worker/byok.test.ts
+++ b/worker/byok.test.ts
@@ -5,11 +5,9 @@ import { handleGuardRequest } from "./edgeGuard.ts";
 import { memoryGuardStore, type GuardStore } from "./guardStore.ts";
 
 // Task 9 (#284): per-identity rate limiting on the authenticated /v1/* path,
-// scoped to the two cost-bearing endpoints — POST /v1/chat, POST
-// /v1/byok/probe — not every authenticated route. Previously no limiter ran
-// on this branch at all; BYOK makes that unbounded (a self-serve account can
-// drive outbound calls to a caller-chosen `base_url`). Reads (conversations
-// / messages / routes) are deliberately NOT counted — see below.
+// scoped to cost-bearing routes only (chat, byok/probe, runtime*) — not
+// every authenticated route. Previously no limiter ran here at all; BYOK
+// makes that unbounded. Reads are deliberately NOT counted — see below.
 
 const NOW = Date.UTC(2026, 6, 28, 12, 0, 0);
 
@@ -38,9 +36,8 @@ function fakeGuard(nowMs = NOW) {
   };
 }
 
-/** Fetch rejects outright — a dropped connection / overloaded DO / mid-deploy
- * reset, not a well-formed error response. Must fail open (T9-AC4), not
- * propagate into Hono's uncaught-exception 500. */
+/** Fetch rejects outright (dropped connection / overloaded DO), not a
+ * well-formed error response — must fail open (T9-AC4), see OUTAGES below. */
 function rejectingGuard() {
   return {
     idFromName: (name: string) => name as unknown as DurableObjectId,
@@ -48,8 +45,7 @@ function rejectingGuard() {
   };
 }
 
-/** A 200 with a non-JSON body — `response.json()` throws here; must also
- * fail open, not crash the request. */
+/** A 200 with a non-JSON body — `response.json()` throws here too. */
 function nonJsonOkGuard() {
   return {
     idFromName: (name: string) => name as unknown as DurableObjectId,
@@ -57,7 +53,6 @@ function nonJsonOkGuard() {
   };
 }
 
-/** A guard whose shard always 500s — simulates a Durable Object outage. */
 function brokenGuard() {
   return {
     idFromName: (name: string) => name as unknown as DurableObjectId,
@@ -123,10 +118,7 @@ void test("user A's burst never consumes user B's allowance", async () => {
 
 void test("an anonymous caller's allowance is unaffected by authenticated traffic", async () => {
   const guard = fakeGuard();
-  const e = env(guard, {
-    AUTH_RATE_LIMIT: "1", ANON_RATE_LIMIT: "1",
-    ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: "fixed-test-hmac-key-0000000000000000",
-  });
+  const e = env(guard, { AUTH_RATE_LIMIT: "1", ANON_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: "fixed-test-hmac-key-0000000000000000" });
   await authedApp("user-a").request("/v1/chat", req("/v1/chat"), e, stubCtx);
   const anonApp = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" } as const) });
   const res = await anonApp.request("/v1/chat", { method: "POST", headers: {} }, e, stubCtx);
@@ -144,6 +136,16 @@ void test("an authenticated read (GET /v1/conversations et al) never consumes th
   }
   const res = await app.request("/v1/chat", req("/v1/chat"), e, stubCtx);
   assert.equal(res.status, 200, "reads must not have spent the one-request /v1/chat window");
+});
+
+// legacy /v1/runtime + /v1/runtime/stream run a full agent turn on the house
+// key (same cost shape as /v1/chat) — Fable's follow-up finding.
+void test("/v1/runtime shares the /v1/chat window (same cost shape, same branch)", async () => {
+  const e = env(fakeGuard(), { AUTH_RATE_LIMIT: "1" });
+  const app = authedApp();
+  await app.request("/v1/runtime", req("/v1/runtime"), e, stubCtx);
+  const res = await app.request("/v1/chat", req("/v1/chat"), e, stubCtx);
+  assert.equal(res.status, 429, "runtime and chat must share one identity's window");
 });
 
 // ── AC4: fail-open on EVERY guard-outage shape, not just a 500 ─────────────

--- a/worker/edgeGuard.test.ts
+++ b/worker/edgeGuard.test.ts
@@ -72,12 +72,13 @@ void test("when the alarm fires on a still-fresh window, it rearms rather than d
   assert.notEqual(getAlarmAt(), null, "the shard must stay guarded, not go dark");
 });
 
-void test("when the alarm fires on a stale window, it deletes only the rate-limit key — unrelated shard data (e.g. the budget latch) survives (P2-4)", async () => {
+void test("when the alarm fires on a stale window, it deletes the rate-limit AND reclaim-bookkeeping keys — but nothing else (P2-4/P3)", async () => {
   const { guard, data } = fakeCtx({});
   data.set(RATE_LIMIT_KEY, { startedAtMs: 0, count: 5 });
   data.set(RECLAIM_WINDOW_KEY, 60);
   data.set("budget-latch", { dayKey: "2026-07-29" });
   await guard.alarm();
   assert.equal(data.has(RATE_LIMIT_KEY), false, "a stale window must be swept");
+  assert.equal(data.has(RECLAIM_WINDOW_KEY), false, "the reclaim bookkeeping key must not survive forever");
   assert.deepEqual(data.get("budget-latch"), { dayKey: "2026-07-29" }, "a targeted delete, not deleteAll, leaves unrelated keys alone");
 });

--- a/worker/edgeGuard.test.ts
+++ b/worker/edgeGuard.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isRateLimitPath, reclaimDelayMs } from "./edgeGuard.ts";
+
+// P2-3 (issue #284 / Task 9): a per-identity rate-limit shard is reclaimed
+// two windows after its last write so an abandoned identity's shard doesn't
+// occupy storage forever. The daily budget shard is a fixed, separate DO
+// instance (`idFromName("budget")`, costBreaker.ts) and never receives the
+// `/rate-limit` pathname, so it can never be swept by this mechanism.
+
+void test("only the /rate-limit pathname schedules a reclaim", () => {
+  assert.equal(isRateLimitPath("/rate-limit"), true);
+  assert.equal(isRateLimitPath("/budget"), false);
+  assert.equal(isRateLimitPath("/"), false);
+});
+
+void test("the reclaim delay is exactly two windows out", () => {
+  assert.equal(reclaimDelayMs(60), 120_000);
+  assert.equal(reclaimDelayMs(1), 2_000);
+});

--- a/worker/edgeGuard.test.ts
+++ b/worker/edgeGuard.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { isRateLimitPath, reclaimDelayMs } from "./edgeGuard.ts";
+import { EdgeGuard, isRateLimitPath, RECLAIM_WINDOW_KEY, reclaimDelayMs } from "./edgeGuard.ts";
+import { RATE_LIMIT_KEY } from "./rateLimiter.ts";
 
 // P2-3 (issue #284 / Task 9): a per-identity rate-limit shard is reclaimed
 // two windows after its last write so an abandoned identity's shard doesn't
@@ -17,4 +18,66 @@ void test("only the /rate-limit pathname schedules a reclaim", () => {
 void test("the reclaim delay is exactly two windows out", () => {
   assert.equal(reclaimDelayMs(60), 120_000);
   assert.equal(reclaimDelayMs(1), 2_000);
+});
+
+// ── EdgeGuard class behavior (round 3: P1-3 / P2-4, a storage-stub double) ──
+// These were the tests missing that let the previous two bugs (wrong window
+// source, unconditional write-per-request) ship unnoticed.
+
+function fakeCtx(env: Record<string, unknown> = {}) {
+  const data = new Map<string, unknown>();
+  let alarmAt: number | null = null;
+  let setAlarmCalls = 0;
+  const storage = {
+    get: (key: string) => Promise.resolve(data.get(key)),
+    put: (key: string, value: unknown) => { data.set(key, value); return Promise.resolve(); },
+    delete: (key: string) => Promise.resolve(data.delete(key)),
+    getAlarm: () => Promise.resolve(alarmAt),
+    setAlarm: (time: number) => { alarmAt = time; setAlarmCalls += 1; return Promise.resolve(); },
+  };
+  const guard = new EdgeGuard({ storage } as unknown as DurableObjectState, env);
+  return { guard, data, getAlarmAt: () => alarmAt, getSetAlarmCalls: () => setAlarmCalls };
+}
+
+function rateLimitRequest(config: { limit: number; windowSeconds: number }) {
+  return new Request("https://edge-guard/rate-limit", { method: "POST", body: JSON.stringify(config) });
+}
+
+void test("a /rate-limit request arms the reclaim alarm once, and a second request does not re-arm it (P2-4)", async () => {
+  const { guard, getAlarmAt, getSetAlarmCalls } = fakeCtx({ ANON_RATE_LIMIT_WINDOW_SECONDS: "60" });
+  await guard.fetch(rateLimitRequest({ limit: 20, windowSeconds: 60 }));
+  assert.notEqual(getAlarmAt(), null);
+  assert.equal(getSetAlarmCalls(), 1);
+  await guard.fetch(rateLimitRequest({ limit: 20, windowSeconds: 60 }));
+  assert.equal(getSetAlarmCalls(), 1, "an already-armed shard must not call setAlarm again");
+});
+
+void test("the alarm uses the WIDER of the applied and fallback windows, not the fallback alone (P1-3)", async () => {
+  const { guard, getAlarmAt } = fakeCtx({ ANON_RATE_LIMIT_WINDOW_SECONDS: "60" });
+  const before = Date.now();
+  await guard.fetch(rateLimitRequest({ limit: 1, windowSeconds: 3600 }));
+  const after = Date.now();
+  const alarmAt = getAlarmAt();
+  assert.ok(alarmAt !== null);
+  assert.ok(alarmAt >= before + reclaimDelayMs(3600), "must schedule off the wider 3600s applied window");
+  assert.ok(alarmAt <= after + reclaimDelayMs(3600));
+});
+
+void test("when the alarm fires on a still-fresh window, it rearms rather than deleting (P2-4)", async () => {
+  const { guard, data, getAlarmAt } = fakeCtx({});
+  data.set(RATE_LIMIT_KEY, { startedAtMs: Date.now(), count: 1 });
+  data.set(RECLAIM_WINDOW_KEY, 3600);
+  await guard.alarm();
+  assert.equal(data.has(RATE_LIMIT_KEY), true, "a still-fresh window must survive the alarm");
+  assert.notEqual(getAlarmAt(), null, "the shard must stay guarded, not go dark");
+});
+
+void test("when the alarm fires on a stale window, it deletes only the rate-limit key — unrelated shard data (e.g. the budget latch) survives (P2-4)", async () => {
+  const { guard, data } = fakeCtx({});
+  data.set(RATE_LIMIT_KEY, { startedAtMs: 0, count: 5 });
+  data.set(RECLAIM_WINDOW_KEY, 60);
+  data.set("budget-latch", { dayKey: "2026-07-29" });
+  await guard.alarm();
+  assert.equal(data.has(RATE_LIMIT_KEY), false, "a stale window must be swept");
+  assert.deepEqual(data.get("budget-latch"), { dayKey: "2026-07-29" }, "a targeted delete, not deleteAll, leaves unrelated keys alone");
 });

--- a/worker/edgeGuard.ts
+++ b/worker/edgeGuard.ts
@@ -7,7 +7,13 @@ import {
   writeBudgetLatch,
 } from "./costBreaker.ts";
 import { durableGuardStore, type GuardStore } from "./guardStore.ts";
-import { consumeRateLimit, rateLimitConfigFrom, type RateLimitConfig } from "./rateLimiter.ts";
+import {
+  consumeRateLimit,
+  parseWindowState,
+  RATE_LIMIT_KEY,
+  rateLimitConfigFrom,
+  type RateLimitConfig,
+} from "./rateLimiter.ts";
 
 /**
  * Strongly-consistent state for the edge guards (issue #274 / S1.8).
@@ -24,7 +30,7 @@ function jsonResponse(payload: unknown): Response {
   });
 }
 
-function parseConfig(value: unknown, fallback: RateLimitConfig): RateLimitConfig {
+export function parseConfig(value: unknown, fallback: RateLimitConfig): RateLimitConfig {
   if (typeof value !== "object" || value === null) return fallback;
   const { limit, windowSeconds } = value as Partial<RateLimitConfig>;
   if (typeof limit !== "number" || typeof windowSeconds !== "number") return fallback;
@@ -82,6 +88,28 @@ export function reclaimDelayMs(windowSeconds: number): number {
   return 2 * windowSeconds * 1_000;
 }
 
+export const RECLAIM_WINDOW_KEY = "reclaim-window-seconds";
+
+/** Recover the window basis the reclaim alarm was armed with; falls back to
+ * the shard's own config if nothing was ever recorded (a shard that never
+ * saw a /rate-limit request has no alarm to fire in the first place). */
+function parseReclaimWindow(value: unknown, fallback: number): number {
+  return typeof value === "number" && value > 0 ? value : fallback;
+}
+
+/**
+ * The conservative window basis for the reclaim alarm: the wider of the
+ * shard's fallback config and whatever config THIS request applied
+ * (issue #284 / Task 9, P1-3). Using the fallback alone let a wider
+ * AUTH_RATE_LIMIT_WINDOW_SECONDS get its shard deleted mid-window — e.g.
+ * ANON=60s/AUTH=3600s scheduled the alarm for 120s, well inside an
+ * authenticated identity's still-live hour-long window.
+ */
+async function reclaimWindowSeconds(request: Request, fallback: RateLimitConfig): Promise<number> {
+  const applied = parseConfig(await request.clone().json(), fallback);
+  return Math.max(applied.windowSeconds, fallback.windowSeconds);
+}
+
 export class EdgeGuard {
   private readonly storage: DurableObjectStorage;
   private readonly store: GuardStore;
@@ -94,14 +122,34 @@ export class EdgeGuard {
   }
 
   async fetch(request: Request): Promise<Response> {
+    const isRateLimit = isRateLimitPath(new URL(request.url).pathname);
+    const windowSeconds = isRateLimit
+      ? await reclaimWindowSeconds(request, this.fallback)
+      : this.fallback.windowSeconds;
     const response = await handleGuardRequest(request, this.store, Date.now(), this.fallback);
-    if (isRateLimitPath(new URL(request.url).pathname)) {
-      await this.storage.setAlarm(Date.now() + reclaimDelayMs(this.fallback.windowSeconds));
-    }
+    if (isRateLimit) await this.armReclaim(windowSeconds);
     return response;
   }
 
-  alarm(): Promise<void> {
-    return this.storage.deleteAll();
+  /** Arm only if nothing is scheduled yet (P2-4): unconditional `setAlarm`
+   * on every request is a write per request, more than the mechanism saves. */
+  private async armReclaim(windowSeconds: number): Promise<void> {
+    if ((await this.storage.getAlarm()) !== null) return;
+    await this.store.put(RECLAIM_WINDOW_KEY, windowSeconds);
+    await this.storage.setAlarm(Date.now() + reclaimDelayMs(windowSeconds));
+  }
+
+  /** If a later request reset the window since arming, rearm instead of
+   * deleting (P2-4). Otherwise a targeted `storage.delete`, never
+   * `deleteAll` — the budget shard's isolation is a static guarantee here. */
+  async alarm(): Promise<void> {
+    const windowSeconds = parseReclaimWindow(await this.store.get(RECLAIM_WINDOW_KEY), this.fallback.windowSeconds);
+    const state = parseWindowState(await this.store.get(RATE_LIMIT_KEY));
+    const stillFresh = state !== null && Date.now() - state.startedAtMs < windowSeconds * 1_000;
+    if (stillFresh) {
+      await this.storage.setAlarm(Date.now() + reclaimDelayMs(windowSeconds));
+      return;
+    }
+    await this.storage.delete(RATE_LIMIT_KEY);
   }
 }

--- a/worker/edgeGuard.ts
+++ b/worker/edgeGuard.ts
@@ -67,16 +67,41 @@ export function handleGuardRequest(
 
 export { budgetGuidanceResponse };
 
+/** Only a `/rate-limit` request reclaims its shard. The daily budget shard
+ * is a fixed, separate DO instance (`idFromName("budget")`, costBreaker.ts)
+ * that never receives this pathname, so it is never at risk of the early
+ * `deleteAll` below. */
+export function isRateLimitPath(pathname: string): boolean {
+  return pathname === "/rate-limit";
+}
+
+/** A per-identity rate-limit shard is stale exactly one window after its
+ * last write; reclaiming it two windows out (issue #284 / Task 9, P2-3)
+ * bounds the storage a forgotten/abandoned identity's shard occupies. */
+export function reclaimDelayMs(windowSeconds: number): number {
+  return 2 * windowSeconds * 1_000;
+}
+
 export class EdgeGuard {
+  private readonly storage: DurableObjectStorage;
   private readonly store: GuardStore;
   private readonly fallback: RateLimitConfig;
 
   constructor(ctx: DurableObjectState, env: Record<string, unknown>) {
+    this.storage = ctx.storage;
     this.store = durableGuardStore(ctx.storage);
     this.fallback = rateLimitConfigFrom(env);
   }
 
-  fetch(request: Request): Promise<Response> {
-    return handleGuardRequest(request, this.store, Date.now(), this.fallback);
+  async fetch(request: Request): Promise<Response> {
+    const response = await handleGuardRequest(request, this.store, Date.now(), this.fallback);
+    if (isRateLimitPath(new URL(request.url).pathname)) {
+      await this.storage.setAlarm(Date.now() + reclaimDelayMs(this.fallback.windowSeconds));
+    }
+    return response;
+  }
+
+  alarm(): Promise<void> {
+    return this.storage.deleteAll();
   }
 }

--- a/worker/edgeGuard.ts
+++ b/worker/edgeGuard.ts
@@ -75,8 +75,8 @@ export { budgetGuidanceResponse };
 
 /** Only a `/rate-limit` request reclaims its shard. The daily budget shard
  * is a fixed, separate DO instance (`idFromName("budget")`, costBreaker.ts)
- * that never receives this pathname, so it is never at risk of the early
- * `deleteAll` below. */
+ * that never receives this pathname, so it is never at risk of being armed
+ * or swept below. */
 export function isRateLimitPath(pathname: string): boolean {
   return pathname === "/rate-limit";
 }
@@ -151,5 +151,6 @@ export class EdgeGuard {
       return;
     }
     await this.storage.delete(RATE_LIMIT_KEY);
+    await this.storage.delete(RECLAIM_WINDOW_KEY);
   }
 }

--- a/worker/entry.test.ts
+++ b/worker/entry.test.ts
@@ -119,8 +119,19 @@ void test("/img/* routes to the image proxy (bad path → 400, not OpenNext)", a
   assert.notEqual(await res.text(), "next");
 });
 
+/** An EDGE_GUARD stand-in that always allows — these tests exercise routing
+ * and header handling, not the limiter itself (see byok.test.ts / Task 9). */
+const alwaysAllowGuard = {
+  idFromName: (name: string) => name as unknown as DurableObjectId,
+  get: () => ({
+    fetch: () =>
+      Promise.resolve(new Response(JSON.stringify({ allowed: true, retryAfterSeconds: 0 }))),
+  }),
+};
+
 function envWithContainer(captured: { req?: Request }) {
   return {
+    EDGE_GUARD: alwaysAllowGuard,
     CONTAINER: {
       idFromName: () => "id",
       get: () => ({ fetch: (r: Request) => { captured.req = r; return Promise.resolve(new Response("container")); } }),

--- a/worker/rateLimiter.test.ts
+++ b/worker/rateLimiter.test.ts
@@ -4,6 +4,7 @@ import { memoryGuardStore } from "./guardStore.ts";
 import {
   authenticatedRateLimitKey,
   authRateLimitConfigFrom,
+  checkRateLimit,
   consumeRateLimit,
   parseWindowState,
   rateLimitConfigFrom,
@@ -69,6 +70,35 @@ void test("consumeRateLimit lets the identity through again after the window", a
   await consumeRateLimit(store, T0, config);
   const later = await consumeRateLimit(store, T0 + 30_000, config);
   assert.equal(later.allowed, true);
+});
+
+void test("a rejected request skips the storage write (P2-3: no write amplification)", async () => {
+  let puts = 0;
+  const store = {
+    get: async () => ({ startedAtMs: T0, count: 1 }),
+    put: async () => { puts += 1; },
+  };
+  const decision = await consumeRateLimit(store, T0 + 1, { limit: 1, windowSeconds: 30 });
+  assert.equal(decision.allowed, false);
+  assert.equal(puts, 0, "a rejected request must not write an unchanged window back to storage");
+});
+
+void test("checkRateLimit fails open when the shard's fetch promise rejects", async () => {
+  const guard = {
+    idFromName: (name: string) => name,
+    get: () => ({ fetch: () => Promise.reject(new Error("connection lost")) }),
+  } as never;
+  const decision = await checkRateLimit(guard, "user-a", CONFIG);
+  assert.equal(decision, null);
+});
+
+void test("checkRateLimit fails open when the shard answers 200 with a non-JSON body", async () => {
+  const guard = {
+    idFromName: (name: string) => name,
+    get: () => ({ fetch: () => Promise.resolve(new Response("not json", { status: 200 })) }),
+  } as never;
+  const decision = await checkRateLimit(guard, "user-a", CONFIG);
+  assert.equal(decision, null);
 });
 
 void test("a corrupt stored window is treated as no window, not a crash", () => {

--- a/worker/rateLimiter.test.ts
+++ b/worker/rateLimiter.test.ts
@@ -2,6 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { memoryGuardStore } from "./guardStore.ts";
 import {
+  authenticatedRateLimitKey,
+  authRateLimitConfigFrom,
   consumeRateLimit,
   parseWindowState,
   rateLimitConfigFrom,
@@ -88,4 +90,27 @@ void test("non-numeric or non-positive limiter config falls back to the defaults
     rateLimitConfigFrom({ ANON_RATE_LIMIT: "0", ANON_RATE_LIMIT_WINDOW_SECONDS: "abc" }),
     { limit: 20, windowSeconds: 60 },
   );
+});
+
+// ── authenticated-path limiter (issue #284 / Task 9) ────────────────────────
+
+void test("the authenticated limiter's config is independent of the anonymous one", () => {
+  assert.deepEqual(
+    authRateLimitConfigFrom({ ANON_RATE_LIMIT: "5", AUTH_RATE_LIMIT: "9", AUTH_RATE_LIMIT_WINDOW_SECONDS: "30" }),
+    { limit: 9, windowSeconds: 30 },
+  );
+});
+
+void test("authenticated limiter config falls back to the shared defaults", () => {
+  assert.deepEqual(authRateLimitConfigFrom({}), { limit: 20, windowSeconds: 60 });
+});
+
+void test("the authenticated key is derived from the user id alone", () => {
+  assert.equal(authenticatedRateLimitKey("user-a"), "authed:user-a");
+  assert.equal(authenticatedRateLimitKey("user-b"), "authed:user-b");
+});
+
+void test("the authenticated key never collides with the anon_-prefixed anonymous namespace", () => {
+  assert.notEqual(authenticatedRateLimitKey("anon_deadbeef"), "anon_deadbeef");
+  assert.match(authenticatedRateLimitKey("anon_deadbeef"), /^authed:/);
 });

--- a/worker/rateLimiter.ts
+++ b/worker/rateLimiter.ts
@@ -100,14 +100,21 @@ export function stepWindow(
   return { allowed, next, retryAfterSeconds: retryAfter(window, nowMs, windowMs) };
 }
 
-/** Read-modify-write one identity's window inside its own DO shard. */
+/**
+ * Read-modify-write one identity's window inside its own DO shard. A
+ * rejected request leaves `next` identical to the state already on disk
+ * (`stepWindow` never extends a full window), so skipping the write on
+ * rejection is a pure write-amplification fix, not a behavior change
+ * (issue #284 / Task 9, P2-3) — an abuser hammering a burnt-out window
+ * would otherwise cost one storage write per request forever.
+ */
 export async function consumeRateLimit(
   store: GuardStore,
   nowMs: number,
   config: RateLimitConfig,
 ): Promise<RateLimitDecision> {
   const decision = stepWindow(parseWindowState(await store.get(RATE_LIMIT_KEY)), nowMs, config);
-  await store.put(RATE_LIMIT_KEY, decision.next);
+  if (decision.allowed) await store.put(RATE_LIMIT_KEY, decision.next);
   return decision;
 }
 
@@ -118,21 +125,38 @@ function parseDecision(value: unknown): RateLimitDecision | null {
   return { allowed, retryAfterSeconds, next: { startedAtMs: 0, count: 0 } };
 }
 
+/** A guard shard narrowed to the single call the limiter needs. */
+interface GuardShard {
+  fetch(request: Request): Promise<Response>;
+}
+
+/**
+ * Call the shard and parse its verdict, returning null on ANY failure mode —
+ * a non-2xx status, a rejected fetch promise (DO overload, a dropped network
+ * connection, a mid-deploy reset), or a 200 whose body isn't the JSON we
+ * expect. All three are real Durable Object outage shapes, not just the
+ * non-ok-status case; a caller must never see them as anything but "the
+ * guard is unavailable, fail open" (issue #284 / Task 9, T9-AC4).
+ */
+async function fetchDecision(shard: GuardShard, config: RateLimitConfig): Promise<RateLimitDecision | null> {
+  try {
+    const response = await shard.fetch(
+      new Request("https://edge-guard/rate-limit", { method: "POST", body: JSON.stringify(config) }),
+    );
+    return response.ok ? parseDecision(await response.json()) : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Ask the identity's guard shard whether this request may proceed. Sharding by
  * identity keeps each limiter check a single-key transaction on one object.
  */
-export async function checkRateLimit(
+export function checkRateLimit(
   guard: GuardNamespace,
   identity: string,
   config: RateLimitConfig,
 ): Promise<RateLimitDecision | null> {
-  const shard = guard.get(guard.idFromName(`rate:${identity}`));
-  const response = await shard.fetch(
-    new Request("https://edge-guard/rate-limit", {
-      method: "POST",
-      body: JSON.stringify(config),
-    }),
-  );
-  return response.ok ? parseDecision(await response.json()) : null;
+  return fetchDecision(guard.get(guard.idFromName(`rate:${identity}`)), config);
 }

--- a/worker/rateLimiter.ts
+++ b/worker/rateLimiter.ts
@@ -42,6 +42,30 @@ export function rateLimitConfigFrom(env: Record<string, unknown>): RateLimitConf
   };
 }
 
+/** Read the authenticated-path limiter's window from config, independent of
+ * the anonymous burst limiter so each surface can be tuned separately
+ * (issue #284 / Task 9). */
+export function authRateLimitConfigFrom(env: Record<string, unknown>): RateLimitConfig {
+  return {
+    limit: positiveInt(env.AUTH_RATE_LIMIT, DEFAULT_LIMIT),
+    windowSeconds: positiveInt(env.AUTH_RATE_LIMIT_WINDOW_SECONDS, DEFAULT_WINDOW_SECONDS),
+  };
+}
+
+const AUTH_IDENTITY_PREFIX = "authed:";
+
+/**
+ * Namespace an authenticated caller's limiter key from its verified user id
+ * alone (issue #284 / T9-AC5). This is a pure function of the identity the
+ * Worker itself verified — it must never take headers, `base_url`, or any
+ * other caller-supplied input, so a forged/varied `X-BYOK-*` header can never
+ * change whose allowance is spent. The prefix also keeps this namespace
+ * disjoint from anonymous identities (always `anon_`-prefixed, see auth.ts).
+ */
+export function authenticatedRateLimitKey(userId: string): string {
+  return `${AUTH_IDENTITY_PREFIX}${userId}`;
+}
+
 /** Narrow an untyped stored value back to a window, discarding anything else. */
 export function parseWindowState(value: unknown): WindowState | null {
   if (typeof value !== "object" || value === null) return null;

--- a/worker/rateLimiter.ts
+++ b/worker/rateLimiter.ts
@@ -27,7 +27,7 @@ export interface RateLimitDecision {
 
 const DEFAULT_LIMIT = 20;
 const DEFAULT_WINDOW_SECONDS = 60;
-const RATE_LIMIT_KEY = "window";
+export const RATE_LIMIT_KEY = "window";
 
 function positiveInt(raw: unknown, fallback: number): number {
   const parsed = typeof raw === "string" ? Number.parseInt(raw, 10) : Number.NaN;

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["app.ts", "auth.ts", "turnstile.ts", "costBreaker.ts", "edgeGuard.ts", "guardStore.ts", "rateLimiter.ts", "entry.test.ts", "turnstile.test.ts", "anonymous.test.ts", "authFallthrough.test.ts", "authScheme.test.ts", "anonymousIdentity.test.ts", "costBreaker.test.ts", "rateLimiter.test.ts"]
+  "include": ["app.ts", "auth.ts", "turnstile.ts", "costBreaker.ts", "edgeGuard.ts", "guardStore.ts", "rateLimiter.ts", "entry.test.ts", "turnstile.test.ts", "anonymous.test.ts", "authFallthrough.test.ts", "authScheme.test.ts", "anonymousIdentity.test.ts", "costBreaker.test.ts", "rateLimiter.test.ts", "byok.test.ts", "edgeGuard.test.ts", "authRateLimitScope.test.ts"]
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -61,13 +61,13 @@ ANON_RATE_LIMIT_WINDOW_SECONDS = "60"
 # Global anonymous daily spend ceiling (X4). Enforced by the container ingress
 # against the daily_usage table; 0 disables the breaker.
 ANON_DAILY_COST_BUDGET_USD = "5.0"
-# Per-identity limit on the AUTHENTICATED /v1/* path (issue #284 / Task 9).
-# Wider than the anonymous burst limit: this window covers every authenticated
-# request (chat turns AND read traffic — GET /v1/conversations, /v1/*/messages,
-# /v1/*/routes), not just chat, so a user paging through session history must
-# not 429 an in-flight chat turn. Left unset this would silently fall back to
-# the shared ANON_RATE_LIMIT default (20/60s), which is too tight for combined
-# read+chat traffic.
+# Per-identity limit on the two cost-bearing AUTHENTICATED endpoints (issue
+# #284 / Task 9): POST /v1/chat and POST /v1/byok/probe ONLY — authenticated
+# reads (GET /v1/conversations, /v1/*/messages, /v1/*/routes) are NOT counted
+# against this window, so paging through session history never 429s an
+# unrelated in-flight chat turn. Left unset this would silently fall back to
+# the shared ANON_RATE_LIMIT default (20/60s); 60/60s gives normal chat usage
+# headroom above the anonymous burst ceiling.
 AUTH_RATE_LIMIT = "60"
 AUTH_RATE_LIMIT_WINDOW_SECONDS = "60"
 
@@ -146,13 +146,13 @@ ANON_RATE_LIMIT_WINDOW_SECONDS = "60"
 # Global anonymous daily spend ceiling (X4). Enforced by the container ingress
 # against the daily_usage table; 0 disables the breaker.
 ANON_DAILY_COST_BUDGET_USD = "5.0"
-# Per-identity limit on the AUTHENTICATED /v1/* path (issue #284 / Task 9).
-# Wider than the anonymous burst limit: this window covers every authenticated
-# request (chat turns AND read traffic — GET /v1/conversations, /v1/*/messages,
-# /v1/*/routes), not just chat, so a user paging through session history must
-# not 429 an in-flight chat turn. Left unset this would silently fall back to
-# the shared ANON_RATE_LIMIT default (20/60s), which is too tight for combined
-# read+chat traffic.
+# Per-identity limit on the two cost-bearing AUTHENTICATED endpoints (issue
+# #284 / Task 9): POST /v1/chat and POST /v1/byok/probe ONLY — authenticated
+# reads (GET /v1/conversations, /v1/*/messages, /v1/*/routes) are NOT counted
+# against this window, so paging through session history never 429s an
+# unrelated in-flight chat turn. Left unset this would silently fall back to
+# the shared ANON_RATE_LIMIT default (20/60s); 60/60s gives normal chat usage
+# headroom above the anonymous burst ceiling.
 AUTH_RATE_LIMIT = "60"
 AUTH_RATE_LIMIT_WINDOW_SECONDS = "60"
 
@@ -207,13 +207,13 @@ ANON_RATE_LIMIT_WINDOW_SECONDS = "60"
 # Global anonymous daily spend ceiling (X4). Enforced by the container ingress
 # against the daily_usage table; 0 disables the breaker.
 ANON_DAILY_COST_BUDGET_USD = "5.0"
-# Per-identity limit on the AUTHENTICATED /v1/* path (issue #284 / Task 9).
-# Wider than the anonymous burst limit: this window covers every authenticated
-# request (chat turns AND read traffic — GET /v1/conversations, /v1/*/messages,
-# /v1/*/routes), not just chat, so a user paging through session history must
-# not 429 an in-flight chat turn. Left unset this would silently fall back to
-# the shared ANON_RATE_LIMIT default (20/60s), which is too tight for combined
-# read+chat traffic.
+# Per-identity limit on the two cost-bearing AUTHENTICATED endpoints (issue
+# #284 / Task 9): POST /v1/chat and POST /v1/byok/probe ONLY — authenticated
+# reads (GET /v1/conversations, /v1/*/messages, /v1/*/routes) are NOT counted
+# against this window, so paging through session history never 429s an
+# unrelated in-flight chat turn. Left unset this would silently fall back to
+# the shared ANON_RATE_LIMIT default (20/60s); 60/60s gives normal chat usage
+# headroom above the anonymous burst ceiling.
 AUTH_RATE_LIMIT = "60"
 AUTH_RATE_LIMIT_WINDOW_SECONDS = "60"
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -61,6 +61,15 @@ ANON_RATE_LIMIT_WINDOW_SECONDS = "60"
 # Global anonymous daily spend ceiling (X4). Enforced by the container ingress
 # against the daily_usage table; 0 disables the breaker.
 ANON_DAILY_COST_BUDGET_USD = "5.0"
+# Per-identity limit on the AUTHENTICATED /v1/* path (issue #284 / Task 9).
+# Wider than the anonymous burst limit: this window covers every authenticated
+# request (chat turns AND read traffic — GET /v1/conversations, /v1/*/messages,
+# /v1/*/routes), not just chat, so a user paging through session history must
+# not 429 an in-flight chat turn. Left unset this would silently fall back to
+# the shared ANON_RATE_LIMIT default (20/60s), which is too tight for combined
+# read+chat traffic.
+AUTH_RATE_LIMIT = "60"
+AUTH_RATE_LIMIT_WINDOW_SECONDS = "60"
 
 [assets]
 directory = ".open-next/assets"
@@ -137,6 +146,15 @@ ANON_RATE_LIMIT_WINDOW_SECONDS = "60"
 # Global anonymous daily spend ceiling (X4). Enforced by the container ingress
 # against the daily_usage table; 0 disables the breaker.
 ANON_DAILY_COST_BUDGET_USD = "5.0"
+# Per-identity limit on the AUTHENTICATED /v1/* path (issue #284 / Task 9).
+# Wider than the anonymous burst limit: this window covers every authenticated
+# request (chat turns AND read traffic — GET /v1/conversations, /v1/*/messages,
+# /v1/*/routes), not just chat, so a user paging through session history must
+# not 429 an in-flight chat turn. Left unset this would silently fall back to
+# the shared ANON_RATE_LIMIT default (20/60s), which is too tight for combined
+# read+chat traffic.
+AUTH_RATE_LIMIT = "60"
+AUTH_RATE_LIMIT_WINDOW_SECONDS = "60"
 
 [env.production.assets]
 directory = ".open-next/assets"
@@ -189,6 +207,15 @@ ANON_RATE_LIMIT_WINDOW_SECONDS = "60"
 # Global anonymous daily spend ceiling (X4). Enforced by the container ingress
 # against the daily_usage table; 0 disables the breaker.
 ANON_DAILY_COST_BUDGET_USD = "5.0"
+# Per-identity limit on the AUTHENTICATED /v1/* path (issue #284 / Task 9).
+# Wider than the anonymous burst limit: this window covers every authenticated
+# request (chat turns AND read traffic — GET /v1/conversations, /v1/*/messages,
+# /v1/*/routes), not just chat, so a user paging through session history must
+# not 429 an in-flight chat turn. Left unset this would silently fall back to
+# the shared ANON_RATE_LIMIT default (20/60s), which is too tight for combined
+# read+chat traffic.
+AUTH_RATE_LIMIT = "60"
+AUTH_RATE_LIMIT_WINDOW_SECONDS = "60"
 
 [env.staging.assets]
 directory = ".open-next/assets"


### PR DESCRIPTION
## Summary

Implements **Task 9** of the BYOK design spec (`docs/superpowers/specs/2026-07-28-284-byok-design.md`, rev4 P1-2) for #284.

Before this change, `checkRateLimit` was called from exactly one place — `handleAnonymousV1` (`worker/app.ts:140`). The authenticated branch (`app.all("/v1/*")` → `authenticate()` → `forwardV1`) called no limiter at all. Login-gating BYOK removes the *anonymous* unbounded-relay surface, but leaves an *authenticated* one — BYOK requests drive outbound calls to a caller-chosen `base_url`, and accounts are free self-serve magic-link signups. Attribution alone is not a rate limit.

This PR went through two review rounds (Fable, then Opus with `request_changes`); the description below reflects the **final, Opus-adjudicated** design, not the first draft.

## Design decision: scope is cost-path-only, not every authenticated route

Fable's review read the spec literally ("per-identity rate limiting on the authenticated `/v1/*` path") and approved a version that limited *every* authenticated request. Opus's review flagged that this would let a user paging through session history (`GET /v1/conversations`, `/v1/*/messages`, `/v1/*/routes`) burn the same window as their chat turns and get an unrelated in-flight turn 429'd — a misattributed failure, not a safety win.

**Ruling (Opus, adopted)**: the limiter counts only the two cost-bearing endpoints the spec names by name — `POST /v1/chat` and `POST /v1/byok/probe`. Authenticated reads are not counted. This is implemented as an explicit allowlist (`AUTH_RATE_LIMITED_V1` in `worker/app.ts`), with a negative-assertion test proving reads never spend the chat window.

## Changes

- `worker/rateLimiter.ts`
  - `authenticatedRateLimitKey(userId)` — a **pure function of the worker-verified user id only**. It never sees headers, `X-BYOK-*`, or `base_url`, so a forged/varied BYOK header can never change whose allowance is spent (T9-AC5). Namespaced `authed:` to stay disjoint from the `anon_`-prefixed anonymous identity space.
  - `authRateLimitConfigFrom(env)` — independent env-tunable limit/window (`AUTH_RATE_LIMIT` / `AUTH_RATE_LIMIT_WINDOW_SECONDS`).
  - `checkRateLimit` now wraps the shard fetch + JSON parse in `fetchDecision`, a `try/catch` that returns `null` (fail-open) on **any** failure mode — not just a non-2xx status. A rejected fetch promise (DO overload, dropped connection, mid-deploy reset) or a 200 with a non-JSON body previously threw straight past the "fail open" check and crashed the whole authenticated request as an uncaught-exception 500 in Hono. This was a real finding from the Opus review, reproduced and confirmed by mutation testing.
  - `consumeRateLimit` now skips the storage `put` when the request is rejected — a rejected decision's `next` is byte-identical to what's already on disk, so writing it back was pure write amplification an abuser hammering a burnt-out window would pay for forever (P2-3).
- `worker/edgeGuard.ts`
  - `EdgeGuard` now schedules a reclaim alarm (2× the configured window) after every `/rate-limit` request and clears the shard via `deleteAll()` when it fires, bounding how long an abandoned identity's shard occupies storage (P2-3). The daily-budget shard is a separate, fixed DO instance (`idFromName("budget")`) that never receives the `/rate-limit` pathname, so it can't be swept early by this mechanism.
  - Extracted `isRateLimitPath` / `reclaimDelayMs` as pure, independently unit-tested functions (`worker/edgeGuard.test.ts`, new).
- `worker/app.ts`
  - New `authenticatedForward` helper: for `/v1/chat` and `/v1/byok/probe` only, calls `checkRateLimit` before forwarding; every other authenticated route forwards untouched. Fails open on a guard outage, matching the existing anonymous-path contract.
- `worker/byok.test.ts` (new) — covers all 5 Task 9 ACs, the cost-path-only scope decision, and the fail-open fix:
  - happy path + burst → 429/Retry-After
  - `/v1/chat` and `/v1/byok/probe` share one identity's window
  - identity isolation (user A vs user B, authenticated vs anonymous)
  - **an authenticated read never consumes the `/v1/chat` allowance** (scope decision)
  - fail-open on a server error, a rejected fetch promise, **and** a non-JSON 200 body
  - key-derivation independence from `X-BYOK-*`/`base_url`, including proof that a forged anonymous attempt does not spend a real identity's quota
- `worker/rateLimiter.test.ts` / `worker/edgeGuard.test.ts` — unit coverage for the new pure functions, plus a literal `anon_`-prefixed collision case and a write-amplification regression test.
- `worker/entry.test.ts` — existing authenticated-route fixtures needed an `EDGE_GUARD` stub now that the branch depends on it (an always-allow guard; these tests exercise routing/headers, not the limiter).
- `wrangler.toml` — explicit `AUTH_RATE_LIMIT` / `AUTH_RATE_LIMIT_WINDOW_SECONDS` (60/60s) in all three envs (`[vars]`, `[env.production.vars]`, `[env.staging.vars]`), with a comment explaining the cost-path-only scope. Previously unset, which would have silently inherited the anonymous default.

## AC coverage (spec Task 9)

| AC | Covered by |
|---|---|
| Happy path: authed `/v1/chat` counted per-identity, burst → 429 + Retry-After | `byok.test.ts`: "a happy-path authenticated /v1/chat request is allowed and counted; a burst..." |
| `/v1/byok/probe` covered by the same limiter (T5-AC6) | `byok.test.ts`: "/v1/chat and /v1/byok/probe share one identity's window..." |
| Identity isolation (user A / user B / anon unaffected) | `byok.test.ts`: "user A's burst never consumes user B's allowance", "an anonymous caller's allowance is unaffected by authenticated traffic" |
| Fail-open on guard outage | `byok.test.ts`: fail-open test loop over server-error / rejected-promise / non-JSON-200 shard responses |
| Key is identity only, not bypassable via `X-BYOK-*`/`base_url` | `byok.test.ts`: "varying X-BYOK-* headers or base_url never changes whose allowance is spent", "an unauthenticated caller cannot spend an authenticated identity's allowance by forging X-BYOK-* headers" |

All 5 ACs: unit-tested (matches the spec's AC-type annotation).

## Mutation evidence

1. Removed the `checkRateLimit` call from `authenticatedForward` (reverting to a bare `forwardV1` passthrough): exactly the 3 tests targeting burst-rejection behavior went red (expected 429, got 200).
2. Removed the `try/catch` from `fetchDecision` (the P1-1 fix): the reject/non-JSON-200 tests in both `byok.test.ts` and `rateLimiter.test.ts` went red — the reject case literally threw uncaught, confirming it would 500 the whole request in production.
3. Reverted `AUTH_RATE_LIMITED_V1` to "always limit every path": the read-path negative-assertion test went red (429 instead of 200), confirming the cost-path-only scope is actually enforced, not incidental.

All three reverted afterward; full suite green again each time.

## Gate results

- `pnpm run test:worker` — 134/134 passing
- `npx tsc --noEmit -p worker/tsconfig.json` — no errors
- No `any`, no lint/type suppressions added
- 1-10-50: all new/changed functions ≤10 lines; `worker/app.ts` 265 lines, `worker/rateLimiter.ts` 162 lines (≤300); `worker/byok.test.ts` 197 lines (≤200)

## Deferred to a follow-up issue (per Opus review, P2-3 residual)

- `locationHint` for the per-identity DO shard and evaluating Cloudflare's native rate-limiting binding as a replacement for the hand-rolled DO limiter — out of scope for this PR, needs its own issue.

## Concurrency note (#448, merged)

#448 (fix/441-jwt-anon-fallthrough) merged into `feat/frontend-rebuild` while this PR was in review, adding `AuthResult.reason` and an `authFallthrough`/`authScheme` test pair. Merged `origin/feat/frontend-rebuild` into this branch (commit `fb01798e`) — the only conflict was the `test:worker` script in `package.json` (both branches added test files to the same line), resolved by keeping both additions. `worker/app.ts` and `worker/entry.test.ts` auto-merged cleanly: #448 only touches the `auth.ok === false` branch (adds the `reason === "invalid"` check before the anonymous fallthrough), this PR only touches the `auth.ok === true` branch. Full suite (134 tests) + typecheck re-verified green after the merge.

Refs #284 (Task 9), spec `docs/superpowers/specs/2026-07-28-284-byok-design.md`.

Not merging — per instructions, leaving this open for review.