### PR TITLE
feat(273): session identity transition + anonymous retention (Task 3)

### DIFF
--- a/.github/workflows/_python-ci.yml
+++ b/.github/workflows/_python-ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv run ruff format --check agent/
 
       - name: Type check (mypy strict)
-        run: uv run mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/
+        run: uv run mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/ agent/scripts/purge_anonymous_sessions.py
 
       - name: Dead code (vulture)
         run: uv run vulture agent/ vulture_whitelist.py

--- a/.github/workflows/_python-ci.yml
+++ b/.github/workflows/_python-ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv run ruff format --check agent/
 
       - name: Type check (mypy strict)
-        run: uv run mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/ agent/scripts/purge_anonymous_sessions.py
+        run: uv run --frozen mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/ agent/scripts/purge_anonymous_sessions.py
 
       - name: Dead code (vulture)
         run: uv run vulture agent/ vulture_whitelist.py

--- a/.github/workflows/purge-anonymous-sessions.yml
+++ b/.github/workflows/purge-anonymous-sessions.yml
@@ -1,0 +1,47 @@
+# Standalone top-level workflow (see agent-eval-nightly.yml precedent) — kept
+# separate from ci.yml so this cron cadence never rides along with every
+# push/PR trigger in the main CI matrix.
+name: Purge Anonymous Sessions
+
+# Issue #273 Task 3: routeless anonymous sessions accumulate free-text queries
+# and locations with no TTL otherwise. Cadence is discretionary; daily,
+# off-peak. Needs the SUPABASE_DB_URL secret in this environment — without
+# it the job fails outright rather than silently purging nothing.
+on:
+  schedule:
+    - cron: "37 18 * * *" # 18:37 UTC daily — low-traffic, off the hour
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: purge-anonymous-sessions
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  purge:
+    name: Purge routeless anonymous sessions
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/agent
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+        with:
+          python: "true"
+
+      - run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - run: uv sync --frozen --all-extras
+
+      - name: Run the anonymous-session retention sweep
+        run: uv run --frozen python -m agent.scripts.purge_anonymous_sessions
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}

--- a/.github/workflows/purge-anonymous-sessions.yml
+++ b/.github/workflows/purge-anonymous-sessions.yml
@@ -26,6 +26,9 @@ jobs:
   purge:
     name: Purge routeless anonymous sessions
     runs-on: ubuntu-latest
+    # This job holds a real secret (SUPABASE_DB_URL) — bound generously in
+    # case of a hung connection pool, not because the sweep itself is slow.
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: apps/agent
@@ -39,9 +42,21 @@ jobs:
 
       - run: uv python install ${{ env.PYTHON_VERSION }}
 
+      # NOTE (review round 2): a blanket `--no-build` (wheel-only, no sdist
+      # builds) was evaluated for this secret-bearing job and reverted —
+      # verified locally against the pinned uv (0.11.14): it refuses to
+      # install this project's own editable package ("marked as --no-build
+      # but has no binary distribution"), which is not optional here. The
+      # narrower `--no-build-package <name>` per third-party dependency
+      # exists but needs an explicit, maintained allowlist; tracked as a
+      # follow-up rather than shipped half-verified in this PR.
       - run: uv sync --frozen --all-extras
 
       - name: Run the anonymous-session retention sweep
+        # The script itself writes "purged=N raced=N failed=N" to
+        # $GITHUB_STEP_SUMMARY (agent.scripts.purge_anonymous_sessions.
+        # _write_step_summary) — GitHub Actions sets that path for every
+        # step automatically, no extra wiring needed here.
         run: uv run --frozen python -m agent.scripts.purge_anonymous_sessions
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ format:
 	cd apps/agent && uv run ruff check --fix agent/ scripts/
 
 typecheck:
-	cd apps/agent && uv run mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/ agent/tests/eval/
+	cd apps/agent && uv run mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/ agent/tests/eval/ agent/scripts/purge_anonymous_sessions.py
 
 check: lint typecheck test test-integration
 

--- a/apps/agent/agent/agents/session_ownership.py
+++ b/apps/agent/agent/agents/session_ownership.py
@@ -1,0 +1,47 @@
+"""Session identity ownership transition (issue #273 Task 3).
+
+On login, every session belonging to the calling browser's anonymous
+identity is re-pointed to the real user with a single identity-dimensional
+`UPDATE conversations SET user_id = $to WHERE user_id = $from_anon` — not
+scoped to any one `session_id`, so a browser with multiple anonymous
+sessions migrates all of them in one call.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class MigrationOutcome:
+    """`False` is the typed no-op — that identity owned nothing — not an error."""
+
+    migrated: bool
+
+
+class SupportsOwnershipMigration(Protocol):
+    async def migrate_ownership(self, from_anon_id: str, to_user_id: str) -> bool: ...
+
+
+class SupportsSessionRepo(Protocol):
+    @property
+    def session(self) -> SupportsOwnershipMigration: ...
+
+
+async def migrate_session_ownership(
+    db: SupportsSessionRepo,
+    *,
+    from_anon_id: str | None,
+    to_user_id: str,
+) -> MigrationOutcome:
+    """Move ownership of every anonymous session to the real user.
+
+    A missing `from_anon_id` (no trusted anonymous history for this caller)
+    is a normal outcome, not an exception: the caller was never anonymous
+    here, so there is nothing to migrate.
+    """
+    if from_anon_id is None:
+        return MigrationOutcome(migrated=False)
+    changed = await db.session.migrate_ownership(from_anon_id, to_user_id)
+    return MigrationOutcome(migrated=changed)

--- a/apps/agent/agent/config/settings.py
+++ b/apps/agent/agent/config/settings.py
@@ -152,6 +152,15 @@ class Settings(BaseSettings):
     model_output_cost_per_mtok_usd: float = Field(
         default=0.0, ge=0, description="Output token price per million tokens (USD)"
     )
+    # Anonymous-session retention sweep (issue #273 Task 3). A session with no
+    # route output is purged once its conversation has gone this many days
+    # without an update; route-bearing sessions are retained permanently
+    # regardless of this window (not configurable — see purge_anonymous_sessions).
+    anonymous_session_retention_days: int = Field(
+        default=30,
+        ge=1,
+        description="Days of inactivity before a routeless anonymous session is purged",
+    )
     service_host: str = Field(default="0.0.0.0", description="HTTP service bind host")
     service_port: int = Field(default=8080, description="HTTP service bind port")
     observability_service_name: str = Field(

--- a/apps/agent/agent/infrastructure/supabase/repositories/session.py
+++ b/apps/agent/agent/infrastructure/supabase/repositories/session.py
@@ -35,6 +35,19 @@ _FIND_PURGEABLE_SQL = """
       AND c.updated_at < $1
       AND NOT EXISTS (SELECT 1 FROM routes r WHERE r.session_id = c.session_id)
 """
+#: The DELETE re-asserts the SAME eligibility predicate the scan used
+#: (anon-owned, still older than cutoff) rather than trusting the
+#: session_id alone. This closes the find-then-delete race: if the owner
+#: logged in (migrate_ownership) or the session was otherwise touched
+#: between the scan and this delete, zero rows match here and nothing is
+#: destroyed — a stale candidate list can only ever under-delete, never
+#: over-delete.
+_PURGE_CONVERSATION_SQL = """
+    DELETE FROM conversations
+    WHERE session_id = $1
+      AND user_id LIKE 'anon\\_%' ESCAPE '\\'
+      AND updated_at < $2
+"""
 
 
 def _rows_affected(status: str) -> int:
@@ -226,18 +239,28 @@ class SessionRepository:
         rows = await self._pool.fetch(_FIND_PURGEABLE_SQL, cutoff)
         return [str(row["session_id"]) for row in rows]
 
-    async def purge_session(self, session_id: str) -> None:
+    async def purge_session(self, session_id: str, cutoff: datetime) -> bool:
         """Delete one session's conversation (cascading its messages) and its
         session row, in a single transaction per session. Ordering matters:
         conversations first, sessions last — the `routes.session_id` FK is
         the transactional backstop if the exclusion predicate is ever wrong,
         and it can only fire on the sessions delete, rolling the whole unit
-        back rather than half-destroying a route-bearing session."""
+        back rather than half-destroying a route-bearing session.
+
+        The conversation delete re-checks eligibility (anon-owned, still
+        older than `cutoff`) rather than trusting the caller's candidate
+        list — closes the find-then-delete race, so a session whose owner
+        logged in between the scan and this call is left untouched. Returns
+        True iff the session was actually purged.
+        """
         async with self._pool.acquire() as connection:
             async with connection.transaction():
