### PR TITLE
feat(agent): SSRF egress guard for BYOK egress (#284 Task 1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM public.ecr.aws/docker/library/python:3.11-slim AS builder
+# Pinned to a patch tag, not the floating `3.11-slim` — #284 Task 1 raises the
+# interpreter floor to >=3.11.10 (CPython gh-113171 fixed `ipaddress.is_global`
+# classification for CGNAT/metadata ranges in 3.11.10/3.12.4). A floating minor
+# tag could silently regress below that fix.
+FROM public.ecr.aws/docker/library/python:3.11.13-slim AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
 
@@ -17,7 +21,7 @@ COPY apps/agent/agent /app/agent
 
 RUN uv sync --no-dev
 
-FROM public.ecr.aws/docker/library/python:3.11-slim
+FROM public.ecr.aws/docker/library/python:3.11.13-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/apps/agent/agent/infrastructure/egress_errors.py
+++ b/apps/agent/agent/infrastructure/egress_errors.py
@@ -1,0 +1,67 @@
+"""Typed error taxonomy for the SSRF egress guard (#284 Task 1).
+
+Split out from `egress_guard.py` to keep that module under the 300-line file
+cap; imported by both `egress_guard.py` (raises) and `egress_transport.py`
+(raises on redirect refusal).
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Final
+
+
+class EgressBlockReason(enum.Enum):
+    """Machine-readable rejection category.
+
+    Task 3 maps these to a public error taxonomy — match on `.reason`, never
+    on `str(exc)`, which carries only a fixed, non-identifying message.
+    """
+
+    EMPTY_URL = "empty_url"
+    INVALID_URL = "invalid_url"
+    INVALID_SCHEME = "invalid_scheme"
+    INVALID_USERINFO = "invalid_userinfo"
+    INVALID_HOST = "invalid_host"
+    INVALID_HOSTNAME_ENCODING = "invalid_hostname_encoding"
+    INVALID_PORT = "invalid_port"
+    OWN_INFRASTRUCTURE = "own_infrastructure"
+    RESOLUTION_TIMEOUT = "resolution_timeout"
+    RESOLUTION_FAILED = "resolution_failed"
+    NO_ADDRESSES = "no_addresses"
+    ADDRESS_NOT_ROUTABLE = "address_not_routable"
+    REDIRECT_REFUSED = "redirect_refused"
+
+
+_REASON_MESSAGES: Final[dict[EgressBlockReason, str]] = {
+    EgressBlockReason.EMPTY_URL: "egress URL is empty",
+    EgressBlockReason.INVALID_URL: "egress URL could not be parsed",
+    EgressBlockReason.INVALID_SCHEME: "egress URL scheme is not allowed",
+    EgressBlockReason.INVALID_USERINFO: "userinfo is not allowed in the egress URL",
+    EgressBlockReason.INVALID_HOST: "egress URL is missing a host",
+    EgressBlockReason.INVALID_HOSTNAME_ENCODING: "egress URL host is not a valid hostname",
+    EgressBlockReason.INVALID_PORT: "egress URL port is not on the allowlist",
+    EgressBlockReason.OWN_INFRASTRUCTURE: "egress host is own infrastructure",
+    EgressBlockReason.RESOLUTION_TIMEOUT: "DNS resolution timed out",
+    EgressBlockReason.RESOLUTION_FAILED: "DNS resolution failed",
+    EgressBlockReason.NO_ADDRESSES: "no addresses resolved for host",
+    EgressBlockReason.ADDRESS_NOT_ROUTABLE: "resolved address is not publicly routable",
+    EgressBlockReason.REDIRECT_REFUSED: "redirect response refused",
+}
+
+
+class EgressBlocked(Exception):
+    """Raised whenever a candidate egress destination fails SSRF validation.
+
+    `str(exc)` is always one of the fixed `_REASON_MESSAGES` — it never
+    embeds the submitted URL, hostname, resolved IP, or the underlying
+    `OSError` text, none of which should reach a caller or an unguarded log
+    line (an internal-network DNS oracle is still an oracle). Anything
+    diagnostic is on `.detail`, for structured logging only, subject to the
+    same redaction path as everything else (Task 2).
+    """
+
+    def __init__(self, reason: EgressBlockReason, *, detail: str | None = None) -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(_REASON_MESSAGES[reason])

--- a/apps/agent/agent/infrastructure/egress_guard.py
+++ b/apps/agent/agent/infrastructure/egress_guard.py
@@ -1,31 +1,30 @@
-"""SSRF egress guard for user-influenceable outbound HTTP calls (#284 Task 1).
+"""SSRF pre-flight validation for user-influenceable outbound HTTP calls (#284 T1).
 
-Two layers, both required (see `docs/superpowers/specs/2026-07-28-284-byok-design.md`):
+`validate_base_url` is the pre-flight, request-boundary check: resolves the
+host exactly once for that call and accepts an address only under a **dual
+condition**: `ip.is_global is True` AND it trips none of the private/loopback/
+link-local/reserved/multicast/unspecified flags. Neither half is redundant —
+see the docstring on `_is_address_accepted` for the two address families each
+half alone would miss. No domain allowlist.
 
-1. `validate_base_url` — a pre-flight, resolve-once check at the request boundary.
-2. `GuardedAsyncTransport` — an `httpx` transport that re-validates at connect time,
-   pins the socket to the already-validated IP literal, preserves TLS hostname
-   verification via `sni_hostname`, and refuses every 3xx response.
-
-No domain allowlist. Acceptance is a **dual condition** on the resolved IP:
-`ip.is_global is True` AND it trips none of the private/loopback/link-local/
-reserved/multicast/unspecified flags. Neither half is redundant — see the
-docstring on `_is_address_accepted` for the two address families each half alone
-would miss.
+`GuardedAsyncTransport` (in `egress_transport.py`) is the second, independent
+layer: it re-runs this same check at connect time and pins the socket to the
+address *that* call validated — see its docstring for why that closes the
+TOCTOU/DNS-rebinding window.
 """
 
 from __future__ import annotations
 
 import ipaddress
 import socket
-import ssl
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Final
-from urllib.parse import urlsplit
+from urllib.parse import SplitResult, urlsplit
 
 import anyio
-import httpx
+
+from agent.infrastructure.egress_errors import EgressBlocked, EgressBlockReason
 
 IpAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
 
@@ -34,6 +33,12 @@ Resolver = Callable[[str, int], Awaitable[list[str]]]
 ALLOWED_SCHEME: Final[str] = "https"
 ALLOWED_PORTS: Final[frozenset[int]] = frozenset({443, 8000, 8443})
 RESOLUTION_TIMEOUT_SECONDS: Final[float] = 5.0
+
+# DNS resolution runs on its own capacity limiter, not anyio's shared default
+# thread pool (40 tokens, shared with every other `to_thread.run_sync` call in
+# the process). A `base_url` pointing at a black-hole nameserver must not be
+# able to exhaust threads other subsystems depend on.
+_DNS_THREAD_LIMITER: Final[anyio.CapacityLimiter] = anyio.CapacityLimiter(4)
 
 # Belt-and-suspenders explicit deny set for well-known cloud-metadata endpoints.
 # These IPs already fail the `is_global`/deny-flag classification below on their
@@ -50,12 +55,20 @@ _METADATA_DENY_IPS: Final[frozenset[str]] = frozenset(
 
 # Our own public-facing origins are legitimately globally routable, so every IP
 # check above passes them. Without an explicit deny, BYOK egress becomes a
-# confused-deputy path back into our own authenticated surfaces.
-OWN_INFRASTRUCTURE_HOSTNAMES: Final[frozenset[str]] = frozenset({"animichi.com"})
-
-
-class EgressBlocked(Exception):
-    """Raised whenever a candidate egress destination fails SSRF validation."""
+# confused-deputy path back into our own authenticated surfaces, where a
+# request may carry more implicit trust than it would from the open internet.
+#
+# This is a hostname-suffix match, not an IP-based one — it does not follow
+# CNAMEs and will not catch a hostname that merely *resolves to* our
+# infrastructure's IPs under a different name. Whenever a new public-facing
+# origin is added (a new custom domain, a new auth provider host, a new
+# internal service hostname), add it here in the same commit.
+OWN_INFRASTRUCTURE_HOSTNAMES: Final[frozenset[str]] = frozenset(
+    {
+        "animichi.com",  # apex + `*.animichi.com` (wrangler.toml route)
+        "stack-auth.com",  # Neon Auth (Better Auth) — per-project subdomain
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,6 +84,17 @@ def _is_own_infrastructure(hostname: str) -> bool:
     return any(
         hostname == domain or hostname.endswith(f".{domain}")
         for domain in OWN_INFRASTRUCTURE_HOSTNAMES
+    )
+
+
+def _trips_any_deny_flag(ip: IpAddress) -> bool:
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
     )
 
 
@@ -91,52 +115,124 @@ def _is_address_accepted(ip: IpAddress) -> bool:
     """
     if ip.is_global is not True:
         return False
-    if (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_reserved
-        or ip.is_multicast
-        or ip.is_unspecified
-    ):
+    if _trips_any_deny_flag(ip):
         return False
     return str(ip) not in _METADATA_DENY_IPS
 
 
+def _blocking_getaddrinfo(host: str, port: int) -> list[str]:
+    infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    return [str(info[4][0]) for info in infos]
+
+
 async def _default_resolve(host: str, port: int) -> list[str]:
-    """Resolve `host` once, off the event loop, with a short timeout."""
+    """Resolve `host` once, off the event loop, with a short timeout.
 
-    def _getaddrinfo() -> list[str]:
-        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
-        return [str(info[4][0]) for info in infos]
-
+    `abandon_on_cancel=True` is load-bearing: `getaddrinfo` is a blocking libc
+    call with no cancellation hook, so without it `anyio.fail_after` cannot
+    actually interrupt a thread stuck resolving a black-holed nameserver — the
+    timeout would be cosmetic. The thread is abandoned (not joined) on
+    timeout and runs on its own 4-slot limiter rather than anyio's shared
+    default thread pool, which other subsystems depend on.
+    """
     try:
         with anyio.fail_after(RESOLUTION_TIMEOUT_SECONDS):
-            return await anyio.to_thread.run_sync(_getaddrinfo)
+            return await anyio.to_thread.run_sync(
+                _blocking_getaddrinfo,
+                host,
+                port,
+                abandon_on_cancel=True,
+                limiter=_DNS_THREAD_LIMITER,
+            )
     except TimeoutError as exc:
-        raise EgressBlocked(f"DNS resolution timed out for {host!r}") from exc
+        raise EgressBlocked(EgressBlockReason.RESOLUTION_TIMEOUT, detail=host) from exc
     except OSError as exc:
-        raise EgressBlocked(f"DNS resolution failed for {host!r}: {exc}") from exc
+        raise EgressBlocked(
+            EgressBlockReason.RESOLUTION_FAILED, detail=str(exc)
+        ) from exc
+
+
+def _check_scheme_and_userinfo(parsed: SplitResult) -> None:
+    if parsed.scheme != ALLOWED_SCHEME:
+        raise EgressBlocked(EgressBlockReason.INVALID_SCHEME, detail=parsed.scheme)
+    if parsed.username or parsed.password:
+        raise EgressBlocked(EgressBlockReason.INVALID_USERINFO)
+
+
+def _encode_hostname(hostname: str) -> str:
+    """IDNA-encode to the A-label and strip a trailing root-label dot.
+
+    Normalizing the trailing dot is load-bearing, not cosmetic:
+    `"animichi.com."`, `"animichi.com。"` (ideographic full stop), and
+    `"animichi.com｡"` (halfwidth ideographic full stop) all IDNA-encode to
+    `"animichi.com."` — a string distinct from `"animichi.com"` that would
+    otherwise slip past `_is_own_infrastructure`'s suffix match even though
+    `getaddrinfo` treats a trailing root dot as equivalent to none.
+    """
+    try:
+        return hostname.encode("idna").decode("ascii").rstrip(".")
+    except UnicodeError as exc:
+        raise EgressBlocked(
+            EgressBlockReason.INVALID_HOSTNAME_ENCODING, detail=hostname
+        ) from exc
+
+
+def _check_port(port: int) -> None:
+    if port not in ALLOWED_PORTS:
+        raise EgressBlocked(EgressBlockReason.INVALID_PORT, detail=str(port))
+
+
+def _split_url(url: str) -> SplitResult:
+    try:
+        return urlsplit(url)
+    except ValueError as exc:
+        # `urlsplit` raises a bare `ValueError` for a netloc that fails its
+        # NFKC-normalization safety check (e.g. a confusable/compatibility
+        # character, such as U+2100, that expands into a different netloc
+        # under normalization). Uncaught, that would break the "every
+        # rejection is a typed EgressBlocked" contract Task 3/5 depend on.
+        raise EgressBlocked(EgressBlockReason.INVALID_URL) from exc
 
 
 def _parse_endpoint_shape(url: str) -> tuple[str, int]:
     """Scheme/userinfo/host/port shape validation, before any I/O."""
-    parsed = urlsplit(url)
-    if parsed.scheme != ALLOWED_SCHEME:
-        raise EgressBlocked(f"scheme must be {ALLOWED_SCHEME!r}, got {parsed.scheme!r}")
-    if parsed.username or parsed.password:
-        raise EgressBlocked("userinfo is not allowed in the egress URL")
-    hostname = parsed.hostname
-    if not hostname:
-        raise EgressBlocked("egress URL is missing a host")
-    try:
-        a_label = hostname.encode("idna").decode("ascii")
-    except UnicodeError as exc:
-        raise EgressBlocked(f"invalid hostname: {hostname!r}") from exc
+    parsed = _split_url(url)
+    _check_scheme_and_userinfo(parsed)
+    if not parsed.hostname:
+        raise EgressBlocked(EgressBlockReason.INVALID_HOST)
+    a_label = _encode_hostname(parsed.hostname)
     port = parsed.port or 443
-    if port not in ALLOWED_PORTS:
-        raise EgressBlocked(f"port {port} is not on the egress allowlist")
+    _check_port(port)
     return a_label, port
+
+
+def _parse_ip_address(candidate: str) -> IpAddress:
+    try:
+        return ipaddress.ip_address(candidate)
+    except ValueError as exc:
+        # A resolver is caller-suppliable (tests inject one; a future
+        # capability could source one from less-trusted config). A malformed
+        # candidate is certainly not an acceptable egress address either way.
+        raise EgressBlocked(
+            EgressBlockReason.ADDRESS_NOT_ROUTABLE, detail=candidate
+        ) from exc
+
+
+async def _resolve_and_classify(
+    hostname: str, port: int, resolver: Resolver
+) -> IpAddress:
+    addresses = await resolver(hostname, port)
+    if not addresses:
+        raise EgressBlocked(EgressBlockReason.NO_ADDRESSES, detail=hostname)
+    accepted: list[IpAddress] = []
+    for candidate in addresses:
+        ip = _parse_ip_address(candidate)
+        if not _is_address_accepted(ip):
+            raise EgressBlocked(
+                EgressBlockReason.ADDRESS_NOT_ROUTABLE, detail=candidate
+            )
+        accepted.append(ip)
+    return accepted[0]
 
 
 async def validate_base_url(
@@ -146,95 +242,12 @@ async def validate_base_url(
 ) -> ValidatedEndpoint:
     """Pre-flight SSRF validation. Raises `EgressBlocked` before any socket opens."""
     if url is None or not url.strip():
-        raise EgressBlocked("egress URL is empty")
+        raise EgressBlocked(EgressBlockReason.EMPTY_URL)
 
     hostname, port = _parse_endpoint_shape(url.strip())
 
     if _is_own_infrastructure(hostname):
-        raise EgressBlocked(f"host {hostname!r} is own infrastructure")
+        raise EgressBlocked(EgressBlockReason.OWN_INFRASTRUCTURE, detail=hostname)
 
-    addresses = await resolver(hostname, port)
-    if not addresses:
-        raise EgressBlocked(f"no addresses resolved for {hostname!r}")
-
-    accepted: list[IpAddress] = []
-    for candidate in addresses:
-        ip = ipaddress.ip_address(candidate)
-        if not _is_address_accepted(ip):
-            raise EgressBlocked(
-                f"resolved address {candidate} is not publicly routable"
-            )
-        accepted.append(ip)
-
-    return ValidatedEndpoint(hostname=hostname, port=port, pinned_ip=str(accepted[0]))
-
-
-def _format_host_header(hostname: str, port: int) -> str:
-    host_part = f"[{hostname}]" if ":" in hostname else hostname
-    return host_part if port == 443 else f"{host_part}:{port}"
-
-
-class GuardedAsyncTransport(httpx.AsyncBaseTransport):
-    """`httpx` transport enforcing SSRF validation at connect time.
-
-    Re-runs `validate_base_url` per request (covers a provider SDK appending
-    paths or a redirect target), rewrites the request to the pinned IP literal
-    while preserving the original `Host` header and TLS SNI hostname, and
-    rejects every 3xx response outright.
-    """
-
-    def __init__(
-        self,
-        *,
-        resolver: Resolver = _default_resolve,
-        inner: httpx.AsyncBaseTransport | None = None,
-        verify: ssl.SSLContext | str | bool = True,
-    ) -> None:
-        self._resolver = resolver
-        self._inner = (
-            inner
-            if inner is not None
-            else httpx.AsyncHTTPTransport(verify=verify, trust_env=False)
-        )
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        endpoint = await validate_base_url(str(request.url), resolver=self._resolver)
-        request.url = request.url.copy_with(host=endpoint.pinned_ip)
-        request.headers["host"] = _format_host_header(endpoint.hostname, endpoint.port)
-        request.extensions = {
-            **request.extensions,
-            "sni_hostname": endpoint.hostname,
-        }
-        response = await self._inner.handle_async_request(request)
-        if 300 <= response.status_code < 400:
-            await response.aread()
-            await response.aclose()
-            raise EgressBlocked(
-                f"redirect response ({response.status_code}) refused for {endpoint.hostname!r}"
-            )
-        return response
-
-    async def aclose(self) -> None:
-        await self._inner.aclose()
-
-
-def build_guarded_async_client(
-    *,
-    resolver: Resolver = _default_resolve,
-    timeout: httpx.Timeout | float | None = None,
-    verify: ssl.SSLContext | str | bool = True,
-) -> httpx.AsyncClient:
-    """Build the per-request BYOK transport.
-
-    `trust_env=False` and no `mounts`/`proxy` (T13): a proxy environment
-    variable would otherwise route the "pinned-IP" connection through a proxy
-    that re-resolves the hostname itself, silently voiding the pinning
-    guarantee. `verify` is exposed only so tests can pin a private test CA;
-    production callers should leave it at the default.
-    """
-    return httpx.AsyncClient(
-        transport=GuardedAsyncTransport(resolver=resolver, verify=verify),
-        trust_env=False,
-        follow_redirects=False,
-        timeout=timeout if timeout is not None else httpx.Timeout(30.0),
-    )
+    pinned = await _resolve_and_classify(hostname, port, resolver)
+    return ValidatedEndpoint(hostname=hostname, port=port, pinned_ip=str(pinned))

--- a/apps/agent/agent/infrastructure/egress_guard.py
+++ b/apps/agent/agent/infrastructure/egress_guard.py
@@ -125,7 +125,7 @@ def _blocking_getaddrinfo(host: str, port: int) -> list[str]:
     return [str(info[4][0]) for info in infos]
 
 
-async def _default_resolve(host: str, port: int) -> list[str]:
+async def default_resolve(host: str, port: int) -> list[str]:
     """Resolve `host` once, off the event loop, with a short timeout.
 
     `abandon_on_cancel=True` is load-bearing: `getaddrinfo` is a blocking libc
@@ -238,7 +238,7 @@ async def _resolve_and_classify(
 async def validate_base_url(
     url: str | None,
     *,
-    resolver: Resolver = _default_resolve,
+    resolver: Resolver = default_resolve,
 ) -> ValidatedEndpoint:
     """Pre-flight SSRF validation. Raises `EgressBlocked` before any socket opens."""
     if url is None or not url.strip():

--- a/apps/agent/agent/infrastructure/egress_guard.py
+++ b/apps/agent/agent/infrastructure/egress_guard.py
@@ -1,0 +1,240 @@
+"""SSRF egress guard for user-influenceable outbound HTTP calls (#284 Task 1).
+
+Two layers, both required (see `docs/superpowers/specs/2026-07-28-284-byok-design.md`):
+
+1. `validate_base_url` — a pre-flight, resolve-once check at the request boundary.
+2. `GuardedAsyncTransport` — an `httpx` transport that re-validates at connect time,
+   pins the socket to the already-validated IP literal, preserves TLS hostname
+   verification via `sni_hostname`, and refuses every 3xx response.
+
+No domain allowlist. Acceptance is a **dual condition** on the resolved IP:
+`ip.is_global is True` AND it trips none of the private/loopback/link-local/
+reserved/multicast/unspecified flags. Neither half is redundant — see the
+docstring on `_is_address_accepted` for the two address families each half alone
+would miss.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import ssl
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Final
+from urllib.parse import urlsplit
+
+import anyio
+import httpx
+
+IpAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+Resolver = Callable[[str, int], Awaitable[list[str]]]
+
+ALLOWED_SCHEME: Final[str] = "https"
+ALLOWED_PORTS: Final[frozenset[int]] = frozenset({443, 8000, 8443})
+RESOLUTION_TIMEOUT_SECONDS: Final[float] = 5.0
+
+# Belt-and-suspenders explicit deny set for well-known cloud-metadata endpoints.
+# These IPs already fail the `is_global`/deny-flag classification below on their
+# own (169.254.169.254 is link-local; fd00:ec2::254 is a ULA); they are listed
+# here anyway so the guard is not silently relying on flag semantics alone for
+# the most commonly attacked addresses.
+_METADATA_DENY_IPS: Final[frozenset[str]] = frozenset(
+    {
+        "169.254.169.254",  # AWS / Azure / GCP IMDS
+        "fd00:ec2::254",  # AWS IMDSv2 IPv6
+        "100.100.100.200",  # Alibaba Cloud / Tencent Cloud metadata
+    }
+)
+
+# Our own public-facing origins are legitimately globally routable, so every IP
+# check above passes them. Without an explicit deny, BYOK egress becomes a
+# confused-deputy path back into our own authenticated surfaces.
+OWN_INFRASTRUCTURE_HOSTNAMES: Final[frozenset[str]] = frozenset({"animichi.com"})
+
+
+class EgressBlocked(Exception):
+    """Raised whenever a candidate egress destination fails SSRF validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedEndpoint:
+    """A resolve-once, dual-condition-validated egress destination."""
+
+    hostname: str
+    port: int
+    pinned_ip: str
+
+
+def _is_own_infrastructure(hostname: str) -> bool:
+    return any(
+        hostname == domain or hostname.endswith(f".{domain}")
+        for domain in OWN_INFRASTRUCTURE_HOSTNAMES
+    )
+
+
+def _is_address_accepted(ip: IpAddress) -> bool:
+    """Dual-condition acceptance test (P1-1 in the spec).
+
+    `ip.is_global is True` alone is insufficient: `64:ff9b::7f00:1` (NAT64
+    mapping of 127.0.0.1) is `is_global is True` but `is_reserved is True`, so
+    the deny-flag half catches it.
+
+    The deny-flag enumeration alone is also insufficient: `100.64.0.1` (CGNAT,
+    RFC 6598) and `100.100.100.200` (Alibaba/Tencent metadata) trip none of
+    `is_private`/`is_loopback`/`is_link_local`/`is_reserved`/`is_multicast`/
+    `is_unspecified` — all six are False for the whole `100.64.0.0/10` block —
+    so only `is_global is False` catches them.
+
+    Both conditions are required; neither is redundant.
+    """
+    if ip.is_global is not True:
+        return False
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    ):
+        return False
+    return str(ip) not in _METADATA_DENY_IPS
+
+
+async def _default_resolve(host: str, port: int) -> list[str]:
+    """Resolve `host` once, off the event loop, with a short timeout."""
+
+    def _getaddrinfo() -> list[str]:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        return [str(info[4][0]) for info in infos]
+
+    try:
+        with anyio.fail_after(RESOLUTION_TIMEOUT_SECONDS):
+            return await anyio.to_thread.run_sync(_getaddrinfo)
+    except TimeoutError as exc:
+        raise EgressBlocked(f"DNS resolution timed out for {host!r}") from exc
+    except OSError as exc:
+        raise EgressBlocked(f"DNS resolution failed for {host!r}: {exc}") from exc
+
+
+def _parse_endpoint_shape(url: str) -> tuple[str, int]:
+    """Scheme/userinfo/host/port shape validation, before any I/O."""
+    parsed = urlsplit(url)
+    if parsed.scheme != ALLOWED_SCHEME:
+        raise EgressBlocked(f"scheme must be {ALLOWED_SCHEME!r}, got {parsed.scheme!r}")
+    if parsed.username or parsed.password:
+        raise EgressBlocked("userinfo is not allowed in the egress URL")
+    hostname = parsed.hostname
+    if not hostname:
+        raise EgressBlocked("egress URL is missing a host")
+    try:
+        a_label = hostname.encode("idna").decode("ascii")
+    except UnicodeError as exc:
+        raise EgressBlocked(f"invalid hostname: {hostname!r}") from exc
+    port = parsed.port or 443
+    if port not in ALLOWED_PORTS:
+        raise EgressBlocked(f"port {port} is not on the egress allowlist")
+    return a_label, port
+
+
+async def validate_base_url(
+    url: str | None,
+    *,
+    resolver: Resolver = _default_resolve,
+) -> ValidatedEndpoint:
+    """Pre-flight SSRF validation. Raises `EgressBlocked` before any socket opens."""
+    if url is None or not url.strip():
+        raise EgressBlocked("egress URL is empty")
+
+    hostname, port = _parse_endpoint_shape(url.strip())
+
+    if _is_own_infrastructure(hostname):
+        raise EgressBlocked(f"host {hostname!r} is own infrastructure")
+
+    addresses = await resolver(hostname, port)
+    if not addresses:
+        raise EgressBlocked(f"no addresses resolved for {hostname!r}")
+
+    accepted: list[IpAddress] = []
+    for candidate in addresses:
+        ip = ipaddress.ip_address(candidate)
+        if not _is_address_accepted(ip):
+            raise EgressBlocked(
+                f"resolved address {candidate} is not publicly routable"
+            )
+        accepted.append(ip)
+
+    return ValidatedEndpoint(hostname=hostname, port=port, pinned_ip=str(accepted[0]))
+
+
+def _format_host_header(hostname: str, port: int) -> str:
+    host_part = f"[{hostname}]" if ":" in hostname else hostname
+    return host_part if port == 443 else f"{host_part}:{port}"
+
+
+class GuardedAsyncTransport(httpx.AsyncBaseTransport):
+    """`httpx` transport enforcing SSRF validation at connect time.
+
+    Re-runs `validate_base_url` per request (covers a provider SDK appending
+    paths or a redirect target), rewrites the request to the pinned IP literal
+    while preserving the original `Host` header and TLS SNI hostname, and
+    rejects every 3xx response outright.
+    """
+
+    def __init__(
+        self,
+        *,
+        resolver: Resolver = _default_resolve,
+        inner: httpx.AsyncBaseTransport | None = None,
+        verify: ssl.SSLContext | str | bool = True,
+    ) -> None:
+        self._resolver = resolver
+        self._inner = (
+            inner
+            if inner is not None
+            else httpx.AsyncHTTPTransport(verify=verify, trust_env=False)
+        )
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        endpoint = await validate_base_url(str(request.url), resolver=self._resolver)
+        request.url = request.url.copy_with(host=endpoint.pinned_ip)
+        request.headers["host"] = _format_host_header(endpoint.hostname, endpoint.port)
+        request.extensions = {
+            **request.extensions,
+            "sni_hostname": endpoint.hostname,
+        }
+        response = await self._inner.handle_async_request(request)
+        if 300 <= response.status_code < 400:
+            await response.aread()
+            await response.aclose()
+            raise EgressBlocked(
+                f"redirect response ({response.status_code}) refused for {endpoint.hostname!r}"
+            )
+        return response
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+def build_guarded_async_client(
+    *,
+    resolver: Resolver = _default_resolve,
+    timeout: httpx.Timeout | float | None = None,
+    verify: ssl.SSLContext | str | bool = True,
+) -> httpx.AsyncClient:
+    """Build the per-request BYOK transport.
+
+    `trust_env=False` and no `mounts`/`proxy` (T13): a proxy environment
+    variable would otherwise route the "pinned-IP" connection through a proxy
+    that re-resolves the hostname itself, silently voiding the pinning
+    guarantee. `verify` is exposed only so tests can pin a private test CA;
+    production callers should leave it at the default.
+    """
+    return httpx.AsyncClient(
+        transport=GuardedAsyncTransport(resolver=resolver, verify=verify),
+        trust_env=False,
+        follow_redirects=False,
+        timeout=timeout if timeout is not None else httpx.Timeout(30.0),
+    )

--- a/apps/agent/agent/infrastructure/egress_transport.py
+++ b/apps/agent/agent/infrastructure/egress_transport.py
@@ -19,7 +19,7 @@ from agent.infrastructure.egress_errors import EgressBlocked, EgressBlockReason
 from agent.infrastructure.egress_guard import (
     Resolver,
     ValidatedEndpoint,
-    _default_resolve,
+    default_resolve,
     validate_base_url,
 )
 
@@ -83,7 +83,7 @@ class GuardedAsyncTransport(httpx.AsyncBaseTransport):
     def __init__(
         self,
         *,
-        resolver: Resolver = _default_resolve,
+        resolver: Resolver = default_resolve,
         inner: httpx.AsyncBaseTransport | None = None,
         verify: ssl.SSLContext | str | bool = True,
     ) -> None:
@@ -103,7 +103,7 @@ class GuardedAsyncTransport(httpx.AsyncBaseTransport):
 
 def build_guarded_async_client(
     *,
-    resolver: Resolver = _default_resolve,
+    resolver: Resolver = default_resolve,
     timeout: httpx.Timeout | float | None = None,
     verify: ssl.SSLContext | str | bool = True,
 ) -> httpx.AsyncClient:

--- a/apps/agent/agent/infrastructure/egress_transport.py
+++ b/apps/agent/agent/infrastructure/egress_transport.py
@@ -1,0 +1,123 @@
+"""Connect-time SSRF enforcement transport for BYOK egress (#284 Task 1).
+
+`GuardedAsyncTransport` independently re-runs `egress_guard.validate_base_url`
+at connect time (its own single resolution), pins the socket to the address
+*that* call validated, preserves TLS hostname verification via
+`sni_hostname`, and refuses every 3xx response. This is what closes the
+TOCTOU/DNS-rebinding window: httpcore never resolves the hostname itself,
+because by the time it sees the request the host has already been rewritten
+to a validated IP literal.
+"""
+
+from __future__ import annotations
+
+import ssl
+
+import httpx
+
+from agent.infrastructure.egress_errors import EgressBlocked, EgressBlockReason
+from agent.infrastructure.egress_guard import (
+    Resolver,
+    ValidatedEndpoint,
+    _default_resolve,
+    validate_base_url,
+)
+
+
+def _format_host_header(hostname: str, port: int) -> str:
+    host_part = f"[{hostname}]" if ":" in hostname else hostname
+    return host_part if port == 443 else f"{host_part}:{port}"
+
+
+def _rewrite_for_pinned_endpoint(
+    request: httpx.Request, endpoint: ValidatedEndpoint
+) -> None:
+    request.url = request.url.copy_with(host=endpoint.pinned_ip)
+    request.headers["host"] = _format_host_header(endpoint.hostname, endpoint.port)
+    request.extensions = {**request.extensions, "sni_hostname": endpoint.hostname}
+
+
+async def _reject_if_redirect(
+    response: httpx.Response, endpoint: ValidatedEndpoint
+) -> None:
+    if not (300 <= response.status_code < 400):
+        return
+    await response.aread()
+    await response.aclose()
+    raise EgressBlocked(EgressBlockReason.REDIRECT_REFUSED, detail=endpoint.hostname)
+
+
+def _build_inner_transport(
+    verify: ssl.SSLContext | str | bool,
+) -> httpx.AsyncHTTPTransport:
+    # `max_keepalive_connections=0` (P2-A): see GuardedAsyncTransport docstring
+    # — without it, two different BYOK hostnames resolving to the same pinned
+    # IP could reuse a pooled connection whose TLS session was verified for
+    # the *other* hostname's SNI.
+    return httpx.AsyncHTTPTransport(
+        verify=verify,
+        trust_env=False,
+        limits=httpx.Limits(max_connections=100, max_keepalive_connections=0),
+    )
+
+
+class GuardedAsyncTransport(httpx.AsyncBaseTransport):
+    """`httpx` transport enforcing SSRF validation at connect time.
+
+    Re-runs `validate_base_url` per request (covers a provider SDK appending
+    paths or a redirect target), rewrites the request to the pinned IP literal
+    while preserving the original `Host` header and TLS SNI hostname, and
+    rejects every 3xx response outright.
+
+    Constructed with `max_keepalive_connections=0` on the inner transport
+    (P2-A): httpcore's connection pool keys a pooled connection by
+    `(scheme, host, port)` — and after the host rewrite, `host` is the
+    *pinned IP*, not the original hostname. Two different BYOK hostnames that
+    happen to resolve to the same IP would otherwise be able to reuse a
+    keep-alive connection whose TLS session was verified for the *other*
+    hostname's SNI, silently sending a second identity's request over the
+    first's authenticated channel. Disabling keep-alive forces a fresh
+    connection (and thus a fresh, correctly-SNI'd handshake) per request.
+    """
+
+    def __init__(
+        self,
+        *,
+        resolver: Resolver = _default_resolve,
+        inner: httpx.AsyncBaseTransport | None = None,
+        verify: ssl.SSLContext | str | bool = True,
+    ) -> None:
+        self._resolver = resolver
+        self._inner = inner if inner is not None else _build_inner_transport(verify)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        endpoint = await validate_base_url(str(request.url), resolver=self._resolver)
+        _rewrite_for_pinned_endpoint(request, endpoint)
+        response = await self._inner.handle_async_request(request)
+        await _reject_if_redirect(response, endpoint)
+        return response
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+def build_guarded_async_client(
+    *,
+    resolver: Resolver = _default_resolve,
+    timeout: httpx.Timeout | float | None = None,
+    verify: ssl.SSLContext | str | bool = True,
+) -> httpx.AsyncClient:
+    """Build the per-request BYOK transport.
+
+    `trust_env=False` and no `mounts`/`proxy` (T13): a proxy environment
+    variable would otherwise route the "pinned-IP" connection through a proxy
+    that re-resolves the hostname itself, silently voiding the pinning
+    guarantee. `verify` is exposed only so tests can pin a private test CA;
+    production callers should leave it at the default.
+    """
+    return httpx.AsyncClient(
+        transport=GuardedAsyncTransport(resolver=resolver, verify=verify),
+        trust_env=False,
+        follow_redirects=False,
+        timeout=timeout if timeout is not None else httpx.Timeout(30.0),
+    )

--- a/apps/agent/agent/tests/integration/_egress_tls_stub.py
+++ b/apps/agent/agent/tests/integration/_egress_tls_stub.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import ssl
+from pathlib import Path
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
@@ -21,9 +22,14 @@ from cryptography.hazmat.primitives.serialization import (
 from cryptography.x509.oid import NameOID
 
 TEST_HOSTNAME = "guarded.egress-guard.test"
+# A second name on the *same* cert (via SAN), used only by the P2-A
+# keep-alive/TLS-identity regression test: two different original hostnames
+# that happen to resolve to the same pinned IP must each get their own
+# connection/handshake, never a connection reused from the other's identity.
+TEST_HOSTNAME_B = "guarded-b.egress-guard.test"
 
 
-def write_self_signed_cert(directory: object) -> tuple[str, str]:
+def write_self_signed_cert(directory: Path) -> tuple[str, str]:
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, TEST_HOSTNAME)])
     now = datetime.datetime.now(datetime.UTC)
@@ -36,13 +42,15 @@ def write_self_signed_cert(directory: object) -> tuple[str, str]:
         .not_valid_before(now - datetime.timedelta(minutes=5))
         .not_valid_after(now + datetime.timedelta(days=1))
         .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(TEST_HOSTNAME)]),
