### PR TITLE
feat(web): #273 T1 — E2 selection tray + selected_point_ids recompute bypass (living document)

### DIFF
--- a/apps/agent/agent/interfaces/persistence.py
+++ b/apps/agent/agent/interfaces/persistence.py
@@ -159,9 +159,13 @@ async def persist_messages(
     if insert_message is None:
         return
 
-    await _safe_insert_message(
-        insert_message, session_id, "user", user_text, label="insert_user_message"
-    )
+    # #273 T1: a selected_point_ids recompute carries no new utterance (the
+    # client sends a part-less marker; ``_last_user_text`` derives ""). Never
+    # persist an empty user row — history would render it as an empty bubble.
+    if user_text != "":
+        await _safe_insert_message(
+            insert_message, session_id, "user", user_text, label="insert_user_message"
+        )
 
     if persist_user_only:
         return

--- a/apps/agent/agent/tests/unit/test_persistence_helpers.py
+++ b/apps/agent/agent/tests/unit/test_persistence_helpers.py
@@ -11,7 +11,54 @@ from agent.interfaces.persistence import (
     _safe_insert_message,
     build_response_session,
     extract_plan_steps,
+    persist_messages,
 )
+from agent.interfaces.schemas import PublicAPIResponse
+
+
+class _Db:
+    def __init__(self) -> None:
+        self.insert_message = AsyncMock()
+
+
+def _response() -> PublicAPIResponse:
+    return PublicAPIResponse(
+        success=True, status="ok", intent="plan_selected", message="route"
+    )
+
+
+async def test_persist_messages_skips_empty_user_utterance() -> None:
+    """#273 T1: a bypass recompute carries no new utterance (marker ->
+    ``text == ""``) and must not persist an empty user row that the
+    conversation history would render as an empty bubble."""
+    db = _Db()
+    await persist_messages(
+        db=db, session_id="s1", user_text="", result=None, response=_response()
+    )
+    roles = [call.args[1] for call in db.insert_message.await_args_list]
+    assert roles == ["assistant"]
+
+
+async def test_persist_messages_inserts_genuine_user_turn() -> None:
+    db = _Db()
+    await persist_messages(
+        db=db, session_id="s1", user_text="ユーフォ", result=None, response=_response()
+    )
+    roles = [call.args[1] for call in db.insert_message.await_args_list]
+    assert roles == ["user", "assistant"]
+
+
+async def test_persist_messages_empty_utterance_failure_persists_nothing() -> None:
+    db = _Db()
+    await persist_messages(
+        db=db,
+        session_id="s1",
+        user_text="",
+        result=None,
+        response=_response(),
+        persist_user_only=True,
+    )
+    assert db.insert_message.await_args_list == []
 
 
 async def test_safe_insert_message_succeeds() -> None:

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -103,10 +103,25 @@ function isInputLocked(props: ShellProps): boolean {
   return props.entry === "A5" || busy || historyBlocked;
 }
 
-/** The E2 sticky recompute bar docks above the composer (design `.dock`). */
-function RecomputeTray({ dict, recompute }: Readonly<{ dict: ChatDict; recompute: RecomputeTurn }>) {
+/** P1-3: the tray must not fire while ANY turn is in flight — the AI SDK's
+ * `makeRequest` has no concurrency guard, so a mid-stream tap would clobber
+ * the active response. Chat busy always reads as `busy` here. */
+function trayStatus(chat: ChatSession, recompute: RecomputeTurn): RecomputeTurn["status"] {
+  const active = chat.status === "submitted" || chat.status === "streaming";
+  return active ? "busy" : recompute.status;
+}
+
+type TrayHostProps = Readonly<{ dict: ChatDict; chat: ChatSession; recompute: RecomputeTurn }>;
+
+/** The E2 recompute bar docks above the composer (design `.dock`); the live
+ * region keeps announcing after the bar unmounts on fire (a11y handoff). */
+function RecomputeTray({ dict, chat, recompute }: TrayHostProps) {
+  const status = trayStatus(chat, recompute);
   return (
-    <SelectionTray dict={dict} status={recompute.status} lastSentIds={recompute.lastSentIds} onRecompute={recompute.fire} />
+    <>
+      <span className="chat-live-note" aria-live="polite">{status === "busy" ? dict.preparing : ""}</span>
+      <SelectionTray dict={dict} status={status} lastSentIds={recompute.lastSentIds} onRecompute={recompute.fire} />
+    </>
   );
 }
 
@@ -124,7 +139,7 @@ function ChatShell(props: ShellProps) {
     <main className="chat-page">
       <ShellNotices {...props} />
       <ChatBody {...props} />
-      <RecomputeTray dict={props.dict} recompute={props.recompute} />
+      <RecomputeTray dict={props.dict} chat={props.chat} recompute={props.recompute} />
       <ChatInput dict={props.dict} disabled={isInputLocked(props)} onSend={props.onSend} />
     </main>
   );

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -7,6 +7,7 @@ import type { ChatActions } from "./chat-actions";
 import { ChatInput } from "./components/ChatInput";
 import { ColdStart } from "./components/ColdStart";
 import { ErrorBanner } from "./components/ErrorBanner";
+import { SelectionTray } from "./components/SelectionTray";
 import { TurnFailure } from "./components/ErrorStates/TurnFailure";
 import type { TurnFailureView } from "./components/ErrorStates/TurnFailure";
 import { HistoryList } from "./components/HistoryList";
@@ -18,6 +19,9 @@ import type { ChatEntryState } from "./entry-state";
 import { chatDictFor } from "./i18n";
 import type { ChatDict } from "./i18n";
 import type { ChatSearch } from "./search";
+import { SpotSelectionProvider, useSpotSelectionState } from "./selection/useSpotSelection";
+import { useRecomputeTurn } from "./selection/useRecomputeTurn";
+import type { RecomputeTurn } from "./selection/useRecomputeTurn";
 import { useAutoSend } from "./use-auto-send";
 import { useBackendHealth } from "./use-backend-health";
 import type { BackendHealth } from "./use-backend-health";
@@ -39,6 +43,7 @@ type ShellProps = Readonly<{
   chat: ChatSession;
   history: ConversationHistory;
   failure: TurnFailureView | undefined;
+  recompute: RecomputeTurn;
   onRetry: () => void;
   onSend: (text: string) => void;
 }>;
@@ -98,12 +103,28 @@ function isInputLocked(props: ShellProps): boolean {
   return props.entry === "A5" || busy || historyBlocked;
 }
 
+/** The E2 sticky recompute bar docks above the composer (design `.dock`). */
+function RecomputeTray({ dict, recompute }: Readonly<{ dict: ChatDict; recompute: RecomputeTurn }>) {
+  return (
+    <SelectionTray dict={dict} status={recompute.status} lastSentIds={recompute.lastSentIds} onRecompute={recompute.fire} />
+  );
+}
+
+function ShellNotices(props: ShellProps) {
+  return (
+    <>
+      {props.entry === "A5" ? <ErrorBanner dict={props.dict} onRetry={props.onRetry} /> : null}
+      <HistoryErrorGate history={props.history} dict={props.dict} />
+    </>
+  );
+}
+
 function ChatShell(props: ShellProps) {
   return (
     <main className="chat-page">
-      {props.entry === "A5" ? <ErrorBanner dict={props.dict} onRetry={props.onRetry} /> : null}
-      <HistoryErrorGate history={props.history} dict={props.dict} />
+      <ShellNotices {...props} />
       <ChatBody {...props} />
+      <RecomputeTray dict={props.dict} recompute={props.recompute} />
       <ChatInput dict={props.dict} disabled={isInputLocked(props)} onSend={props.onSend} />
     </main>
   );
@@ -171,13 +192,36 @@ function useChatState(search: ChatSearch) {
   return { config, health, chat, history };
 }
 
-export function ChatPage({ search }: ChatPageProps) {
+/** A failed recompute retries inline on the tray, never as a full-page D-state. */
+function maskRecomputeFailure(recompute: RecomputeTurn, failure: TurnFailureView | undefined): TurnFailureView | undefined {
+  return recompute.status === "failed" ? undefined : failure;
+}
+
+function useChatPage(search: ChatSearch) {
   const { config, health, chat, history } = useChatState(search);
   const actions = useTurnActions(chat);
+  const recompute = useRecomputeTurn(chat);
+  const failure = maskRecomputeFailure(recompute, useTurnFailure(chat, config.baseUrl));
+  const selection = useSpotSelectionState();
   useAutoSendFromQuery(search, health, actions.send);
+  return { health, chat, history, actions, recompute, failure, selection };
+}
+
+type PageState = ReturnType<typeof useChatPage>;
+
+function ChatPageView({ search, page }: Readonly<{ search: ChatSearch; page: PageState }>) {
   return (
-    <ChatActionsProvider actions={actions}>
-      <ChatShell entry={entryStateOf(search, health)} dict={chatDictFor(useLocale())} chat={chat} history={history} failure={useTurnFailure(chat, config.baseUrl)} onRetry={health.retry} onSend={actions.send} />
-    </ChatActionsProvider>
+    <ChatShell entry={entryStateOf(search, page.health)} dict={chatDictFor(useLocale())} chat={page.chat} history={page.history} failure={page.failure} recompute={page.recompute} onRetry={page.health.retry} onSend={page.actions.send} />
+  );
+}
+
+export function ChatPage({ search }: ChatPageProps) {
+  const page = useChatPage(search);
+  return (
+    <SpotSelectionProvider selection={page.selection}>
+      <ChatActionsProvider actions={page.actions}>
+        <ChatPageView search={search} page={page} />
+      </ChatActionsProvider>
+    </SpotSelectionProvider>
   );
 }

--- a/apps/web/src/features/chat/components/MessageList.tsx
+++ b/apps/web/src/features/chat/components/MessageList.tsx
@@ -170,10 +170,10 @@ function visibleMessages(messages: readonly UIMessage[]): readonly UIMessage[] {
 export function MessageList({ messages, dict, status, settledDurationMs }: ListProps) {
   const visible = visibleMessages(messages);
   if (visible.length === 0) return null;
-  const last = messages.at(-1);
+  const lastId = messages.at(-1)?.id;
   const supersededKeys = supersededPartKeys(visible);
   const items = visible.map((message) => (
-    <MessageRow key={message.id} message={message} isLast={message === last} dict={dict} status={status} settledDurationMs={settledDurationMs} supersededKeys={supersededKeys} />
+    <MessageRow key={message.id} message={message} isLast={message.id === lastId} dict={dict} status={status} settledDurationMs={settledDurationMs} supersededKeys={supersededKeys} />
   ));
   return <ol className="chat-messages">{items}</ol>;
 }

--- a/apps/web/src/features/chat/components/MessageList.tsx
+++ b/apps/web/src/features/chat/components/MessageList.tsx
@@ -1,5 +1,5 @@
 import type { ChatStatus, UIMessage } from "ai";
-import { hasRecomputePart } from "../../../lib/chat/selectedPointsBypass";
+import { isBypassTurn } from "../../../lib/chat/selectedPointsBypass";
 import { routeDocumentKey, supersededFlags } from "../../../lib/chat/supersession";
 import type { ChatDict } from "../i18n";
 import { formatElapsed } from "../telemetry";
@@ -89,14 +89,14 @@ function RecomputeFootprint({ settled, elapsedLabel, dict }: RecomputeProps) {
 
 type RailProps = Readonly<{ message: UIMessage; settled: boolean; elapsedLabel?: string; dict: ChatDict }>;
 
-/** The turn's progress rail: tool badges for agent turns, the recompute
- * footprint for `selected_point_ids` bypass turns (which run no tools). */
+/** The turn's progress rail: tool badges for agent turns; a bypass turn
+ * SUPPRESSES its streamed `plan_selected` step part and renders the
+ * footprint instead (review P1-1 — the backend always emits that part). */
 function MessageRail({ message, settled, elapsedLabel, dict }: RailProps) {
-  const tools = message.parts.filter(isToolPart);
-  if (tools.length === 0 && hasRecomputePart(message.parts)) {
+  if (isBypassTurn(message.parts)) {
     return <RecomputeFootprint settled={settled} elapsedLabel={elapsedLabel} dict={dict} />;
   }
-  return <Pipeline parts={tools} settled={settled} elapsedLabel={elapsedLabel} dict={dict} />;
+  return <Pipeline parts={message.parts.filter(isToolPart)} settled={settled} elapsedLabel={elapsedLabel} dict={dict} />;
 }
 
 type BodyProps = Readonly<{

--- a/apps/web/src/features/chat/components/MessageList.tsx
+++ b/apps/web/src/features/chat/components/MessageList.tsx
@@ -1,4 +1,5 @@
 import type { ChatStatus, UIMessage } from "ai";
+import { hasRecomputePart } from "../../../lib/chat/selectedPointsBypass";
 import { routeDocumentKey, supersededFlags } from "../../../lib/chat/supersession";
 import type { ChatDict } from "../i18n";
 import { formatElapsed } from "../telemetry";
@@ -73,6 +74,31 @@ function Pipeline({ parts, settled, elapsedLabel, dict }: PipelineProps) {
   return <SettledFootprint elapsedLabel={elapsedLabel} dict={dict}>{badges}</SettledFootprint>;
 }
 
+type RecomputeProps = Readonly<{ settled: boolean; elapsedLabel?: string; dict: ChatDict }>;
+
+/** E2 bypass footprint (issue #273 S1.7): 「✓ 再計算 1.2s」 — no pipeline. */
+function RecomputeFootprint({ settled, elapsedLabel, dict }: RecomputeProps) {
+  if (!settled) return null;
+  return (
+    <p className="chat-settled chat-settled--recompute">
+      ✓ {dict.search.recompute}
+      {elapsedLabel ? <span className="chat-settled__elapsed"> {elapsedLabel}</span> : null}
+    </p>
+  );
+}
+
+type RailProps = Readonly<{ message: UIMessage; settled: boolean; elapsedLabel?: string; dict: ChatDict }>;
+
+/** The turn's progress rail: tool badges for agent turns, the recompute
+ * footprint for `selected_point_ids` bypass turns (which run no tools). */
+function MessageRail({ message, settled, elapsedLabel, dict }: RailProps) {
+  const tools = message.parts.filter(isToolPart);
+  if (tools.length === 0 && hasRecomputePart(message.parts)) {
+    return <RecomputeFootprint settled={settled} elapsedLabel={elapsedLabel} dict={dict} />;
+  }
+  return <Pipeline parts={tools} settled={settled} elapsedLabel={elapsedLabel} dict={dict} />;
+}
+
 type BodyProps = Readonly<{
   parts: readonly Part[];
   messageId: string;
@@ -96,10 +122,9 @@ type ItemProps = Readonly<{
 }>;
 
 function MessageItem({ message, dict, settled, elapsedLabel, supersededKeys }: ItemProps) {
-  const tools = message.parts.filter(isToolPart);
   return (
     <li className={`chat-message chat-message--${message.role}`}>
-      <Pipeline parts={tools} settled={settled} elapsedLabel={elapsedLabel} dict={dict} />
+      <MessageRail message={message} settled={settled} elapsedLabel={elapsedLabel} dict={dict} />
       <MessageBody parts={nonToolParts(message)} messageId={message.id} dict={dict} supersededKeys={supersededKeys} />
     </li>
   );
@@ -137,12 +162,18 @@ type ListProps = Readonly<{
   settledDurationMs?: number;
 }>;
 
+/** Part-less messages are recompute turn boundaries, never rendered rows. */
+function visibleMessages(messages: readonly UIMessage[]): readonly UIMessage[] {
+  return messages.filter((message) => message.parts.length > 0);
+}
+
 export function MessageList({ messages, dict, status, settledDurationMs }: ListProps) {
-  if (messages.length === 0) return null;
-  const lastIndex = messages.length - 1;
-  const supersededKeys = supersededPartKeys(messages);
-  const items = messages.map((message, index) => (
-    <MessageRow key={message.id} message={message} isLast={index === lastIndex} dict={dict} status={status} settledDurationMs={settledDurationMs} supersededKeys={supersededKeys} />
+  const visible = visibleMessages(messages);
+  if (visible.length === 0) return null;
+  const last = messages.at(-1);
+  const supersededKeys = supersededPartKeys(visible);
+  const items = visible.map((message) => (
+    <MessageRow key={message.id} message={message} isLast={message === last} dict={dict} status={status} settledDurationMs={settledDurationMs} supersededKeys={supersededKeys} />
   ));
   return <ol className="chat-messages">{items}</ol>;
 }

--- a/apps/web/src/features/chat/components/SearchResult.tsx
+++ b/apps/web/src/features/chat/components/SearchResult.tsx
@@ -3,6 +3,7 @@ import { MAX_MAP_PINS, searchMapView, topSpots } from "../../../lib/chat/spotClu
 import type { SearchSpot, SpotCluster } from "../../../lib/chat/spotClusters";
 import { attachBasemap } from "../../bubble-map/bubbleMapController";
 import { episodeTag } from "../search-copy";
+import { useSpotSelection } from "../selection/useSpotSelection";
 import type { ChatDict } from "../i18n";
 import { EnvelopeFallback } from "./ErrorStates/EnvelopeFallback";
 import { SceneThumb } from "./ErrorStates/SceneThumb";
@@ -13,10 +14,12 @@ type SpotProps = Readonly<{ spot: SearchSpot; dict: ChatDict }>;
 type GridProps = Readonly<{ spots: readonly SearchSpot[]; dict: ChatDict }>;
 type ClusterProps = Readonly<{ cluster: SpotCluster; dict: ChatDict; attach: AttachBasemap }>;
 
+/** E2 (issue #273 S1.7): the pick is controlled by the shared spot selection. */
 function SpotPick({ spot, dict }: SpotProps) {
+  const { selected, toggle } = useSpotSelection();
   return (
     <label className="chat-spot-card__pick">
-      <input type="checkbox" className="chat-spot-card__check" aria-label={`${dict.search.select}: ${spot.name}`} />
+      <input type="checkbox" className="chat-spot-card__check" checked={selected.has(spot.id)} onChange={() => { toggle(spot.id); }} aria-label={`${dict.search.select}: ${spot.name}`} />
       <span className="chat-spot-card__name">{spot.name}</span>
     </label>
   );

--- a/apps/web/src/features/chat/components/SelectionTray.tsx
+++ b/apps/web/src/features/chat/components/SelectionTray.tsx
@@ -1,0 +1,63 @@
+import { useSpotSelection } from "../selection/useSpotSelection";
+import { sameIds } from "../../../lib/chat/selectedPointsBypass";
+import type { ChatDict } from "../i18n";
+
+/** The recompute turn's lifecycle as the tray sees it (issue #273 S1.7 E2). */
+export type RecomputeStatus = "idle" | "busy" | "failed";
+
+type TrayProps = Readonly<{
+  dict: ChatDict;
+  status: RecomputeStatus;
+  /** Ids of the last recompute actually sent; hides the tray until they change. */
+  lastSentIds?: readonly string[];
+  onRecompute: (ids: readonly string[]) => void;
+}>;
+
+type SummaryProps = Readonly<{ dict: ChatDict; count: number; failed: boolean }>;
+
+function traySub(dict: ChatDict, failed: boolean): string {
+  return failed ? dict.search.trayFailed : dict.search.trayChanged;
+}
+
+function TraySummary({ dict, count, failed }: SummaryProps) {
+  return (
+    <span className="chat-selection-tray__summary">
+      <span className="chat-selection-tray__sub">{traySub(dict, failed)}</span>
+      <span className="chat-selection-tray__count">
+        {dict.search.traySelected.replace("{count}", String(count))}
+      </span>
+    </span>
+  );
+}
+
+/** The sticky bar hides while a recompute flies or right after one succeeded. */
+function trayHidden(props: TrayProps, selected: ReadonlySet<string>): boolean {
+  if (selected.size === 0 || props.status === "busy") return true;
+  return props.status !== "failed" && sameIds(selected, props.lastSentIds);
+}
+
+type ActionProps = Readonly<{ dict: ChatDict; failed: boolean; fire: () => void }>;
+
+function TrayAction({ dict, failed, fire }: ActionProps) {
+  return (
+    <button type="button" className="chat-selection-tray__action" onClick={fire}>
+      {failed ? dict.search.trayRetry : dict.search.trayAction}
+    </button>
+  );
+}
+
+/**
+ * E2 sticky recompute bar (design-sync `Chat 完整状态.html` `.rebar`): summary
+ * line + count on the left, the gold action on the right. A failed bypass
+ * turn retries here inline — it never escalates to the full-page D-states.
+ */
+export function SelectionTray(props: TrayProps) {
+  const { selected } = useSpotSelection();
+  if (trayHidden(props, selected)) return null;
+  return (
+    <div className="chat-selection-tray" role="status">
+      <TraySummary dict={props.dict} count={selected.size} failed={props.status === "failed"} />
+      <TrayAction dict={props.dict} failed={props.status === "failed"} fire={() => { props.onRecompute([...selected]); }} />
+    </div>
+  );
+}

--- a/apps/web/src/features/chat/components/SelectionTray.tsx
+++ b/apps/web/src/features/chat/components/SelectionTray.tsx
@@ -15,15 +15,20 @@ type TrayProps = Readonly<{
 
 type SummaryProps = Readonly<{ dict: ChatDict; count: number; failed: boolean }>;
 
-function traySub(dict: ChatDict, failed: boolean): string {
-  return failed ? dict.search.trayFailed : dict.search.trayChanged;
+/** Design `Chat 完整状态.html` syncRebar: below two picks the bar asks for
+ * more (「2件以上選んでください」) and the action disables. */
+const MIN_SELECTION = 2;
+
+function traySub(dict: ChatDict, count: number, failed: boolean): string {
+  if (failed) return dict.search.trayFailed;
+  return count < MIN_SELECTION ? dict.search.trayMinimum : dict.search.trayChanged;
 }
 
 function TraySummary({ dict, count, failed }: SummaryProps) {
   return (
     <span className="chat-selection-tray__summary">
-      <span className="chat-selection-tray__sub">{traySub(dict, failed)}</span>
-      <span className="chat-selection-tray__count">
+      <span className="chat-selection-tray__sub">{traySub(dict, count, failed)}</span>
+      <span className="chat-selection-tray__count" role="status">
         {dict.search.traySelected.replace("{count}", String(count))}
       </span>
     </span>
@@ -36,11 +41,11 @@ function trayHidden(props: TrayProps, selected: ReadonlySet<string>): boolean {
   return props.status !== "failed" && sameIds(selected, props.lastSentIds);
 }
 
-type ActionProps = Readonly<{ dict: ChatDict; failed: boolean; fire: () => void }>;
+type ActionProps = Readonly<{ dict: ChatDict; failed: boolean; disabled: boolean; fire: () => void }>;
 
-function TrayAction({ dict, failed, fire }: ActionProps) {
+function TrayAction({ dict, failed, disabled, fire }: ActionProps) {
   return (
-    <button type="button" className="chat-selection-tray__action" onClick={fire}>
+    <button type="button" className="chat-selection-tray__action" disabled={disabled} onClick={fire}>
       {failed ? dict.search.trayRetry : dict.search.trayAction}
     </button>
   );
@@ -55,9 +60,9 @@ export function SelectionTray(props: TrayProps) {
   const { selected } = useSpotSelection();
   if (trayHidden(props, selected)) return null;
   return (
-    <div className="chat-selection-tray" role="status">
+    <div className="chat-selection-tray">
       <TraySummary dict={props.dict} count={selected.size} failed={props.status === "failed"} />
-      <TrayAction dict={props.dict} failed={props.status === "failed"} fire={() => { props.onRecompute([...selected]); }} />
+      <TrayAction dict={props.dict} failed={props.status === "failed"} disabled={selected.size < MIN_SELECTION} fire={() => { props.onRecompute([...selected]); }} />
     </div>
   );
 }

--- a/apps/web/src/features/chat/search-i18n.ts
+++ b/apps/web/src/features/chat/search-i18n.ts
@@ -6,6 +6,7 @@ export interface ChatSearchDict {
   readonly areaFallback: string;
   readonly mapLabel: string;
   readonly trayChanged: string;
+  readonly trayMinimum: string;
   readonly traySelected: string;
   readonly trayAction: string;
   readonly trayFailed: string;
@@ -19,6 +20,7 @@ export const jaSearch: ChatSearchDict = {
   areaFallback: "エリア{n}",
   mapLabel: "聖地マップ",
   trayChanged: "スポットの選択が変わりました",
+  trayMinimum: "2件以上選んでください",
   traySelected: "{count}件選択中",
   trayAction: "ルートを組み直す",
   trayFailed: "組み直せなかったみたい",
@@ -32,6 +34,7 @@ export const zhSearch: ChatSearchDict = {
   areaFallback: "区域{n}",
   mapLabel: "圣地地图",
   trayChanged: "圣地的选择有变化",
+  trayMinimum: "请至少选择 2 处",
   traySelected: "已选 {count} 处",
   trayAction: "重新规划路线",
   trayFailed: "这次没排好路线",
@@ -45,6 +48,7 @@ export const enSearch: ChatSearchDict = {
   areaFallback: "Area {n}",
   mapLabel: "Spot map",
   trayChanged: "Your spot selection changed",
+  trayMinimum: "Select at least 2 spots",
   traySelected: "{count} selected",
   trayAction: "Rebuild the route",
   trayFailed: "That rebuild didn't work",

--- a/apps/web/src/features/chat/search-i18n.ts
+++ b/apps/web/src/features/chat/search-i18n.ts
@@ -1,9 +1,16 @@
-/** Copy for the C3a/C3b search result cards and static map (issue #261 S1.4). */
+/** Copy for the C3a/C3b search result cards, static map (issue #261 S1.4) and
+ * the E2 selection tray + recompute footprint (issue #273 S1.7). */
 export interface ChatSearchDict {
   readonly select: string;
   readonly spotCount: string;
   readonly areaFallback: string;
   readonly mapLabel: string;
+  readonly trayChanged: string;
+  readonly traySelected: string;
+  readonly trayAction: string;
+  readonly trayFailed: string;
+  readonly trayRetry: string;
+  readonly recompute: string;
 }
 
 export const jaSearch: ChatSearchDict = {
@@ -11,6 +18,12 @@ export const jaSearch: ChatSearchDict = {
   spotCount: "{count}件",
   areaFallback: "エリア{n}",
   mapLabel: "聖地マップ",
+  trayChanged: "スポットの選択が変わりました",
+  traySelected: "{count}件選択中",
+  trayAction: "ルートを組み直す",
+  trayFailed: "組み直せなかったみたい",
+  trayRetry: "もう一度ためす",
+  recompute: "再計算",
 };
 
 export const zhSearch: ChatSearchDict = {
@@ -18,6 +31,12 @@ export const zhSearch: ChatSearchDict = {
   spotCount: "{count} 处",
   areaFallback: "区域{n}",
   mapLabel: "圣地地图",
+  trayChanged: "圣地的选择有变化",
+  traySelected: "已选 {count} 处",
+  trayAction: "重新规划路线",
+  trayFailed: "这次没排好路线",
+  trayRetry: "再试一次",
+  recompute: "重新计算",
 };
 
 export const enSearch: ChatSearchDict = {
@@ -25,4 +44,10 @@ export const enSearch: ChatSearchDict = {
   spotCount: "{count} spots",
   areaFallback: "Area {n}",
   mapLabel: "Spot map",
+  trayChanged: "Your spot selection changed",
+  traySelected: "{count} selected",
+  trayAction: "Rebuild the route",
+  trayFailed: "That rebuild didn't work",
+  trayRetry: "Try again",
+  recompute: "Recalculated",
 };

--- a/apps/web/src/features/chat/selection/useRecomputeTurn.ts
+++ b/apps/web/src/features/chat/selection/useRecomputeTurn.ts
@@ -44,10 +44,16 @@ function useFire(chat: ChatSession, setStatus: SetStatus, setIds: SetIds) {
   );
 }
 
-type ChatStatus = ChatSession["status"];
+type WatcherStep = Readonly<{
+  status: RecomputeStatus;
+  chatStatus: ChatSession["status"];
+  error: Error | undefined;
+  started: RefObject<boolean>;
+  setStatus: SetStatus;
+}>;
 
 /** A busy recompute settles once its turn went active and came back. */
-function settleBusy(chatStatus: ChatStatus, error: Error | undefined, started: RefObject<boolean>, setStatus: SetStatus): void {
+function settleBusy({ chatStatus, error, started, setStatus }: WatcherStep): void {
   if (isActive(chatStatus)) {
     started.current = true;
     return;
@@ -56,20 +62,20 @@ function settleBusy(chatStatus: ChatStatus, error: Error | undefined, started: R
 }
 
 /** One watcher step; a later non-recompute turn going active clears a stale verdict. */
-function stepWatcher(status: RecomputeStatus, chatStatus: ChatStatus, error: Error | undefined, started: RefObject<boolean>, setStatus: SetStatus): void {
-  if (status === "busy") {
-    settleBusy(chatStatus, error, started, setStatus);
+function stepWatcher(step: WatcherStep): void {
+  if (step.status === "busy") {
+    settleBusy(step);
     return;
   }
-  started.current = false;
-  if (status === "failed" && isActive(chatStatus)) setStatus("idle");
+  step.started.current = false;
+  if (step.status === "failed" && isActive(step.chatStatus)) step.setStatus("idle");
 }
 
 function useSettleWatcher(status: RecomputeStatus, chat: ChatSession, setStatus: SetStatus): void {
   const started = useRef(false);
   const { status: chatStatus, error } = chat;
   useEffect(() => {
-    stepWatcher(status, chatStatus, error, started, setStatus);
+    stepWatcher({ status, chatStatus, error, started, setStatus });
   }, [status, chatStatus, error, setStatus]);
 }
 

--- a/apps/web/src/features/chat/selection/useRecomputeTurn.ts
+++ b/apps/web/src/features/chat/selection/useRecomputeTurn.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { selectedPointsBody } from "../../../lib/chat/selectedPointsBypass";
+import type { SelectedPointsBody } from "../../../lib/chat/selectedPointsBypass";
+import type { RecomputeStatus } from "../components/SelectionTray";
+import type { ChatSession } from "../use-chat-session";
+
+/**
+ * Tracks the E2 recompute turn (issue #273 S1.7): `fire` sends the bypass
+ * body; the settle watcher classifies the turn as idle again or failed. A
+ * failed recompute stays on the tray — ChatPage masks the full-page
+ * `TurnFailure` surface while this hook reports `failed`.
+ */
+export interface RecomputeTurn {
+  readonly status: RecomputeStatus;
+  readonly lastSentIds: readonly string[] | undefined;
+  readonly fire: (ids: readonly string[]) => void;
+}
+
+function isActive(status: ChatSession["status"]): boolean {
+  return status === "submitted" || status === "streaming";
+}
+
+type SetStatus = (status: RecomputeStatus) => void;
+type SetIds = (ids: readonly string[]) => void;
+type SendBypass = (body: SelectedPointsBody) => void;
+
+/** The guard: an empty selection produces no body, so the bypass never fires empty. */
+function fireRecompute(ids: readonly string[], send: SendBypass, setStatus: SetStatus, setIds: SetIds): void {
+  const body = selectedPointsBody(ids);
+  if (body === undefined) return;
+  setIds(body.selected_point_ids);
+  setStatus("busy");
+  send(body);
+}
+
+function useFire(chat: ChatSession, setStatus: SetStatus, setIds: SetIds) {
+  const { sendSelectedPoints } = chat;
+  return useCallback(
+    (ids: readonly string[]) => {
+      fireRecompute(ids, sendSelectedPoints, setStatus, setIds);
+    },
+    [sendSelectedPoints, setStatus, setIds],
+  );
+}
+
+type ChatStatus = ChatSession["status"];
+
+/** A busy recompute settles once its turn went active and came back. */
+function settleBusy(chatStatus: ChatStatus, error: Error | undefined, started: RefObject<boolean>, setStatus: SetStatus): void {
+  if (isActive(chatStatus)) {
+    started.current = true;
+    return;
+  }
+  if (started.current) setStatus(error === undefined ? "idle" : "failed");
+}
+
+/** One watcher step; a later non-recompute turn going active clears a stale verdict. */
+function stepWatcher(status: RecomputeStatus, chatStatus: ChatStatus, error: Error | undefined, started: RefObject<boolean>, setStatus: SetStatus): void {
+  if (status === "busy") {
+    settleBusy(chatStatus, error, started, setStatus);
+    return;
+  }
+  started.current = false;
+  if (status === "failed" && isActive(chatStatus)) setStatus("idle");
+}
+
+function useSettleWatcher(status: RecomputeStatus, chat: ChatSession, setStatus: SetStatus): void {
+  const started = useRef(false);
+  const { status: chatStatus, error } = chat;
+  useEffect(() => {
+    stepWatcher(status, chatStatus, error, started, setStatus);
+  }, [status, chatStatus, error, setStatus]);
+}
+
+export function useRecomputeTurn(chat: ChatSession): RecomputeTurn {
+  const [status, setStatus] = useState<RecomputeStatus>("idle");
+  const [lastSentIds, setLastSentIds] = useState<readonly string[]>();
+  const fire = useFire(chat, setStatus, setLastSentIds);
+  useSettleWatcher(status, chat, setStatus);
+  return { status, lastSentIds, fire };
+}

--- a/apps/web/src/features/chat/selection/useSpotSelection.tsx
+++ b/apps/web/src/features/chat/selection/useSpotSelection.tsx
@@ -5,14 +5,12 @@ import type { ReactNode } from "react";
 export interface SpotSelection {
   readonly selected: ReadonlySet<string>;
   readonly toggle: (id: string) => void;
-  readonly clear: () => void;
 }
 
 /** Outside a selection scope (history rows, bare card tests) checkboxes are inert. */
 const DISABLED_SELECTION: SpotSelection = {
   selected: new Set<string>(),
   toggle: () => undefined,
-  clear: () => undefined,
 };
 
 const SpotSelectionContext = createContext<SpotSelection>(DISABLED_SELECTION);
@@ -29,10 +27,7 @@ export function useSpotSelectionState(): SpotSelection {
   const toggle = useCallback((id: string) => {
     setSelected((previous) => toggled(previous, id));
   }, []);
-  const clear = useCallback(() => {
-    setSelected(new Set());
-  }, []);
-  return useMemo(() => ({ selected, toggle, clear }), [selected, toggle, clear]);
+  return useMemo(() => ({ selected, toggle }), [selected, toggle]);
 }
 
 type ProviderProps = Readonly<{ selection: SpotSelection; children: ReactNode }>;

--- a/apps/web/src/features/chat/selection/useSpotSelection.tsx
+++ b/apps/web/src/features/chat/selection/useSpotSelection.tsx
@@ -1,0 +1,46 @@
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+/** E2 spot selection (issue #273 S1.7): a Set keyed by result spot identity. */
+export interface SpotSelection {
+  readonly selected: ReadonlySet<string>;
+  readonly toggle: (id: string) => void;
+  readonly clear: () => void;
+}
+
+/** Outside a selection scope (history rows, bare card tests) checkboxes are inert. */
+const DISABLED_SELECTION: SpotSelection = {
+  selected: new Set<string>(),
+  toggle: () => undefined,
+  clear: () => undefined,
+};
+
+const SpotSelectionContext = createContext<SpotSelection>(DISABLED_SELECTION);
+
+function toggled(previous: ReadonlySet<string>, id: string): ReadonlySet<string> {
+  const next = new Set(previous);
+  if (!next.delete(id)) next.add(id);
+  return next;
+}
+
+/** The live selection state; owned by ChatPage, shared through the provider. */
+export function useSpotSelectionState(): SpotSelection {
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  const toggle = useCallback((id: string) => {
+    setSelected((previous) => toggled(previous, id));
+  }, []);
+  const clear = useCallback(() => {
+    setSelected(new Set());
+  }, []);
+  return useMemo(() => ({ selected, toggle, clear }), [selected, toggle, clear]);
+}
+
+type ProviderProps = Readonly<{ selection: SpotSelection; children: ReactNode }>;
+
+export function SpotSelectionProvider({ selection, children }: ProviderProps) {
+  return <SpotSelectionContext.Provider value={selection}>{children}</SpotSelectionContext.Provider>;
+}
+
+export function useSpotSelection(): SpotSelection {
+  return useContext(SpotSelectionContext);
+}

--- a/apps/web/src/features/chat/use-chat-session.ts
+++ b/apps/web/src/features/chat/use-chat-session.ts
@@ -1,4 +1,5 @@
 import { Chat, useChat } from "@ai-sdk/react";
+import type { UseChatHelpers } from "@ai-sdk/react";
 import { ChatResponseDataPart } from "@seichijunrei/contract";
 import type { ChatDataPart } from "@seichijunrei/contract";
 import { DefaultChatTransport } from "ai";
@@ -6,6 +7,7 @@ import type { UIMessage } from "ai";
 import { useCallback, useRef } from "react";
 import type { RefObject } from "react";
 import { authHeaders } from "../../lib/auth/authSession";
+import type { SelectedPointsBody } from "../../lib/chat/selectedPointsBypass";
 import { turnstileHeaders } from "../../lib/turnstile/tokenStore";
 
 /**
@@ -157,14 +159,47 @@ function useScopedChat(chatUrl: string, scope: string, ref: SessionRef): Chat<Ch
  * backend-assigned `session_id` from `data-response` frames is fed back into
  * follow-up requests through the transport's dynamic `headers` function.
  */
+function useTrackerReaders(ref: SessionRef) {
+  const sessionIdOf = useCallback(() => ref.current.id, [ref]);
+  const lastHttpStatus = useCallback(() => ref.current.lastHttpStatus, [ref]);
+  const lastErrorCode = useCallback(() => ref.current.lastErrorCode, [ref]);
+  return { sessionIdOf, lastHttpStatus, lastErrorCode };
+}
+
+/** A part-less turn boundary. Without it ai@6.0.225 continues the previous
+ * assistant message (`createStreamingUIMessageState` reuses an assistant
+ * `lastMessage`) and the same-ID `response` part would overwrite the prior
+ * card instead of appending the E1 living-document version. It carries no
+ * user utterance — the server must not persist a user row for it (the
+ * skip-empty-utterance guard in `persistence.py`, #273 Task 3). */
+function recomputeMarker(): ChatUIMessage {
+  return { id: `recompute-${crypto.randomUUID()}`, role: "user", parts: [] };
+}
+
+type SendHelpers = Pick<UseChatHelpers<ChatUIMessage>, "sendMessage" | "setMessages">;
+
+/**
+ * E2 bypass send (issue #273 S1.7): re-submit the conversation with only a
+ * `selected_point_ids` body — no new user utterance. ai@6.0.225's
+ * `DefaultChatTransport` merges the per-call body (`{...resolvedBody,
+ * ...options.body}`), so the field reaches `_optional_ids` unchanged.
+ */
+function useSendSelectedPoints({ sendMessage, setMessages }: SendHelpers) {
+  return useCallback(
+    (body: SelectedPointsBody) => {
+      setMessages((current) => [...current, recomputeMarker()]);
+      void sendMessage(undefined, { body: { ...body } });
+    },
+    [sendMessage, setMessages],
+  );
+}
+
 export function useChatSession(chatUrl: string, sessionId?: string) {
   const scope = scopeOf(sessionId);
   const ref = useSessionTracker(sessionId, scope);
   const chat = useScopedChat(chatUrl, scope, ref);
-  const sessionIdOf = useCallback(() => ref.current.id, [ref]);
-  const lastHttpStatus = useCallback(() => ref.current.lastHttpStatus, [ref]);
-  const lastErrorCode = useCallback(() => ref.current.lastErrorCode, [ref]);
-  return { ...useChat<ChatUIMessage>({ chat }), sessionIdOf, lastHttpStatus, lastErrorCode };
+  const helpers = useChat<ChatUIMessage>({ chat });
+  return { ...helpers, sendSelectedPoints: useSendSelectedPoints(helpers), ...useTrackerReaders(ref) };
 }
 
 export type ChatSession = ReturnType<typeof useChatSession>;

--- a/apps/web/src/features/chat/use-chat-session.ts
+++ b/apps/web/src/features/chat/use-chat-session.ts
@@ -2,7 +2,7 @@ import { Chat, useChat } from "@ai-sdk/react";
 import type { UseChatHelpers } from "@ai-sdk/react";
 import { ChatResponseDataPart } from "@seichijunrei/contract";
 import type { ChatDataPart } from "@seichijunrei/contract";
-import { DefaultChatTransport } from "ai";
+import { DefaultChatTransport, generateId } from "ai";
 import type { UIMessage } from "ai";
 import { useCallback, useRef } from "react";
 import type { RefObject } from "react";
@@ -173,7 +173,7 @@ function useTrackerReaders(ref: SessionRef) {
  * user utterance — the server must not persist a user row for it (the
  * skip-empty-utterance guard in `persistence.py`, #273 Task 3). */
 function recomputeMarker(): ChatUIMessage {
-  return { id: `recompute-${crypto.randomUUID()}`, role: "user", parts: [] };
+  return { id: `recompute-${generateId()}`, role: "user", parts: [] };
 }
 
 type SendHelpers = Pick<UseChatHelpers<ChatUIMessage>, "sendMessage" | "setMessages">;

--- a/apps/web/src/lib/chat/selectedPointsBypass.ts
+++ b/apps/web/src/lib/chat/selectedPointsBypass.ts
@@ -36,13 +36,16 @@ function isToolLike(part: PartLike): boolean {
 }
 
 /**
- * A bypass recompute turn: a `plan_selected` card whose only tool part is the
- * `plan_selected` step the backend always streams for the bypass
- * (`execute_selected_route` → `chat_stream._ToolPartTranslator`). The UI
- * suppresses that pipeline — "没经过 agent 就不演 agent 的戏". Agent-path
- * turns that ran other tools keep their badges.
+ * A bypass recompute turn: only `plan_selected` step parts, or a
+ * `plan_selected` card before any step streamed — the backend always streams
+ * that step for the bypass (`execute_selected_route` →
+ * `chat_stream._ToolPartTranslator`) and the UI suppresses it: "没经过 agent
+ * 就不演 agent 的戏". Order-independent so the step frame arriving BEFORE the
+ * data part cannot flash a badge; agent-path turns that ran other tools keep
+ * their badges.
  */
 export function isBypassTurn(parts: readonly PartLike[]): boolean {
-  if (!parts.some(isRecomputeData)) return false;
-  return parts.filter(isToolLike).every((part) => part.type === "tool-plan_selected");
+  const tools = parts.filter(isToolLike);
+  if (tools.length > 0) return tools.every((part) => part.type === "tool-plan_selected");
+  return parts.some(isRecomputeData);
 }

--- a/apps/web/src/lib/chat/selectedPointsBypass.ts
+++ b/apps/web/src/lib/chat/selectedPointsBypass.ts
@@ -1,0 +1,37 @@
+/**
+ * E2 recompute bypass (issue #273 S1.7): a checkbox reselection re-sends the
+ * conversation with `selected_point_ids`, so `_dispatch_request` takes the
+ * `execute_selected_route` branch and the agent never runs. The turn carries
+ * no new user utterance — the body field is the whole request delta.
+ */
+export interface SelectedPointsBody {
+  readonly selected_point_ids: readonly string[];
+}
+
+/** The bypass can never fire empty: an empty selection produces no body. */
+export function selectedPointsBody(ids: readonly string[]): SelectedPointsBody | undefined {
+  if (ids.length === 0) return undefined;
+  return { selected_point_ids: [...ids] };
+}
+
+/** Order-insensitive match of the live selection against the last-sent ids. */
+export function sameIds(selected: ReadonlySet<string>, ids: readonly string[] | undefined): boolean {
+  if (ids === undefined || selected.size !== ids.length) return false;
+  return ids.every((id) => selected.has(id));
+}
+
+function intentOf(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null || !("intent" in data)) return undefined;
+  const { intent } = data;
+  return typeof intent === "string" ? intent : undefined;
+}
+
+interface PartLike {
+  readonly type: string;
+  readonly data?: unknown;
+}
+
+/** A bypass recompute's card: `plan_selected` streamed with no tool pipeline. */
+export function hasRecomputePart(parts: readonly PartLike[]): boolean {
+  return parts.some((part) => part.type === "data-response" && intentOf(part.data) === "plan_selected");
+}

--- a/apps/web/src/lib/chat/selectedPointsBypass.ts
+++ b/apps/web/src/lib/chat/selectedPointsBypass.ts
@@ -1,3 +1,5 @@
+import { intentOf } from "./supersession";
+
 /**
  * E2 recompute bypass (issue #273 S1.7): a checkbox reselection re-sends the
  * conversation with `selected_point_ids`, so `_dispatch_request` takes the
@@ -20,18 +22,27 @@ export function sameIds(selected: ReadonlySet<string>, ids: readonly string[] | 
   return ids.every((id) => selected.has(id));
 }
 
-function intentOf(data: unknown): string | undefined {
-  if (typeof data !== "object" || data === null || !("intent" in data)) return undefined;
-  const { intent } = data;
-  return typeof intent === "string" ? intent : undefined;
-}
-
 interface PartLike {
   readonly type: string;
   readonly data?: unknown;
 }
 
-/** A bypass recompute's card: `plan_selected` streamed with no tool pipeline. */
-export function hasRecomputePart(parts: readonly PartLike[]): boolean {
-  return parts.some((part) => part.type === "data-response" && intentOf(part.data) === "plan_selected");
+function isRecomputeData(part: PartLike): boolean {
+  return part.type === "data-response" && intentOf(part.data) === "plan_selected";
+}
+
+function isToolLike(part: PartLike): boolean {
+  return part.type.startsWith("tool-") || part.type === "dynamic-tool";
+}
+
+/**
+ * A bypass recompute turn: a `plan_selected` card whose only tool part is the
+ * `plan_selected` step the backend always streams for the bypass
+ * (`execute_selected_route` → `chat_stream._ToolPartTranslator`). The UI
+ * suppresses that pipeline — "没经过 agent 就不演 agent 的戏". Agent-path
+ * turns that ran other tools keep their badges.
+ */
+export function isBypassTurn(parts: readonly PartLike[]): boolean {
+  if (!parts.some(isRecomputeData)) return false;
+  return parts.filter(isToolLike).every((part) => part.type === "tool-plan_selected");
 }

--- a/apps/web/src/lib/chat/supersession.ts
+++ b/apps/web/src/lib/chat/supersession.ts
@@ -21,7 +21,9 @@ const ROUTE_INTENTS: ReadonlySet<string> = new Set([
   "partial",
 ]);
 
-function intentOf(data: unknown): string | undefined {
+/** Intent discriminator of a streamed `data-response` payload (shared with
+ * the E2 bypass detection in `selectedPointsBypass.ts` — one implementation). */
+export function intentOf(data: unknown): string | undefined {
   if (typeof data !== "object" || data === null || !("intent" in data)) return undefined;
   const { intent } = data;
   return typeof intent === "string" ? intent : undefined;

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -740,8 +740,6 @@
    (`selected_point_ids` bypass — no agent, no agent theater). */
 
 .chat-selection-tray {
-  position: sticky;
-  bottom: 0;
   display: flex;
   align-items: center;
   gap: 0.625rem;
@@ -772,6 +770,7 @@
 }
 
 .chat-selection-tray__action {
+  min-height: 44px;
   border: 0;
   border-radius: 999px;
   padding: 0.5625rem 1rem;
@@ -790,4 +789,18 @@
 
 .chat-settled--recompute {
   margin: 0;
+}
+
+/* Persistent polite live region: keeps announcing the recompute after the
+   tray unmounts on fire (a11y focus handoff, #461 review). */
+.chat-live-note {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  clip-path: inset(50%);
 }

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -733,3 +733,61 @@
   color: var(--color-muted-fg);
   font-size: 0.6875rem;
 }
+
+/* --- E2 selection tray + recompute footprint (issue #273 S1.7) ---
+   Design-sync `Chat 完整状态.html` `.rebar`: gold-bordered sticky bar docked
+   above the composer; the recompute footprint replaces the tool pipeline
+   (`selected_point_ids` bypass — no agent, no agent theater). */
+
+.chat-selection-tray {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  margin: 0 1rem 0.5rem;
+  padding: 0.5625rem 0.625rem 0.5625rem 0.875rem;
+  border: 2px solid var(--color-gold);
+  border-radius: 16px;
+  background: var(--color-card);
+  color: var(--color-fg);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  box-shadow: 0 3px 0 var(--shadow-3d);
+}
+
+.chat-selection-tray__summary {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-selection-tray__sub {
+  color: var(--color-muted-fg);
+  font-size: 0.71875rem;
+}
+
+.chat-selection-tray__count {
+  color: var(--color-fg);
+}
+
+.chat-selection-tray__action {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.5625rem 1rem;
+  background: var(--color-gold);
+  color: var(--color-gold-fg);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  box-shadow: 0 3px 0 var(--shadow-3d);
+  cursor: pointer;
+}
+
+.chat-selection-tray__action:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 var(--shadow-3d);
+}
+
+.chat-settled--recompute {
+  margin: 0;
+}

--- a/apps/web/tests/msw/chat-handlers.ts
+++ b/apps/web/tests/msw/chat-handlers.ts
@@ -187,25 +187,70 @@ export function searchResultsPatch(envelope: Record<string, unknown>): Record<st
   return { ...envelope, intent: "search_bangumi", data: { results: { rows } } };
 }
 
-function stripToolFrames(recording: string): string {
+/** The real bypass step frames: `execute_selected_route` emits one
+ * `plan_selected` running/done step pair (`test_selected_route.py`), which
+ * `chat_stream._ToolPartTranslator` translates into exactly these tool
+ * chunks. The UI must prove it SUPPRESSES them — a fixture without them
+ * would certify the wrong tree (#461 review P1-1). */
+const PLAN_SELECTED_STEP_FRAMES = [
+  'data: {"type":"tool-input-start","toolCallId":"plan_selected-fixture","toolName":"plan_selected"}',
+  'data: {"type":"tool-input-available","toolCallId":"plan_selected-fixture","toolName":"plan_selected","input":{}}',
+  'data: {"type":"tool-output-available","toolCallId":"plan_selected-fixture","output":{"point_count":2}}',
+].join("\n\n");
+
+const START_STEP_FRAME = 'data: {"type":"start-step"}';
+
+/**
+ * The `selected_point_ids` bypass stream (issue #273 S1.7 E2): the recorded
+ * search stream with the agent-path tool frames replaced by the bypass's own
+ * `plan_selected` step frames, and the route re-intended as `plan_selected`.
+ */
+function toRecomputeStream(recording: string): string {
   return recording
     .split("\n")
     .filter((line) => !line.startsWith('data: {"type":"tool-'))
     .join("\n")
+    .replace(START_STEP_FRAME, `${START_STEP_FRAME}\n\n${PLAN_SELECTED_STEP_FRAMES}`)
     .replaceAll('"intent":"plan_route"', '"intent":"plan_selected"');
 }
 
-/**
- * The `selected_point_ids` bypass stream (issue #273 S1.7 E2): the recorded
- * search stream with every tool frame stripped and the route re-intended as
- * `plan_selected` — the bypass never runs the agent, so no pipeline streams.
- */
 export function chatRecomputeHandler(options: ChatStreamOptions = {}): HttpHandler {
-  const recorded = stripToolFrames(streamText("search", options));
+  const recorded = toRecomputeStream(streamText("search", options));
   return http.post(CHAT_URL, ({ request }) => {
     options.spy?.(request);
     return sseResponse(recorded);
   });
+}
+
+export interface ControlledRecomputeStream {
+  readonly handler: HttpHandler;
+  /** Flush the final full envelope (and close); the skeleton shows until then. */
+  readonly releaseFinal: () => void;
+}
+
+/** The recompute stream held open before its final full envelope, so a test
+ * can assert the skeleton state actually appeared (review P2-⑥). */
+export function chatRecomputeControlledHandler(): ControlledRecomputeStream {
+  const recorded = toRecomputeStream(chatStreamFixture("search"));
+  const splitAt = recorded.lastIndexOf('data: {"type":"data-response"');
+  let release: () => void = () => undefined;
+  const handler = http.post(CHAT_URL, () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(recorded.slice(0, splitAt)));
+        release = () => {
+          flushTail(controller, recorded.slice(splitAt));
+        };
+      },
+    });
+    return new HttpResponse(body, { headers: SSE_HEADERS });
+  });
+  return {
+    handler,
+    releaseFinal: () => {
+      release();
+    },
+  };
 }
 
 /** Replays the recording up to (excluding) the first data-response frame and holds the stream open. */

--- a/apps/web/tests/msw/chat-handlers.ts
+++ b/apps/web/tests/msw/chat-handlers.ts
@@ -37,6 +37,8 @@ export interface ChatStreamOptions {
   readonly spy?: (request: Request) => void;
   /** Corrupt the recorded final frame (type-invalid `success`) to probe schema guards. */
   readonly malformedFinal?: boolean;
+  /** Serve this handler for a single request only (msw one-time handler). */
+  readonly once?: boolean;
 }
 
 function patchSessionId(text: string, sessionId?: string): string {
@@ -164,9 +166,45 @@ export function chatStreamPatchedHandler(
     .split("\n")
     .map((line) => patchFinalFrameLine(line, patch))
     .join("\n");
+  return http.post(
+    CHAT_URL,
+    ({ request }) => {
+      options.spy?.(request);
+      return sseResponse(patched);
+    },
+    { once: options.once === true },
+  );
+}
+
+/** The E2 search-results envelope: derived from the real capture, like the
+ * D-state variants, until a search_bangumi results recording ships. */
+export function searchResultsPatch(envelope: Record<string, unknown>): Record<string, unknown> {
+  const rows = [
+    { id: "p1", name: "宇治橋", latitude: 34.891, longitude: 135.807 },
+    { id: "p2", name: "京阪宇治駅", latitude: 34.911, longitude: 135.806 },
+    { id: "p3", name: "宇治神社", latitude: 34.9, longitude: 135.81 },
+  ];
+  return { ...envelope, intent: "search_bangumi", data: { results: { rows } } };
+}
+
+function stripToolFrames(recording: string): string {
+  return recording
+    .split("\n")
+    .filter((line) => !line.startsWith('data: {"type":"tool-'))
+    .join("\n")
+    .replaceAll('"intent":"plan_route"', '"intent":"plan_selected"');
+}
+
+/**
+ * The `selected_point_ids` bypass stream (issue #273 S1.7 E2): the recorded
+ * search stream with every tool frame stripped and the route re-intended as
+ * `plan_selected` — the bypass never runs the agent, so no pipeline streams.
+ */
+export function chatRecomputeHandler(options: ChatStreamOptions = {}): HttpHandler {
+  const recorded = stripToolFrames(streamText("search", options));
   return http.post(CHAT_URL, ({ request }) => {
     options.spy?.(request);
-    return sseResponse(patched);
+    return sseResponse(recorded);
   });
 }
 

--- a/apps/web/tests/msw/chat-handlers.ts
+++ b/apps/web/tests/msw/chat-handlers.ts
@@ -214,6 +214,13 @@ function toRecomputeStream(recording: string): string {
     .replaceAll('"intent":"plan_route"', '"intent":"plan_selected"');
 }
 
+/** Fixture self-guard: the recompute stream a test replays. Tests assert it
+ * still carries the injected `plan_selected` step frames — deleting them
+ * would silently re-certify the P1-1 false-green tree. */
+export function recomputeStreamFixture(): string {
+  return toRecomputeStream(chatStreamFixture("search"));
+}
+
 export function chatRecomputeHandler(options: ChatStreamOptions = {}): HttpHandler {
   const recorded = toRecomputeStream(streamText("search", options));
   return http.post(CHAT_URL, ({ request }) => {

--- a/apps/web/tests/unit/chat/chat-page-selection.test.tsx
+++ b/apps/web/tests/unit/chat/chat-page-selection.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { setLanguages } from "../_i18n";
+import { server } from "../../msw/node";
+import {
+  chatHttpErrorHandler,
+  chatRecomputeHandler,
+  chatStreamPatchedHandler,
+  searchResultsPatch,
+} from "../../msw/chat-handlers";
+import { chatSearch, renderChatPage } from "./_chat-page";
+
+const ja = chatDictFor("ja");
+
+interface SentPart {
+  readonly type: string;
+  readonly text?: string;
+}
+
+interface SentMessage {
+  readonly role: string;
+  readonly parts: readonly SentPart[];
+}
+
+interface SentBody {
+  readonly selected_point_ids?: readonly string[];
+  readonly messages?: readonly SentMessage[];
+}
+
+/** A genuine user turn carries a non-empty text part; markers carry none. */
+function userTurns(body?: SentBody): number {
+  const spoken = (message: SentMessage) =>
+    message.role === "user" && message.parts.some((part) => part.type === "text" && part.text !== "");
+  return (body?.messages ?? []).filter(spoken).length;
+}
+
+beforeEach(() => {
+  setLanguages(["ja"]);
+});
+
+async function searchThenTickTwo(bodies: SentBody[]): Promise<void> {
+  const spy = (request: Request) => {
+    void request.clone().json().then((body: SentBody) => bodies.push(body));
+  };
+  server.use(chatRecomputeHandler({ spy }));
+  server.use(chatStreamPatchedHandler("search", searchResultsPatch, { spy, once: true }));
+  renderChatPage(chatSearch({ q: "ユーフォ" }));
+  await screen.findByText("宇治橋");
+  fireEvent.click(screen.getByRole("checkbox", { name: `${ja.search.select}: 宇治橋` }));
+  fireEvent.click(screen.getByRole("checkbox", { name: `${ja.search.select}: 宇治神社` }));
+}
+
+function recomputeNow(): void {
+  fireEvent.click(screen.getByRole("button", { name: ja.search.trayAction }));
+}
+
+describe("AC: the tray action drives the selected_point_ids bypass", () => {
+  it("issues exactly one extra POST whose body carries the ticked ids and no new user turn", async () => {
+    const bodies: SentBody[] = [];
+    await searchThenTickTwo(bodies);
+    recomputeNow();
+    await waitFor(() => {
+      expect(document.querySelector('article[data-intent="plan_selected"]')).toBeTruthy();
+    });
+    expect(bodies).toHaveLength(2);
+    const [search, recompute] = bodies;
+    expect(search?.selected_point_ids).toBeUndefined();
+    expect(recompute?.selected_point_ids).toEqual(["p1", "p3"]);
+    expect(userTurns(recompute)).toBe(userTurns(search));
+  });
+
+  it("renders the recompute as footprint + card, with no tool badges and the old card dimmed", async () => {
+    const bodies: SentBody[] = [];
+    await searchThenTickTwo(bodies);
+    recomputeNow();
+    await waitFor(() => {
+      expect(document.querySelector(".chat-settled--recompute")).toBeTruthy();
+    });
+    const recomputeTurn = document.querySelector('article[data-intent="plan_selected"]');
+    expect(recomputeTurn?.className).toBe("chat-card");
+    expect(recomputeTurn?.closest("li")?.querySelector(".chat-step")).toBeNull();
+    expect(document.querySelector('article[data-intent="search_bangumi"]')?.className).toBe("chat-card");
+  });
+});
+
+describe("AC error path: a failed recompute stays on the tray", () => {
+  it("shows the inline retry, keeps the selection and the old card, and skips TurnFailure", async () => {
+    const bodies: SentBody[] = [];
+    await searchThenTickTwo(bodies);
+    server.use(chatHttpErrorHandler(500));
+    recomputeNow();
+    const retry = await screen.findByRole("button", { name: ja.search.trayRetry });
+    expect(retry).toBeTruthy();
+    expect(screen.queryByText(ja.errorStates.d4Message)).toBeNull();
+    expect(screen.getByText("宇治橋")).toBeTruthy();
+    const checked = screen.getAllByRole<HTMLInputElement>("checkbox").filter((box) => box.checked);
+    expect(checked).toHaveLength(2);
+  });
+
+  it("recovers when the tray retry succeeds", async () => {
+    const bodies: SentBody[] = [];
+    await searchThenTickTwo(bodies);
+    server.use(chatHttpErrorHandler(500));
+    recomputeNow();
+    await screen.findByRole("button", { name: ja.search.trayRetry });
+    server.use(chatRecomputeHandler());
+    fireEvent.click(screen.getByRole("button", { name: ja.search.trayRetry }));
+    await waitFor(() => {
+      expect(document.querySelector('article[data-intent="plan_selected"]')).toBeTruthy();
+    });
+    expect(screen.queryByRole("button", { name: ja.search.trayRetry })).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/chat/chat-page-selection.test.tsx
+++ b/apps/web/tests/unit/chat/chat-page-selection.test.tsx
@@ -8,7 +8,9 @@ import { setLanguages } from "../_i18n";
 import { server } from "../../msw/node";
 import {
   chatHttpErrorHandler,
+  chatRecomputeControlledHandler,
   chatRecomputeHandler,
+  chatStreamHeldOpenHandler,
   chatStreamPatchedHandler,
   searchResultsPatch,
 } from "../../msw/chat-handlers";
@@ -66,11 +68,18 @@ describe("AC: the tray action drives the selected_point_ids bypass", () => {
     await waitFor(() => {
       expect(document.querySelector('article[data-intent="plan_selected"]')).toBeTruthy();
     });
-    expect(bodies).toHaveLength(2);
+    // The spy decodes bodies asynchronously — wait, don't race (#461 review).
+    await waitFor(() => {
+      expect(bodies).toHaveLength(2);
+    });
     const [search, recompute] = bodies;
     expect(search?.selected_point_ids).toBeUndefined();
     expect(recompute?.selected_point_ids).toEqual(["p1", "p3"]);
     expect(userTurns(recompute)).toBe(userTurns(search));
+    // The wire shape Task 3's persistence skip keys on: a part-less user marker.
+    const marker = recompute?.messages?.at(-1);
+    expect(marker?.role).toBe("user");
+    expect(marker?.parts).toEqual([]);
   });
 
   it("renders the recompute as footprint + card, with no tool badges and the old card dimmed", async () => {
@@ -84,6 +93,39 @@ describe("AC: the tray action drives the selected_point_ids bypass", () => {
     expect(recomputeTurn?.className).toBe("chat-card");
     expect(recomputeTurn?.closest("li")?.querySelector(".chat-step")).toBeNull();
     expect(document.querySelector('article[data-intent="search_bangumi"]')?.className).toBe("chat-card");
+  });
+});
+
+describe("P1-3: no concurrent turns from the tray", () => {
+  it("hides the tray while any turn is streaming, so it cannot fire mid-stream", async () => {
+    const bodies: SentBody[] = [];
+    await searchThenTickTwo(bodies);
+    expect(document.querySelector(".chat-selection-tray")).toBeTruthy();
+    server.use(chatStreamHeldOpenHandler("search"));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "図書館は外して" } });
+    fireEvent.click(screen.getByRole("button", { name: ja.send }));
+    await waitFor(() => {
+      expect(document.querySelector(".chat-selection-tray")).toBeNull();
+    });
+    expect(screen.queryByRole("button", { name: ja.search.trayAction })).toBeNull();
+  });
+});
+
+describe("P2-6: the recompute skeleton state actually appears", () => {
+  it("shows the plan_selected skeleton until the final envelope lands", async () => {
+    const bodies: SentBody[] = [];
+    await searchThenTickTwo(bodies);
+    const controlled = chatRecomputeControlledHandler();
+    server.use(controlled.handler);
+    recomputeNow();
+    await waitFor(() => {
+      expect(document.querySelector('.chat-card--skeleton[data-intent="plan_selected"]')).toBeTruthy();
+    });
+    controlled.releaseFinal();
+    await waitFor(() => {
+      expect(document.querySelector('article[data-intent="plan_selected"]')).toBeTruthy();
+    });
+    expect(document.querySelector('.chat-card--skeleton[data-intent="plan_selected"]')).toBeNull();
   });
 });
 

--- a/apps/web/tests/unit/chat/chat-page-selection.test.tsx
+++ b/apps/web/tests/unit/chat/chat-page-selection.test.tsx
@@ -12,6 +12,7 @@ import {
   chatRecomputeHandler,
   chatStreamHeldOpenHandler,
   chatStreamPatchedHandler,
+  recomputeStreamFixture,
   searchResultsPatch,
 } from "../../msw/chat-handlers";
 import { chatSearch, renderChatPage } from "./_chat-page";
@@ -93,6 +94,12 @@ describe("AC: the tray action drives the selected_point_ids bypass", () => {
     expect(recomputeTurn?.className).toBe("chat-card");
     expect(recomputeTurn?.closest("li")?.querySelector(".chat-step")).toBeNull();
     expect(document.querySelector('article[data-intent="search_bangumi"]')?.className).toBe("chat-card");
+  });
+});
+
+describe("fixture self-guard (P1-1)", () => {
+  it("keeps the plan_selected step frames the backend always streams in the recompute fixture", () => {
+    expect(recomputeStreamFixture()).toContain('"toolName":"plan_selected"');
   });
 });
 

--- a/apps/web/tests/unit/chat/recompute-footprint.test.tsx
+++ b/apps/web/tests/unit/chat/recompute-footprint.test.tsx
@@ -23,8 +23,18 @@ function userMessage(id: string, text: string): UIMessage {
   return { id, role: "user", parts: [{ type: "text", text }] };
 }
 
-function recomputeRaw(points: readonly Record<string, unknown>[]): Record<string, unknown> {
-  return { ...routePartRaw(points), intent: "plan_selected" };
+/** The real bypass turn as streamed: the `plan_selected` step's tool part
+ * (which `chat_stream` always emits — review P1-1) plus the data part. */
+function recomputeMessage(id: string, points: readonly Record<string, unknown>[]): UIMessage {
+  const tool = {
+    type: "tool-plan_selected",
+    toolCallId: "plan_selected-fixture",
+    state: "output-available",
+    input: {},
+    output: { point_count: points.length },
+  };
+  const data = { type: "data-response", id: "response", data: { ...routePartRaw(points), intent: "plan_selected" } };
+  return { id, role: "assistant", parts: [tool, data] as unknown as UIMessage["parts"] };
 }
 
 function renderList(messages: readonly UIMessage[], status: ChatStatus = "ready") {
@@ -39,7 +49,7 @@ function ClockHarness({ status }: Readonly<{ status: ChatStatus }>) {
   const settled = useTurnTiming(status, () => undefined);
   return (
     <ChatActionsProvider actions={{ send: vi.fn(), regenerate: vi.fn() }}>
-      <MessageList messages={[assistantMessage("a1", recomputeRaw(ujiPoints().slice()))]} dict={ja} status={status} settledDurationMs={settled} />
+      <MessageList messages={[recomputeMessage("a1", ujiPoints().slice())]} dict={ja} status={status} settledDurationMs={settled} />
     </ChatActionsProvider>
   );
 }
@@ -72,7 +82,7 @@ describe("AC: the settled 再計算 footprint reads an injected, mocked clock", 
 
 describe("AC: the bypass renders no tool pipeline (no agent, no agent theater)", () => {
   it("shows the recompute footprint and zero step badges for a plan_selected turn", () => {
-    renderList([assistantMessage("a1", recomputeRaw(ujiPoints().slice()))]);
+    renderList([recomputeMessage("a1", ujiPoints().slice())]);
     expect(document.querySelector(".chat-settled--recompute")).not.toBeNull();
     expect(document.querySelector(".chat-step")).toBeNull();
   });
@@ -94,7 +104,7 @@ describe("AC multi-turn: follow-up plus recompute keep every version in order", 
       assistantMessage("a1", routePartRaw(ujiPoints().slice())),
       userMessage("u2", "図書館は外して"),
       assistantMessage("a2", routePartRaw(ujiPoints().slice(0, 2))),
-      assistantMessage("a3", recomputeRaw(ujiPoints().slice(1))),
+      recomputeMessage("a3", ujiPoints().slice(1)),
     ]);
     const cards = routeCards();
     expect(cards.map((card) => card.getAttribute("data-intent"))).toEqual([
@@ -108,7 +118,7 @@ describe("AC multi-turn: follow-up plus recompute keep every version in order", 
   it("appends the recompute card via the existing supersededFlags, badge on the prior card", () => {
     renderList([
       assistantMessage("a1", routePartRaw(ujiPoints().slice())),
-      assistantMessage("a2", recomputeRaw(ujiPoints().slice(0, 2))),
+      recomputeMessage("a2", ujiPoints().slice(0, 2)),
     ]);
     const [oldCard, newCard] = routeCards();
     expect(oldCard?.className).toBe("chat-card chat-card--superseded");

--- a/apps/web/tests/unit/chat/recompute-footprint.test.tsx
+++ b/apps/web/tests/unit/chat/recompute-footprint.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { ChatStatus, UIMessage } from "ai";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatActionsProvider } from "../../../src/features/chat/chat-actions";
+import { MessageList } from "../../../src/features/chat/components/MessageList";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { useTurnTiming } from "../../../src/features/chat/use-turn-timing";
+import { routePartRaw, ujiPoints } from "./_route-fixtures";
+
+afterEach(cleanup);
+
+const ja = chatDictFor("ja");
+
+function assistantMessage(id: string, data: unknown): UIMessage {
+  const part = { type: "data-response", id: "response", data };
+  return { id, role: "assistant", parts: [part] as unknown as UIMessage["parts"] };
+}
+
+function userMessage(id: string, text: string): UIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] };
+}
+
+function recomputeRaw(points: readonly Record<string, unknown>[]): Record<string, unknown> {
+  return { ...routePartRaw(points), intent: "plan_selected" };
+}
+
+function renderList(messages: readonly UIMessage[], status: ChatStatus = "ready") {
+  return render(
+    <ChatActionsProvider actions={{ send: vi.fn(), regenerate: vi.fn() }}>
+      <MessageList messages={messages} dict={ja} status={status} />
+    </ChatActionsProvider>,
+  );
+}
+
+function ClockHarness({ status }: Readonly<{ status: ChatStatus }>) {
+  const settled = useTurnTiming(status, () => undefined);
+  return (
+    <ChatActionsProvider actions={{ send: vi.fn(), regenerate: vi.fn() }}>
+      <MessageList messages={[assistantMessage("a1", recomputeRaw(ujiPoints().slice()))]} dict={ja} status={status} settledDurationMs={settled} />
+    </ChatActionsProvider>
+  );
+}
+
+describe("AC: the settled 再計算 footprint reads an injected, mocked clock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders exactly 「✓ 再計算 1.2s」 after the fake clock advances 1200ms", () => {
+    const { rerender } = render(<ClockHarness status="ready" />);
+    rerender(<ClockHarness status="submitted" />);
+    vi.advanceTimersByTime(1200);
+    rerender(<ClockHarness status="ready" />);
+    const footprint = document.querySelector(".chat-settled--recompute");
+    expect(footprint?.textContent).toBe("✓ 再計算 1.2s");
+  });
+
+  it("renders no footprint while the recompute turn is still active", () => {
+    const { rerender } = render(<ClockHarness status="ready" />);
+    rerender(<ClockHarness status="submitted" />);
+    vi.advanceTimersByTime(500);
+    rerender(<ClockHarness status="streaming" />);
+    expect(document.querySelector(".chat-settled--recompute")).toBeNull();
+  });
+});
+
+describe("AC: the bypass renders no tool pipeline (no agent, no agent theater)", () => {
+  it("shows the recompute footprint and zero step badges for a plan_selected turn", () => {
+    renderList([assistantMessage("a1", recomputeRaw(ujiPoints().slice()))]);
+    expect(document.querySelector(".chat-settled--recompute")).not.toBeNull();
+    expect(document.querySelector(".chat-step")).toBeNull();
+  });
+
+  it("keeps the footprint off agent-path route cards", () => {
+    renderList([assistantMessage("a1", routePartRaw(ujiPoints().slice()))]);
+    expect(document.querySelector(".chat-settled--recompute")).toBeNull();
+  });
+});
+
+function routeCards(): readonly Element[] {
+  return [...document.querySelectorAll("article[data-intent]")];
+}
+
+describe("AC multi-turn: follow-up plus recompute keep every version in order", () => {
+  it("renders three versions ascending with exactly the newest un-superseded", () => {
+    renderList([
+      userMessage("u1", "ユーフォ"),
+      assistantMessage("a1", routePartRaw(ujiPoints().slice())),
+      userMessage("u2", "図書館は外して"),
+      assistantMessage("a2", routePartRaw(ujiPoints().slice(0, 2))),
+      assistantMessage("a3", recomputeRaw(ujiPoints().slice(1))),
+    ]);
+    const cards = routeCards();
+    expect(cards.map((card) => card.getAttribute("data-intent"))).toEqual([
+      "plan_route",
+      "plan_route",
+      "plan_selected",
+    ]);
+    expect(cards.map((card) => card.className.includes("chat-card--superseded"))).toEqual([true, true, false]);
+  });
+
+  it("appends the recompute card via the existing supersededFlags, badge on the prior card", () => {
+    renderList([
+      assistantMessage("a1", routePartRaw(ujiPoints().slice())),
+      assistantMessage("a2", recomputeRaw(ujiPoints().slice(0, 2))),
+    ]);
+    const [oldCard, newCard] = routeCards();
+    expect(oldCard?.className).toBe("chat-card chat-card--superseded");
+    expect(oldCard?.querySelector(".chat-card__version-badge")?.textContent).toBe(ja.previousVersion);
+    expect(newCard?.className).toBe("chat-card");
+  });
+});

--- a/apps/web/tests/unit/chat/selected-points-bypass.test.ts
+++ b/apps/web/tests/unit/chat/selected-points-bypass.test.ts
@@ -2,7 +2,7 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-  hasRecomputePart,
+  isBypassTurn,
   sameIds,
   selectedPointsBody,
 } from "../../../src/lib/chat/selectedPointsBypass";
@@ -42,21 +42,28 @@ describe("sameIds", () => {
   });
 });
 
-describe("hasRecomputePart (bypass turns render the footprint, not the pipeline)", () => {
-  const part = (data: unknown) => ({ type: "data-response", data });
+describe("isBypassTurn (bypass turns suppress their plan_selected step part)", () => {
+  const data = (intent: unknown) => ({ type: "data-response", data: { intent } });
+  const tool = (type: string) => ({ type });
 
-  it("detects a plan_selected data part on the message", () => {
-    const message = { parts: [part({ intent: "plan_selected" })] };
-    expect(hasRecomputePart(message.parts)).toBe(true);
+  it("detects the real bypass wire shape: plan_selected card + plan_selected step part", () => {
+    expect(isBypassTurn([tool("tool-plan_selected"), data("plan_selected")])).toBe(true);
+  });
+
+  it("still detects a bypass card whose step part has not streamed yet", () => {
+    expect(isBypassTurn([data("plan_selected")])).toBe(true);
   });
 
   it("ignores agent-path route intents", () => {
-    const message = { parts: [part({ intent: "plan_route" }), { type: "text", text: "hi" }] };
-    expect(hasRecomputePart(message.parts)).toBe(false);
+    expect(isBypassTurn([tool("tool-plan_route"), data("plan_route"), { type: "text" }])).toBe(false);
+  });
+
+  it("keeps badges for an agent-path plan_selected turn that ran other tools", () => {
+    expect(isBypassTurn([tool("tool-resolve_anime"), tool("tool-plan_selected"), data("plan_selected")])).toBe(false);
   });
 
   it("ignores malformed data parts", () => {
-    expect(hasRecomputePart([part(null), part({})])).toBe(false);
+    expect(isBypassTurn([data(undefined), { type: "data-response", data: null }])).toBe(false);
   });
 });
 

--- a/apps/web/tests/unit/chat/selected-points-bypass.test.ts
+++ b/apps/web/tests/unit/chat/selected-points-bypass.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  hasRecomputePart,
+  sameIds,
+  selectedPointsBody,
+} from "../../../src/lib/chat/selectedPointsBypass";
+
+describe("selectedPointsBody (AC: the tray action can never fire empty)", () => {
+  it("returns undefined for an empty selection", () => {
+    expect(selectedPointsBody([])).toBeUndefined();
+  });
+
+  it("wraps a non-empty selection as the bypass body field", () => {
+    expect(selectedPointsBody(["a", "b"])).toEqual({ selected_point_ids: ["a", "b"] });
+  });
+
+  it("copies the ids so later selection changes cannot mutate an in-flight body", () => {
+    const ids = ["a"];
+    const body = selectedPointsBody(ids);
+    ids.push("b");
+    expect(body?.selected_point_ids).toEqual(["a"]);
+  });
+});
+
+describe("sameIds", () => {
+  it("matches a set against the id list regardless of order", () => {
+    expect(sameIds(new Set(["b", "a"]), ["a", "b"])).toBe(true);
+  });
+
+  it("rejects a size mismatch", () => {
+    expect(sameIds(new Set(["a"]), ["a", "b"])).toBe(false);
+  });
+
+  it("rejects a same-size membership mismatch", () => {
+    expect(sameIds(new Set(["a", "c"]), ["a", "b"])).toBe(false);
+  });
+
+  it("treats an undefined baseline as never matching", () => {
+    expect(sameIds(new Set(["a"]), undefined)).toBe(false);
+  });
+});
+
+describe("hasRecomputePart (bypass turns render the footprint, not the pipeline)", () => {
+  const part = (data: unknown) => ({ type: "data-response", data });
+
+  it("detects a plan_selected data part on the message", () => {
+    const message = { parts: [part({ intent: "plan_selected" })] };
+    expect(hasRecomputePart(message.parts)).toBe(true);
+  });
+
+  it("ignores agent-path route intents", () => {
+    const message = { parts: [part({ intent: "plan_route" }), { type: "text", text: "hi" }] };
+    expect(hasRecomputePart(message.parts)).toBe(false);
+  });
+
+  it("ignores malformed data parts", () => {
+    expect(hasRecomputePart([part(null), part({})])).toBe(false);
+  });
+});
+
+function sourceFiles(dir: string): readonly string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) return sourceFiles(path);
+    return /\.(ts|tsx)$/u.test(name) ? [path] : [];
+  });
+}
+
+describe("AC: no second supersession implementation exists under apps/web/src", () => {
+  const src = join(process.cwd(), "src");
+
+  it("defines supersededFlags exactly once, in lib/chat/supersession.ts", () => {
+    const defining = sourceFiles(src).filter((path) =>
+      /function supersededFlags|supersededFlags\s*=/u.test(readFileSync(path, "utf8")),
+    );
+    expect(defining).toEqual([join(src, "lib", "chat", "supersession.ts")]);
+  });
+
+  it("keeps every superseded-class producer on the one shared helper", () => {
+    const producers = sourceFiles(src).filter((path) =>
+      readFileSync(path, "utf8").includes("chat-card--superseded"),
+    );
+    expect(producers).toEqual([join(src, "features", "chat", "components", "DataPartCard.tsx")]);
+  });
+});

--- a/apps/web/tests/unit/chat/selected-points-bypass.test.ts
+++ b/apps/web/tests/unit/chat/selected-points-bypass.test.ts
@@ -54,6 +54,10 @@ describe("isBypassTurn (bypass turns suppress their plan_selected step part)", (
     expect(isBypassTurn([data("plan_selected")])).toBe(true);
   });
 
+  it("detects the mid-stream state where only the step frame has arrived (no badge flash)", () => {
+    expect(isBypassTurn([tool("tool-plan_selected")])).toBe(true);
+  });
+
   it("ignores agent-path route intents", () => {
     expect(isBypassTurn([tool("tool-plan_route"), data("plan_route"), { type: "text" }])).toBe(false);
   });

--- a/apps/web/tests/unit/chat/selected-points-bypass.test.ts
+++ b/apps/web/tests/unit/chat/selected-points-bypass.test.ts
@@ -85,9 +85,11 @@ describe("AC: no second supersession implementation exists under apps/web/src", 
     expect(defining).toEqual([join(src, "lib", "chat", "supersession.ts")]);
   });
 
-  it("keeps every superseded-class producer on the one shared helper", () => {
+  it("keeps the one composed superseded-class producer in DataPartCard", () => {
+    // The composed class string is the assembly site; bare references to the
+    // class name (styles, selectors) in future files must not trip this.
     const producers = sourceFiles(src).filter((path) =>
-      readFileSync(path, "utf8").includes("chat-card--superseded"),
+      readFileSync(path, "utf8").includes("chat-card chat-card--superseded"),
     );
     expect(producers).toEqual([join(src, "features", "chat", "components", "DataPartCard.tsx")]);
   });

--- a/apps/web/tests/unit/chat/selection-tray.test.tsx
+++ b/apps/web/tests/unit/chat/selection-tray.test.tsx
@@ -122,6 +122,15 @@ describe("AC error path: a failed recompute retries on the tray and keeps the se
   });
 });
 
+describe("outside a selection scope the checkboxes are inert", () => {
+  it("renders unchecked, unswitchable picks without a provider", () => {
+    render(<SearchResult spots={toSearchSpots(spotRows(2))} dict={chatDictFor("ja")} attach={attachReady} />);
+    tick("spot-0");
+    const boxes = screen.getAllByRole<HTMLInputElement>("checkbox");
+    expect(boxes.every((box) => !box.checked)).toBe(true);
+  });
+});
+
 describe("tray visibility vs. the recompute lifecycle", () => {
   it("hides while the recompute is in flight", () => {
     render(<Harness status="busy" />);

--- a/apps/web/tests/unit/chat/selection-tray.test.tsx
+++ b/apps/web/tests/unit/chat/selection-tray.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SelectionTray } from "../../../src/features/chat/components/SelectionTray";
+import type { RecomputeStatus } from "../../../src/features/chat/components/SelectionTray";
+import { SearchResult } from "../../../src/features/chat/components/SearchResult";
+import type { AttachBasemap } from "../../../src/features/chat/components/SearchMap";
+import {
+  SpotSelectionProvider,
+  useSpotSelectionState,
+} from "../../../src/features/chat/selection/useSpotSelection";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import type { Locale } from "../../../src/i18n/locales";
+import { toSearchSpots } from "../../../src/lib/chat/spotClusters";
+
+afterEach(cleanup);
+
+const attachReady: AttachBasemap = ({ onStatus }) => {
+  onStatus("ready");
+  return () => undefined;
+};
+
+function spotRows(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `p${String(i)}`,
+    name: `spot-${String(i)}`,
+    lat: 34.89 + i * 0.001,
+    lng: 135.8,
+  }));
+}
+
+type HarnessProps = Readonly<{
+  locale?: Locale;
+  status?: RecomputeStatus;
+  lastSentIds?: readonly string[];
+  onRecompute?: (ids: readonly string[]) => void;
+}>;
+
+function Harness({ locale = "ja", status = "idle", lastSentIds, onRecompute = () => undefined }: HarnessProps) {
+  const selection = useSpotSelectionState();
+  const dict = chatDictFor(locale);
+  return (
+    <SpotSelectionProvider selection={selection}>
+      <SearchResult spots={toSearchSpots(spotRows(3))} dict={dict} attach={attachReady} />
+      <SelectionTray dict={dict} status={status} lastSentIds={lastSentIds} onRecompute={onRecompute} />
+    </SpotSelectionProvider>
+  );
+}
+
+function tray(): Element | null {
+  return document.querySelector(".chat-selection-tray");
+}
+
+function tick(name: string) {
+  fireEvent.click(screen.getByRole("checkbox", { name: new RegExp(name, "u") }));
+}
+
+describe("AC null/empty: the tray follows the live selection", () => {
+  it("is absent from the DOM with zero checkboxes ticked", () => {
+    render(<Harness />);
+    expect(tray()).toBeNull();
+  });
+
+  it("appears on the first tick and leaves when the last selection is unticked", () => {
+    render(<Harness />);
+    tick("spot-1");
+    expect(tray()).not.toBeNull();
+    tick("spot-1");
+    expect(tray()).toBeNull();
+  });
+
+  it("keeps the checkboxes controlled: ticking marks exactly that card checked", () => {
+    render(<Harness />);
+    tick("spot-1");
+    const boxes = screen.getAllByRole<HTMLInputElement>("checkbox");
+    expect(boxes.map((box) => box.checked)).toContain(true);
+    expect(boxes.filter((box) => box.checked)).toHaveLength(1);
+  });
+});
+
+describe("AC i18n: count copy, action label and retry label render per locale", () => {
+  const cases: readonly [Locale, string, string, string][] = [
+    ["ja", "2件選択中", "ルートを組み直す", "もう一度ためす"],
+    ["zh", "已选 2 处", "重新规划路线", "再试一次"],
+    ["en", "2 selected", "Rebuild the route", "Try again"],
+  ];
+
+  for (const [locale, count, action, retry] of cases) {
+    it(`interpolates the count and labels the actions in ${locale}`, () => {
+      render(<Harness locale={locale} />);
+      tick("spot-0");
+      tick("spot-1");
+      expect(screen.getByText(count)).toBeTruthy();
+      expect(screen.getByRole("button", { name: action })).toBeTruthy();
+      cleanup();
+      render(<Harness locale={locale} status="failed" />);
+      tick("spot-0");
+      tick("spot-1");
+      expect(screen.getByRole("button", { name: retry })).toBeTruthy();
+    });
+  }
+});
+
+describe("AC error path: a failed recompute retries on the tray and keeps the selection", () => {
+  it("shows the failure copy and fires the retry with the preserved selection", () => {
+    const onRecompute = vi.fn();
+    render(<Harness status="failed" onRecompute={onRecompute} />);
+    tick("spot-0");
+    tick("spot-2");
+    fireEvent.click(screen.getByRole("button", { name: chatDictFor("ja").search.trayRetry }));
+    expect(onRecompute).toHaveBeenCalledExactlyOnceWith(["p0", "p2"]);
+    const checked = screen.getAllByRole<HTMLInputElement>("checkbox").filter((box) => box.checked);
+    expect(checked).toHaveLength(2);
+  });
+
+  it("stays visible on failure even when the selection matches the last sent ids", () => {
+    render(<Harness status="failed" lastSentIds={["p0"]} />);
+    tick("spot-0");
+    expect(tray()).not.toBeNull();
+  });
+});
+
+describe("tray visibility vs. the recompute lifecycle", () => {
+  it("hides while the recompute is in flight", () => {
+    render(<Harness status="busy" />);
+    tick("spot-0");
+    expect(tray()).toBeNull();
+  });
+
+  it("hides after a successful recompute until the selection changes again", () => {
+    render(<Harness lastSentIds={["p0", "p1"]} />);
+    tick("spot-0");
+    tick("spot-1");
+    expect(tray()).toBeNull();
+    tick("spot-2");
+    expect(tray()).not.toBeNull();
+  });
+});

--- a/apps/web/tests/unit/chat/selection-tray.test.tsx
+++ b/apps/web/tests/unit/chat/selection-tray.test.tsx
@@ -71,6 +71,17 @@ describe("AC null/empty: the tray follows the live selection", () => {
     expect(tray()).toBeNull();
   });
 
+  it("disables the action below two picks and asks for at least two (design syncRebar)", () => {
+    render(<Harness />);
+    tick("spot-0");
+    const action = screen.getByRole<HTMLButtonElement>("button", { name: "ルートを組み直す" });
+    expect(action.disabled).toBe(true);
+    expect(screen.getByText(chatDictFor("ja").search.trayMinimum)).toBeTruthy();
+    tick("spot-1");
+    expect(action.disabled).toBe(false);
+    expect(screen.getByText(chatDictFor("ja").search.trayChanged)).toBeTruthy();
+  });
+
   it("keeps the checkboxes controlled: ticking marks exactly that card checked", () => {
     render(<Harness />);
     tick("spot-1");

--- a/apps/web/tests/unit/chat/use-recompute-turn.test.tsx
+++ b/apps/web/tests/unit/chat/use-recompute-turn.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useRecomputeTurn } from "../../../src/features/chat/selection/useRecomputeTurn";
+import type { ChatSession } from "../../../src/features/chat/use-chat-session";
+
+type ChatStub = Readonly<{
+  sendSelectedPoints: ReturnType<typeof vi.fn>;
+  status: string;
+  error: Error | undefined;
+}>;
+
+function chatStub(status: string, error?: Error): ChatStub {
+  return { sendSelectedPoints: vi.fn(), status, error };
+}
+
+function renderTurn(initial: ChatStub) {
+  return renderHook(({ chat }: { chat: ChatStub }) => useRecomputeTurn(chat as unknown as ChatSession), {
+    initialProps: { chat: initial },
+  });
+}
+
+describe("useRecomputeTurn", () => {
+  it("never fires the bypass with an empty selection", () => {
+    const chat = chatStub("ready");
+    const { result } = renderTurn(chat);
+    act(() => {
+      result.current.fire([]);
+    });
+    expect(chat.sendSelectedPoints).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("idle");
+    expect(result.current.lastSentIds).toBeUndefined();
+  });
+
+  it("sends the body, tracks the sent ids, and settles back to idle on success", () => {
+    const chat = chatStub("ready");
+    const { result, rerender } = renderTurn(chat);
+    act(() => {
+      result.current.fire(["a", "b"]);
+    });
+    expect(chat.sendSelectedPoints).toHaveBeenCalledExactlyOnceWith({ selected_point_ids: ["a", "b"] });
+    expect(result.current.status).toBe("busy");
+    rerender({ chat: { ...chat, status: "streaming" } });
+    rerender({ chat: { ...chat, status: "ready" } });
+    expect(result.current.status).toBe("idle");
+    expect(result.current.lastSentIds).toEqual(["a", "b"]);
+  });
+
+  it("reports failed on a settled error and clears once a new turn goes active", () => {
+    const chat = chatStub("ready");
+    const { result, rerender } = renderTurn(chat);
+    act(() => {
+      result.current.fire(["a"]);
+    });
+    rerender({ chat: { ...chat, status: "submitted" } });
+    rerender({ chat: { ...chat, status: "error", error: new Error("boom") } });
+    expect(result.current.status).toBe("failed");
+    rerender({ chat: { ...chat, status: "submitted" } });
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("stays idle when the turn settles without ever having gone active", () => {
+    const chat = chatStub("ready");
+    const { result, rerender } = renderTurn(chat);
+    act(() => {
+      result.current.fire(["a"]);
+    });
+    rerender({ chat: { ...chat, status: "ready", error: new Error("stale") } });
+    expect(result.current.status).toBe("busy");
+  });
+});

--- a/apps/web/tests/unit/chat/use-recompute-turn.test.tsx
+++ b/apps/web/tests/unit/chat/use-recompute-turn.test.tsx
@@ -62,7 +62,9 @@ describe("useRecomputeTurn", () => {
     expect(result.current.status).toBe("idle");
   });
 
-  it("stays idle when the turn settles without ever having gone active", () => {
+  // Race guard: fire() flips to busy before the SDK reports "submitted"; a
+  // settle signal seen before the turn ever went active must be ignored.
+  it("ignores a settle that arrives before the turn ever went active", () => {
     const chat = chatStub("ready");
     const { result, rerender } = renderTurn(chat);
     act(() => {

--- a/e2e/web-chat-selection.spec.ts
+++ b/e2e/web-chat-selection.spec.ts
@@ -32,10 +32,20 @@ const searchResultsBody = patchFinalFrame(chatStreamRecording("search"), (envelo
   },
 }));
 
+/** The real bypass wire shape: `execute_selected_route` emits a
+ * `plan_selected` running/done step pair, translated by `chat_stream` into
+ * these tool chunks — the UI must suppress them, so the fixture keeps them. */
+const planSelectedStepFrames = [
+  'data: {"type":"tool-input-start","toolCallId":"plan_selected-fixture","toolName":"plan_selected"}',
+  'data: {"type":"tool-input-available","toolCallId":"plan_selected-fixture","toolName":"plan_selected","input":{}}',
+  'data: {"type":"tool-output-available","toolCallId":"plan_selected-fixture","output":{"point_count":2}}',
+].join("\n\n");
+
 const recomputeBody = chatStreamRecording("search")
   .split("\n")
   .filter((line) => !line.startsWith('data: {"type":"tool-'))
   .join("\n")
+  .replace('data: {"type":"start-step"}', `data: {"type":"start-step"}\n\n${planSelectedStepFrames}`)
   .replaceAll('"intent":"plan_route"', '"intent":"plan_selected"');
 
 async function openChat(page: Page): Promise<void> {

--- a/e2e/web-chat-selection.spec.ts
+++ b/e2e/web-chat-selection.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { chatDictFor } from "../apps/web/src/features/chat/i18n";
+import { SSE_HEADERS, chatStreamRecording, patchFinalFrame } from "./fixtures/chat-stream";
+
+/**
+ * Issue #273 (S1.7) Task 1 browser ACs — the E2 selection tray and the
+ * `selected_point_ids` recompute bypass. Streams are the real agent
+ * recordings, patched with the same discipline as the D-state variants:
+ * the search body's final envelope becomes a search_bangumi result set, and
+ * the recompute body is the recording with every tool frame stripped
+ * (the bypass never runs the agent, so no pipeline ever streams).
+ */
+test.use({
+  baseURL: process.env.E2E_WEB_BASE_URL ?? "http://localhost:3000",
+  locale: "ja-JP",
+});
+
+const ja = chatDictFor("ja");
+
+const searchResultsBody = patchFinalFrame(chatStreamRecording("search"), (envelope) => ({
+  ...envelope,
+  intent: "search_bangumi",
+  data: {
+    results: {
+      rows: [
+        { id: "p1", name: "宇治橋", latitude: 34.891, longitude: 135.807 },
+        { id: "p2", name: "京阪宇治駅", latitude: 34.911, longitude: 135.806 },
+        { id: "p3", name: "宇治神社", latitude: 34.9, longitude: 135.81 },
+      ],
+    },
+  },
+}));
+
+const recomputeBody = chatStreamRecording("search")
+  .split("\n")
+  .filter((line) => !line.startsWith('data: {"type":"tool-'))
+  .join("\n")
+  .replaceAll('"intent":"plan_route"', '"intent":"plan_selected"');
+
+async function openChat(page: Page): Promise<void> {
+  await page.route("**/healthz", (route) => route.fulfill({ json: { status: "ok" } }));
+  const hydrated = page.waitForResponse((response) => response.url().includes("/healthz"));
+  await page.goto("/chat");
+  await hydrated;
+}
+
+interface SentBody {
+  readonly selected_point_ids?: readonly string[];
+}
+
+async function searchThenTickTwo(page: Page, bodies: SentBody[], failRecompute = false): Promise<void> {
+  let calls = 0;
+  await page.route("**/v1/chat", (route) => {
+    bodies.push(route.request().postDataJSON() as SentBody);
+    calls += 1;
+    if (calls === 1) return route.fulfill({ status: 200, headers: SSE_HEADERS, body: searchResultsBody });
+    if (failRecompute) return route.fulfill({ status: 500, body: "" });
+    return route.fulfill({ status: 200, headers: SSE_HEADERS, body: recomputeBody });
+  });
+  await openChat(page);
+  await page.getByRole("textbox").fill("ユーフォ");
+  await page.getByRole("button", { name: ja.send }).click();
+  await expect(page.getByText("宇治橋")).toBeVisible();
+  await page.getByRole("checkbox", { name: `${ja.search.select}: 宇治橋` }).check();
+  await page.getByRole("checkbox", { name: `${ja.search.select}: 宇治神社` }).check();
+}
+
+test("ticking two spots surfaces the tray; the recompute renders only skeleton + footprint states", async ({ page }) => {
+  const bodies: SentBody[] = [];
+  await searchThenTickTwo(page, bodies);
+  await expect(page.getByText(ja.search.traySelected.replace("{count}", "2"))).toBeVisible();
+  await page.getByRole("button", { name: ja.search.trayAction }).click();
+  const recomputeCard = page.locator('article[data-intent="plan_selected"]');
+  await expect(recomputeCard).toBeVisible();
+  // Structural enumeration of the recompute turn's rendered states: the turn
+  // row contains the settled footprint and the card, no skeleton remains, and
+  // the tool-badge selector is absent from the whole set — not time-sampled.
+  const turn = page.locator("li.chat-message--assistant", { has: recomputeCard });
+  await expect(turn.locator(".chat-settled--recompute")).toHaveCount(1);
+  await expect(turn.locator(".chat-settled--recompute")).toContainText(ja.search.recompute);
+  await expect(turn.locator(".chat-step")).toHaveCount(0);
+  await expect(turn.locator(".chat-card--skeleton")).toHaveCount(0);
+  expect(bodies).toHaveLength(2);
+  expect(bodies[1]?.selected_point_ids).toEqual(["p1", "p3"]);
+});
+
+test("a failed recompute retries inline on the tray and never escalates to TurnFailure", async ({ page }) => {
+  const bodies: SentBody[] = [];
+  await searchThenTickTwo(page, bodies, true);
+  await page.getByRole("button", { name: ja.search.trayAction }).click();
+  await expect(page.getByRole("button", { name: ja.search.trayRetry })).toBeVisible();
+  // The selection and the prior card survive; no full-page D4 surface appears.
+  await expect(page.getByText(ja.errorStates.d4Message)).toHaveCount(0);
+  await expect(page.getByText("宇治橋")).toBeVisible();
+  await expect(page.getByRole("checkbox", { name: `${ja.search.select}: 宇治橋` })).toBeChecked();
+  await expect(page.getByRole("checkbox", { name: `${ja.search.select}: 宇治神社` })).toBeChecked();
+});


### PR DESCRIPTION
Implements **#273 S1.7 Task 1** — E2 checkbox selection tray and the `selected_point_ids` recompute bypass, per spec `docs/superpowers/specs/2026-07-28-s1.7-living-document-save-login-wall-design.md` (final, `fa8d4448` on `docs/spec-273-s1.7`).

## What changed

**New**
- `apps/web/src/features/chat/selection/useSpotSelection.tsx` — shared spot-selection Set (context; inert default outside a selection scope)
- `apps/web/src/features/chat/selection/useRecomputeTurn.ts` — recompute turn lifecycle (idle/busy/failed) + empty-fire guard
- `apps/web/src/features/chat/components/SelectionTray.tsx` — sticky E2 recompute bar (design `.rebar`)
- `apps/web/src/lib/chat/selectedPointsBypass.ts` — bypass body builder, `sameIds`, recompute-part detection

**Changed**
- `SearchResult.tsx` — the C3a checkbox becomes controlled
- `use-chat-session.ts` — `sendSelectedPoints`: `sendMessage(undefined, { body })` via ai@6.0.225's per-call body merge (verified against installed source: `{...resolvedBody, ...options.body}`)
- `MessageList.tsx` — recompute turns render the 「✓ 再計算 1.2s」 footprint instead of tool badges; part-less marker messages never render
- `ChatPage.tsx` — provider + tray mount; a failed recompute masks the full-page `TurnFailure`
- `search-i18n.ts` — tray/footprint copy ja/zh/en
- `styles/chat.css` — tray styles, Animal Island semantic tokens only

## The one non-obvious mechanism (please review)

`sendMessage(undefined, {body})` in ai@6.0.225 **continues the previous assistant message** (`createStreamingUIMessageState` reuses an assistant `lastMessage`), so the streamed same-ID `response` part would *overwrite* the prior route card — destroying the E1 append semantics. The fix appends a **part-less user marker message** before sending, forcing a fresh assistant message. Consequences:
- The marker is filtered from rendering (`MessageList.visibleMessages`).
- On the wire the marker joins `messages`; `routes/chat.py::_last_user_text` derives `text=""` (verified) — i.e. "no new utterance".

## AC coverage (9 ACs / 9 annotations)

| AC | Type | Test |
|---|---|---|
| Happy path: tray + skeleton→card, only skeleton/footprint states, no tool badges (structural) | browser | `e2e/web-chat-selection.spec.ts` (both specs **run green** against the local dev server) |
| Exactly one `POST /v1/chat` with `selected_point_ids`, no free-text turn | integration | `tests/unit/chat/chat-page-selection.test.tsx` (MSW spy on the real transport; body + user-turn-count asserted). Backend bypass dispatch is pre-existing behavior covered by the agent suite (`test_selected_route.py` etc.) |
| 「再計算 1.2s」 from an injected, mocked clock — exact string, no sleeps | unit | `tests/unit/chat/recompute-footprint.test.tsx` (fake timers advance 1200ms → `✓ 再計算 1.2s`) |
| Appended card + prior `.chat-card--superseded` + 「以前の版」 via the **existing** `supersededFlags`; static no-second-implementation check | unit | `recompute-footprint.test.tsx` + `selected-points-bypass.test.ts` (fs scan: exactly one definition; one class producer) |
| Null/empty: no tray at zero; untick-last removes; can never fire empty | unit | `selection-tray.test.tsx`, `use-recompute-turn.test.tsx` |
| Error path: inline tray retry, selection + prior card preserved, no `TurnFailure` | browser | `e2e/web-chat-selection.spec.ts` (+ jsdom reinforcement in `chat-page-selection.test.tsx`) |
| i18n ja/zh/en incl. count interpolation | unit | `selection-tray.test.tsx` |
| Multi-turn: three versions ascending, exactly newest un-superseded (render order) | unit | `recompute-footprint.test.tsx` |
| History integrity (P2-⑤): no duplicated user rows on recompute | integration | Client half here: the recompute adds **no genuine user turn** (asserted on the request body). The server half — `persistence.py` skipping the user-message insert when the turn carries no new utterance — is **Task 3 scope** and lands on `feat/273-t3-migration-retention` (parallel); this card's marker (`text=""`) is the interface signal it keys on. The end-to-end row-count integration test rides that branch. |

## Mutation verification (all killed)

1. drop empty-selection guard → `use-recompute-turn` fails
2. add a second `supersededFlags` implementation under `src/` → static check fails
3. drop the `TurnFailure` mask → "skips TurnFailure" fails
4. `sameIds` → always false → tray-visibility tests fail
5. drop the `selected_point_ids` body → body assertion fails
6. drop the marker append (same-ID overwrite returns) → card-append assertions fail
7. hardcode the footprint elapsed → exact-string clock test fails

## Design-sync alignment (`docs/design/2026-07-06-design-sync/Chat 完整状态.html`)

Followed: gold-bordered `.rebar` bar docked above the composer; sub line 「スポットの選択が変わりました」 + 「N件選択中」; gold pill button 「ルートを組み直す」 with 3D press (`:active` translate + shadow collapse); bar hidden while recomputing and after success until the selection changes again; E2 recompute renders only 「✓ 再計算 1.2s」 + card (no pipeline theater); superseded visual reuses the existing `.chat-card--superseded` (`opacity .55`).

Deviations (all token-driven):
1. Design specifies a dedicated gold shadow family (`--gold-deep` press shadow, `#5a3c20`-tinted soft card shadow) that has no token in `globals.css`. This card substitutes the neutral `var(--shadow-3d)` press family — a **different shadow hue than the design intends**, not an equivalent. Adding a `--color-gold-deep` token is a design-system decision left to the owner.
2. Design `.rebar` uses px paddings/radii → rem equivalents matching the file's scale (16px radius kept).
3. Design's tray also hosts chips + order segment (`.sptray`); those belong to later cards — this card ships the E2 recompute bar only. The syncRebar **minimum-selection rule is implemented** (below 2 picks: action disabled + 「2件以上選んでください」 in ja/zh/en).
4. Design shows the elapsed persisting on older recompute rows; ours shows elapsed on the latest settled turn only, matching the existing `SettledFootprint` precedent.

## Gates

- `pnpm run typecheck` ✅ · `pnpm run lint:oxlint` ✅ (10-line function cap respected)
- `pnpm test` ✅ 157 files / 969 tests; coverage **98.96 / 95.30 / 99.68 / 99.88** vs floors 95/94/95/95 (ratchet respected, not lowered)
- e2e: `web-chat-selection.spec.ts` 2/2 green against the local dev server
- Test quality: all new test files ≤200 lines, ≤5 mocks, no timing-dependent assertions (fake timers only)

## Review response (2026-07-29, both seats)

- **P1-1 (fixture false-green)** — accepted and fixed red-first. All fixtures (msw, e2e, unit) now carry the `tool-plan_selected` chunks the backend always streams for the bypass (`execute_selected_route` → `_ToolPartTranslator`); against them the old rail failed 3 tests (footprint never rendered, generic badge leaked). Fix: `isBypassTurn()` — a `plan_selected` card whose only tool part is the `plan_selected` step suppresses the pipeline and renders the footprint; agent-path multi-tool turns keep badges. e2e re-run green against the dev server with the realistic frames.
- **P1-2 (AC-9 orphan)** — pulled back into this card: `persist_messages` now skips the user-message insert when the turn carries no utterance (the bypass marker → `_last_user_text` = `""`), red-first pytest coverage (3 new tests, 1400 agent unit tests green, mypy/ruff clean). This also removes the empty-bubble symptom in reloaded conversation history (the empty row is never created). `upsert_conversation` remains untouched per the review's confirmation that `first_query` is not polluted.
- **P1-3 (mid-stream tray tap → concurrent POST)** — `trayStatus()` forces `busy` whenever the chat is `submitted`/`streaming`; pinned by a held-open-stream test.
- **P2 all applied** — marker wire-shape absolute assertion (`{role:"user",parts:[]}` — the shape the persistence skip keys on); `intentOf` exported from `supersession.ts` and reused (no near-duplicate); min-2 selection rule per design syncRebar; 44px action target; skeleton-appearance test on a controlled recompute stream; the settle watcher takes a props object.
- **P3/Fable follow-ups** — awaited body spy (no assertion race); `isLast` compared by id; dead `position: sticky` removed; `generateId` from the AI SDK; `role="status"` scoped to the count line; a persistent polite live region announces the recompute after the tray unmounts (a11y handoff). The e2e skeleton-order assertion stays jsdom-side (the controlled-stream test); Playwright `route.fulfill` cannot hold a stream open mid-body.
- **Mutation verification, re-run against the committed tree**: chat-busy gate dropped → P1-3 test red; min-2 disable dropped → tray test red; rail suppression dropped → 2 tests red; persistence guard dropped → pytest red. All killed.

## Dependency note

- ~~Task 3 dependency~~ — resolved: the `persistence.py` skip now ships in this PR (review P1-2). Task 3 no longer carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