-                await connection.execute(
-                    "DELETE FROM conversations WHERE session_id = $1", session_id
+                status = await connection.execute(
+                    _PURGE_CONVERSATION_SQL, session_id, cutoff
                 )
+                if _rows_affected(status) == 0:
+                    return False
                 await connection.execute(
                     "DELETE FROM sessions WHERE id = $1", session_id
                 )
+                return True

--- a/apps/agent/agent/infrastructure/supabase/repositories/session.py
+++ b/apps/agent/agent/infrastructure/supabase/repositories/session.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping
 from datetime import datetime
 
 from agent.infrastructure.supabase.client_types import AsyncPGPool, Row
+
+_COMMAND_TAG_ROW_COUNT = re.compile(r"(\d+)\s*$")
 
 _CREATE_SESSION_SQL = """
     INSERT INTO sessions (id, state, metadata) VALUES ($1, $2::jsonb, '{}'::jsonb)
@@ -14,6 +17,11 @@ _CREATE_SESSION_SQL = """
 _CREATE_CONVERSATION_SQL = """
     INSERT INTO conversations (session_id, user_id, first_query) VALUES ($1, $2, $3)
 """
+#: `updated_at = now()` is a deliberate side effect, not an incidental touch:
+#: logging in is itself activity, so a session that was already near the
+#: retention cutoff gets a fresh liveness clock instead of being purged out
+#: from under a user who just claimed it. It never *shortens* the window —
+#: only a real anon-owned row can match the WHERE clause at all.
 _MIGRATE_OWNERSHIP_SQL = """
     UPDATE conversations SET user_id = $1, updated_at = now() WHERE user_id = $2
 """
@@ -30,8 +38,14 @@ _FIND_PURGEABLE_SQL = """
 
 
 def _rows_affected(status: str) -> int:
-    """Parse asyncpg's command-tag status string (e.g. ``"UPDATE 3"``)."""
-    return int(status.rsplit(" ", maxsplit=1)[-1])
+    """Parse asyncpg's command-tag status string (e.g. ``"UPDATE 3"``).
+
+    Falls back to 0 for a tag with no trailing row count (there is no such
+    case for ``UPDATE``/``DELETE`` in practice, but this must never raise —
+    a parse failure here would turn a successful mutation into a 500).
+    """
+    match = _COMMAND_TAG_ROW_COUNT.search(status)
+    return int(match.group(1)) if match else 0
 
 
 class SessionRepository:

--- a/apps/agent/agent/infrastructure/supabase/repositories/session.py
+++ b/apps/agent/agent/infrastructure/supabase/repositories/session.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from agent.infrastructure.supabase.client_types import AsyncPGPool, Row
 
-_COMMAND_TAG_ROW_COUNT = re.compile(r"(\d+)\s*$")
+_COMMAND_TAG_ROW_COUNT = re.compile(r"(\d+)$")
 
 _CREATE_SESSION_SQL = """
     INSERT INTO sessions (id, state, metadata) VALUES ($1, $2::jsonb, '{}'::jsonb)
@@ -57,7 +57,7 @@ def _rows_affected(status: str) -> int:
     case for ``UPDATE``/``DELETE`` in practice, but this must never raise —
     a parse failure here would turn a successful mutation into a 500).
     """
-    match = _COMMAND_TAG_ROW_COUNT.search(status)
+    match = _COMMAND_TAG_ROW_COUNT.search(status.rstrip())
     return int(match.group(1)) if match else 0
 
 

--- a/apps/agent/agent/infrastructure/supabase/repositories/session.py
+++ b/apps/agent/agent/infrastructure/supabase/repositories/session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from datetime import datetime
 
 from agent.infrastructure.supabase.client_types import AsyncPGPool, Row
 
@@ -13,6 +14,24 @@ _CREATE_SESSION_SQL = """
 _CREATE_CONVERSATION_SQL = """
     INSERT INTO conversations (session_id, user_id, first_query) VALUES ($1, $2, $3)
 """
+_MIGRATE_OWNERSHIP_SQL = """
+    UPDATE conversations SET user_id = $1, updated_at = now() WHERE user_id = $2
+"""
+#: Anonymous identities always carry the `anon_` prefix (worker/auth.ts); the
+#: escaped LIKE — not a `>=`/`<` range predicate — is the collation-safe match
+#: this partial scan relies on (paired with the `text_pattern_ops` index).
+_FIND_PURGEABLE_SQL = """
+    SELECT c.session_id
+    FROM conversations c
+    WHERE c.user_id LIKE 'anon\\_%' ESCAPE '\\'
+      AND c.updated_at < $1
+      AND NOT EXISTS (SELECT 1 FROM routes r WHERE r.session_id = c.session_id)
+"""
+
+
+def _rows_affected(status: str) -> int:
+    """Parse asyncpg's command-tag status string (e.g. ``"UPDATE 3"``)."""
+    return int(status.rsplit(" ", maxsplit=1)[-1])
 
 
 class SessionRepository:
@@ -176,3 +195,35 @@ class SessionRepository:
     async def delete_session_state(self, session_id: str) -> None:
         """Delete session state by session ID."""
         await self._pool.execute("DELETE FROM sessions WHERE id = $1", session_id)
+
+    async def migrate_ownership(self, from_anon_id: str, to_user_id: str) -> bool:
+        """Re-point every conversation owned by an anonymous identity to the
+        real user in a single identity-dimensional UPDATE (not INSERT — this
+        never creates a conversation). Idempotent: a second run matches zero
+        rows. Returns True iff at least one row changed."""
+        status = await self._pool.execute(
+            _MIGRATE_OWNERSHIP_SQL, to_user_id, from_anon_id
+        )
+        return _rows_affected(status) > 0
+
+    async def find_purgeable_anonymous_sessions(self, cutoff: datetime) -> list[str]:
+        """Session ids of anonymous, routeless conversations inactive since
+        cutoff. `updated_at` is read as liveness, not creation age."""
+        rows = await self._pool.fetch(_FIND_PURGEABLE_SQL, cutoff)
+        return [str(row["session_id"]) for row in rows]
+
+    async def purge_session(self, session_id: str) -> None:
+        """Delete one session's conversation (cascading its messages) and its
+        session row, in a single transaction per session. Ordering matters:
+        conversations first, sessions last — the `routes.session_id` FK is
+        the transactional backstop if the exclusion predicate is ever wrong,
+        and it can only fire on the sessions delete, rolling the whole unit
+        back rather than half-destroying a route-bearing session."""
+        async with self._pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute(
+                    "DELETE FROM conversations WHERE session_id = $1", session_id
+                )
+                await connection.execute(
+                    "DELETE FROM sessions WHERE id = $1", session_id
+                )

--- a/apps/agent/agent/interfaces/fastapi_service.py
+++ b/apps/agent/agent/interfaces/fastapi_service.py
@@ -37,6 +37,7 @@ from agent.interfaces.routes.health import router as health_router
 from agent.interfaces.routes.photo_search import router as photo_search_router
 from agent.interfaces.routes.runtime import router as runtime_router
 from agent.interfaces.routes.search_preview import router as search_preview_router
+from agent.interfaces.routes.session_migration import router as session_migration_router
 
 # Re-export _call_optional_async for test backward compatibility.
 _call_optional_async = call_optional_async
@@ -172,6 +173,7 @@ def create_fastapi_app(
     app.include_router(bangumi_router)
     app.include_router(search_preview_router)
     app.include_router(photo_search_router)
+    app.include_router(session_migration_router)
     return app
 
 

--- a/apps/agent/agent/interfaces/routes/_deps.py
+++ b/apps/agent/agent/interfaces/routes/_deps.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import re
 from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Literal, cast
@@ -19,7 +20,7 @@ from agent.infrastructure.session import SessionStore, create_session_store
 from agent.infrastructure.supabase.client import SupabaseClient
 from agent.interfaces.public_api import PublicAPIResponse, RuntimeAPI
 from agent.interfaces.schemas import GRACEFUL_TERMINAL_STATUSES
-from agent.interfaces.usage_metering import ANONYMOUS_USER_TYPE
+from agent.interfaces.usage_metering import ANON_USER_ID_PREFIX, ANONYMOUS_USER_TYPE
 
 if TYPE_CHECKING:
     import logfire
@@ -131,6 +132,44 @@ def _require_trusted_user(
     if auth.user_id is None:
         raise HTTPException(status_code=400, detail="X-User-Id header required.")
     return auth
+
+
+def _require_non_anonymous_user(
+    auth: Annotated[TrustedAuthContext, Depends(_get_trusted_auth_context)],
+) -> TrustedAuthContext:
+    """Reject-anonymous, not allow-list (session_migration, #273 Task 3).
+
+    Mirrors ``usage_metering.scope_for_identity``'s classification exactly:
+    anonymous is either the edge's typed marker or the ``anon_`` id prefix.
+    There is no ``"user"`` literal anywhere in the system — real humans are
+    stamped ``"human"``, ``sk_*`` API keys ``"agent"`` — so this must not be
+    an allow-list, which would 403 every genuine caller.
+    """
+    if auth.user_id is None:
+        raise HTTPException(status_code=400, detail="X-User-Id header required.")
+    is_anonymous = auth.user_type == ANONYMOUS_USER_TYPE or auth.user_id.startswith(
+        ANON_USER_ID_PREFIX
+    )
+    if is_anonymous:
+        raise HTTPException(
+            status_code=403, detail="Anonymous identity cannot migrate sessions."
+        )
+    return auth
+
+
+#: The container's own re-validation of the edge-forwarded X-Anon-Id (re-P3):
+#: anything not matching this shape is treated as missing, not as an identity,
+#: so structural safety does not depend on the edge being bug-free.
+_ANON_ID_PATTERN = re.compile(r"^anon_[0-9a-f]{32}$")
+
+
+def _get_trusted_anon_id(
+    x_anon_id: Annotated[str | None, Header(alias="X-Anon-Id")] = None,
+) -> str | None:
+    value = _normalize_optional_header(x_anon_id)
+    if value is None or not _ANON_ID_PATTERN.fullmatch(value):
+        return None
+    return value
 
 
 def _get_runtime_api(request: Request) -> RuntimeAPI:

--- a/apps/agent/agent/interfaces/routes/session_migration.py
+++ b/apps/agent/agent/interfaces/routes/session_migration.py
@@ -1,0 +1,42 @@
+"""Session identity transition on login (issue #273 Task 3).
+
+`POST /v1/session/migrate` re-points every session owned by the calling
+browser's anonymous identity to the real, logged-in user. Identity-
+dimensional: no `session_id` (the magic-link tab has none) and no request
+body (nothing to probe with) — the only inputs are trusted headers.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, cast
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+
+from agent.agents.session_ownership import migrate_session_ownership
+from agent.interfaces.routes._deps import (
+    TrustedAuthContext,
+    _get_db_from_request,
+    _get_trusted_anon_id,
+    _json_response,
+    _require_non_anonymous_user,
+    _require_supabase,
+)
+
+router = APIRouter(prefix="/v1", tags=["session"])
+
+
+@router.post("/session/migrate")
+async def handle_session_migrate(
+    request: Request,
+    auth: Annotated[TrustedAuthContext, Depends(_require_non_anonymous_user)],
+    from_anon_id: Annotated[str | None, Depends(_get_trusted_anon_id)],
+) -> JSONResponse:
+    db = _require_supabase(_get_db_from_request(request))
+    # `_require_non_anonymous_user` raises before this handler runs unless
+    # `auth.user_id` is set; the cast documents that contract for mypy.
+    to_user_id = cast(str, auth.user_id)
+    outcome = await migrate_session_ownership(
+        db, from_anon_id=from_anon_id, to_user_id=to_user_id
+    )
+    return _json_response({"migrated": outcome.migrated})

--- a/apps/agent/agent/scripts/purge_anonymous_sessions.py
+++ b/apps/agent/agent/scripts/purge_anonymous_sessions.py
@@ -15,8 +15,11 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import sys
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import asyncpg
 
@@ -25,6 +28,19 @@ from agent.infrastructure.supabase.client import SupabaseClient
 from agent.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class PurgeReport:
+    """Outcome of one sweep. `raced` is the find-then-delete race being
+    caught structurally (a session whose owner logged in mid-sweep) — a
+    normal outcome, not a failure. `failed` is a per-session database error
+    (e.g. the FK backstop firing) that was isolated and logged."""
+
+    purged: int
+    raced: int
+    failed: int
+
 
 #: A single session's purge can lose a benign race — another request wrote a
 #: route between the eligibility scan and this delete, so the FK backstop
@@ -43,38 +59,61 @@ async def purge_anonymous_sessions(
     retention_days: int,
     now: datetime | None = None,
     dry_run: bool = False,
-) -> int:
+) -> PurgeReport:
     """Sweep routeless anonymous sessions inactive since the cutoff.
 
     Per-session transaction AND per-session error isolation: each purge
     deletes that session's conversation (cascading its messages) and its
-    session row as one unit, and a failure on one session (e.g. the FK
-    backstop catching a concurrent route write) is logged and skipped rather
-    than aborting the rest of the sweep.
+    session row as one unit. A session raced away by a concurrent login
+    (`raced`) or refused by the FK backstop (`failed`) is logged and skipped
+    rather than aborting the rest of the sweep.
     """
     cutoff = (now or datetime.now(UTC)) - timedelta(days=retention_days)
     session_ids = await db.session.find_purgeable_anonymous_sessions(cutoff)
     if dry_run:
         logger.info("anonymous_purge_dry_run", eligible=len(session_ids))
-        return len(session_ids)
-    purged, failed = await _purge_each(db, session_ids)
-    logger.info("anonymous_sessions_purged", count=purged, failed=failed)
-    return purged
+        return PurgeReport(purged=len(session_ids), raced=0, failed=0)
+    report = await _purge_each(db, session_ids, cutoff)
+    logger.info(
+        "anonymous_sessions_purged",
+        count=report.purged,
+        raced=report.raced,
+        failed=report.failed,
+    )
+    return report
 
 
-async def _purge_each(db: SupabaseClient, session_ids: list[str]) -> tuple[int, int]:
+async def _purge_each(
+    db: SupabaseClient, session_ids: list[str], cutoff: datetime
+) -> PurgeReport:
     purged = 0
+    raced = 0
     failed = 0
     for session_id in session_ids:
         try:
-            await db.session.purge_session(session_id)
-            purged += 1
+            if await db.session.purge_session(session_id, cutoff):
+                purged += 1
+            else:
+                raced += 1
         except _EXPECTED_PER_SESSION_ERRORS:
             failed += 1
             logger.warning(
                 "anonymous_session_purge_failed", session_id=session_id, exc_info=True
             )
-    return purged, failed
+    return PurgeReport(purged=purged, raced=raced, failed=failed)
+
+
+def _write_step_summary(report: PurgeReport) -> None:
+    """Best-effort: record purged/raced/failed where the workflow's job
+    summary can show it, if running under GitHub Actions."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    line = (
+        f"anonymous-session purge: purged={report.purged} "
+        f"raced={report.raced} failed={report.failed}\n"
+    )
+    Path(summary_path).open("a", encoding="utf-8").write(line)
 
 
 async def _main(dry_run: bool) -> None:
@@ -84,11 +123,12 @@ async def _main(dry_run: bool) -> None:
         logger.error("SUPABASE_DB_URL is not set")
         sys.exit(1)
     async with SupabaseClient(dsn) as db:
-        await purge_anonymous_sessions(
+        report = await purge_anonymous_sessions(
             db,
             retention_days=settings.anonymous_session_retention_days,
             dry_run=dry_run,
         )
+    _write_step_summary(report)
 
 
 def _parse_args() -> argparse.Namespace:

--- a/apps/agent/agent/scripts/purge_anonymous_sessions.py
+++ b/apps/agent/agent/scripts/purge_anonymous_sessions.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Purge stale anonymous sessions with no route output (issue #273 Task 3).
+
+Anonymous conversations accumulate free-text queries and locations with no
+TTL. A conversation is eligible once it has gone `anonymous_session_retention_
+days` without an update AND is associated with no `routes` row — a session
+that produced a route is retained permanently, unconditionally.
+
+Usage:
+    uv run python -m agent.scripts.purge_anonymous_sessions
+    uv run python -m agent.scripts.purge_anonymous_sessions --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import UTC, datetime, timedelta
+
+from agent.config.settings import get_settings
+from agent.infrastructure.supabase.client import SupabaseClient
+from agent.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def purge_anonymous_sessions(
+    db: SupabaseClient,
+    *,
+    retention_days: int,
+    now: datetime | None = None,
+    dry_run: bool = False,
+) -> int:
+    """Sweep routeless anonymous sessions inactive since the cutoff.
+
+    Per-session transaction: each purge deletes that session's conversation
+    (cascading its messages) and its session row as one unit, so the
+    `routes.session_id` FK backstop can only ever roll back one session, not
+    the whole sweep.
+    """
+    cutoff = (now or datetime.now(UTC)) - timedelta(days=retention_days)
+    session_ids = await db.session.find_purgeable_anonymous_sessions(cutoff)
+    if dry_run:
+        logger.info("anonymous_purge_dry_run", eligible=len(session_ids))
+        return len(session_ids)
+    for session_id in session_ids:
+        await db.session.purge_session(session_id)
+    logger.info("anonymous_sessions_purged", count=len(session_ids))
+    return len(session_ids)
+
+
+async def _main(dry_run: bool) -> None:
+    settings = get_settings()
+    dsn = settings.supabase_db_url
+    if not dsn:
+        logger.error("SUPABASE_DB_URL is not set")
+        sys.exit(1)
+    async with SupabaseClient(dsn) as db:
+        await purge_anonymous_sessions(
+            db,
+            retention_days=settings.anonymous_session_retention_days,
+            dry_run=dry_run,
+        )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report eligible sessions without deleting",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main(_parse_args().dry_run))

--- a/apps/agent/agent/scripts/purge_anonymous_sessions.py
+++ b/apps/agent/agent/scripts/purge_anonymous_sessions.py
@@ -18,11 +18,23 @@ import asyncio
 import sys
 from datetime import UTC, datetime, timedelta
 
+import asyncpg
+
 from agent.config.settings import get_settings
 from agent.infrastructure.supabase.client import SupabaseClient
 from agent.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+#: A single session's purge can lose a benign race — another request wrote a
+#: route between the eligibility scan and this delete, so the FK backstop
+#: fires for that one row. That is exactly the case the backstop exists to
+#: catch, not a reason to abort the sweep: everything asyncpg raises for a
+#: real database-level failure (including the FK violation) derives from
+#: this. A non-Postgres exception (a programming bug) is deliberately NOT
+#: caught here — it propagates out of the sweep and crashes the CLI with a
+#: nonzero exit, which is what should page someone.
+_EXPECTED_PER_SESSION_ERRORS = asyncpg.PostgresError
 
 
 async def purge_anonymous_sessions(
@@ -34,20 +46,35 @@ async def purge_anonymous_sessions(
 ) -> int:
     """Sweep routeless anonymous sessions inactive since the cutoff.
 
-    Per-session transaction: each purge deletes that session's conversation
-    (cascading its messages) and its session row as one unit, so the
-    `routes.session_id` FK backstop can only ever roll back one session, not
-    the whole sweep.
+    Per-session transaction AND per-session error isolation: each purge
+    deletes that session's conversation (cascading its messages) and its
+    session row as one unit, and a failure on one session (e.g. the FK
+    backstop catching a concurrent route write) is logged and skipped rather
+    than aborting the rest of the sweep.
     """
     cutoff = (now or datetime.now(UTC)) - timedelta(days=retention_days)
     session_ids = await db.session.find_purgeable_anonymous_sessions(cutoff)
     if dry_run:
         logger.info("anonymous_purge_dry_run", eligible=len(session_ids))
         return len(session_ids)
+    purged, failed = await _purge_each(db, session_ids)
+    logger.info("anonymous_sessions_purged", count=purged, failed=failed)
+    return purged
+
+
+async def _purge_each(db: SupabaseClient, session_ids: list[str]) -> tuple[int, int]:
+    purged = 0
+    failed = 0
     for session_id in session_ids:
-        await db.session.purge_session(session_id)
-    logger.info("anonymous_sessions_purged", count=len(session_ids))
-    return len(session_ids)
+        try:
+            await db.session.purge_session(session_id)
+            purged += 1
+        except _EXPECTED_PER_SESSION_ERRORS:
+            failed += 1
+            logger.warning(
+                "anonymous_session_purge_failed", session_id=session_id, exc_info=True
+            )
+    return purged, failed
 
 
 async def _main(dry_run: bool) -> None:

--- a/apps/agent/agent/tests/integration/test_session_identity_transition.py
+++ b/apps/agent/agent/tests/integration/test_session_identity_transition.py
@@ -28,9 +28,16 @@ async def _seed_session(
 
 @pytest.mark.integration
 async def test_migration_moves_ownership_and_preserves_content(real_db) -> None:
+    """Reading state AND message history after the transition must match the
+    pre-login read exactly — the migration re-points ownership only."""
     anon = _anon_id()
     session_id = f"sess-{uuid.uuid4().hex}"
     await _seed_session(real_db, session_id, anon, "君の名はの聖地は？")
+    await real_db.messages.insert_message(session_id, "user", "君の名はの聖地は？")
+    await real_db.messages.insert_message(
+        session_id, "assistant", "3件見つかりました。"
+    )
+    messages_before = await real_db.messages.get_messages(session_id)
 
     changed = await real_db.session.migrate_ownership(anon, "real-user-1")
     assert changed is True
@@ -40,6 +47,9 @@ async def test_migration_moves_ownership_and_preserves_content(real_db) -> None:
     assert conversation["user_id"] == "real-user-1"
     state = await real_db.session.get_session_state(session_id)
     assert state == {"k": "v"}
+    messages_after = await real_db.messages.get_messages(session_id)
+    assert messages_after == messages_before
+    assert len(messages_after) == 2
 
 
 @pytest.mark.integration

--- a/apps/agent/agent/tests/integration/test_session_identity_transition.py
+++ b/apps/agent/agent/tests/integration/test_session_identity_transition.py
@@ -1,0 +1,166 @@
+"""Real-Postgres coverage for session identity transition + anonymous
+retention (issue #273 Task 3). Uses testcontainer Postgres via `real_db`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import asyncpg
+import pytest
+
+from agent.infrastructure.supabase.client import SupabaseClient
+from agent.scripts.purge_anonymous_sessions import purge_anonymous_sessions
+
+pytest_plugins = ("agent.tests.conftest_db",)
+
+
+def _anon_id() -> str:
+    return "anon_" + uuid.uuid4().hex
+
+
+async def _seed_session(
+    db: SupabaseClient, session_id: str, user_id: str, query: str = "hello"
+) -> None:
+    await db.session.create_owned_session(session_id, user_id, query, {"k": "v"})
+
+
+@pytest.mark.integration
+async def test_migration_moves_ownership_and_preserves_content(real_db) -> None:
+    anon = _anon_id()
+    session_id = f"sess-{uuid.uuid4().hex}"
+    await _seed_session(real_db, session_id, anon, "君の名はの聖地は？")
+
+    changed = await real_db.session.migrate_ownership(anon, "real-user-1")
+    assert changed is True
+
+    conversation = await real_db.session.get_conversation(session_id)
+    assert conversation is not None
+    assert conversation["user_id"] == "real-user-1"
+    state = await real_db.session.get_session_state(session_id)
+    assert state == {"k": "v"}
+
+
+@pytest.mark.integration
+async def test_migration_moves_every_session_for_the_same_anon_identity(
+    real_db,
+) -> None:
+    anon = _anon_id()
+    session_a = f"sess-{uuid.uuid4().hex}"
+    session_b = f"sess-{uuid.uuid4().hex}"
+    await _seed_session(real_db, session_a, anon, "query a")
+    await _seed_session(real_db, session_b, anon, "query b")
+
+    changed = await real_db.session.migrate_ownership(anon, "real-user-2")
+    assert changed is True
+
+    conv_a = await real_db.session.get_conversation(session_a)
+    conv_b = await real_db.session.get_conversation(session_b)
+    assert conv_a["user_id"] == "real-user-2"
+    assert conv_b["user_id"] == "real-user-2"
+
+
+@pytest.mark.integration
+async def test_original_anon_identity_loses_ownership_after_transition(
+    real_db,
+) -> None:
+    anon = _anon_id()
+    session_id = f"sess-{uuid.uuid4().hex}"
+    await _seed_session(real_db, session_id, anon, "query")
+
+    await real_db.session.migrate_ownership(anon, "real-user-3")
+
+    assert await real_db.session.check_session_owner(session_id, anon) is False
+    assert await real_db.session.check_session_owner(session_id, "real-user-3") is True
+
+
+@pytest.mark.integration
+async def test_retention_purges_only_the_inactive_routeless_sibling(real_db) -> None:
+    anon = _anon_id()
+    stale = f"sess-{uuid.uuid4().hex}"
+    fresh = f"sess-{uuid.uuid4().hex}"
+    await _seed_session(real_db, stale, anon, "stale query")
+    await _seed_session(real_db, fresh, anon, "fresh query")
+    old_cutoff = _days_ago(40)
+    await _backdate_conversation(real_db, stale, old_cutoff)
+
+    purged = await purge_anonymous_sessions(real_db, retention_days=30)
+
+    assert purged == 1
+    assert await real_db.session.get_conversation(stale) is None
+    assert await real_db.session.get_conversation(fresh) is not None
+
+
+@pytest.mark.integration
+async def test_route_bearing_session_is_retained_permanently(real_db) -> None:
+    anon = _anon_id()
+    with_route = f"sess-{uuid.uuid4().hex}"
+    without_route = f"sess-{uuid.uuid4().hex}"
+    await _seed_session(real_db, with_route, anon, "routed query")
+    await _seed_session(real_db, without_route, anon, "routeless query")
+    await real_db.routes.save_route(with_route, [], ["pt-1"], {})
+    old_cutoff = _days_ago(400)
+    await _backdate_conversation(real_db, with_route, old_cutoff)
+    await _backdate_conversation(real_db, without_route, old_cutoff)
+
+    purged = await purge_anonymous_sessions(real_db, retention_days=30)
+
+    assert purged == 1
+    assert await real_db.session.get_conversation(with_route) is not None
+    assert await real_db.session.get_session(with_route) is not None
+    assert await real_db.session.get_conversation(without_route) is None
+
+
+@pytest.mark.integration
+async def test_purge_deletes_conversations_before_sessions_leaving_no_orphans(
+    real_db,
+) -> None:
+    anon = _anon_id()
+    session_id = f"sess-{uuid.uuid4().hex}"
+    await _seed_session(real_db, session_id, anon, "orphan check")
+    await _backdate_conversation(real_db, session_id, _days_ago(40))
+
+    purged = await purge_anonymous_sessions(real_db, retention_days=30)
+
+    assert purged == 1
+    assert await real_db.session.get_conversation(session_id) is None
+    assert await real_db.session.get_session(session_id) is None
+    messages = await real_db.pool.fetch(
+        "SELECT 1 FROM conversation_messages WHERE session_id = $1", session_id
+    )
+    assert messages == []
+
+
+@pytest.mark.integration
+async def test_purge_transaction_rolls_back_whole_unit_when_fk_backstop_fires(
+    real_db,
+) -> None:
+    """With the exclusion predicate deliberately bypassed (calling
+    `purge_session` directly on a route-bearing session), the routes FK
+    refuses the sessions delete and the whole transaction rolls back — the
+    conversation and its messages must still exist afterwards."""
+    anon = _anon_id()
+    session_id = f"sess-{uuid.uuid4().hex}"
+    await _seed_session(real_db, session_id, anon, "fk backstop check")
+    await real_db.routes.save_route(session_id, [], ["pt-1"], {})
+
+    with pytest.raises(asyncpg.ForeignKeyViolationError):
+        await real_db.session.purge_session(session_id)
+
+    assert await real_db.session.get_conversation(session_id) is not None
+    assert await real_db.session.get_session(session_id) is not None
+
+
+def _days_ago(days: int) -> datetime:
+    return datetime.now(UTC) - timedelta(days=days)
+
+
+async def _backdate_conversation(
+    db: SupabaseClient, session_id: str, when: datetime
+) -> None:
+    await db.pool.execute(
+        "UPDATE conversations SET updated_at = $1 WHERE session_id = $2",
+        when,
+        session_id,
+    )

--- a/apps/agent/agent/tests/integration/test_session_identity_transition.py
+++ b/apps/agent/agent/tests/integration/test_session_identity_transition.py
@@ -13,7 +13,9 @@ import pytest
 from agent.infrastructure.supabase.client import SupabaseClient
 from agent.scripts.purge_anonymous_sessions import purge_anonymous_sessions
 
-pytest_plugins = ("agent.tests.conftest_db",)
+# `agent.tests.conftest_db` is already registered by the directory-level
+# `tests/integration/conftest.py` (`pytest_plugins`) — redeclaring it here
+# would be a no-op duplicate (review round 2 Sonar smell).
 
 
 def _anon_id() -> str:
@@ -95,9 +97,9 @@ async def test_retention_purges_only_the_inactive_routeless_sibling(real_db) -> 
     old_cutoff = _days_ago(40)
     await _backdate_conversation(real_db, stale, old_cutoff)
 
-    purged = await purge_anonymous_sessions(real_db, retention_days=30)
+    report = await purge_anonymous_sessions(real_db, retention_days=30)
 
-    assert purged == 1
+    assert report.purged == 1
     assert await real_db.session.get_conversation(stale) is None
     assert await real_db.session.get_conversation(fresh) is not None
 
@@ -114,9 +116,9 @@ async def test_route_bearing_session_is_retained_permanently(real_db) -> None:
     await _backdate_conversation(real_db, with_route, old_cutoff)
     await _backdate_conversation(real_db, without_route, old_cutoff)
 
-    purged = await purge_anonymous_sessions(real_db, retention_days=30)
+    report = await purge_anonymous_sessions(real_db, retention_days=30)
 
-    assert purged == 1
+    assert report.purged == 1
     assert await real_db.session.get_conversation(with_route) is not None
     assert await real_db.session.get_session(with_route) is not None
     assert await real_db.session.get_conversation(without_route) is None
@@ -131,9 +133,9 @@ async def test_purge_deletes_conversations_before_sessions_leaving_no_orphans(
     await _seed_session(real_db, session_id, anon, "orphan check")
     await _backdate_conversation(real_db, session_id, _days_ago(40))
 
-    purged = await purge_anonymous_sessions(real_db, retention_days=30)
+    report = await purge_anonymous_sessions(real_db, retention_days=30)
 
-    assert purged == 1
+    assert report.purged == 1
     assert await real_db.session.get_conversation(session_id) is None
     assert await real_db.session.get_session(session_id) is None
     messages = await real_db.pool.fetch(
@@ -154,9 +156,10 @@ async def test_purge_transaction_rolls_back_whole_unit_when_fk_backstop_fires(
     session_id = f"sess-{uuid.uuid4().hex}"
     await _seed_session(real_db, session_id, anon, "fk backstop check")
     await real_db.routes.save_route(session_id, [], ["pt-1"], {})
+    await _backdate_conversation(real_db, session_id, _days_ago(40))
 
     with pytest.raises(asyncpg.ForeignKeyViolationError):
-        await real_db.session.purge_session(session_id)
+        await real_db.session.purge_session(session_id, _days_ago(30))
 
     assert await real_db.session.get_conversation(session_id) is not None
     assert await real_db.session.get_session(session_id) is not None

--- a/apps/agent/agent/tests/integration/test_session_retention_integrity.py
+++ b/apps/agent/agent/tests/integration/test_session_retention_integrity.py
@@ -86,20 +86,26 @@ async def test_purge_session_race_a_concurrent_login_saves_the_session(
     assert await real_db.session.get_session(session_id) is not None
 
 
-#: The purge sweep's own test images/Neon branches are provisioned as
-#: en_US.utf8 (documented in docs/ops/anonymous-session-purge.md) — a
-#: non-C collation, which is exactly the condition under which a plain
-#: btree cannot service a LIKE prefix match and text_pattern_ops matters.
-_EXPECTED_COLLATION = "en_US.utf8"
+#: Documented in docs/ops/anonymous-session-purge.md: the offline test
+#: image is provisioned `en_US.utf8` (a non-C collation — exactly the case
+#: a plain btree cannot service a LIKE prefix match, which is why
+#: text_pattern_ops matters there); live Neon test branches are `C.UTF-8`
+#: (confirmed against a real CI run), under which a plain btree already
+#: orders bytewise and the index is a belt-and-suspenders match rather
+#: than a strict requirement. Both are legitimate, observed values for
+#: this suite's two arms — an unrecognized third value likely means the
+#: base image or Neon's default collation changed and this list (and the
+#: runbook) needs updating alongside it.
+_KNOWN_TEST_COLLATIONS = frozenset({"en_US.utf8", "C.UTF-8"})
 
 
 @pytest.mark.integration
 async def test_purge_predicate_hits_the_pattern_ops_index_not_a_seq_scan(
     real_db,
 ) -> None:
-    """Index/collation integrity (rev6 P1-1). Under the documented non-C
-    collation, a plain btree on `user_id` cannot service a LIKE prefix
-    match at all — only `text_pattern_ops` can.
+    """Index/collation integrity (rev6 P1-1). Under a non-C collation
+    (this suite's offline arm), a plain btree on `user_id` cannot service a
+    LIKE prefix match at all — only `text_pattern_ops` can.
 
     Mutation-direction verified locally: reverting the index to default ops
     (drop + recreate without `text_pattern_ops`) makes THIS test fail while
@@ -110,12 +116,12 @@ async def test_purge_predicate_hits_the_pattern_ops_index_not_a_seq_scan(
     under `enable_seqscan = off` (any btree scan, pattern-capable or not,
     satisfies it), so this pins the actual pattern range-scan operators
     (`~>=~` / `~<~`) that only appear in the plan when a pattern opclass
-    index services the LIKE prefix."""
+    index services the LIKE prefix — confirmed empirically on both arms."""
     async with real_db.pool.acquire() as connection:
         collation = await connection.fetchval(
             "SELECT datcollate FROM pg_database WHERE datname = current_database()"
         )
-        assert collation == _EXPECTED_COLLATION
+        assert collation in _KNOWN_TEST_COLLATIONS
         index_def = await connection.fetchval(
             "SELECT indexdef FROM pg_indexes "
             "WHERE indexname = 'idx_conversations_user_id_pattern'"

--- a/apps/agent/agent/tests/integration/test_session_retention_integrity.py
+++ b/apps/agent/agent/tests/integration/test_session_retention_integrity.py
@@ -86,33 +86,36 @@ async def test_purge_session_race_a_concurrent_login_saves_the_session(
     assert await real_db.session.get_session(session_id) is not None
 
 
+#: The purge sweep's own test images/Neon branches are provisioned as
+#: en_US.utf8 (documented in docs/ops/anonymous-session-purge.md) — a
+#: non-C collation, which is exactly the condition under which a plain
+#: btree cannot service a LIKE prefix match and text_pattern_ops matters.
+_EXPECTED_COLLATION = "en_US.utf8"
+
+
 @pytest.mark.integration
 async def test_purge_predicate_hits_the_pattern_ops_index_not_a_seq_scan(
     real_db,
 ) -> None:
-    """Index/collation integrity (rev6 P1-1). Under a non-C collation, a
-    plain btree on `user_id` cannot service a LIKE prefix match at all — only
-    `text_pattern_ops` can. Recording the collation makes that context
-    explicit rather than assumed.
+    """Index/collation integrity (rev6 P1-1). Under the documented non-C
+    collation, a plain btree on `user_id` cannot service a LIKE prefix
+    match at all — only `text_pattern_ops` can.
 
-    The opclass assertion below (not the plan shape) is what catches the
-    mutation: reverting the index to default ops (drop + recreate without
-    `text_pattern_ops`) makes THIS test fail while
+    Mutation-direction verified locally: reverting the index to default ops
+    (drop + recreate without `text_pattern_ops`) makes THIS test fail while
     `test_retention_purges_only_the_inactive_routeless_sibling` (the
-    behavioral happy path) keeps passing — verified locally. The plan
-    assertion intentionally does not pin the exact index name: on a
-    populated environment (e.g. a shared Neon branch with rows accumulated
-    across the whole suite) the planner may reasonably prefer the
-    pre-existing `idx_conversations_user_id_updated_at` composite index
-    over this one — both are index scans, and choosing between two valid
-    index paths is a cost decision outside this migration's control. What
-    must always hold, regardless of which valid index wins, is that no
-    `Seq Scan` on `conversations` appears."""
+    behavioral happy path) keeps passing. Two independent assertions catch
+    it: the opclass check (structural) and the pattern-operator check
+    (behavioral) — a bare "no Seq Scan" assertion would be a tautology
+    under `enable_seqscan = off` (any btree scan, pattern-capable or not,
+    satisfies it), so this pins the actual pattern range-scan operators
+    (`~>=~` / `~<~`) that only appear in the plan when a pattern opclass
+    index services the LIKE prefix."""
     async with real_db.pool.acquire() as connection:
         collation = await connection.fetchval(
             "SELECT datcollate FROM pg_database WHERE datname = current_database()"
         )
-        assert collation
+        assert collation == _EXPECTED_COLLATION
         index_def = await connection.fetchval(
             "SELECT indexdef FROM pg_indexes "
             "WHERE indexname = 'idx_conversations_user_id_pattern'"
@@ -128,4 +131,5 @@ async def test_purge_predicate_hits_the_pattern_ops_index_not_a_seq_scan(
         finally:
             await connection.execute("SET enable_seqscan = on")
     plan_text = "\n".join(row["QUERY PLAN"] for row in plan_rows)
-    assert "Seq Scan on conversations" not in plan_text
+    assert "~>=~" in plan_text
+    assert "~<~" in plan_text

--- a/apps/agent/agent/tests/integration/test_session_retention_integrity.py
+++ b/apps/agent/agent/tests/integration/test_session_retention_integrity.py
@@ -86,17 +86,26 @@ async def test_purge_session_race_a_concurrent_login_saves_the_session(
     assert await real_db.session.get_session(session_id) is not None
 
 
-#: Documented in docs/ops/anonymous-session-purge.md: the offline test
-#: image is provisioned `en_US.utf8` (a non-C collation — exactly the case
-#: a plain btree cannot service a LIKE prefix match, which is why
-#: text_pattern_ops matters there); live Neon test branches are `C.UTF-8`
-#: (confirmed against a real CI run), under which a plain btree already
-#: orders bytewise and the index is a belt-and-suspenders match rather
-#: than a strict requirement. Both are legitimate, observed values for
-#: this suite's two arms — an unrecognized third value likely means the
-#: base image or Neon's default collation changed and this list (and the
-#: runbook) needs updating alongside it.
-_KNOWN_TEST_COLLATIONS = frozenset({"en_US.utf8", "C.UTF-8"})
+#: Documented in docs/ops/anonymous-session-purge.md. Both are legitimate,
+#: observed values for this suite's two arms; an unrecognized third value
+#: likely means the base image or Neon's default collation changed and
+#: this needs updating alongside it (here and in the runbook).
+#:
+#: `en_US.utf8` (offline Docker image) is non-C: a plain btree cannot
+#: service a LIKE prefix match at all there, which is exactly the case
+#: text_pattern_ops exists for — the plan-shape assertion below is only
+#: meaningful, and only enforced, on this collation.
+#:
+#: `C.UTF-8` (live Neon test branches) already orders bytewise, so ANY
+#: btree — with or without a pattern opclass — can service the same LIKE
+#: prefix natively. Under this collation the planner is free to prefer a
+#: cheaper pre-existing index (e.g. idx_conversations_user_id_updated_at)
+#: for this query, confirmed against real CI runs on a populated shared
+#: branch — that is a correct cost decision, not a bug, so the plan-shape
+#: assertion is skipped here. The opclass check (the index exists with
+#: text_pattern_ops) still runs unconditionally in both arms.
+_NON_C_COLLATIONS = frozenset({"en_US.utf8"})
+_KNOWN_TEST_COLLATIONS = _NON_C_COLLATIONS | {"C.UTF-8"}
 
 
 @pytest.mark.integration
@@ -108,15 +117,15 @@ async def test_purge_predicate_hits_the_pattern_ops_index_not_a_seq_scan(
     LIKE prefix match at all — only `text_pattern_ops` can.
 
     Mutation-direction verified locally: reverting the index to default ops
-    (drop + recreate without `text_pattern_ops`) makes THIS test fail while
-    `test_retention_purges_only_the_inactive_routeless_sibling` (the
-    behavioral happy path) keeps passing. Two independent assertions catch
-    it: the opclass check (structural) and the pattern-operator check
-    (behavioral) — a bare "no Seq Scan" assertion would be a tautology
-    under `enable_seqscan = off` (any btree scan, pattern-capable or not,
-    satisfies it), so this pins the actual pattern range-scan operators
-    (`~>=~` / `~<~`) that only appear in the plan when a pattern opclass
-    index services the LIKE prefix — confirmed empirically on both arms."""
+    (drop + recreate without `text_pattern_ops`) makes THIS test fail on
+    the non-C arm while `test_retention_purges_only_the_inactive_routeless_
+    sibling` (the behavioral happy path) keeps passing. The opclass check
+    (structural, always) and the pattern-operator check (behavioral,
+    non-C-collation-only — see `_NON_C_COLLATIONS`) catch it; a bare "no
+    Seq Scan" assertion would be a tautology under `enable_seqscan = off`
+    (any btree scan satisfies it), so this pins the actual pattern
+    range-scan operators (`~>=~` / `~<~`) that only appear in the plan
+    when a pattern opclass index services the LIKE prefix."""
     async with real_db.pool.acquire() as connection:
         collation = await connection.fetchval(
             "SELECT datcollate FROM pg_database WHERE datname = current_database()"
@@ -128,6 +137,9 @@ async def test_purge_predicate_hits_the_pattern_ops_index_not_a_seq_scan(
         )
         assert index_def is not None
         assert "text_pattern_ops" in index_def
+
+        if collation not in _NON_C_COLLATIONS:
+            return
 
         await connection.execute("SET enable_seqscan = off")
         try:

--- a/apps/agent/agent/tests/integration/test_session_retention_integrity.py
+++ b/apps/agent/agent/tests/integration/test_session_retention_integrity.py
@@ -93,11 +93,21 @@ async def test_purge_predicate_hits_the_pattern_ops_index_not_a_seq_scan(
     """Index/collation integrity (rev6 P1-1). Under a non-C collation, a
     plain btree on `user_id` cannot service a LIKE prefix match at all — only
     `text_pattern_ops` can. Recording the collation makes that context
-    explicit rather than assumed. Reverting the index to default ops (drop
-    + recreate without `text_pattern_ops`) makes this assertion fail while
-    `test_retention_purges_only_the_inactive_routeless_sibling`
-    (the behavioral happy path) keeps passing — proving this is a distinct,
-    necessary check, not a duplicate of the behavioral test."""
+    explicit rather than assumed.
+
+    The opclass assertion below (not the plan shape) is what catches the
+    mutation: reverting the index to default ops (drop + recreate without
+    `text_pattern_ops`) makes THIS test fail while
+    `test_retention_purges_only_the_inactive_routeless_sibling` (the
+    behavioral happy path) keeps passing — verified locally. The plan
+    assertion intentionally does not pin the exact index name: on a
+    populated environment (e.g. a shared Neon branch with rows accumulated
+    across the whole suite) the planner may reasonably prefer the
+    pre-existing `idx_conversations_user_id_updated_at` composite index
+    over this one — both are index scans, and choosing between two valid
+    index paths is a cost decision outside this migration's control. What
+    must always hold, regardless of which valid index wins, is that no
+    `Seq Scan` on `conversations` appears."""
     async with real_db.pool.acquire() as connection:
         collation = await connection.fetchval(
             "SELECT datcollate FROM pg_database WHERE datname = current_database()"
@@ -118,4 +128,4 @@ async def test_purge_predicate_hits_the_pattern_ops_index_not_a_seq_scan(
         finally:
             await connection.execute("SET enable_seqscan = on")
     plan_text = "\n".join(row["QUERY PLAN"] for row in plan_rows)
-    assert "idx_conversations_user_id_pattern" in plan_text
+    assert "Seq Scan on conversations" not in plan_text

--- a/apps/agent/agent/tests/integration/test_session_retention_integrity.py
+++ b/apps/agent/agent/tests/integration/test_session_retention_integrity.py
@@ -1,0 +1,121 @@
+"""Real-Postgres coverage for the retention sweep's structural safety nets
+(issue #273 Task 3, review round 2). Complements
+`test_session_identity_transition.py`: this file proves the things a
+mocked-pool unit test cannot — that a real user's row survives the sweep
+(not just "the SQL string mentions a prefix check"), that the DELETE closes
+the find-then-delete race against a real concurrent write, and that the
+purge predicate actually uses the `text_pattern_ops` index rather than a
+sequential scan.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agent.infrastructure.supabase.client import SupabaseClient
+from agent.infrastructure.supabase.repositories.session import _FIND_PURGEABLE_SQL
+from agent.scripts.purge_anonymous_sessions import purge_anonymous_sessions
+
+# `agent.tests.conftest_db` is already registered by the directory-level
+# `tests/integration/conftest.py` (`pytest_plugins`) — redeclaring it here
+# would be a no-op duplicate (review round 2 Sonar smell).
+
+
+def _anon_id() -> str:
+    return "anon_" + uuid.uuid4().hex
+
+
+def _days_ago(days: int) -> datetime:
+    return datetime.now(UTC) - timedelta(days=days)
+
+
+async def _seed_session(db: SupabaseClient, session_id: str, user_id: str) -> None:
+    await db.session.create_owned_session(session_id, user_id, "hello", {})
+
+
+async def _backdate(db: SupabaseClient, session_id: str, when: datetime) -> None:
+    await db.pool.execute(
+        "UPDATE conversations SET updated_at = $1 WHERE session_id = $2",
+        when,
+        session_id,
+    )
+
+
+@pytest.mark.integration
+async def test_a_real_logged_in_user_row_survives_regardless_of_age(real_db) -> None:
+    """Real behavioral proof, not a SQL-text assertion: a genuinely present
+    real-user conversation, 400 days stale, must never be swept — widening
+    the anon-prefix LIKE would make this go red."""
+    real_user_session = f"sess-{uuid.uuid4().hex}"
+    await _seed_session(real_db, real_user_session, "real-user-survivor")
+    await _backdate(real_db, real_user_session, _days_ago(400))
+
+    report = await purge_anonymous_sessions(real_db, retention_days=30)
+
+    assert report.purged == 0
+    assert await real_db.session.get_conversation(real_user_session) is not None
+
+
+@pytest.mark.integration
+async def test_purge_session_race_a_concurrent_login_saves_the_session(
+    real_db,
+) -> None:
+    """A real find-then-delete race: the eligibility scan runs, then the
+    owner logs in (migrate_ownership) before the delete executes. The
+    DELETE's own re-asserted predicate must find zero rows and leave the
+    session untouched — not rely on the caller's stale candidate list."""
+    anon = _anon_id()
+    session_id = f"sess-{uuid.uuid4().hex}"
+    await _seed_session(real_db, session_id, anon)
+    cutoff = _days_ago(30)
+    await _backdate(real_db, session_id, _days_ago(40))
+
+    candidates = await real_db.session.find_purgeable_anonymous_sessions(cutoff)
+    assert session_id in candidates
+
+    # The race: the owner logs in between the scan above and the delete below.
+    await real_db.session.migrate_ownership(anon, "real-user-race")
+
+    purged = await real_db.session.purge_session(session_id, cutoff)
+
+    assert purged is False
+    assert await real_db.session.get_conversation(session_id) is not None
+    assert await real_db.session.get_session(session_id) is not None
+
+
+@pytest.mark.integration
+async def test_purge_predicate_hits_the_pattern_ops_index_not_a_seq_scan(
+    real_db,
+) -> None:
+    """Index/collation integrity (rev6 P1-1). Under a non-C collation, a
+    plain btree on `user_id` cannot service a LIKE prefix match at all — only
+    `text_pattern_ops` can. Recording the collation makes that context
+    explicit rather than assumed. Reverting the index to default ops (drop
+    + recreate without `text_pattern_ops`) makes this assertion fail while
+    `test_retention_purges_only_the_inactive_routeless_sibling`
+    (the behavioral happy path) keeps passing — proving this is a distinct,
+    necessary check, not a duplicate of the behavioral test."""
+    async with real_db.pool.acquire() as connection:
+        collation = await connection.fetchval(
+            "SELECT datcollate FROM pg_database WHERE datname = current_database()"
+        )
+        assert collation
+        index_def = await connection.fetchval(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE indexname = 'idx_conversations_user_id_pattern'"
+        )
+        assert index_def is not None
+        assert "text_pattern_ops" in index_def
+
+        await connection.execute("SET enable_seqscan = off")
+        try:
+            plan_rows = await connection.fetch(
+                f"EXPLAIN {_FIND_PURGEABLE_SQL}", _days_ago(0)
+            )
+        finally:
+            await connection.execute("SET enable_seqscan = on")
+    plan_text = "\n".join(row["QUERY PLAN"] for row in plan_rows)
+    assert "idx_conversations_user_id_pattern" in plan_text

--- a/apps/agent/agent/tests/unit/repositories/test_session_repo.py
+++ b/apps/agent/agent/tests/unit/repositories/test_session_repo.py
@@ -128,3 +128,37 @@ async def test_check_session_owner_returns_false_when_not_owned(
     pool.fetchrow.return_value = None
     result = await repo.check_session_owner("sess-1", "user-999")
     assert result is False
+
+
+async def test_migrate_ownership_returns_true_when_rows_changed(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = "UPDATE 2"
+    result = await repo.migrate_ownership("anon_" + "a" * 32, "user-1")
+    assert result is True
+    sql, to_user, from_anon = pool.execute.await_args.args
+    assert "UPDATE conversations" in sql
+    assert to_user == "user-1"
+    assert from_anon == "anon_" + "a" * 32
+
+
+async def test_migrate_ownership_is_idempotent_second_run_is_a_no_op(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    """Running the transition twice: the second run matches zero rows and
+    reports the no-op outcome without error — an UPDATE, never an INSERT."""
+    pool.execute.return_value = "UPDATE 0"
+    result = await repo.migrate_ownership("anon_" + "a" * 32, "user-1")
+    assert result is False
+
+
+async def test_migrate_ownership_where_clause_only_ever_matches_the_anon_param(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    """Structural safety: the WHERE predicate binds to $2 (the anon id), so a
+    real user's row is unmatchable by construction, not by a runtime guard."""
+    pool.execute.return_value = "UPDATE 0"
+    await repo.migrate_ownership("anon_" + "a" * 32, "user-1")
+    sql = pool.execute.await_args.args[0]
+    assert "WHERE user_id = $2" in sql
+    assert "SET user_id = $1" in sql

--- a/apps/agent/agent/tests/unit/repositories/test_session_repo.py
+++ b/apps/agent/agent/tests/unit/repositories/test_session_repo.py
@@ -162,3 +162,13 @@ async def test_migrate_ownership_where_clause_only_ever_matches_the_anon_param(
     sql = pool.execute.await_args.args[0]
     assert "WHERE user_id = $2" in sql
     assert "SET user_id = $1" in sql
+
+
+async def test_migrate_ownership_survives_a_malformed_command_tag(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    """A command tag with no trailing row count must never raise — a parse
+    failure here would turn a successful mutation into a 500."""
+    pool.execute.return_value = ""
+    result = await repo.migrate_ownership("anon_" + "a" * 32, "user-1")
+    assert result is False

--- a/apps/agent/agent/tests/unit/routes/test_session_migration.py
+++ b/apps/agent/agent/tests/unit/routes/test_session_migration.py
@@ -1,0 +1,127 @@
+"""Unit tests for POST /v1/session/migrate (issue #273 Task 3).
+
+Covers the endpoint contract: auth predicate positive/negative, response
+shape, and trusted-input validation of X-Anon-Id.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+VALID_ANON_ID = "anon_" + "a" * 32
+
+
+def _headers(
+    *,
+    user_id: str = "user-1",
+    user_type: str = "human",
+    anon_id: str | None = VALID_ANON_ID,
+) -> dict[str, str]:
+    headers = {"X-User-Id": user_id, "X-User-Type": user_type}
+    if anon_id is not None:
+        headers["X-Anon-Id"] = anon_id
+    return headers
+
+
+async def test_happy_path_migrates_and_returns_true() -> None:
+    db = build_stub_db()
+    db.session.migrate_ownership = AsyncMock(return_value=True)
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        resp = await client.post("/v1/session/migrate", headers=_headers())
+    assert resp.status_code == 200
+    assert resp.json() == {"migrated": True}
+    db.session.migrate_ownership.assert_awaited_once_with(VALID_ANON_ID, "user-1")
+
+
+async def test_no_owned_conversations_returns_false_not_error() -> None:
+    db = build_stub_db()
+    db.session.migrate_ownership = AsyncMock(return_value=False)
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        resp = await client.post("/v1/session/migrate", headers=_headers())
+    assert resp.status_code == 200
+    assert resp.json() == {"migrated": False}
+
+
+async def test_missing_x_anon_id_returns_false_and_mutates_nothing() -> None:
+    db = build_stub_db()
+    db.session.migrate_ownership = AsyncMock(return_value=True)
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        resp = await client.post("/v1/session/migrate", headers=_headers(anon_id=None))
+    assert resp.status_code == 200
+    assert resp.json() == {"migrated": False}
+    db.session.migrate_ownership.assert_not_called()
+
+
+async def test_anonymous_user_type_is_rejected_403_and_mutates_nothing() -> None:
+    db = build_stub_db()
+    db.session.migrate_ownership = AsyncMock(return_value=True)
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        resp = await client.post(
+            "/v1/session/migrate",
+            headers=_headers(user_id=VALID_ANON_ID, user_type="anonymous"),
+        )
+    assert resp.status_code == 403
+    db.session.migrate_ownership.assert_not_called()
+
+
+async def test_anon_prefixed_user_id_is_rejected_even_with_human_type() -> None:
+    db = build_stub_db()
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        resp = await client.post(
+            "/v1/session/migrate",
+            headers=_headers(user_id=VALID_ANON_ID, user_type="human"),
+        )
+    assert resp.status_code == 403
+    db.session.migrate_ownership.assert_not_called()
+
+
+async def test_real_production_literal_human_is_accepted() -> None:
+    db = build_stub_db()
+    db.session.migrate_ownership = AsyncMock(return_value=False)
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        resp = await client.post(
+            "/v1/session/migrate", headers=_headers(user_type="human")
+        )
+    assert resp.status_code == 200
+
+
+async def test_real_production_literal_agent_is_accepted() -> None:
+    db = build_stub_db()
+    db.session.migrate_ownership = AsyncMock(return_value=False)
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        resp = await client.post(
+            "/v1/session/migrate", headers=_headers(user_type="agent")
+        )
+    assert resp.status_code == 200
+
+
+async def test_malformed_x_anon_id_is_treated_as_missing() -> None:
+    db = build_stub_db()
+    db.session.migrate_ownership = AsyncMock(return_value=True)
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        resp = await client.post(
+            "/v1/session/migrate", headers=_headers(anon_id="not-an-anon-id")
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"migrated": False}
+    db.session.migrate_ownership.assert_not_called()
+
+
+async def test_response_shape_is_exactly_migrated_bool() -> None:
+    db = build_stub_db()
+    db.session.migrate_ownership = AsyncMock(return_value=True)
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        resp = await client.post("/v1/session/migrate", headers=_headers())
+    assert set(resp.json().keys()) == {"migrated"}
+    assert isinstance(resp.json()["migrated"], bool)

--- a/apps/agent/agent/tests/unit/test_purge_workflow_trigger.py
+++ b/apps/agent/agent/tests/unit/test_purge_workflow_trigger.py
@@ -1,12 +1,18 @@
 """The purge sweep must have a scheduled trigger (issue #273 Task 3, P1-5).
 
 Follows the agent-eval-nightly.yml precedent: a standalone workflow with a
-`schedule:` cron trigger that invokes the purge CLI as a module.
+`schedule:` cron trigger that invokes the purge CLI as a module. Parsed with
+`yaml.safe_load` rather than string containment (review round 2) — a broken
+or reformatted YAML file with the right substrings anywhere in it would
+otherwise still pass.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
+
+import yaml
 
 WORKFLOW = (
     Path(__file__).resolve().parents[5]
@@ -15,23 +21,61 @@ WORKFLOW = (
     / "purge-anonymous-sessions.yml"
 )
 
+#: PyYAML's default (YAML 1.1) resolver parses the unquoted `on:` workflow
+#: key as the boolean `True`, not the string `"on"` — a well-known gotcha.
+#: Reading via this constant documents that rather than silently relying on
+#: it, so anyone reading `doc[_ON]` doesn't mistake it for a typo.
+_ON = True
+
+
+def _load() -> dict[str, object]:
+    return cast(dict[str, object], yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+
 
 def test_workflow_file_exists() -> None:
     assert WORKFLOW.is_file()
 
 
+def test_workflow_parses_as_valid_yaml_with_the_expected_top_level_shape() -> None:
+    doc = _load()
+    assert isinstance(doc, dict)
+    assert {"name", "jobs", _ON} <= doc.keys()
+
+
 def test_workflow_has_a_cron_schedule_trigger() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
-    assert "schedule:" in text
-    assert "cron:" in text
+    doc = _load()
+    triggers = doc[_ON]
+    assert isinstance(triggers, dict)
+    assert "schedule" in triggers
+    schedule = triggers["schedule"]
+    assert isinstance(schedule, list) and len(schedule) == 1
+    assert "cron" in schedule[0]
+    assert isinstance(schedule[0]["cron"], str)
+
+
+def test_workflow_also_allows_manual_dispatch() -> None:
+    doc = _load()
+    assert "workflow_dispatch" in doc[_ON]
 
 
 def test_workflow_invokes_the_purge_cli_module() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
-    assert "agent.scripts.purge_anonymous_sessions" in text
+    doc = _load()
+    steps = doc["jobs"]["purge"]["steps"]
+    run_commands = [step["run"] for step in steps if "run" in step]
+    assert any("agent.scripts.purge_anonymous_sessions" in cmd for cmd in run_commands)
 
 
 def test_workflow_supplies_the_supabase_db_url_secret() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
-    assert "SUPABASE_DB_URL" in text
-    assert "secrets.SUPABASE_DB_URL" in text
+    doc = _load()
+    steps = doc["jobs"]["purge"]["steps"]
+    sweep_step = next(
+        step
+        for step in steps
+        if "run" in step and "purge_anonymous_sessions" in step["run"]
+    )
+    assert sweep_step["env"]["SUPABASE_DB_URL"] == "${{ secrets.SUPABASE_DB_URL }}"
+
+
+def test_workflow_job_has_a_timeout() -> None:
+    doc = _load()
+    assert isinstance(doc["jobs"]["purge"]["timeout-minutes"], int)

--- a/apps/agent/agent/tests/unit/test_purge_workflow_trigger.py
+++ b/apps/agent/agent/tests/unit/test_purge_workflow_trigger.py
@@ -1,0 +1,37 @@
+"""The purge sweep must have a scheduled trigger (issue #273 Task 3, P1-5).
+
+Follows the agent-eval-nightly.yml precedent: a standalone workflow with a
+`schedule:` cron trigger that invokes the purge CLI as a module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[5]
+    / ".github"
+    / "workflows"
+    / "purge-anonymous-sessions.yml"
+)
+
+
+def test_workflow_file_exists() -> None:
+    assert WORKFLOW.is_file()
+
+
+def test_workflow_has_a_cron_schedule_trigger() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "schedule:" in text
+    assert "cron:" in text
+
+
+def test_workflow_invokes_the_purge_cli_module() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "agent.scripts.purge_anonymous_sessions" in text
+
+
+def test_workflow_supplies_the_supabase_db_url_secret() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "SUPABASE_DB_URL" in text
+    assert "secrets.SUPABASE_DB_URL" in text

--- a/apps/agent/agent/tests/unit/test_session_ownership.py
+++ b/apps/agent/agent/tests/unit/test_session_ownership.py
@@ -1,0 +1,39 @@
+"""Unit tests for agent.agents.session_ownership (issue #273 Task 3)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from agent.agents.session_ownership import migrate_session_ownership
+
+
+def _db(*, migrate_return: bool = True) -> MagicMock:
+    db = MagicMock()
+    db.session.migrate_ownership = AsyncMock(return_value=migrate_return)
+    return db
+
+
+async def test_missing_from_anon_id_is_a_no_op_without_a_db_call() -> None:
+    db = _db()
+    outcome = await migrate_session_ownership(
+        db, from_anon_id=None, to_user_id="user-1"
+    )
+    assert outcome.migrated is False
+    db.session.migrate_ownership.assert_not_called()
+
+
+async def test_forwards_to_repository_and_returns_true_on_match() -> None:
+    db = _db(migrate_return=True)
+    outcome = await migrate_session_ownership(
+        db, from_anon_id="anon_" + "a" * 32, to_user_id="user-1"
+    )
+    assert outcome.migrated is True
+    db.session.migrate_ownership.assert_awaited_once_with("anon_" + "a" * 32, "user-1")
+
+
+async def test_zero_matched_rows_is_a_typed_no_op_not_an_exception() -> None:
+    db = _db(migrate_return=False)
+    outcome = await migrate_session_ownership(
+        db, from_anon_id="anon_" + "b" * 32, to_user_id="user-1"
+    )
+    assert outcome.migrated is False

--- a/apps/agent/agent/tests/unit/test_session_retention.py
+++ b/apps/agent/agent/tests/unit/test_session_retention.py
@@ -1,0 +1,108 @@
+"""Unit tests for the retention query shape (issue #273 Task 3).
+
+Behavioral proof that the exclusion predicate is selective (not a blanket
+skip) and that real users are never touched lives in the Docker-backed
+`tests/integration/test_session_identity_transition.py`. These tests pin the
+generated SQL's structural contract with a mocked pool, so a later edit that
+deletes the route-association `NOT EXISTS` clause or swaps the collation-
+unsafe range scan back in fails immediately, without needing Postgres.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.infrastructure.supabase.repositories.session import SessionRepository
+from agent.scripts.purge_anonymous_sessions import purge_anonymous_sessions
+
+CUTOFF = datetime(2026, 6, 28, tzinfo=UTC)
+
+
+@pytest.fixture
+def pool() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def repo(pool: AsyncMock) -> SessionRepository:
+    return SessionRepository(pool)
+
+
+async def test_find_purgeable_excludes_route_bearing_sessions_by_construction(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    """The exclusion pair: the predicate must carry a NOT EXISTS against
+    routes, not a blanket "no filter at all" scan."""
+    pool.fetch.return_value = []
+    await repo.find_purgeable_anonymous_sessions(CUTOFF)
+    sql = pool.fetch.await_args.args[0]
+    assert "NOT EXISTS" in sql
+    assert "routes r" in sql
+    assert "r.session_id = c.session_id" in sql
+
+
+async def test_find_purgeable_uses_collation_safe_like_not_a_range_scan(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    """Collation trap guard: an anon-prefix match must be an escaped LIKE
+    (paired with the text_pattern_ops index), never a `>=`/`<` range scan."""
+    pool.fetch.return_value = []
+    await repo.find_purgeable_anonymous_sessions(CUTOFF)
+    sql = pool.fetch.await_args.args[0]
+    assert "LIKE 'anon\\_%' ESCAPE '\\'" in sql
+    assert ">=" not in sql
+    assert "<=" not in sql
+
+
+async def test_find_purgeable_passes_cutoff_as_the_liveness_bound(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = []
+    await repo.find_purgeable_anonymous_sessions(CUTOFF)
+    sql, cutoff_arg = pool.fetch.await_args.args
+    assert "c.updated_at < $1" in sql
+    assert cutoff_arg == CUTOFF
+
+
+async def test_find_purgeable_returns_session_ids_from_rows(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    pool.fetch.return_value = [{"session_id": "sess-a"}, {"session_id": "sess-b"}]
+    result = await repo.find_purgeable_anonymous_sessions(CUTOFF)
+    assert result == ["sess-a", "sess-b"]
+
+
+async def test_purge_run_with_no_eligible_rows_deletes_nothing() -> None:
+    db = AsyncMock()
+    db.session.find_purgeable_anonymous_sessions = AsyncMock(return_value=[])
+    db.session.purge_session = AsyncMock()
+    purged = await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)
+    assert purged == 0
+    db.session.purge_session.assert_not_called()
+
+
+async def test_purge_run_deletes_every_eligible_session_once() -> None:
+    db = AsyncMock()
+    db.session.find_purgeable_anonymous_sessions = AsyncMock(
+        return_value=["sess-a", "sess-b"]
+    )
+    db.session.purge_session = AsyncMock()
+    purged = await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)
+    assert purged == 2
+    assert db.session.purge_session.await_count == 2
+    db.session.purge_session.assert_any_await("sess-a")
+    db.session.purge_session.assert_any_await("sess-b")
+
+
+async def test_dry_run_reports_without_deleting() -> None:
+    db = AsyncMock()
+    db.session.find_purgeable_anonymous_sessions = AsyncMock(return_value=["sess-a"])
+    db.session.purge_session = AsyncMock()
+    purged = await purge_anonymous_sessions(
+        db, retention_days=30, now=CUTOFF, dry_run=True
+    )
+    assert purged == 1
+    db.session.purge_session.assert_not_called()

--- a/apps/agent/agent/tests/unit/test_session_retention.py
+++ b/apps/agent/agent/tests/unit/test_session_retention.py
@@ -1,17 +1,19 @@
 """Unit tests for the retention query shape (issue #273 Task 3).
 
 Behavioral proof that the exclusion predicate is selective (not a blanket
-skip) and that real users are never touched lives in the Docker-backed
-`tests/integration/test_session_identity_transition.py`. These tests pin the
-generated SQL's structural contract with a mocked pool, so a later edit that
-deletes the route-association `NOT EXISTS` clause or swaps the collation-
-unsafe range scan back in fails immediately, without needing Postgres.
+skip), that real users are never touched, and that the index/collation
+contract holds lives in the Docker-backed integration suite
+(`tests/integration/test_session_identity_transition.py` and
+`test_session_retention_integrity.py`). These tests pin the generated SQL's
+structural contract with a mocked pool, so a later edit that deletes the
+route-association `NOT EXISTS` clause or swaps the collation-unsafe range
+scan back in fails immediately, without needing Postgres.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-from unittest.mock import AsyncMock
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
 
 import asyncpg
 import pytest
@@ -76,12 +78,37 @@ async def test_find_purgeable_returns_session_ids_from_rows(
     assert result == ["sess-a", "sess-b"]
 
 
+async def test_purge_session_delete_reasserts_the_anon_and_cutoff_predicate(
+    repo: SessionRepository, pool: AsyncMock
+) -> None:
+    """Race guard, structural: the conversation DELETE re-checks anon
+    ownership and the cutoff, not just session_id — so a row changed
+    between the scan and this call (e.g. by a login) cannot be matched."""
+    connection = AsyncMock()
+    connection.execute.return_value = "DELETE 0"
+    transaction = MagicMock()
+    connection.transaction = MagicMock(return_value=transaction)
+    acquire = MagicMock()
+    acquire.__aenter__ = AsyncMock(return_value=connection)
+    pool.acquire = MagicMock(return_value=acquire)
+
+    purged = await repo.purge_session("sess-a", CUTOFF)
+
+    assert purged is False
+    sql = connection.execute.await_args_list[0].args[0]
+    assert "user_id LIKE 'anon\\_%' ESCAPE '\\'" in sql
+    assert "updated_at < $2" in sql
+    assert "session_id = $1" in sql
+    # Zero rows matched -> the sessions delete must never run.
+    assert connection.execute.await_count == 1
+
+
 async def test_purge_run_with_no_eligible_rows_deletes_nothing() -> None:
     db = AsyncMock()
     db.session.find_purgeable_anonymous_sessions = AsyncMock(return_value=[])
     db.session.purge_session = AsyncMock()
-    purged = await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)
-    assert purged == 0
+    report = await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)
+    assert report.purged == 0
     db.session.purge_session.assert_not_called()
 
 
@@ -90,23 +117,40 @@ async def test_purge_run_deletes_every_eligible_session_once() -> None:
     db.session.find_purgeable_anonymous_sessions = AsyncMock(
         return_value=["sess-a", "sess-b"]
     )
-    db.session.purge_session = AsyncMock()
-    purged = await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)
-    assert purged == 2
+    db.session.purge_session = AsyncMock(return_value=True)
+    report = await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)
+    assert report.purged == 2
     assert db.session.purge_session.await_count == 2
-    db.session.purge_session.assert_any_await("sess-a")
-    db.session.purge_session.assert_any_await("sess-b")
+    expected_cutoff = CUTOFF - timedelta(days=30)
+    db.session.purge_session.assert_any_await("sess-a", expected_cutoff)
+    db.session.purge_session.assert_any_await("sess-b", expected_cutoff)
 
 
 async def test_dry_run_reports_without_deleting() -> None:
     db = AsyncMock()
     db.session.find_purgeable_anonymous_sessions = AsyncMock(return_value=["sess-a"])
     db.session.purge_session = AsyncMock()
-    purged = await purge_anonymous_sessions(
+    report = await purge_anonymous_sessions(
         db, retention_days=30, now=CUTOFF, dry_run=True
     )
-    assert purged == 1
+    assert report.purged == 1
     db.session.purge_session.assert_not_called()
+
+
+async def test_a_raced_session_is_not_counted_as_purged_or_failed() -> None:
+    """`purge_session` returning False (its own predicate matched zero rows)
+    is the find-then-delete race resolving itself — not a failure."""
+    db = AsyncMock()
+    db.session.find_purgeable_anonymous_sessions = AsyncMock(
+        return_value=["sess-a", "sess-raced"]
+    )
+    db.session.purge_session = AsyncMock(side_effect=[True, False])
+
+    report = await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)
+
+    assert report.purged == 1
+    assert report.raced == 1
+    assert report.failed == 0
 
 
 async def test_one_session_fk_race_is_isolated_the_sweep_continues() -> None:
@@ -118,15 +162,17 @@ async def test_one_session_fk_race_is_isolated_the_sweep_continues() -> None:
         return_value=["sess-a", "sess-race", "sess-b"]
     )
 
-    async def _purge(session_id: str) -> None:
+    async def _purge(session_id: str, cutoff: datetime) -> bool:
         if session_id == "sess-race":
             raise asyncpg.ForeignKeyViolationError("routes_session_id_fkey")
+        return True
 
     db.session.purge_session = AsyncMock(side_effect=_purge)
 
-    purged = await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)
+    report = await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)
 
-    assert purged == 2
+    assert report.purged == 2
+    assert report.failed == 1
     assert db.session.purge_session.await_count == 3
 
 

--- a/apps/agent/agent/tests/unit/test_session_retention.py
+++ b/apps/agent/agent/tests/unit/test_session_retention.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
+import asyncpg
 import pytest
 
 from agent.infrastructure.supabase.repositories.session import SessionRepository
@@ -106,3 +107,35 @@ async def test_dry_run_reports_without_deleting() -> None:
     )
     assert purged == 1
     db.session.purge_session.assert_not_called()
+
+
+async def test_one_session_fk_race_is_isolated_the_sweep_continues() -> None:
+    """A concurrent-race FK backstop hit on one session must not abort the
+    rest of the sweep — it is exactly the case the backstop exists to catch,
+    not a reason to red the whole cron run."""
+    db = AsyncMock()
+    db.session.find_purgeable_anonymous_sessions = AsyncMock(
+        return_value=["sess-a", "sess-race", "sess-b"]
+    )
+
+    async def _purge(session_id: str) -> None:
+        if session_id == "sess-race":
+            raise asyncpg.ForeignKeyViolationError("routes_session_id_fkey")
+
+    db.session.purge_session = AsyncMock(side_effect=_purge)
+
+    purged = await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)
+
+    assert purged == 2
+    assert db.session.purge_session.await_count == 3
+
+
+async def test_a_non_postgres_error_is_not_swallowed_and_propagates() -> None:
+    """An unexpected (non-database) failure is a programming bug, not a
+    benign race — it must propagate so the CLI exits nonzero."""
+    db = AsyncMock()
+    db.session.find_purgeable_anonymous_sessions = AsyncMock(return_value=["sess-a"])
+    db.session.purge_session = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await purge_anonymous_sessions(db, retention_days=30, now=CUTOFF)

--- a/db/migrations/20260728000001_conversations_user_id_pattern_ops.sql
+++ b/db/migrations/20260728000001_conversations_user_id_pattern_ops.sql
@@ -1,0 +1,10 @@
+-- Auth-stripped Atlas twin of
+-- supabase/migrations/20260728000001_conversations_user_id_pattern_ops.sql.
+--
+-- Collation-safe index for the anonymous-session retention sweep (issue #273
+-- Task 3). The purge predicate matches `user_id LIKE 'anon\_%' ESCAPE '\'`
+-- rather than a `>=`/`<` range scan — the latter is a collation trap under
+-- non-C locales. `text_pattern_ops` is what lets that LIKE prefix match use
+-- an index instead of a full table scan.
+CREATE INDEX IF NOT EXISTS idx_conversations_user_id_pattern
+    ON conversations (user_id text_pattern_ops);

--- a/db/migrations/20260728000001_conversations_user_id_pattern_ops.sql
+++ b/db/migrations/20260728000001_conversations_user_id_pattern_ops.sql
@@ -6,5 +6,15 @@
 -- rather than a `>=`/`<` range scan — the latter is a collation trap under
 -- non-C locales. `text_pattern_ops` is what lets that LIKE prefix match use
 -- an index instead of a full table scan.
+--
+-- Lock behavior (CONCURRENTLY evaluated, not used): CREATE INDEX takes a
+-- SHARE lock on `conversations` for the build's duration, blocking writers
+-- but not readers. CREATE INDEX CONCURRENTLY avoids that at the cost of two
+-- table scans and no transactional guarantee — and both this Atlas apply and
+-- the Supabase migration runner execute each file inside one transaction, a
+-- context CONCURRENTLY cannot run in at all (Postgres rejects it outright).
+-- `conversations` is small pre-launch, so the plain build's brief lock is the
+-- right trade; revisit if the table grows enough for the lock window itself
+-- to matter.
 CREATE INDEX IF NOT EXISTS idx_conversations_user_id_pattern
     ON conversations (user_id text_pattern_ops);

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:EffLb6pV9SMrftmi1hLeZTwOsVtoA2DPZV1GAhn+r88=
+h1:Y3AvBx7jEkPGh6dSEUWkBfSZNM3E6wHYwAQCQ+FN4K0=
 20260623000001_init.sql h1:j96dtVbOQB/5eNuug4tZpdgURdZ5h0Zh4Vka7/dy1A0=
 20260713000001_user_routes.sql h1:th9ag/cdiRp9plYQraVBGIuRXeH4g5R3XvCuGZeFx8Q=
 20260714000001_catalog_geocoding.sql h1:EwkJGRPfg5camebXRzw+5xRVf6TWu23t3/tnw91uPwY=
@@ -8,4 +8,4 @@ h1:EffLb6pV9SMrftmi1hLeZTwOsVtoA2DPZV1GAhn+r88=
 20260718000001_route_anime.sql h1:aNfUvjp3QCuhrePCZTDzZ4vtCFMVdj/wZG4xsQ9m8Kw=
 20260719000001_agent_memory.sql h1:YRvJLyq+VR6A42DfNC9rAczEaxjaVHsPZMlaNCBZiGQ=
 20260726000001_daily_usage.sql h1:sBFx7wFXsR8SKXqny7S87YZiamGNDA0FXMrSV3EXj7c=
-20260728000001_conversations_user_id_pattern_ops.sql h1:OfQscuOBN6UwrfXfMGXzF3FOutvWesVu6/AB6xFNh3A=
+20260728000001_conversations_user_id_pattern_ops.sql h1:7SCuWtKAHlYDv4EINCwR6NYWw/qJ7afcC3+rUoqHuaM=

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:29u6tCsL1OMHpJouw2hjm6SyoR44FWYl1MUB7MkJups=
+h1:EffLb6pV9SMrftmi1hLeZTwOsVtoA2DPZV1GAhn+r88=
 20260623000001_init.sql h1:j96dtVbOQB/5eNuug4tZpdgURdZ5h0Zh4Vka7/dy1A0=
 20260713000001_user_routes.sql h1:th9ag/cdiRp9plYQraVBGIuRXeH4g5R3XvCuGZeFx8Q=
 20260714000001_catalog_geocoding.sql h1:EwkJGRPfg5camebXRzw+5xRVf6TWu23t3/tnw91uPwY=
@@ -8,3 +8,4 @@ h1:29u6tCsL1OMHpJouw2hjm6SyoR44FWYl1MUB7MkJups=
 20260718000001_route_anime.sql h1:aNfUvjp3QCuhrePCZTDzZ4vtCFMVdj/wZG4xsQ9m8Kw=
 20260719000001_agent_memory.sql h1:YRvJLyq+VR6A42DfNC9rAczEaxjaVHsPZMlaNCBZiGQ=
 20260726000001_daily_usage.sql h1:sBFx7wFXsR8SKXqny7S87YZiamGNDA0FXMrSV3EXj7c=
+20260728000001_conversations_user_id_pattern_ops.sql h1:OfQscuOBN6UwrfXfMGXzF3FOutvWesVu6/AB6xFNh3A=

--- a/docs/DOCS_POLICY.md
+++ b/docs/DOCS_POLICY.md
@@ -74,6 +74,7 @@ the current monorepo layout; `backend/…` and `worker/worker.js` are pre-monore
 | Eval | `apps/agent/agent/tests/eval/` (Python) | |
 | Testing strategy | `docs/testing-strategy.md` | |
 | Deployment ops | `docs/ops/deployment.md`, `docs/ops/cloudflare-hardening.md` | |
+| Anonymous session purge | `docs/ops/anonymous-session-purge.md`, `.github/workflows/purge-anonymous-sessions.yml` | scheduled retention sweep, issue #273 Task 3 |
 
 ## Review Check
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -12,5 +12,6 @@ Current canonical docs:
 - `deployment.md` — Cloudflare Workers + Containers deployment runbook (topology, auth flow, env boundaries, rollback)
 - `cloudflare-hardening.md` — WAF rate limiting, prompt-injection filtering, rollback for edge rules
 - `preview.md` — per-PR preview environments (label-gated CF preview URLs + Neon branch-per-PR + auto-teardown)
+- `anonymous-session-purge.md` — scheduled anonymous-session retention sweep (cron cadence, required secret, reading a run)
 
 Keep iteration task trackers, progress logs, and findings under `docs/iterations/`.

--- a/docs/ops/anonymous-session-purge.md
+++ b/docs/ops/anonymous-session-purge.md
@@ -74,10 +74,15 @@ someone.
 
 - `db/migrations/20260728000001_conversations_user_id_pattern_ops.sql` +
   the `supabase/migrations/` twin — the `text_pattern_ops` index the purge
-  scan's `LIKE 'anon\_%'` match depends on. The test Postgres image and the
-  Neon test branches this runs against are both provisioned as `en_US.utf8`
-  (a non-C collation) — `tests/integration/test_session_retention_integrity.py`
-  asserts against this value directly; if the environment's collation is
-  ever intentionally changed, update both places together.
+  scan's `LIKE 'anon\_%'` match depends on. The two arms this test suite
+  runs on have **different** observed collations, both legitimate: the
+  offline Docker test image is `en_US.utf8` (non-C — the case this index
+  actually matters for: a plain btree cannot service a LIKE prefix match
+  there), while live Neon test branches are `C.UTF-8` (already
+  byte-ordered, so the index is a belt-and-suspenders match rather than a
+  strict requirement there). `test_session_retention_integrity.py` asserts
+  the observed collation is one of these two known values — if a third
+  value shows up, the base image or Neon's default changed and this list
+  needs updating alongside it.
 - `apps/agent/agent/interfaces/routes/session_migration.py` — the login-time
   ownership transition this purge coexists with.

--- a/docs/ops/anonymous-session-purge.md
+++ b/docs/ops/anonymous-session-purge.md
@@ -79,10 +79,15 @@ someone.
   offline Docker test image is `en_US.utf8` (non-C — the case this index
   actually matters for: a plain btree cannot service a LIKE prefix match
   there), while live Neon test branches are `C.UTF-8` (already
-  byte-ordered, so the index is a belt-and-suspenders match rather than a
-  strict requirement there). `test_session_retention_integrity.py` asserts
-  the observed collation is one of these two known values — if a third
-  value shows up, the base image or Neon's default changed and this list
-  needs updating alongside it.
+  byte-ordered, so ANY btree — with or without the pattern opclass — can
+  service the same LIKE prefix natively, and the query planner is free to
+  prefer a cheaper pre-existing index there instead — confirmed against
+  real CI runs on a populated shared Neon branch, not a bug).
+  `test_session_retention_integrity.py` asserts the observed collation is
+  one of these two known values (always) and additionally asserts the
+  pattern-opclass index is actually used in the query plan, but **only on
+  the non-C arm** where that's the architecturally correct expectation —
+  if a third collation value shows up, the base image or Neon's default
+  changed and this needs updating alongside it.
 - `apps/agent/agent/interfaces/routes/session_migration.py` — the login-time
   ownership transition this purge coexists with.

--- a/docs/ops/anonymous-session-purge.md
+++ b/docs/ops/anonymous-session-purge.md
@@ -74,6 +74,10 @@ someone.
 
 - `db/migrations/20260728000001_conversations_user_id_pattern_ops.sql` +
   the `supabase/migrations/` twin — the `text_pattern_ops` index the purge
-  scan's `LIKE 'anon\_%'` match depends on.
+  scan's `LIKE 'anon\_%'` match depends on. The test Postgres image and the
+  Neon test branches this runs against are both provisioned as `en_US.utf8`
+  (a non-C collation) — `tests/integration/test_session_retention_integrity.py`
+  asserts against this value directly; if the environment's collation is
+  ever intentionally changed, update both places together.
 - `apps/agent/agent/interfaces/routes/session_migration.py` — the login-time
   ownership transition this purge coexists with.

--- a/docs/ops/anonymous-session-purge.md
+++ b/docs/ops/anonymous-session-purge.md
@@ -1,0 +1,79 @@
+# Anonymous session purge runbook
+
+Issue #273 Task 3: the scheduled sweep that deletes stale, routeless anonymous
+sessions so anonymous free-text queries and locations don't accumulate
+without a TTL.
+
+## What it does
+
+`apps/agent/agent/scripts/purge_anonymous_sessions.py` deletes an anonymous
+conversation (and its cascaded `conversation_messages`) plus its `sessions`
+row once:
+
+- `conversations.user_id` matches the `anon_` prefix, and
+- `conversations.updated_at` is older than `anonymous_session_retention_days`
+  (`Settings`, default 30 days), and
+- the session produced **no** `routes` row.
+
+A session that produced a route is retained **permanently**, unconditionally
+— that exclusion is not configurable, only the retention window is.
+
+Each session is purged in its own transaction, and the conversation delete
+re-checks the anon/cutoff predicate rather than trusting the earlier scan —
+closing the race where the owner logs in (`POST /v1/session/migrate`)
+between the eligibility scan and the delete. A session lost to that race, or
+refused by the `routes.session_id` FK backstop, is logged and skipped; the
+rest of the sweep continues. See `agent/scripts/purge_anonymous_sessions.py`
+docstrings and `agent/infrastructure/supabase/repositories/session.py`
+(`purge_session`) for the mechanics.
+
+## Trigger: `.github/workflows/purge-anonymous-sessions.yml`
+
+- **Cron cadence:** `37 18 * * *` (18:37 UTC daily, off-peak, off the hour —
+  matches the `agent-eval-nightly.yml` precedent). Discretionary; change the
+  `cron:` line to retune.
+- **Scheduled workflows only run from the repository's default branch.**
+  Merging this workflow file to a non-default branch (or a stale PR base)
+  will never fire the cron — only `workflow_dispatch` works off-branch. If
+  the sweep appears to have stopped running, confirm the workflow file is
+  actually present on `main`/the default branch, not just on a feature
+  branch or an unmerged PR.
+- **Manual trigger:** `workflow_dispatch` — run it on demand from the Actions
+  tab, or `gh workflow run purge-anonymous-sessions.yml`.
+- **Required secret:** `SUPABASE_DB_URL` in this workflow's GitHub Actions
+  environment. Without it, `Settings` fails fast (`SUPABASE_DB_URL is not
+  set`) and the job goes red — this is deliberate: a missing secret must
+  **fail loudly**, not silently report "nothing to purge" (which is
+  indistinguishable from a healthy day with no eligible sessions).
+- **Local dry run:**
+  ```bash
+  cd apps/agent
+  SUPABASE_DB_URL=... uv run python -m agent.scripts.purge_anonymous_sessions --dry-run
+  ```
+  Reports the eligible-session count without deleting anything.
+
+## Reading a run
+
+The job writes `purged=N raced=N failed=N` to the step's `$GITHUB_STEP_SUMMARY`
+(via `agent.scripts.purge_anonymous_sessions._write_step_summary`):
+
+- `purged` — sessions actually deleted this run.
+- `raced` — the find-then-delete race resolved itself (the session was no
+  longer anon-owned or no longer past cutoff by the time the delete ran,
+  typically because the owner logged in mid-sweep). Not a failure.
+- `failed` — a per-session database error (most likely the `routes` FK
+  backstop catching a route written between the scan and the delete). Logged
+  as `anonymous_session_purge_failed` with the session id; the sweep still
+  exits 0 unless something outside the per-session loop breaks.
+
+A nonzero exit code means an **unexpected** (non-Postgres) error escaped the
+per-session isolation — that's a programming bug, not a race, and should page
+someone.
+
+## Related
+
+- `db/migrations/20260728000001_conversations_user_id_pattern_ops.sql` +
+  the `supabase/migrations/` twin — the `text_pattern_ops` index the purge
+  scan's `LIKE 'anon\_%'` match depends on.
+- `apps/agent/agent/interfaces/routes/session_migration.py` — the login-time
+  ownership transition this purge coexists with.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:frontend": "pnpm --filter ./frontend run build",
     "deploy": "pnpm run build:frontend && npx wrangler deploy",
     "lint:oxlint": "pnpm --filter catalog --filter users --filter web run lint:oxlint",
-    "test:worker": "node --test worker/entry.test.ts worker/photoSearch.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/turnstileArm.test.ts worker/turnstileReplay.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/edgeGuard.test.ts worker/authRateLimitScope.test.ts"
+    "test:worker": "node --test worker/entry.test.ts worker/photoSearch.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/turnstileArm.test.ts worker/turnstileReplay.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/sessionMigration.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/edgeGuard.test.ts worker/authRateLimitScope.test.ts"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",

--- a/supabase/migrations/20260728000001_conversations_user_id_pattern_ops.sql
+++ b/supabase/migrations/20260728000001_conversations_user_id_pattern_ops.sql
@@ -3,5 +3,15 @@
 -- rather than a `>=`/`<` range scan — the latter is a collation trap under
 -- non-C locales. `text_pattern_ops` is what lets that LIKE prefix match use
 -- an index instead of a full table scan.
+--
+-- Lock behavior (CONCURRENTLY evaluated, not used): CREATE INDEX takes a
+-- SHARE lock on `conversations` for the build's duration, blocking writers
+-- but not readers. CREATE INDEX CONCURRENTLY avoids that at the cost of two
+-- table scans and no transactional guarantee — and both this Atlas apply and
+-- the Supabase migration runner execute each file inside one transaction, a
+-- context CONCURRENTLY cannot run in at all (Postgres rejects it outright).
+-- `conversations` is small pre-launch, so the plain build's brief lock is the
+-- right trade; revisit if the table grows enough for the lock window itself
+-- to matter.
 CREATE INDEX IF NOT EXISTS idx_conversations_user_id_pattern
     ON conversations (user_id text_pattern_ops);

--- a/supabase/migrations/20260728000001_conversations_user_id_pattern_ops.sql
+++ b/supabase/migrations/20260728000001_conversations_user_id_pattern_ops.sql
@@ -1,0 +1,7 @@
+-- Collation-safe index for the anonymous-session retention sweep (issue #273
+-- Task 3). The purge predicate matches `user_id LIKE 'anon\_%' ESCAPE '\'`
+-- rather than a `>=`/`<` range scan — the latter is a collation trap under
+-- non-C locales. `text_pattern_ops` is what lets that LIKE prefix match use
+-- an index instead of a full table scan.
+CREATE INDEX IF NOT EXISTS idx_conversations_user_id_pattern
+    ON conversations (user_id text_pattern_ops);

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -5,6 +5,8 @@ import {
   type AuthResult,
   authenticate as realAuthenticate,
   resolveAnonymous,
+  resolveAnonymousReadOnly,
+  retireAnonymousCookie,
 } from "./auth.ts";
 import {
   budgetGuidanceResponse,
@@ -66,21 +68,31 @@ function forwardPublicCatalog(env: Env, request: Request): Promise<Response> {
 }
 
 /** Forward a /v1 request to the container's default instance. Always strips
- * client-supplied X-User-* (anti-forgery) and x-byok-endpoint (documented as
- * trusted by the container but client-settable — closed until BYOK launches);
- * on authed paths also strips Authorization and injects the worker-verified
- * identity. `x-session-id` is intentionally forwarded: chat session continuity
- * needs it, so the container must never treat it as a trust signal. */
-function forwardV1(env: Env, request: Request, auth?: { userId: string; userType: string }): Promise<Response> {
+ * client-supplied X-User-*, X-Anon-Id (anti-forgery), and x-byok-endpoint
+ * (documented as trusted by the container but client-settable — closed
+ * until BYOK launches); on authed paths also strips Authorization and
+ * injects the worker-verified identity. A trusted `X-Anon-Id` is set only
+ * when the caller passes one explicitly (the session-migration route,
+ * re-P2-1) — every other route forwards none. `x-session-id` is
+ * intentionally forwarded: chat session continuity needs it, so the
+ * container must never treat it as a trust signal. */
+function forwardV1(
+  env: Env,
+  request: Request,
+  auth?: { userId: string; userType: string },
+  trustedAnonId?: string | null,
+): Promise<Response> {
   const headers = new Headers(request.headers);
   headers.delete("X-User-Id");
   headers.delete("X-User-Type");
   headers.delete("x-byok-endpoint");
+  headers.delete("X-Anon-Id");
   if (auth) {
     headers.delete("Authorization");
     headers.set("X-User-Id", auth.userId);
     headers.set("X-User-Type", auth.userType);
   }
+  if (trustedAnonId) headers.set("X-Anon-Id", trustedAnonId);
   const forwarded = new Request(request, { headers });
   return env.CONTAINER.get(env.CONTAINER.idFromName("default")).fetch(forwarded);
 }
@@ -228,6 +240,39 @@ function unauthorized(pathname: string): Response {
   return Response.json(UNAUTHORIZED_BODY, { status: 401 });
 }
 
+// ── Session migration (issue #273 Task 3) ──────────────────────────────────
+//
+// The only route where the edge forwards a trusted X-Anon-Id: it resolves
+// (never mints) the caller's `aid` cookie into the header the container
+// re-validates, then — only once the container reports an actual migration —
+// rotates the cookie so a shared browser's next visitor cannot inherit the
+// consumed identity.
+
+const SESSION_MIGRATE_PATH = "/v1/session/migrate";
+
+async function didMigrate(response: Response): Promise<boolean> {
+  if (response.status !== 200) return false;
+  try {
+    const body: unknown = await response.clone().json();
+    return typeof body === "object" && body !== null && (body as { migrated?: unknown }).migrated === true;
+  } catch {
+    return false;
+  }
+}
+
+async function handleSessionMigrate(
+  env: Env,
+  request: Request,
+  auth: { userId: string; userType: string },
+): Promise<Response> {
+  const identity = await resolveAnonymousReadOnly(request, env);
+  const forwarded = await forwardV1(env, request, auth, identity?.userId ?? null);
+  if (!(await didMigrate(forwarded))) return forwarded;
+  const headers = new Headers(forwarded.headers);
+  headers.append("Set-Cookie", retireAnonymousCookie());
+  return new Response(forwarded.body, { status: forwarded.status, headers });
+}
+
 /** Forward a container-originated catalog request to the private CATALOG binding
  * (in-datacenter hop, never the public internet). Wired as the container's
  * outboundByHost handler in entry.ts. */
@@ -293,7 +338,16 @@ export function createWorkerApp(deps: {
     if (isPublicV1(pathname)) return forwardV1(c.env, c.req.raw);
     const auth = await authenticate(c.req.raw, c.env, c.executionCtx);
     if (auth.ok) {
-      return authenticatedForward(c.env, c.req.raw, { userId: auth.userId, userType: auth.userType }, pathname);
+      const identity = { userId: auth.userId, userType: auth.userType };
+      // Session migration runs ahead of the per-identity rate limiter (#284
+      // Task 9): it is an identity-only DB update, not a cost-bearing route,
+      // and is not in AUTH_RATE_LIMITED_EXACT — routing it through
+      // authenticatedForward would be a silent no-op today, but checking it
+      // first keeps that true by construction rather than by omission.
+      if (pathname === SESSION_MIGRATE_PATH) {
+        return handleSessionMigrate(c.env, c.req.raw, identity);
+      }
+      return authenticatedForward(c.env, c.req.raw, identity, pathname);
     }
     // S1.9 Turnstile (issue #281) is ARMED as of issue #447: `handleAnonymousV1`
     // below challenges every anonymous turn before it can reach the limiter or

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -253,3 +253,30 @@ export async function resolveAnonymous(
   if (verified === null) return mintAnonymousIdentity(secret);
   return { userId: `${ANON_ID_PREFIX}${verified}`, setCookie: null };
 }
+
+/**
+ * Resolve-only variant for the session-migration route (issue #273 Task 3,
+ * re-P2-1): verifies an existing `aid` cookie but never mints one. A missing
+ * or tampered cookie returns null rather than a fresh identity, so a request
+ * with no anonymous history forwards no `X-Anon-Id` and the response carries
+ * no `Set-Cookie` — minting here would silently give the migration endpoint
+ * side effects no other route has.
+ */
+export async function resolveAnonymousReadOnly(
+  request: Request,
+  env: AnonymousEnv,
+): Promise<AnonymousIdentity | null> {
+  const secret = env.ANON_ID_SECRET;
+  if (!anonymousEnabled(env) || secret === undefined) return null;
+  const cookie = readCookie(request, ANON_COOKIE);
+  if (cookie === null) return null;
+  const verified = await verifyAnonymousToken(cookie, secret);
+  if (verified === null) return null;
+  return { userId: `${ANON_ID_PREFIX}${verified}`, setCookie: null };
+}
+
+/** Rotate/clear the `aid` cookie after a successful migration (rev5 P2-b) so
+ * a shared browser's next visitor cannot inherit the consumed identity. */
+export function retireAnonymousCookie(): string {
+  return `${ANON_COOKIE}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`;
+}

--- a/worker/sessionMigration.test.ts
+++ b/worker/sessionMigration.test.ts
@@ -12,9 +12,21 @@ const stubCtx = {
 
 const authOk = () => Promise.resolve({ ok: true, userId: "real-user-1", userType: "human" } as const);
 
+/** An EDGE_GUARD stand-in that always allows (mirrors entry.test.ts): the
+ * migration route is not in AUTH_RATE_LIMITED_EXACT, but it still passes
+ * through `authenticatedForward`'s check, which reads `env.EDGE_GUARD`. */
+const alwaysAllowGuard = {
+  idFromName: (name: string) => name as unknown as DurableObjectId,
+  get: () => ({
+    fetch: () =>
+      Promise.resolve(new Response(JSON.stringify({ allowed: true, retryAfterSeconds: 0 }))),
+  }),
+};
+
 function envWithContainer(captured: { req?: Request }, body: object = { migrated: true }) {
   return {
     ...ANON_ENV,
+    EDGE_GUARD: alwaysAllowGuard,
     CONTAINER: {
       idFromName: () => "id",
       get: () => ({

--- a/worker/sessionMigration.test.ts
+++ b/worker/sessionMigration.test.ts
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createWorkerApp } from "./app.ts";
+
+const SECRET = "fixed-test-hmac-key-0000000000000000";
+const ANON_ENV = { ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: SECRET };
+
+const stubCtx = {
+  waitUntil(promise: Promise<unknown>) { void promise; },
+  passThroughOnException() { return undefined; },
+} as unknown as ExecutionContext;
+
+const authOk = () => Promise.resolve({ ok: true, userId: "real-user-1", userType: "human" } as const);
+
+function envWithContainer(captured: { req?: Request }, body: object = { migrated: true }) {
+  return {
+    ...ANON_ENV,
+    CONTAINER: {
+      idFromName: () => "id",
+      get: () => ({
+        fetch: (r: Request) => {
+          captured.req = r;
+          return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+        },
+      }),
+    },
+  } as never;
+}
+
+async function anonCookieFor(userId: string): Promise<string> {
+  // Mirrors auth.ts's HMAC scheme with the fixed test secret above.
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", encoder.encode(SECRET), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const raw = userId.replace(/^anon_/, "");
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(raw));
+  const hex = Array.from(new Uint8Array(signature)).map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `aid=${raw}.${hex}`;
+}
+
+void test("a valid aid cookie reaches the container as X-Anon-Id, exactly", async () => {
+  const cap: { req?: Request } = {};
+  const app = createWorkerApp({ nextHandler: { fetch: () => Promise.resolve(new Response("next")) }, authenticate: authOk });
+  const cookie = await anonCookieFor("anon_" + "a".repeat(32));
+  await app.request("/v1/session/migrate", { method: "POST", headers: { Cookie: cookie } }, envWithContainer(cap), stubCtx);
+  assert.equal(cap.req?.headers.get("X-Anon-Id"), "anon_" + "a".repeat(32));
+});
+
+void test("no aid cookie -> no X-Anon-Id forwarded, and no Set-Cookie on the response", async () => {
+  const cap: { req?: Request } = {};
+  const app = createWorkerApp({ nextHandler: { fetch: () => Promise.resolve(new Response("next")) }, authenticate: authOk });
+  const res = await app.request(
+    "/v1/session/migrate", { method: "POST" }, envWithContainer(cap, { migrated: false }), stubCtx,
+  );
+  assert.equal(cap.req?.headers.get("X-Anon-Id"), null);
+  assert.equal(res.headers.get("Set-Cookie"), null);
+});
+
+void test("a tampered aid cookie -> no X-Anon-Id forwarded, and no Set-Cookie on the response", async () => {
+  const cap: { req?: Request } = {};
+  const app = createWorkerApp({ nextHandler: { fetch: () => Promise.resolve(new Response("next")) }, authenticate: authOk });
+  const res = await app.request(
+    "/v1/session/migrate",
+    { method: "POST", headers: { Cookie: `aid=${"a".repeat(32)}.${"b".repeat(64)}` } },
+    envWithContainer(cap, { migrated: false }),
+    stubCtx,
+  );
+  assert.equal(cap.req?.headers.get("X-Anon-Id"), null);
+  assert.equal(res.headers.get("Set-Cookie"), null);
+});
+
+void test("a client-forged X-Anon-Id is overwritten by the edge's own resolution", async () => {
+  const cap: { req?: Request } = {};
+  const app = createWorkerApp({ nextHandler: { fetch: () => Promise.resolve(new Response("next")) }, authenticate: authOk });
+  const cookie = await anonCookieFor("anon_" + "c".repeat(32));
+  await app.request(
+    "/v1/session/migrate",
+    { method: "POST", headers: { Cookie: cookie, "X-Anon-Id": "anon_" + "f".repeat(32) } },
+    envWithContainer(cap),
+    stubCtx,
+  );
+  assert.equal(cap.req?.headers.get("X-Anon-Id"), "anon_" + "c".repeat(32));
+  assert.notEqual(cap.req?.headers.get("X-Anon-Id"), "anon_" + "f".repeat(32));
+});
+
+void test("a successful migration rotates/clears the aid cookie", async () => {
+  const cap: { req?: Request } = {};
+  const app = createWorkerApp({ nextHandler: { fetch: () => Promise.resolve(new Response("next")) }, authenticate: authOk });
+  const cookie = await anonCookieFor("anon_" + "d".repeat(32));
+  const res = await app.request(
+    "/v1/session/migrate", { method: "POST", headers: { Cookie: cookie } }, envWithContainer(cap, { migrated: true }), stubCtx,
+  );
+  const setCookie = String(res.headers.get("Set-Cookie"));
+  assert.match(setCookie, /^aid=;/);
+  assert.match(setCookie, /Max-Age=0/);
+});
+
+void test("a no-op migration (migrated: false) does not rotate the cookie", async () => {
+  const cap: { req?: Request } = {};
+  const app = createWorkerApp({ nextHandler: { fetch: () => Promise.resolve(new Response("next")) }, authenticate: authOk });
+  const cookie = await anonCookieFor("anon_" + "e".repeat(32));
+  const res = await app.request(
+    "/v1/session/migrate", { method: "POST", headers: { Cookie: cookie } }, envWithContainer(cap, { migrated: false }), stubCtx,
+  );
+  assert.equal(res.headers.get("Set-Cookie"), null);
+});
+
+void test("X-Anon-Id is stripped on every OTHER /v1 route, even with a valid cookie", async () => {
+  const cap: { req?: Request } = {};
+  const app = createWorkerApp({ nextHandler: { fetch: () => Promise.resolve(new Response("next")) }, authenticate: authOk });
+  const cookie = await anonCookieFor("anon_" + "b".repeat(32));
+  await app.request(
+    "/v1/chat", { method: "POST", headers: { Cookie: cookie, "X-Anon-Id": "anon_" + "b".repeat(32) } }, envWithContainer(cap), stubCtx,
+  );
+  assert.equal(cap.req?.headers.get("X-Anon-Id"), null);
+});


### PR DESCRIPTION
## Summary

Implements #273 Task 3 (24 AC): session identity transition on login + anonymous-session retention.

**Part A — identity transition**
- `POST /v1/session/migrate` (new `interfaces/routes/session_migration.py`): identity-dimensional `UPDATE conversations SET user_id = $to WHERE user_id = $from_anon`, no body, no `session_id`.
- New auth predicate `_require_non_anonymous_user` (`interfaces/routes/_deps.py`) — reject-anonymous, not allow-list, mirroring `usage_metering.scope_for_identity`. Pins the real literals `X-User-Type: human` / `agent`.
- Container re-validates `X-Anon-Id` against `^anon_[0-9a-f]{32}$`; anything else is treated as missing.
- `worker/app.ts`: the migration route resolves (never mints) the `aid` cookie into a trusted `X-Anon-Id` via new `resolveAnonymousReadOnly` (`worker/auth.ts`); `forwardV1` now unconditionally strips any client-supplied `X-Anon-Id` on every other route; a successful migration rotates/clears the `aid` cookie (`retireAnonymousCookie`).

**Part B — anonymous retention**
- `scripts/purge_anonymous_sessions.py` (new CLI) + `.github/workflows/purge-anonymous-sessions.yml` (new cron, follows `agent-eval-nightly.yml` precedent).
- `SessionRepository.find_purgeable_anonymous_sessions` / `.purge_session`: routeless anonymous sessions inactive past `anonymous_session_retention_days` (default 30) are purged; route-bearing sessions are retained **permanently** via an explicit `NOT EXISTS` exclusion against `routes`.
- Per-session transaction: `conversations` deleted before `sessions` — the `routes.session_id` FK is the transactional backstop if the exclusion predicate is ever wrong (verified by mutation test, see below).
- New collation-safe `text_pattern_ops` index on `conversations(user_id)` backing the `LIKE 'anon\_%' ESCAPE '\'` match (twin migrations in `db/migrations/` + `supabase/migrations/`, `atlas.sum` updated).

## AC coverage (24/24)

| # | AC | Type | Test |
|---|---|---|---|
| 1 | Happy path: migrate all conversations for `anon_<hex>` | integration | `test_session_identity_transition.py::test_migration_moves_ownership_and_preserves_content` |
| 2 | Happy path: multi-session, one call migrates both | integration | `::test_migration_moves_every_session_for_the_same_anon_identity` |
| 3 | Happy path: original anon identity loses ownership | integration | `::test_original_anon_identity_loses_ownership_after_transition` |
| 4 | Null/empty: no owned conversations → `migrated:false` | unit | `test_session_migration.py::test_no_owned_conversations_returns_false_not_error` |
| 5 | Null/empty: no `X-Anon-Id` → `migrated:false`, no mutation | unit | `::test_missing_x_anon_id_returns_false_and_mutates_nothing` |
| 6 | Auth predicate negative: anon caller → 403 | unit | `::test_anonymous_user_type_is_rejected_403_and_mutates_nothing`, `::test_anon_prefixed_user_id_is_rejected_even_with_human_type` |
| 7 | Response shape `{"migrated": bool}` | unit | `::test_response_shape_is_exactly_migrated_bool` |
| 8 | Structural safety: WHERE only matches `anon_` param | unit | `test_session_repo.py::test_migrate_ownership_where_clause_only_ever_matches_the_anon_param` |
| 9 | Boundary: idempotent UPDATE, second run no-op | unit | `test_session_repo.py::test_migrate_ownership_is_idempotent_second_run_is_a_no_op` |
| 10 | Retention happy path (route vs no-route sibling) | integration | `::test_retention_purges_only_the_inactive_routeless_sibling` |
| 11 | Retention exclusion — route present | unit | `test_session_retention.py::test_find_purgeable_excludes_route_bearing_sessions_by_construction` (+ integration `::test_route_bearing_session_is_retained_permanently`) |
| 12 | Retention exclusion — no route (matched pair) | unit | same SQL-shape test + integration companion |
| 13 | Retention safety: real users never touched | unit | `test_session_retention.py::test_find_purgeable_uses_collation_safe_like_not_a_range_scan` |
| 14 | Retention null/empty | unit | `test_session_retention.py::test_purge_run_with_no_eligible_rows_deletes_nothing` |
| 15 | Purge ordering, no orphans | integration | `::test_purge_deletes_conversations_before_sessions_leaving_no_orphans` |
| 16 | Purge FK backstop is transactional | integration | `::test_purge_transaction_rolls_back_whole_unit_when_fk_backstop_fires` |
| 17 | Edge forwarding happy path | unit (worker) | `sessionMigration.test.ts::"a valid aid cookie reaches the container as X-Anon-Id, exactly"` |
| 18 | Auth predicate positive: `human`/`agent` | unit | `test_session_migration.py::test_real_production_literal_human_is_accepted`, `::test_real_production_literal_agent_is_accepted` |
| 19 | Trusted-input validation | unit | `::test_malformed_x_anon_id_is_treated_as_missing` |
| 20 | Cookie retirement | unit (worker) | `sessionMigration.test.ts::"a successful migration rotates/clears the aid cookie"` |
| 21 | Edge forwarding scoped strip | unit (worker) | `sessionMigration.test.ts::"X-Anon-Id is stripped on every OTHER /v1 route..."` |
| 22 | Edge resolve-only | unit (worker) | `sessionMigration.test.ts::"no aid cookie..."`, `"a tampered aid cookie..."` |
| 23 | Purge trigger workflow | unit | `test_purge_workflow_trigger.py` (4 tests) |
| 24 | Edge forwarding forgery negative | unit (worker) | `sessionMigration.test.ts::"a client-forged X-Anon-Id is overwritten..."` |

**Note on test-type placement:** ACs 11-14 are placed as SQL-shape unit tests (mocked pool, asserting the generated SQL structurally) per this repo's `tests/unit/` convention (no real DB in that directory); the true behavioral proof (exclusion pair, safety, ordering) lives in the Docker-backed integration suite, which covers the same scenarios end-to-end.

## Mutation testing evidence (spec-mandated)

Ran locally, each mutation applied then reverted:
1. **Deleted the `NOT EXISTS` route-exclusion clause** from `_FIND_PURGEABLE_SQL` → `test_find_purgeable_excludes_route_bearing_sessions_by_construction` failed immediately (SQL-shape assertion); separately, running the full integration test with the mutation in place made `test_route_bearing_session_is_retained_permanently` fail with `asyncpg.exceptions.ForeignKeyViolationError` (the route row blocked the sessions delete) — proving the exclusion is load-bearing at the behavioral level too.
2. **Removed `BEGIN`/`COMMIT`** (the `connection.transaction()` wrapper) from `purge_session` → `test_purge_transaction_rolls_back_whole_unit_when_fk_backstop_fires` failed: the conversation was deleted and NOT rolled back even though the sessions delete hit the FK violation, proving atomicity was actually required.
3. **Removed the unconditional `X-Anon-Id` strip** in `forwardV1` → `sessionMigration.test.ts`'s cross-route strip test failed, proving the strip (not just the trusted-header set) is load-bearing.

All mutations reverted after verification; final diff is clean (`git diff` against the committed state shows no residual mutation).

## Gates

- `make lint` — pass (ruff check + format)
- `make typecheck` — pass (mypy strict on `agent/agents`, `agent/interfaces`, `agent/domain`, `agent/infrastructure`, `agent/clients`, `agent/tests/eval`)
- `make test` — 1423 passed, coverage 88.40% (floor 87%)
- `make test-integration` — 94 passed, 22 skipped (env-gated, pre-existing)
- `pnpm run test:worker` — 104 passed (97 baseline + 7 new)

No suppressions added (`# noqa`, `# type: ignore`, `eslint-disable`, etc.). No `Any`/`dict[str, object]` introduced — the ownership-migration domain module uses a typed `Protocol` + `MigrationOutcome` dataclass.

## Concurrency notes (per dispatch instructions)

- **PR #448** is touching `worker/auth.ts` semantics; this PR **adds** two new exported functions (`resolveAnonymousReadOnly`, `retireAnonymousCookie`) without modifying any existing function body — should rebase cleanly, but flagging for awareness.
- **#284 Task 9** is touching `worker/app.ts` auth/rate-limit flow; this PR's `app.ts` changes are localized to: (a) `forwardV1`'s signature gaining an optional 4th param + one added `headers.delete("X-Anon-Id")` line, (b) a new `handleSessionMigrate`/`didMigrate` block, (c) one added branch inside the existing `/v1/*` handler (`if (pathname === SESSION_MIGRATE_PATH) ...`). Small, additive diff — should merge easily either direction, but calling it out since both PRs touch the same file.

## Environment note

Local verification required the atlas pinned binary (`v0.30.0`, not the Homebrew-installed `v1.2.4`) and dummy `SUPABASE_DB_URL`/`MIMO_API_KEY` env vars for `make test-integration` (no `.env.test` present in a fresh worktree) — same requirement pre-existing for any Task-3-adjacent work in this repo, not introduced by this PR.

Not merging — per dispatch instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 2 (Fable + Opus, both request_changes) — addressed

**Fable — P1-1, 25th AC (index/collation integrity):** added
`tests/integration/test_session_retention_integrity.py::test_purge_predicate_hits_the_pattern_ops_index_not_a_seq_scan`
— asserts `pg_database.datcollate` is recorded, and that
`idx_conversations_user_id_pattern`'s `indexdef` actually carries
`text_pattern_ops` (the opclass check — this is what catches the mutation).
**Mutation direction verified locally:** reverted the migration's index to
default btree ops → this test fails while
`test_retention_purges_only_the_inactive_routeless_sibling` (behavioral
happy path) keeps passing. Quality ratchet is now 25/25 AC with test.

Note: the initial version also pinned the exact index name in the `EXPLAIN`
plan text. CI's live Neon integration job (shared branch, rows accumulated
across the whole suite) showed the planner reasonably preferring the
pre-existing `idx_conversations_user_id_updated_at` composite index over the
new one for this specific query shape — a legitimate cost-based choice
between two valid index paths, not a bug. Relaxed that part of the
assertion to the environment-independent invariant ("no `Seq Scan` on
`conversations`"); the opclass check above is unaffected and is what
actually proves the collation-safety contract.

**Fable — P2-1, per-session error isolation:** `purge_anonymous_sessions`
now isolates each session's purge in its own `try`/`except`; a `PurgeReport`
(`purged`/`raced`/`failed`) is returned instead of a bare int. A
`ForeignKeyViolationError` (or any `asyncpg.PostgresError`) on one session
is logged and the sweep continues; a non-Postgres exception still
propagates and exits nonzero (that's a programming bug, not a race).

**Fable — P2-2, runbook:** `docs/ops/anonymous-session-purge.md` (cron
cadence, required `SUPABASE_DB_URL` secret + "missing secret looks like
nothing to purge" warning, manual `workflow_dispatch`, reading
`$GITHUB_STEP_SUMMARY`) + registered in `docs/ops/README.md` and
`docs/DOCS_POLICY.md`.

**Fable — P2-3, rebase:** rebased onto `origin/feat/frontend-rebuild`
(#448/#449/#451 now merged). `worker/app.ts`'s session-migrate branch now
runs **ahead of** #451's `authenticatedForward` rate limiter (identity-only
DB update, not cost-bearing, and not in `AUTH_RATE_LIMITED_EXACT` anyway —
checking it first keeps that true by construction). `rateLimiter.test.ts` +
`sessionMigration.test.ts` rerun green (151/151 `pnpm run test:worker`).

**Fable — P3:** AC1 test now also seeds + asserts message-history
round-trip (not just session state). `updated_at = now()` side effect on
migration documented in a comment (deliberate: login is activity, resets
the retention clock, never shortens it). `CREATE INDEX CONCURRENTLY`
evaluated and documented in both migration files: not usable inside
Atlas's/Supabase's single-transaction-per-file apply, and the table is
small pre-launch — plain build's brief lock is the right trade for now.
`_rows_affected` now regex-based, never raises on a malformed command tag
(+ unit test).

**Opus — P1-2, CI + Sonar:**
- Investigated the "0 CI runs on this branch" report: the branch predated
  #448/#449/#451 landing; rebasing + re-pushing did trigger a real
  `pull_request` CI run. **However, a CI-trigger anomaly recurred on
  subsequent pushes to this same PR** (force-push, plain push, and a
  close/reopen all failed to fire a new automatic `pull_request:
  synchronize` run) — `gh run rerun` against the last real run instead
  confirms **86/87 integration tests green on live Neon, `Edge worker
  tests` green (151/151), `Agent CI / Python CI` green**; the 1 failure was
  the exact plan-assertion flakiness fixed above (verified: same failure
  text, same test, on the pre-fix commit). This looks like a GitHub
  webhook/App delivery issue on this repo, not something fixable from a
  contributor context — flagging for a maintainer to check the Actions app
  install / re-run checks from the UI if this PR's checks still look stale.
- SonarCloud's "`uv sync`/`uv run` need `--no-build`" suggestion: verified
  against the pinned uv (0.11.14) — `--no-build` is a real flag, but it
  refuses to install this project's own editable package ("marked as
  --no-build but has no binary distribution"). Reverted with a comment
  rather than shipping a broken workflow; the narrower
  `--no-build-package <name>` per third-party dependency exists but needs
  an explicit, maintained allowlist — tracked as a follow-up, not shipped
  half-verified here.

**Opus — P2-1, find-then-delete race:** `purge_session`'s `DELETE FROM
conversations` now re-asserts `user_id LIKE 'anon\_%' ESCAPE '\'` **and**
`updated_at < cutoff` (not just `session_id`) — closing the race where the
owner logs in between the eligibility scan and the delete. New tests:
`test_purge_session_delete_reasserts_the_anon_and_cutoff_predicate` (unit,
structural) and `test_purge_session_race_a_concurrent_login_saves_the_session`
(integration, a real concurrent `migrate_ownership` mid-sweep).

**Opus — P2-3, behavioral evidence:**
`test_a_real_logged_in_user_row_survives_regardless_of_age` seeds a real,
400-day-old `real-user-*`-owned conversation and asserts it survives the
sweep — the earlier SQL-text-only assertion couldn't have caught a widened
`LIKE` pattern; this fixture would.

**Opus — P3:** workflow trigger test rewritten with `yaml.safe_load` (was
string containment) — including the `on:` → `True` PyYAML gotcha, handled
explicitly; removed the redundant per-file `pytest_plugins` in two
integration test files (already registered by `tests/integration/conftest.py`,
a Sonar-flagged duplicate); added `timeout-minutes: 10` to the purge job;
the purge script writes `purged=N raced=N failed=N` to
`$GITHUB_STEP_SUMMARY`; `agent/scripts/purge_anonymous_sessions.py` added
to the mypy gate (`Makefile` + `_python-ci.yml` — was previously
unchecked); noted here per request: **scheduled (`cron:`) workflows only
run from the repository's default branch** — this workflow file has no
effect until merged to `main`; `workflow_dispatch` works from any branch in
the meantime. Migration lock behavior (`CREATE INDEX` vs `CONCURRENTLY`)
documented in both migration files per Fable's P3 above.

Gates re-run after all of the above: `make lint` / `make typecheck` (mypy,
now including the script) / `make test` (1449 passed, 88.46% cov, floor
87%) / `make test-integration` (97 passed, 22 env-gated skips, Docker arm)
/ `pnpm run test:worker` (151 passed). Live-Neon signal via `gh run rerun`
on the pre-fix commit: 86/87 passed, the 1 failure being the exact issue
this round's last commit fixes.


---

## Update: rebased again onto #260/#458/#461, CI now fully green

Base moved again after the round-2 fixes above (#260, #284 Task 1 SSRF guard
#458, and #273 Task 1 #461 all merged). Rebased cleanly (conflicts in
`fastapi_service.py`, `package.json`, `worker/app.ts` — all additive
router/test-list/header merges, no logic collisions) and re-verified:

- `make lint` / `make typecheck` — pass
- `make test` — 1524 passed, 89.02% coverage (floor 87%)
- `make test-integration` (Docker arm) — 119 passed, 22 env-gated skips
- `pnpm run test:worker` — 157 passed

**CI run (this exact head commit, `b0ac7498`):
https://github.com/lifeodyssey/animichi/actions/runs/30388265931 — all green**,
including `Python integration (Neon)` (the job that caught and validated the
plan-assertion fix from round 2) and every `Security/*` job
(gitleaks/Semgrep/osv-scanner/zizmor/actionlint/TruffleHog/sqlfluff). The
earlier CI-trigger anomaly (automatic `pull_request: synchronize` not firing
on some pushes) did not recur on this push — resolved itself, or was tied to
the prior stale-base state.

Ready for final review on both sides.


---

## Update: Opus final-verify closeouts + collation reality check

Opus approved (race-fix triple-verified) pending four small items, all addressed:

1. `_python-ci.yml` mypy step now uses `uv run --frozen`, matching the convention elsewhere in `ci.yml`.
2. The "no Seq Scan" plan assertion was a tautology under `enable_seqscan = off` — replaced with an assertion on the actual pattern range-scan operators (`~>=~` / `~<~`) that only appear when a `text_pattern_ops` index services the LIKE prefix (confirmed empirically against a live `EXPLAIN` before writing it).
3. Collation assertion upgraded from "non-null" to comparing against documented expected value(s).
4. `_COMMAND_TAG_ROW_COUNT` simplified to `r"(\d+)$"` + `status.rstrip()` at the call site.

**Then live-Neon CI caught two more real environmental facts, both now fixed:**

- Neon's actual collation is `C.UTF-8`, not `en_US.utf8` (the offline Docker image's value) — my first hardcoded exact-match assertion was wrong for that arm. Both are legitimate; the test now accepts either known value and documents both in `docs/ops/anonymous-session-purge.md`.
- Under `C.UTF-8`, a plain btree already orders bytewise, so **any** index can service the LIKE prefix — `text_pattern_ops` isn't uniquely required there, and the query planner reasonably prefers a cheaper pre-existing index (`idx_conversations_user_id_updated_at`) on Neon's populated shared branch. This is a correct cost decision, not a bug. The plan-shape assertion (pattern operators in the `EXPLAIN` output) is now scoped to run **only** on the non-C collation arm (`en_US.utf8`, where it's architecturally load-bearing); the opclass check (index exists with `text_pattern_ops`) still runs unconditionally on both arms.

Rebased again onto #462 (#273 Task 2)/#463 (Turnstile armed)/#467 (BYOK storage) — conflicts in `package.json` (test file lists) and `worker/app.ts` (import/header merges), all additive, no logic collisions; verified the session-migrate branch still runs ahead of the (now-armed) Turnstile/rate-limit path correctly.

**Final CI run (head `d6113e0a`): https://github.com/lifeodyssey/animichi/actions/runs/30416628853 — fully green**, including `Python integration (Neon)`. Local gates re-verified: `make lint` / `make typecheck` / `make test` (1524 passed, 89.02% cov) / `make test-integration` (123 passed) / `pnpm run test:worker` (183 passed).

Ready to merge.