+            x509.SubjectAlternativeName(
+                [x509.DNSName(TEST_HOSTNAME), x509.DNSName(TEST_HOSTNAME_B)]
+            ),
             critical=False,
         )
         .sign(key, hashes.SHA256())
     )
-    cert_path = directory / "cert.pem"  # type: ignore[operator]
-    key_path = directory / "key.pem"  # type: ignore[operator]
+    cert_path = directory / "cert.pem"
+    key_path = directory / "key.pem"
     cert_path.write_bytes(cert.public_bytes(Encoding.PEM))
     key_path.write_bytes(
         key.private_bytes(
@@ -53,15 +61,30 @@ def write_self_signed_cert(directory: object) -> tuple[str, str]:
 
 
 class TlsProbeServer:
-    """Minimal HTTPS echo server that records the received Host + SNI."""
+    """Minimal HTTPS echo server recording per-connection Host + SNI history.
+
+    History (not a single last-value field) so tests can assert distinct
+    connections got distinct, correctly-scoped handshakes — e.g. the P2-A
+    keep-alive/TLS-identity regression, which needs to see two separate
+    connections each carrying their own request's SNI.
+    """
 
     def __init__(self, cert_path: str, key_path: str) -> None:
         self.cert_path = cert_path
         self.key_path = key_path
-        self.received_host_header: str | None = None
-        self.received_sni: str | None = None
+        self.sni_history: list[str | None] = []
+        self.host_header_history: list[str | None] = []
+        self.connection_count: int = 0
         self.port: int = 0
         self._server: asyncio.AbstractServer | None = None
+
+    @property
+    def received_sni(self) -> str | None:
+        return self.sni_history[-1] if self.sni_history else None
+
+    @property
+    def received_host_header(self) -> str | None:
+        return self.host_header_history[-1] if self.host_header_history else None
 
     async def start(self) -> None:
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
@@ -82,15 +105,18 @@ class TlsProbeServer:
         server_name: str | None,
         _ssl_context: ssl.SSLContext,
     ) -> None:
-        self.received_sni = server_name
+        self.sni_history.append(server_name)
 
     async def _handle(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
+        self.connection_count += 1
         head = await reader.readuntil(b"\r\n\r\n")
+        host_header: str | None = None
         for line in head.split(b"\r\n"):
             if line.lower().startswith(b"host:"):
-                self.received_host_header = line.split(b":", 1)[1].strip().decode()
+                host_header = line.split(b":", 1)[1].strip().decode()
+        self.host_header_history.append(host_header)
         body = b"ok"
         writer.write(
             b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s" % (len(body), body)

--- a/apps/agent/agent/tests/integration/_egress_tls_stub.py
+++ b/apps/agent/agent/tests/integration/_egress_tls_stub.py
@@ -1,0 +1,104 @@
+"""Self-signed TLS stub server for the SSRF egress guard integration tests.
+
+Not a test module itself (no `test_` functions) — a fixture-support helper so
+`test_egress_ssrf_guard.py` can stay under the project's 200-line test-file cap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import ssl
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+from cryptography.x509.oid import NameOID
+
+TEST_HOSTNAME = "guarded.egress-guard.test"
+
+
+def write_self_signed_cert(directory: object) -> tuple[str, str]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, TEST_HOSTNAME)])
+    now = datetime.datetime.now(datetime.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(TEST_HOSTNAME)]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    cert_path = directory / "cert.pem"  # type: ignore[operator]
+    key_path = directory / "key.pem"  # type: ignore[operator]
+    cert_path.write_bytes(cert.public_bytes(Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption()
+        )
+    )
+    return str(cert_path), str(key_path)
+
+
+class TlsProbeServer:
+    """Minimal HTTPS echo server that records the received Host + SNI."""
+
+    def __init__(self, cert_path: str, key_path: str) -> None:
+        self.cert_path = cert_path
+        self.key_path = key_path
+        self.received_host_header: str | None = None
+        self.received_sni: str | None = None
+        self.port: int = 0
+        self._server: asyncio.AbstractServer | None = None
+
+    async def start(self) -> None:
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_context.load_cert_chain(self.cert_path, self.key_path)
+        # `SSLObject.server_hostname` reflects the *client's* view and is
+        # unreliable to read back from the server side of an asyncio
+        # transport; `sni_callback` is the documented way for a server to
+        # observe the SNI value the client actually sent.
+        ssl_context.sni_callback = self._record_sni
+        self._server = await asyncio.start_server(
+            self._handle, "127.0.0.1", 0, ssl=ssl_context
+        )
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    def _record_sni(
+        self,
+        _ssl_socket: ssl.SSLObject,
+        server_name: str | None,
+        _ssl_context: ssl.SSLContext,
+    ) -> None:
+        self.received_sni = server_name
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        head = await reader.readuntil(b"\r\n\r\n")
+        for line in head.split(b"\r\n"):
+            if line.lower().startswith(b"host:"):
+                self.received_host_header = line.split(b":", 1)[1].strip().decode()
+        body = b"ok"
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s" % (len(body), body)
+        )
+        await writer.drain()
+        writer.close()
+
+    async def aclose(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()

--- a/apps/agent/agent/tests/integration/test_egress_ssrf_guard.py
+++ b/apps/agent/agent/tests/integration/test_egress_ssrf_guard.py
@@ -1,14 +1,19 @@
-"""Integration tests for the SSRF egress guard (#284 Task 1).
+"""Integration tests for the SSRF egress guard's transport mechanics (#284 T1).
 
 Uses a real self-signed TLS stub server (`_egress_tls_stub.py`) bound to
 127.0.0.1 so the happy-path assertion can prove `sni_hostname` actually reaches
 the TLS handshake as the *original* hostname while the socket connects to the
-*pinned* IP literal.
+*pinned* IP literal. Pure address-classification cases (AC3/AC4/AC7) live in
+`test_egress_ssrf_guard_addresses.py` to keep this file under the 200-line cap.
+
+The cert/key pair is generated once per test session (`tls_cert_files`,
+session-scoped — RSA key generation is the expensive part); the asyncio
+server itself is started fresh per test (`tls_stub_server`, function-scoped)
+for state isolation and to avoid port/history bleed between tests.
 """
 
 from __future__ import annotations
 
-import ipaddress
 import ssl
 from collections.abc import AsyncIterator, Awaitable, Callable
 
@@ -16,14 +21,11 @@ import httpx
 import pytest
 
 from agent.infrastructure import egress_guard
-from agent.infrastructure.egress_guard import (
-    EgressBlocked,
-    GuardedAsyncTransport,
-    build_guarded_async_client,
-    validate_base_url,
-)
+from agent.infrastructure.egress_guard import EgressBlocked
+from agent.infrastructure.egress_transport import GuardedAsyncTransport
 from agent.tests.integration._egress_tls_stub import (
     TEST_HOSTNAME,
+    TEST_HOSTNAME_B,
     TlsProbeServer,
     write_self_signed_cert,
 )
@@ -50,18 +52,33 @@ def _sequenced_resolver(
     return _resolve, calls
 
 
+@pytest.fixture(scope="session")
+def tls_cert_files(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, str]:
+    directory = tmp_path_factory.mktemp("egress-guard-tls")
+    return write_self_signed_cert(directory)
+
+
 @pytest.fixture
 async def tls_stub_server(
-    tmp_path_factory: pytest.TempPathFactory,
+    tls_cert_files: tuple[str, str],
 ) -> AsyncIterator[TlsProbeServer]:
-    directory = tmp_path_factory.mktemp("egress-guard-tls")
-    cert_path, key_path = write_self_signed_cert(directory)
+    cert_path, key_path = tls_cert_files
     server = TlsProbeServer(cert_path, key_path)
     await server.start()
     try:
         yield server
     finally:
         await server.aclose()
+
+
+def _guarded_client_for_stub(
+    server: TlsProbeServer, resolver: Callable[[str, int], Awaitable[list[str]]]
+) -> httpx.AsyncClient:
+    trust_ctx = ssl.create_default_context(cafile=server.cert_path)
+    transport = GuardedAsyncTransport(resolver=resolver, verify=trust_ctx)
+    return httpx.AsyncClient(
+        transport=transport, trust_env=False, follow_redirects=False
+    )
 
 
 # ── AC1: happy path — pinned connect, correct Host + preserved SNI ──────────
@@ -75,13 +92,11 @@ async def test_happy_path_reaches_stub_with_original_host_and_sni(
         egress_guard, "ALLOWED_PORTS", frozenset({tls_stub_server.port})
     )
     # The stub server only binds to loopback, which the classification
-    # (correctly) denies — exercised thoroughly elsewhere (AC3/AC4/AC7). This
-    # test isolates the pinning/rewrite/TLS wiring, so acceptance is forced
-    # for the single resolved address under test.
+    # (correctly) denies — exercised thoroughly in test_egress_ssrf_guard_addresses.py.
+    # This test isolates the pinning/rewrite/TLS wiring, so acceptance is
+    # forced for the single resolved address under test.
     monkeypatch.setattr(egress_guard, "_is_address_accepted", lambda _ip: True)
-    resolver = _resolver(["127.0.0.1"])
-    trust_ctx = ssl.create_default_context(cafile=tls_stub_server.cert_path)
-    client = build_guarded_async_client(resolver=resolver, verify=trust_ctx)
+    client = _guarded_client_for_stub(tls_stub_server, _resolver(["127.0.0.1"]))
 
     response = await client.get(f"https://{TEST_HOSTNAME}:{tls_stub_server.port}/probe")
     await client.aclose()
@@ -94,39 +109,37 @@ async def test_happy_path_reaches_stub_with_original_host_and_sni(
     assert tls_stub_server.received_sni == TEST_HOSTNAME
 
 
-# ── AC3 (SD-20 case ①): IP-literal base_url rejected, no socket opened ─────
+# ── P2-A regression: distinct hostnames sharing a pinned IP never share a
+#    keep-alive connection (which would reuse a TLS session verified for the
+#    *other* hostname's SNI) ─────────────────────────────────────────────────
 
 
-@pytest.mark.parametrize(
-    "url",
-    [
-        "http://127.0.0.1",
-        "https://127.0.0.1",
-        "https://10.0.0.5",
-        "https://169.254.169.254",
-    ],
-)
-async def test_ip_literal_base_url_rejected_without_opening_a_socket(url: str) -> None:
-    with pytest.raises(EgressBlocked):
-        await validate_base_url(url)
+async def test_distinct_hostnames_sharing_pinned_ip_get_isolated_connections(
+    tls_stub_server: TlsProbeServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        egress_guard, "ALLOWED_PORTS", frozenset({tls_stub_server.port})
+    )
+    monkeypatch.setattr(egress_guard, "_is_address_accepted", lambda _ip: True)
+    # Both hostnames resolve to the *same* pinned IP (the one real server).
+    client = _guarded_client_for_stub(tls_stub_server, _resolver(["127.0.0.1"]))
 
+    port = tls_stub_server.port
+    first = await client.get(f"https://{TEST_HOSTNAME}:{port}/a")
+    second = await client.get(f"https://{TEST_HOSTNAME_B}:{port}/b")
+    await client.aclose()
 
-# ── AC4 (P1-1 regression): dual-condition load-bearing cases ───────────────
-
-
-@pytest.mark.parametrize(
-    "address", ["100.100.100.200", "100.64.0.1", "64:ff9b::7f00:1"]
-)
-async def test_dual_condition_regression_addresses_are_denied(address: str) -> None:
-    with pytest.raises(EgressBlocked):
-        await validate_base_url("https://host", resolver=_resolver([address]))
-
-
-def test_cgnat_is_global_false_asserted_directly() -> None:
-    """P2-3 (rev5): folded into T1-AC4 so a build on CPython 3.11.0-3.11.9
-    (pre gh-113171) fails loudly here instead of silently losing the P1-1
-    protection while every other test stays green."""
-    assert ipaddress.ip_address("100.64.0.1").is_global is False
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert tls_stub_server.connection_count == 2, (
+        "each request must open its own connection"
+    )
+    assert tls_stub_server.sni_history == [TEST_HOSTNAME, TEST_HOSTNAME_B]
+    assert tls_stub_server.host_header_history == [
+        f"{TEST_HOSTNAME}:{port}",
+        f"{TEST_HOSTNAME_B}:{port}",
+    ]
 
 
 # ── AC5 (T4 TOCTOU): resolve-once, pin, never a later re-resolution ─────────
@@ -152,13 +165,6 @@ async def test_toctou_connects_only_to_first_resolved_address() -> None:
     assert calls[0] == 1, "must resolve exactly once per request, never re-query"
 
 
-async def test_forbidden_ip_from_injected_resolver_is_rejected() -> None:
-    with pytest.raises(EgressBlocked):
-        await validate_base_url(
-            "https://internal.example", resolver=_resolver(["10.1.2.3"])
-        )
-
-
 # ── AC6 (SD-20 case ③): redirects are refused, never followed ──────────────
 
 
@@ -181,21 +187,3 @@ async def test_redirect_response_is_refused_not_followed() -> None:
     with pytest.raises(EgressBlocked):
         await client.get("https://host.example/v1")
     await client.aclose()
-
-
-# ── AC7 (SD-20 case ④): IPv6 loopback / mapped / mixed record sets ─────────
-
-
-@pytest.mark.parametrize(
-    "addresses",
-    [
-        ["::1"],
-        ["::ffff:127.0.0.1"],
-        ["8.8.8.8", "fd00::1"],  # mixed public-A + private-AAAA
-    ],
-)
-async def test_ipv6_special_and_mixed_record_sets_are_rejected(
-    addresses: list[str],
-) -> None:
-    with pytest.raises(EgressBlocked):
-        await validate_base_url("https://host", resolver=_resolver(addresses))

--- a/apps/agent/agent/tests/integration/test_egress_ssrf_guard.py
+++ b/apps/agent/agent/tests/integration/test_egress_ssrf_guard.py
@@ -1,0 +1,201 @@
+"""Integration tests for the SSRF egress guard (#284 Task 1).
+
+Uses a real self-signed TLS stub server (`_egress_tls_stub.py`) bound to
+127.0.0.1 so the happy-path assertion can prove `sni_hostname` actually reaches
+the TLS handshake as the *original* hostname while the socket connects to the
+*pinned* IP literal.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import ssl
+from collections.abc import AsyncIterator, Awaitable, Callable
+
+import httpx
+import pytest
+
+from agent.infrastructure import egress_guard
+from agent.infrastructure.egress_guard import (
+    EgressBlocked,
+    GuardedAsyncTransport,
+    build_guarded_async_client,
+    validate_base_url,
+)
+from agent.tests.integration._egress_tls_stub import (
+    TEST_HOSTNAME,
+    TlsProbeServer,
+    write_self_signed_cert,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _resolver(addresses: list[str]) -> Callable[[str, int], Awaitable[list[str]]]:
+    async def _resolve(_host: str, _port: int) -> list[str]:
+        return addresses
+
+    return _resolve
+
+
+def _sequenced_resolver(
+    responses: list[list[str]],
+) -> tuple[Callable[[str, int], Awaitable[list[str]]], list[int]]:
+    calls = [0]
+
+    async def _resolve(_host: str, _port: int) -> list[str]:
+        calls[0] += 1
+        return responses[calls[0] - 1]
+
+    return _resolve, calls
+
+
+@pytest.fixture
+async def tls_stub_server(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> AsyncIterator[TlsProbeServer]:
+    directory = tmp_path_factory.mktemp("egress-guard-tls")
+    cert_path, key_path = write_self_signed_cert(directory)
+    server = TlsProbeServer(cert_path, key_path)
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.aclose()
+
+
+# ── AC1: happy path — pinned connect, correct Host + preserved SNI ──────────
+
+
+async def test_happy_path_reaches_stub_with_original_host_and_sni(
+    tls_stub_server: TlsProbeServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        egress_guard, "ALLOWED_PORTS", frozenset({tls_stub_server.port})
+    )
+    # The stub server only binds to loopback, which the classification
+    # (correctly) denies — exercised thoroughly elsewhere (AC3/AC4/AC7). This
+    # test isolates the pinning/rewrite/TLS wiring, so acceptance is forced
+    # for the single resolved address under test.
+    monkeypatch.setattr(egress_guard, "_is_address_accepted", lambda _ip: True)
+    resolver = _resolver(["127.0.0.1"])
+    trust_ctx = ssl.create_default_context(cafile=tls_stub_server.cert_path)
+    client = build_guarded_async_client(resolver=resolver, verify=trust_ctx)
+
+    response = await client.get(f"https://{TEST_HOSTNAME}:{tls_stub_server.port}/probe")
+    await client.aclose()
+
+    assert response.status_code == 200
+    assert (
+        tls_stub_server.received_host_header
+        == f"{TEST_HOSTNAME}:{tls_stub_server.port}"
+    )
+    assert tls_stub_server.received_sni == TEST_HOSTNAME
+
+
+# ── AC3 (SD-20 case ①): IP-literal base_url rejected, no socket opened ─────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1",
+        "https://127.0.0.1",
+        "https://10.0.0.5",
+        "https://169.254.169.254",
+    ],
+)
+async def test_ip_literal_base_url_rejected_without_opening_a_socket(url: str) -> None:
+    with pytest.raises(EgressBlocked):
+        await validate_base_url(url)
+
+
+# ── AC4 (P1-1 regression): dual-condition load-bearing cases ───────────────
+
+
+@pytest.mark.parametrize(
+    "address", ["100.100.100.200", "100.64.0.1", "64:ff9b::7f00:1"]
+)
+async def test_dual_condition_regression_addresses_are_denied(address: str) -> None:
+    with pytest.raises(EgressBlocked):
+        await validate_base_url("https://host", resolver=_resolver([address]))
+
+
+def test_cgnat_is_global_false_asserted_directly() -> None:
+    """P2-3 (rev5): folded into T1-AC4 so a build on CPython 3.11.0-3.11.9
+    (pre gh-113171) fails loudly here instead of silently losing the P1-1
+    protection while every other test stays green."""
+    assert ipaddress.ip_address("100.64.0.1").is_global is False
+
+
+# ── AC5 (T4 TOCTOU): resolve-once, pin, never a later re-resolution ─────────
+
+
+async def test_toctou_connects_only_to_first_resolved_address() -> None:
+    resolver, calls = _sequenced_resolver([["8.8.8.8"], ["10.0.0.1"]])
+    recorded: dict[str, str] = {}
+
+    async def _fake_handler(request: httpx.Request) -> httpx.Response:
+        recorded["host"] = request.url.host
+        return httpx.Response(200, request=request)
+
+    transport = GuardedAsyncTransport(
+        resolver=resolver, inner=httpx.MockTransport(_fake_handler)
+    )
+    client = httpx.AsyncClient(transport=transport, trust_env=False)
+    response = await client.get("https://rebind.example/v1")
+    await client.aclose()
+
+    assert response.status_code == 200
+    assert recorded["host"] == "8.8.8.8"
+    assert calls[0] == 1, "must resolve exactly once per request, never re-query"
+
+
+async def test_forbidden_ip_from_injected_resolver_is_rejected() -> None:
+    with pytest.raises(EgressBlocked):
+        await validate_base_url(
+            "https://internal.example", resolver=_resolver(["10.1.2.3"])
+        )
+
+
+# ── AC6 (SD-20 case ③): redirects are refused, never followed ──────────────
+
+
+async def test_redirect_response_is_refused_not_followed() -> None:
+    async def _redirecting_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            302,
+            headers={"location": "http://169.254.169.254/latest/meta-data/"},
+            request=request,
+        )
+
+    transport = GuardedAsyncTransport(
+        resolver=_resolver(["8.8.8.8"]), inner=httpx.MockTransport(_redirecting_handler)
+    )
+    client = httpx.AsyncClient(
+        transport=transport, trust_env=False, follow_redirects=False
+    )
+    assert client.follow_redirects is False
+
+    with pytest.raises(EgressBlocked):
+        await client.get("https://host.example/v1")
+    await client.aclose()
+
+
+# ── AC7 (SD-20 case ④): IPv6 loopback / mapped / mixed record sets ─────────
+
+
+@pytest.mark.parametrize(
+    "addresses",
+    [
+        ["::1"],
+        ["::ffff:127.0.0.1"],
+        ["8.8.8.8", "fd00::1"],  # mixed public-A + private-AAAA
+    ],
+)
+async def test_ipv6_special_and_mixed_record_sets_are_rejected(
+    addresses: list[str],
+) -> None:
+    with pytest.raises(EgressBlocked):
+        await validate_base_url("https://host", resolver=_resolver(addresses))

--- a/apps/agent/agent/tests/integration/test_egress_ssrf_guard_addresses.py
+++ b/apps/agent/agent/tests/integration/test_egress_ssrf_guard_addresses.py
@@ -1,0 +1,107 @@
+"""Integration tests for SSRF egress guard address-classification cases (#284 T1).
+
+Split out from `test_egress_ssrf_guard.py` (which covers real TLS/transport
+mechanics) to keep each file under the 200-line test-file cap.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from agent.infrastructure.egress_guard import EgressBlocked, validate_base_url
+from agent.infrastructure.egress_transport import build_guarded_async_client
+
+pytestmark = pytest.mark.integration
+
+
+def _resolver(addresses: list[str]) -> Callable[[str, int], Awaitable[list[str]]]:
+    async def _resolve(_host: str, _port: int) -> list[str]:
+        return addresses
+
+    return _resolve
+
+
+# ── AC3 (SD-20 case ①): IP-literal base_url rejected, no socket opened ─────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1",
+        "https://127.0.0.1",
+        "https://10.0.0.5",
+        "https://169.254.169.254",
+    ],
+)
+async def test_ip_literal_base_url_rejected_without_opening_a_socket(url: str) -> None:
+    with pytest.raises(EgressBlocked):
+        await validate_base_url(url)
+
+
+async def test_ip_literal_url_never_opens_a_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """P3: goes through the full guarded client with the *real* resolver (not
+    a stub) so a real `socket.socket()` call would happen here if the guard's
+    pre-flight rejection didn't fire before the transport ever tried to
+    connect. `getaddrinfo` on a literal IP is a local parse, not network I/O,
+    so this stays hermetic."""
+
+    def _forbidden(*_args: object, **_kwargs: object) -> socket.socket:
+        raise AssertionError(
+            "socket.socket() must not be called for a blocked destination"
+        )
+
+    monkeypatch.setattr(socket, "socket", _forbidden)
+    client = build_guarded_async_client()
+
+    with pytest.raises(EgressBlocked):
+        await client.get("https://169.254.169.254/latest/meta-data/")
+    await client.aclose()
+
+
+# ── AC4 (P1-1 regression): dual-condition load-bearing cases ───────────────
+
+
+@pytest.mark.parametrize(
+    "address", ["100.100.100.200", "100.64.0.1", "64:ff9b::7f00:1"]
+)
+async def test_dual_condition_regression_addresses_are_denied(address: str) -> None:
+    with pytest.raises(EgressBlocked):
+        await validate_base_url("https://host", resolver=_resolver([address]))
+
+
+def test_cgnat_is_global_false_asserted_directly() -> None:
+    """P2-3 (rev5): folded into T1-AC4 so a build on CPython 3.11.0-3.11.9
+    (pre gh-113171) fails loudly here instead of silently losing the P1-1
+    protection while every other test stays green."""
+    assert ipaddress.ip_address("100.64.0.1").is_global is False
+
+
+async def test_forbidden_ip_from_injected_resolver_is_rejected() -> None:
+    with pytest.raises(EgressBlocked):
+        await validate_base_url(
+            "https://internal.example", resolver=_resolver(["10.1.2.3"])
+        )
+
+
+# ── AC7 (SD-20 case ④): IPv6 loopback / mapped / mixed record sets ─────────
+
+
+@pytest.mark.parametrize(
+    "addresses",
+    [
+        ["::1"],
+        ["::ffff:127.0.0.1"],
+        ["8.8.8.8", "fd00::1"],  # mixed public-A + private-AAAA
+    ],
+)
+async def test_ipv6_special_and_mixed_record_sets_are_rejected(
+    addresses: list[str],
+) -> None:
+    with pytest.raises(EgressBlocked):
+        await validate_base_url("https://host", resolver=_resolver(addresses))

--- a/apps/agent/agent/tests/unit/test_egress_dns_resolution.py
+++ b/apps/agent/agent/tests/unit/test_egress_dns_resolution.py
@@ -1,0 +1,66 @@
+"""Unit tests for `egress_guard.default_resolve`'s DNS behaviour (#284 T1).
+
+Split out from `test_egress_guard_classification.py` to keep each file under
+the 200-line test-file cap.
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+
+import pytest
+
+from agent.infrastructure import egress_guard
+from agent.infrastructure.egress_guard import EgressBlocked, EgressBlockReason
+
+pytestmark = pytest.mark.unit
+
+
+# ── P1-A: DNS resolution timeout must actually bound wall-clock time ───────
+
+
+async def test_default_resolve_dns_timeout_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`abandon_on_cancel=True` is what makes this pass: without it,
+    `anyio.fail_after` cannot interrupt a thread blocked in `getaddrinfo`
+    (no cancellation hook in a blocking libc call), so the timeout would be
+    cosmetic and this test would hang for the full blocking duration."""
+    monkeypatch.setattr(egress_guard, "RESOLUTION_TIMEOUT_SECONDS", 0.15)
+
+    def _blocking_getaddrinfo(
+        *_args: object, **_kwargs: object
+    ) -> list[tuple[object, ...]]:
+        time.sleep(2.0)
+        return []
+
+    monkeypatch.setattr(socket, "getaddrinfo", _blocking_getaddrinfo)
+
+    start = time.monotonic()
+    with pytest.raises(EgressBlocked) as exc_info:
+        await egress_guard.default_resolve("blackhole.example", 443)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, (
+        "resolution must be bounded by the timeout, not the blocking call"
+    )
+    assert exc_info.value.reason is EgressBlockReason.RESOLUTION_TIMEOUT
+
+
+# ── P1-B: a real DNS failure (NXDOMAIN etc.) is wrapped, not left as OSError ─
+
+
+async def test_default_resolve_dns_failure_is_wrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _failing_getaddrinfo(
+        *_args: object, **_kwargs: object
+    ) -> list[tuple[object, ...]]:
+        raise socket.gaierror("nodename nor servname provided, or not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _failing_getaddrinfo)
+
+    with pytest.raises(EgressBlocked) as exc_info:
+        await egress_guard.default_resolve("nx-domain.invalid", 443)
+    assert exc_info.value.reason is EgressBlockReason.RESOLUTION_FAILED

--- a/apps/agent/agent/tests/unit/test_egress_guard_classification.py
+++ b/apps/agent/agent/tests/unit/test_egress_guard_classification.py
@@ -1,19 +1,18 @@
 """Unit tests for the SSRF egress guard's classification and shape rules (#284 T1).
 
-Transport-level rewrite/proxy tests live in `test_egress_transport_unit.py` to
-keep each file under the 200-line test-file cap.
+Transport-level rewrite/proxy tests live in `test_egress_transport_unit.py`,
+and `default_resolve`'s DNS-behaviour tests live in
+`test_egress_dns_resolution.py` — split out to keep each file under the
+200-line test-file cap.
 """
 
 from __future__ import annotations
 
 import ipaddress
-import socket
-import time
 from collections.abc import Awaitable, Callable
 
 import pytest
 
-from agent.infrastructure import egress_guard
 from agent.infrastructure.egress_guard import (
     ALLOWED_PORTS,
     EgressBlocked,
@@ -152,37 +151,6 @@ def test_cgnat_address_is_not_global_on_this_interpreter() -> None:
     range would silently lose the P1-1 protection while every other test stays
     green. Fail loudly here instead."""
     assert ipaddress.ip_address("100.64.0.1").is_global is False
-
-
-# ── P1-A: DNS resolution timeout must actually bound wall-clock time ───────
-
-
-async def test_default_resolve_dns_timeout_is_bounded(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """`abandon_on_cancel=True` is what makes this pass: without it,
-    `anyio.fail_after` cannot interrupt a thread blocked in `getaddrinfo`
-    (no cancellation hook in a blocking libc call), so the timeout would be
-    cosmetic and this test would hang for the full blocking duration."""
-    monkeypatch.setattr(egress_guard, "RESOLUTION_TIMEOUT_SECONDS", 0.15)
-
-    def _blocking_getaddrinfo(
-        *_args: object, **_kwargs: object
-    ) -> list[tuple[object, ...]]:
-        time.sleep(2.0)
-        return []
-
-    monkeypatch.setattr(socket, "getaddrinfo", _blocking_getaddrinfo)
-
-    start = time.monotonic()
-    with pytest.raises(EgressBlocked) as exc_info:
-        await egress_guard._default_resolve("blackhole.example", 443)
-    elapsed = time.monotonic() - start
-
-    assert elapsed < 1.0, (
-        "resolution must be bounded by the timeout, not the blocking call"
-    )
-    assert exc_info.value.reason is EgressBlockReason.RESOLUTION_TIMEOUT
 
 
 # ── P2-B: error messages are fixed constants, never interpolated data ──────

--- a/apps/agent/agent/tests/unit/test_egress_guard_classification.py
+++ b/apps/agent/agent/tests/unit/test_egress_guard_classification.py
@@ -1,18 +1,23 @@
-"""Unit tests for the SSRF egress guard's classification and shape rules (#284 T1)."""
+"""Unit tests for the SSRF egress guard's classification and shape rules (#284 T1).
+
+Transport-level rewrite/proxy tests live in `test_egress_transport_unit.py` to
+keep each file under the 200-line test-file cap.
+"""
 
 from __future__ import annotations
 
 import ipaddress
+import socket
+import time
 from collections.abc import Awaitable, Callable
 
-import httpx
 import pytest
 
+from agent.infrastructure import egress_guard
 from agent.infrastructure.egress_guard import (
     ALLOWED_PORTS,
     EgressBlocked,
-    GuardedAsyncTransport,
-    build_guarded_async_client,
+    EgressBlockReason,
     validate_base_url,
 )
 
@@ -31,7 +36,15 @@ def _resolver(addresses: list[str]) -> Callable[[str, int], Awaitable[list[str]]
 
 @pytest.mark.parametrize(
     "url",
-    [None, "", "   ", "host/path", "https://user:pw@host", "https://host:22"],
+    [
+        None,
+        "",
+        "   ",
+        "host/path",
+        "https://user:pw@host",
+        "https://host:22",
+        "https://",
+    ],
 )
 async def test_rejects_malformed_or_boundary_urls_individually(url: str | None) -> None:
     with pytest.raises(EgressBlocked):
@@ -75,6 +88,62 @@ async def test_ipv6_literal_host_is_accepted_when_globally_routable() -> None:
     assert endpoint.pinned_ip == "2606:4700::1"
 
 
+async def test_idna_encoding_error_is_rejected() -> None:
+    oversized_label = "a" * 64  # single DNS label max is 63 octets
+    with pytest.raises(EgressBlocked) as exc_info:
+        await validate_base_url(
+            f"https://{oversized_label}.example", resolver=_resolver(["8.8.8.8"])
+        )
+    assert exc_info.value.reason is EgressBlockReason.INVALID_HOSTNAME_ENCODING
+
+
+async def test_zero_resolved_addresses_is_rejected() -> None:
+    with pytest.raises(EgressBlocked) as exc_info:
+        await validate_base_url("https://host", resolver=_resolver([]))
+    assert exc_info.value.reason is EgressBlockReason.NO_ADDRESSES
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "animichi.com",
+        "api.animichi.com",
+        "stack-auth.com",
+        "project.stack-auth.com",
+        "animichi.com.",  # trailing root-label dot
+        "animichi.com。",  # ideographic full stop — IDNA-normalizes to "."
+        "animichi.com｡",  # halfwidth ideographic full stop — same
+        "api.animichi.com.",
+    ],
+)
+async def test_own_infrastructure_hostname_is_rejected(hostname: str) -> None:
+    """Includes the trailing-dot/full-width-dot variants (Fable review): all
+    four IDNA-encode to a string ending in a literal dot that would otherwise
+    slip past a naive suffix match, even though DNS treats the trailing root
+    dot as equivalent to none."""
+    with pytest.raises(EgressBlocked) as exc_info:
+        await validate_base_url(f"https://{hostname}", resolver=_resolver(["8.8.8.8"]))
+    assert exc_info.value.reason is EgressBlockReason.OWN_INFRASTRUCTURE
+
+
+async def test_nfkc_confusable_netloc_raises_typed_error() -> None:
+    """`urlsplit` raises a bare `ValueError` for a netloc that fails its
+    NFKC-normalization safety check (U+2100 expands to `a/c` under NFKC).
+    Uncaught, this breaks the "every rejection is EgressBlocked" contract
+    Task 3/5 depend on."""
+    with pytest.raises(EgressBlocked) as exc_info:
+        await validate_base_url(
+            "https://℀animichi.com", resolver=_resolver(["8.8.8.8"])
+        )
+    assert exc_info.value.reason is EgressBlockReason.INVALID_URL
+
+
+async def test_malformed_resolver_candidate_raises_typed_error() -> None:
+    with pytest.raises(EgressBlocked) as exc_info:
+        await validate_base_url("https://host", resolver=_resolver(["not-an-ip"]))
+    assert exc_info.value.reason is EgressBlockReason.ADDRESS_NOT_ROUTABLE
+
+
 # ── P2-3: the interpreter primitive itself, asserted directly ───────────────
 
 
@@ -85,87 +154,45 @@ def test_cgnat_address_is_not_global_on_this_interpreter() -> None:
     assert ipaddress.ip_address("100.64.0.1").is_global is False
 
 
-# ── T13 / T1-AC9: proxy-free, trust_env=False client construction ──────────
+# ── P1-A: DNS resolution timeout must actually bound wall-clock time ───────
 
 
-def test_guarded_client_has_no_proxy_mounts_even_with_proxy_env_set(
+async def test_default_resolve_dns_timeout_is_bounded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HTTPS_PROXY", "http://evil-proxy.test:9999")
-    monkeypatch.setenv("ALL_PROXY", "http://evil-proxy.test:9999")
+    """`abandon_on_cancel=True` is what makes this pass: without it,
+    `anyio.fail_after` cannot interrupt a thread blocked in `getaddrinfo`
+    (no cancellation hook in a blocking libc call), so the timeout would be
+    cosmetic and this test would hang for the full blocking duration."""
+    monkeypatch.setattr(egress_guard, "RESOLUTION_TIMEOUT_SECONDS", 0.15)
 
-    # Control: a default (trust_env=True) client DOES pick up the proxy env,
-    # proving the environment variables are actually in effect for this test.
-    control = httpx.AsyncClient()
-    assert len(control._mounts) > 0
+    def _blocking_getaddrinfo(
+        *_args: object, **_kwargs: object
+    ) -> list[tuple[object, ...]]:
+        time.sleep(2.0)
+        return []
 
-    client = build_guarded_async_client()
-    assert client._trust_env is False
-    assert client._mounts == {}
-    assert isinstance(client._transport, GuardedAsyncTransport)
+    monkeypatch.setattr(socket, "getaddrinfo", _blocking_getaddrinfo)
 
+    start = time.monotonic()
+    with pytest.raises(EgressBlocked) as exc_info:
+        await egress_guard._default_resolve("blackhole.example", 443)
+    elapsed = time.monotonic() - start
 
-async def test_guarded_transport_ignores_proxy_env_and_pins_to_resolved_ip(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("HTTPS_PROXY", "http://evil-proxy.test:9999")
-    recorded: dict[str, str] = {}
-
-    async def _fake_handler(request: httpx.Request) -> httpx.Response:
-        recorded["host"] = request.url.host
-        return httpx.Response(200, request=request)
-
-    transport = GuardedAsyncTransport(
-        resolver=_resolver(["8.8.8.8"]),
-        inner=httpx.MockTransport(_fake_handler),
+    assert elapsed < 1.0, (
+        "resolution must be bounded by the timeout, not the blocking call"
     )
-    client = httpx.AsyncClient(transport=transport, trust_env=False)
-    response = await client.request("GET", "https://host.example/v1")
-    assert response.status_code == 200
-    assert recorded["host"] == "8.8.8.8"
-    await client.aclose()
+    assert exc_info.value.reason is EgressBlockReason.RESOLUTION_TIMEOUT
 
 
-# ── Transport-level rewrite: Host header + sni_hostname + IPv6 bracketing ──
+# ── P2-B: error messages are fixed constants, never interpolated data ──────
 
 
-async def test_transport_rewrites_host_header_and_sni_hostname() -> None:
-    recorded: dict[str, object] = {}
-
-    async def _fake_handler(request: httpx.Request) -> httpx.Response:
-        recorded["url"] = str(request.url)
-        recorded["host_header"] = request.headers["host"]
-        recorded["sni_hostname"] = request.extensions.get("sni_hostname")
-        return httpx.Response(200, request=request)
-
-    transport = GuardedAsyncTransport(
-        resolver=_resolver(["93.184.216.34"]),
-        inner=httpx.MockTransport(_fake_handler),
-    )
-    client = httpx.AsyncClient(transport=transport, trust_env=False)
-    await client.request("GET", "https://example.com:8443/v1/chat")
-    await client.aclose()
-
-    assert recorded["url"] == "https://93.184.216.34:8443/v1/chat"
-    assert recorded["host_header"] == "example.com:8443"
-    assert recorded["sni_hostname"] == "example.com"
-
-
-async def test_transport_brackets_ipv6_host_header() -> None:
-    recorded: dict[str, object] = {}
-
-    async def _fake_handler(request: httpx.Request) -> httpx.Response:
-        recorded["url"] = str(request.url)
-        recorded["host_header"] = request.headers["host"]
-        return httpx.Response(200, request=request)
-
-    transport = GuardedAsyncTransport(
-        resolver=_resolver(["2606:4700::1"]),
-        inner=httpx.MockTransport(_fake_handler),
-    )
-    client = httpx.AsyncClient(transport=transport, trust_env=False)
-    await client.request("GET", "https://[2606:4700::1]/v1")
-    await client.aclose()
-
-    assert recorded["url"] == "https://[2606:4700::1]/v1"
-    assert recorded["host_header"] == "[2606:4700::1]"
+async def test_error_message_never_embeds_the_offending_address() -> None:
+    with pytest.raises(EgressBlocked) as exc_info:
+        await validate_base_url(
+            "https://internal.example", resolver=_resolver(["10.1.2.3"])
+        )
+    assert "10.1.2.3" not in str(exc_info.value)
+    assert exc_info.value.reason is EgressBlockReason.ADDRESS_NOT_ROUTABLE
+    assert exc_info.value.detail == "10.1.2.3"

--- a/apps/agent/agent/tests/unit/test_egress_guard_classification.py
+++ b/apps/agent/agent/tests/unit/test_egress_guard_classification.py
@@ -1,0 +1,171 @@
+"""Unit tests for the SSRF egress guard's classification and shape rules (#284 T1)."""
+
+from __future__ import annotations
+
+import ipaddress
+from collections.abc import Awaitable, Callable
+
+import httpx
+import pytest
+
+from agent.infrastructure.egress_guard import (
+    ALLOWED_PORTS,
+    EgressBlocked,
+    GuardedAsyncTransport,
+    build_guarded_async_client,
+    validate_base_url,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resolver(addresses: list[str]) -> Callable[[str, int], Awaitable[list[str]]]:
+    async def _resolve(_host: str, _port: int) -> list[str]:
+        return addresses
+
+    return _resolve
+
+
+# ── Null / empty / boundary shape validation ────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [None, "", "   ", "host/path", "https://user:pw@host", "https://host:22"],
+)
+async def test_rejects_malformed_or_boundary_urls_individually(url: str | None) -> None:
+    with pytest.raises(EgressBlocked):
+        await validate_base_url(url, resolver=_resolver(["8.8.8.8"]))
+
+
+@pytest.mark.parametrize("scheme", ["http", "file", "gopher", "ftp"])
+async def test_rejects_disallowed_schemes_before_resolution(scheme: str) -> None:
+    called = False
+
+    async def _resolve(_host: str, _port: int) -> list[str]:
+        nonlocal called
+        called = True
+        return ["8.8.8.8"]
+
+    with pytest.raises(EgressBlocked):
+        await validate_base_url(f"{scheme}://host", resolver=_resolve)
+    assert called is False, "resolver must not run for a disallowed scheme"
+
+
+@pytest.mark.parametrize("port", sorted(ALLOWED_PORTS))
+async def test_accepts_allowlisted_ports_with_public_address(port: int) -> None:
+    endpoint = await validate_base_url(
+        f"https://host:{port}", resolver=_resolver(["8.8.8.8"])
+    )
+    assert endpoint.port == port
+
+
+async def test_punycode_hostname_resolves_to_a_label() -> None:
+    endpoint = await validate_base_url(
+        "https://ドメイン.jp", resolver=_resolver(["8.8.8.8"])
+    )
+    assert endpoint.hostname == "xn--eckwd4c7c.jp"
+
+
+async def test_ipv6_literal_host_is_accepted_when_globally_routable() -> None:
+    endpoint = await validate_base_url(
+        "https://[2606:4700::1]", resolver=_resolver(["2606:4700::1"])
+    )
+    assert endpoint.hostname == "2606:4700::1"
+    assert endpoint.pinned_ip == "2606:4700::1"
+
+
+# ── P2-3: the interpreter primitive itself, asserted directly ───────────────
+
+
+def test_cgnat_address_is_not_global_on_this_interpreter() -> None:
+    """Guards against CPython 3.11.0-3.11.9 (pre gh-113171): a build on that
+    range would silently lose the P1-1 protection while every other test stays
+    green. Fail loudly here instead."""
+    assert ipaddress.ip_address("100.64.0.1").is_global is False
+
+
+# ── T13 / T1-AC9: proxy-free, trust_env=False client construction ──────────
+
+
+def test_guarded_client_has_no_proxy_mounts_even_with_proxy_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HTTPS_PROXY", "http://evil-proxy.test:9999")
+    monkeypatch.setenv("ALL_PROXY", "http://evil-proxy.test:9999")
+
+    # Control: a default (trust_env=True) client DOES pick up the proxy env,
+    # proving the environment variables are actually in effect for this test.
+    control = httpx.AsyncClient()
+    assert len(control._mounts) > 0
+
+    client = build_guarded_async_client()
+    assert client._trust_env is False
+    assert client._mounts == {}
+    assert isinstance(client._transport, GuardedAsyncTransport)
+
+
+async def test_guarded_transport_ignores_proxy_env_and_pins_to_resolved_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HTTPS_PROXY", "http://evil-proxy.test:9999")
+    recorded: dict[str, str] = {}
+
+    async def _fake_handler(request: httpx.Request) -> httpx.Response:
+        recorded["host"] = request.url.host
+        return httpx.Response(200, request=request)
+
+    transport = GuardedAsyncTransport(
+        resolver=_resolver(["8.8.8.8"]),
+        inner=httpx.MockTransport(_fake_handler),
+    )
+    client = httpx.AsyncClient(transport=transport, trust_env=False)
+    response = await client.request("GET", "https://host.example/v1")
+    assert response.status_code == 200
+    assert recorded["host"] == "8.8.8.8"
+    await client.aclose()
+
+
+# ── Transport-level rewrite: Host header + sni_hostname + IPv6 bracketing ──
+
+
+async def test_transport_rewrites_host_header_and_sni_hostname() -> None:
+    recorded: dict[str, object] = {}
+
+    async def _fake_handler(request: httpx.Request) -> httpx.Response:
+        recorded["url"] = str(request.url)
+        recorded["host_header"] = request.headers["host"]
+        recorded["sni_hostname"] = request.extensions.get("sni_hostname")
+        return httpx.Response(200, request=request)
+
+    transport = GuardedAsyncTransport(
+        resolver=_resolver(["93.184.216.34"]),
+        inner=httpx.MockTransport(_fake_handler),
+    )
+    client = httpx.AsyncClient(transport=transport, trust_env=False)
+    await client.request("GET", "https://example.com:8443/v1/chat")
+    await client.aclose()
+
+    assert recorded["url"] == "https://93.184.216.34:8443/v1/chat"
+    assert recorded["host_header"] == "example.com:8443"
+    assert recorded["sni_hostname"] == "example.com"
+
+
+async def test_transport_brackets_ipv6_host_header() -> None:
+    recorded: dict[str, object] = {}
+
+    async def _fake_handler(request: httpx.Request) -> httpx.Response:
+        recorded["url"] = str(request.url)
+        recorded["host_header"] = request.headers["host"]
+        return httpx.Response(200, request=request)
+
+    transport = GuardedAsyncTransport(
+        resolver=_resolver(["2606:4700::1"]),
+        inner=httpx.MockTransport(_fake_handler),
+    )
+    client = httpx.AsyncClient(transport=transport, trust_env=False)
+    await client.request("GET", "https://[2606:4700::1]/v1")
+    await client.aclose()
+
+    assert recorded["url"] == "https://[2606:4700::1]/v1"
+    assert recorded["host_header"] == "[2606:4700::1]"

--- a/apps/agent/agent/tests/unit/test_egress_transport_unit.py
+++ b/apps/agent/agent/tests/unit/test_egress_transport_unit.py
@@ -1,0 +1,133 @@
+"""Unit tests for `GuardedAsyncTransport` request rewriting (#284 T1).
+
+Split out from `test_egress_guard_classification.py` (which covers
+`validate_base_url` shape/classification rules) to keep each file under the
+200-line test-file cap.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import httpx
+import pytest
+
+from agent.infrastructure.egress_transport import (
+    GuardedAsyncTransport,
+    build_guarded_async_client,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resolver(addresses: list[str]) -> Callable[[str, int], Awaitable[list[str]]]:
+    async def _resolve(_host: str, _port: int) -> list[str]:
+        return addresses
+
+    return _resolve
+
+
+# ── T13 / T1-AC9: proxy-free, trust_env=False client construction ──────────
+
+
+def test_guarded_client_has_no_proxy_mounts_even_with_proxy_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HTTPS_PROXY", "http://evil-proxy.test:9999")
+    monkeypatch.setenv("ALL_PROXY", "http://evil-proxy.test:9999")
+
+    # Control: a default (trust_env=True) client DOES pick up the proxy env,
+    # proving the environment variables are actually in effect for this test.
+    control = httpx.AsyncClient()
+    assert len(control._mounts) > 0
+
+    client = build_guarded_async_client()
+    assert client._trust_env is False
+    assert client._mounts == {}
+    assert isinstance(client._transport, GuardedAsyncTransport)
+
+
+async def test_guarded_transport_ignores_proxy_env_and_pins_to_resolved_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HTTPS_PROXY", "http://evil-proxy.test:9999")
+    recorded: dict[str, str] = {}
+
+    async def _fake_handler(request: httpx.Request) -> httpx.Response:
+        recorded["host"] = request.url.host
+        return httpx.Response(200, request=request)
+
+    transport = GuardedAsyncTransport(
+        resolver=_resolver(["8.8.8.8"]),
+        inner=httpx.MockTransport(_fake_handler),
+    )
+    client = httpx.AsyncClient(transport=transport, trust_env=False)
+    response = await client.request("GET", "https://host.example/v1")
+    assert response.status_code == 200
+    assert recorded["host"] == "8.8.8.8"
+    await client.aclose()
+
+
+# ── Transport-level rewrite: Host header + sni_hostname + IPv6/punycode ────
+
+
+async def test_transport_rewrites_host_header_and_sni_hostname() -> None:
+    recorded: dict[str, object] = {}
+
+    async def _fake_handler(request: httpx.Request) -> httpx.Response:
+        recorded["url"] = str(request.url)
+        recorded["host_header"] = request.headers["host"]
+        recorded["sni_hostname"] = request.extensions.get("sni_hostname")
+        return httpx.Response(200, request=request)
+
+    transport = GuardedAsyncTransport(
+        resolver=_resolver(["93.184.216.34"]),
+        inner=httpx.MockTransport(_fake_handler),
+    )
+    client = httpx.AsyncClient(transport=transport, trust_env=False)
+    await client.request("GET", "https://example.com:8443/v1/chat")
+    await client.aclose()
+
+    assert recorded["url"] == "https://93.184.216.34:8443/v1/chat"
+    assert recorded["host_header"] == "example.com:8443"
+    assert recorded["sni_hostname"] == "example.com"
+
+
+async def test_transport_rewrites_punycode_host_to_a_label() -> None:
+    recorded: dict[str, object] = {}
+
+    async def _fake_handler(request: httpx.Request) -> httpx.Response:
+        recorded["host_header"] = request.headers["host"]
+        recorded["sni_hostname"] = request.extensions.get("sni_hostname")
+        return httpx.Response(200, request=request)
+
+    transport = GuardedAsyncTransport(
+        resolver=_resolver(["8.8.8.8"]),
+        inner=httpx.MockTransport(_fake_handler),
+    )
+    client = httpx.AsyncClient(transport=transport, trust_env=False)
+    await client.request("GET", "https://ドメイン.jp/v1")
+    await client.aclose()
+
+    assert recorded["host_header"] == "xn--eckwd4c7c.jp"
+    assert recorded["sni_hostname"] == "xn--eckwd4c7c.jp"
+
+
+async def test_transport_brackets_ipv6_host_header() -> None:
+    recorded: dict[str, object] = {}
+
+    async def _fake_handler(request: httpx.Request) -> httpx.Response:
+        recorded["url"] = str(request.url)
+        recorded["host_header"] = request.headers["host"]
+        return httpx.Response(200, request=request)
+
+    transport = GuardedAsyncTransport(
+        resolver=_resolver(["2606:4700::1"]),
+        inner=httpx.MockTransport(_fake_handler),
+    )
+    client = httpx.AsyncClient(transport=transport, trust_env=False)
+    await client.request("GET", "https://[2606:4700::1]/v1")
+    await client.aclose()
+
+    assert recorded["url"] == "https://[2606:4700::1]/v1"
+    assert recorded["host_header"] == "[2606:4700::1]"

--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -2,7 +2,7 @@
 name = "animichi"
 version = "0.1.0"
 description = "AI-powered travel assistant for anime pilgrims using Gemini LLM"
-requires-python = ">=3.11"
+requires-python = ">=3.11.10"
 authors = [
     {name = "Animichi Team", email = "team@animichi.com"}
 ]

--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -54,6 +54,11 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
+    # Self-signed TLS fixture for the SSRF egress guard integration tests
+    # (agent/tests/integration/_egress_tls_stub.py). Previously an incidental
+    # transitive dependency (via authlib) — pinned explicitly since tests
+    # import it directly and it must not silently disappear on a dep bump.
+    "cryptography>=46.0.0",
 
     # Code Quality
     "ruff>=0.14.0",

--- a/apps/agent/uv.lock
+++ b/apps/agent/uv.lock
@@ -1,12 +1,17 @@
 version = 1
 revision = 3
-requires-python = ">=3.11"
+requires-python = ">=3.11.10"
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version < '3.12'",
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -764,11 +769,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/b2/d83c5403155172a43ba47c08641bad3f89822d8405102423a41339d2c857/coverage-7.15.1-cp314-cp314t-win_amd64.whl", hash = "sha256:724e878b213b302ad46e9f2fc872d386613f20ebfc492a211482d917ea76c14f", size = 224908, upload-time = "2026-07-12T20:58:13.956Z" },
     { url = "https://files.pythonhosted.org/packages/cc/41/442b74cad832cc77712080585455482e7cc4f4a9a13192f65731dcd18231/coverage-7.15.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ce2f05c14d077f406fefc4fa5e4f093ad0e0787549f6582535d6e28766f0361b", size = 224219, upload-time = "2026-07-12T20:58:16.315Z" },
     { url = "https://files.pythonhosted.org/packages/34/98/07a67cf1a26e795d617ed5c540c042b0ac87b72f810c30c07f076cf334f3/coverage-7.15.1-py3-none-any.whl", hash = "sha256:717d01e6e00bed56ad13306f19e0dd2f4f645ee8159d2c72c72301d6cfc7090c", size = 213284, upload-time = "2026-07-12T20:58:18.079Z" },
-]
-
-[package.optional-dependencies]
-toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -1900,7 +1900,8 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -1982,10 +1983,14 @@ name = "numpy"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
 wheels = [
@@ -2781,7 +2786,7 @@ name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage", extra = ["toml"] },
+    { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
@@ -3218,7 +3223,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -3292,10 +3298,14 @@ name = "scipy"
 version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -3349,8 +3359,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3518,60 +3528,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
     { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
     { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
-]
-
-[[package]]
-name = "tomli"
-version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
-    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
-    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
-    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
-    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
-    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
-    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
-    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
-    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
-    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
-    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
-    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
-    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
-    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
-    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
-    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
-    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
-    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
-    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
-    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
-    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
-    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
-    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
-    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/apps/agent/uv.lock
+++ b/apps/agent/uv.lock
@@ -54,6 +54,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "cryptography" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -82,6 +83,7 @@ scripts = [
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "authlib", specifier = ">=1.6.12" },
+    { name = "cryptography", marker = "extra == 'dev'", specifier = ">=46.0.0" },
     { name = "ddgs", specifier = ">=9.14.1" },
     { name = "fastapi", specifier = ">=0.139.2" },
     { name = "google-genai", specifier = ">=1.16.0" },


### PR DESCRIPTION
## Summary

Implements **Task 1** of the #284 BYOK design spec
(`docs/superpowers/specs/2026-07-28-284-byok-design.md`): the SSRF egress guard
that every other BYOK task depends on. Standalone — no BYOK wiring in this PR.

- `agent/infrastructure/egress_guard.py` (new): `validate_base_url()` (pre-flight,
  resolve-once, dual-condition IP acceptance) + `GuardedAsyncTransport` (connect-time
  re-validation, IP-literal pinning with preserved `Host` header and TLS
  `sni_hostname`, 3xx refusal) + `build_guarded_async_client()` (`trust_env=False`,
  no proxy mounts — T13).
- Interpreter floor raised to `>=3.11.10` in `apps/agent/pyproject.toml` (+ `uv.lock`
  regen); `Dockerfile` pinned to `python:3.11.13-slim` instead of the floating
  `3.11-slim` tag. CPython gh-113171 fixed `ipaddress.is_global` for CGNAT ranges in
  3.11.10/3.12.4 — pre-fix interpreters would silently lose the P1-1 protection.

## AC coverage (Task 1, 9 ACs)

| AC | Test | Type |
|---|---|---|
| Happy path (pinned connect, correct `Host` + TLS `sni_hostname`) | `test_egress_ssrf_guard.py::test_happy_path_reaches_stub_with_original_host_and_sni` (real self-signed TLS stub server) | integration |
| Null/empty/boundary shape (None/""/"   "/no-scheme/userinfo/port-22/port-8443/punycode/IPv6-bracketed) | `test_egress_guard_classification.py` (parametrized, each asserted individually) | unit |
| IP-literal `base_url` rejected (127.0.0.1, 10.0.0.5, 169.254.169.254) | `test_ip_literal_base_url_rejected_without_opening_a_socket` | integration |
| P1-1 dual-condition regression (100.100.100.200, 100.64.0.1 CGNAT, NAT64 `64:ff9b::7f00:1`) + direct `is_global` assertion (P2-3/rev5) | `test_dual_condition_regression_addresses_are_denied` + `test_cgnat_is_global_false_asserted_directly` | integration |
| TOCTOU (resolve-once, pin, never re-query) | `test_toctou_connects_only_to_first_resolved_address` | integration |
| Redirect refusal (3xx never followed) | `test_redirect_response_is_refused_not_followed` | integration |
| IPv6 loopback/mapped/mixed record sets | `test_ipv6_special_and_mixed_record_sets_are_rejected` | integration |
| Scheme enforcement (http/file/gopher/ftp rejected pre-resolution) | `test_rejects_disallowed_schemes_before_resolution` | unit |
| T13: `trust_env=False`, no proxy mounts, even with `HTTPS_PROXY`/`ALL_PROXY` set | `test_guarded_client_has_no_proxy_mounts_even_with_proxy_env_set` + `test_guarded_transport_ignores_proxy_env_and_pins_to_resolved_ip` | unit |

`ac_total == ac_with_test` = 9/9.

## Mutation gate evidence (Verification Plan §3 — both mandatory, verified by hand)

1. **Redirect/TOCTOU gate**: commented out `GuardedAsyncTransport`'s connect-time
   re-validation call (the `validate_base_url` + URL rewrite in
   `handle_async_request`) → `test_toctou_connects_only_to_first_resolved_address`
   goes **red** (`assert 'rebind.example' == '8.8.8.8'` — proves the transport was
   actually pinning, not the pre-flight check alone).
2. **Dual-condition gate — `is_global` half**: deleted the `if ip.is_global is not
   True: return False` branch → `test_dual_condition_regression_addresses_are_denied[100.64.0.1]`
   goes **red** (`DID NOT RAISE EgressBlocked`).
3. **Dual-condition gate — deny-flag half**: deleted the
   `is_private/is_loopback/.../is_unspecified` branch → 
   `test_dual_condition_regression_addresses_are_denied[64:ff9b::7f00:1]` goes **red**.

All three restored and full suite re-verified green after each gate.

## Gate results

- `make lint` — pass (ruff check + format)
- `make typecheck` — pass, 120 source files, 0 errors
- `make test` — 1417 passed, coverage 88.28% (floor 87%)
- New files: 35/35 tests passing (`test_egress_guard_classification.py` unit + 
  `test_egress_ssrf_guard.py` integration, using a real self-signed TLS stub server)
- `make test-integration` (full suite): blocked in this sandbox by a pre-existing,
  unrelated environment mismatch (`installed Atlas is 1.2.4; expected 0.30.0` for the
  DB-backed testcontainer fixtures) — confirmed unrelated to this change since the
  new egress-guard integration tests carry no DB dependency and pass standalone.

## Test plan

- [x] All 9 Task 1 ACs have a corresponding test (unit/integration as annotated above)
- [x] Both mutation gates from the Verification Plan run and confirmed red/green
- [x] `make lint && make typecheck && make test` green
- [x] New test files ≤200 lines (TLS stub server extracted to
      `_egress_tls_stub.py` helper, not itself a test module)
- [x] No suppressions (`noqa`/`type: ignore`/etc.) added
- [ ] Not merging — per harness workflow, awaiting dual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)