### PR TITLE
feat(#273 T2): save CTA, P5 login wall, deferred intent + create-on-login

### DIFF
--- a/apps/agent/agent/tests/integration/test_anonymous_flow_uninterrupted.py
+++ b/apps/agent/agent/tests/integration/test_anonymous_flow_uninterrupted.py
@@ -3,9 +3,13 @@ interrupted by an auth challenge.
 
 The browser ACs pin that no login dialog opens before the 「保存する」 tap. This is
 the server-side half of the same invariant: the identical flow driven through
-the runtime endpoint returns no 401/403 and carries no ``Authorization`` header
-on any request, so the login wall is a product decision made in the client
-rather than something the backend forces.
+the runtime endpoint returns no 401/403, so the login wall is a product decision
+made in the client rather than something the backend forces.
+
+Every assertion here is on **app** behaviour — the route's declared security, the
+`_reject_credentialed_anonymous` guard, and the missing-identity status — rather
+than on headers the test itself constructed, which no production change could
+falsify.
 
 Uses ``httpx.AsyncClient`` + ``ASGITransport`` (the pattern in
 ``test_runtime_journey_contract.py``) because ``TestClient``'s portal thread
@@ -117,8 +121,52 @@ async def test_anonymous_flow_returns_no_auth_challenge(anon_client) -> None:
 
 
 @pytest.mark.integration
-async def test_anonymous_flow_sends_no_authorization_header(anon_client) -> None:
-    for text in _FLOW:
-        resp = await _turn(anon_client, text)
-        sent = {name.lower() for name in resp.request.headers}
-        assert "authorization" not in sent
+async def test_runtime_declares_no_bearer_requirement(anon_client) -> None:
+    """The route must not *demand* a credential the anonymous client cannot mint.
+
+    Asserted against the app's own OpenAPI schema rather than against headers the
+    test constructed: adding an `HTTPBearer` dependency to `/v1/runtime` — the
+    production change that would break the anonymous flow — turns this red.
+    """
+    schema = (await anon_client.get("/openapi.json")).json()
+    operation = schema["paths"]["/v1/runtime"]["post"]
+    assert not operation.get("security"), operation.get("security")
+    assert not schema.get("components", {}).get("securitySchemes")
+
+
+@pytest.mark.integration
+async def test_anonymous_stamp_with_a_credential_is_rejected(anon_client) -> None:
+    """The app enforces the flow's no-`Authorization` property; the test does not
+    merely restate its own request headers.
+
+    `_reject_credentialed_anonymous` (issue #441) refuses an anonymous stamp that
+    arrives with a credential, so a client that leaked a stale bearer into the
+    anonymous flow would be 401'd — which is exactly the interruption the P5
+    invariant forbids. Deleting that guard, or having the web client attach a
+    header while signed out, turns this red.
+    """
+    resp = await anon_client.post(
+        "/v1/runtime",
+        json={"text": _FLOW[0], "locale": "zh"},
+        headers={**_ANON_HEADERS, "Authorization": "Bearer stale-token"},
+    )
+    assert resp.status_code == 401
+
+    clean = await _turn(anon_client, _FLOW[0])
+    assert clean.status_code == 200
+
+
+@pytest.mark.integration
+async def test_identityless_request_is_never_auth_challenged(anon_client) -> None:
+    """Even with no edge-stamped identity at all, the route answers rather than
+    challenging: no 401/403 and no ``WWW-Authenticate`` for the client to react
+    to. Adding an authentication dependency here — the change that would put a
+    login in front of the anonymous flow — turns this red. The exact success
+    status is deliberately not pinned, so a future stricter *request* validation
+    stays free to return 4xx without faking an auth challenge.
+    """
+    resp = await anon_client.post(
+        "/v1/runtime", json={"text": _FLOW[0], "locale": "zh"}
+    )
+    assert resp.status_code not in _AUTH_CHALLENGES
+    assert "www-authenticate" not in {name.lower() for name in resp.headers}

--- a/apps/agent/agent/tests/integration/test_anonymous_flow_uninterrupted.py
+++ b/apps/agent/agent/tests/integration/test_anonymous_flow_uninterrupted.py
@@ -1,0 +1,122 @@
+"""P5 login wall (issue #273 S1.7 Task 2): the anonymous happy path is never
+interrupted by an auth challenge.
+
+The browser ACs pin that no login dialog opens before the 「保存する」 tap. This is
+the server-side half of the same invariant: the identical flow driven through
+the runtime endpoint returns no 401/403 and carries no ``Authorization`` header
+on any request, so the login wall is a product decision made in the client
+rather than something the backend forces.
+
+Uses ``httpx.AsyncClient`` + ``ASGITransport`` (the pattern in
+``test_runtime_journey_contract.py``) because ``TestClient``'s portal thread
+conflicts with asyncpg's event loop.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from agent.agents.agent_result import AgentResult, StepRecord
+from agent.agents.runtime_models import ClarifyResponseModel, QAResponseModel
+from agent.agents.session_state import (
+    OrderedCandidate,
+    PendingClarification,
+    SessionState,
+)
+from agent.infrastructure.session.memory import InMemorySessionStore
+from agent.interfaces.fastapi_service import create_fastapi_app
+from agent.interfaces.public_api import RuntimeAPI
+
+# The edge stamps anonymous callers with this exact wire format
+# (``worker/anonymous.test.ts`` pins ``^anon_[0-9a-f]{32}$``).
+_ANON_HEADERS = {
+    "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
+    "X-User-Type": "anonymous",
+}
+
+# search -> clarify -> route refinement -> conversational follow-up.
+_FLOW = ("宇治站附近的圣地", "凉宫", "帮我规划路线", "你好")
+
+_AUTH_CHALLENGES = (401, 403)
+
+
+def _clarify_result() -> AgentResult:
+    candidates = [
+        OrderedCandidate(id="11291", title="凉宫春日的忧郁", points_count=2, city="西宫")
+    ]
+    state = SessionState(
+        pending_clarification=PendingClarification(
+            reason="anime_ambiguity",
+            candidate_ids=["11291"],
+            ordered_candidates=candidates,
+            revision=1,
+        ),
+        clarification_revision=1,
+    )
+    output = ClarifyResponseModel(
+        reason="anime_ambiguity", message="你是指哪部凉宫？", candidate_ids=["11291"]
+    )
+    return AgentResult(
+        output=output,
+        intent="clarify",
+        session_state=state,
+        steps=[StepRecord(tool="clarify", success=True, model_initiated=False)],
+    )
+
+
+def _qa_result() -> AgentResult:
+    return AgentResult(
+        output=QAResponseModel(message="我可以帮你找动漫圣地。"),
+        intent="general_qa",
+        session_state=SessionState(),
+    )
+
+
+async def _fake_agent(**kwargs: object) -> AgentResult:
+    text = str(kwargs.get("text", ""))
+    return _clarify_result() if "凉宫" in text else _qa_result()
+
+
+@pytest.fixture
+async def anon_client(tc_db):
+    runtime_api = RuntimeAPI(
+        tc_db, session_store=InMemorySessionStore(), model_http_client=MagicMock()
+    )
+    app = create_fastapi_app(runtime_api=runtime_api, db=tc_db)
+    app.state.runtime_api = runtime_api
+    app.state.db_client = tc_db
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    with patch(
+        "agent.interfaces.public_api.run_animichi_agent", side_effect=_fake_agent
+    ):
+        async with httpx.AsyncClient(
+            transport=transport, base_url="https://test"
+        ) as client:
+            yield client
+
+
+async def _turn(client: httpx.AsyncClient, text: str) -> httpx.Response:
+    return await client.post(
+        "/v1/runtime", json={"text": text, "locale": "zh"}, headers=_ANON_HEADERS
+    )
+
+
+@pytest.mark.integration
+async def test_anonymous_flow_returns_no_auth_challenge(anon_client) -> None:
+    for text in _FLOW:
+        resp = await _turn(anon_client, text)
+        assert resp.status_code not in _AUTH_CHALLENGES, (
+            f"anonymous turn {text!r} was auth-challenged with {resp.status_code}"
+        )
+        assert resp.status_code == 200
+
+
+@pytest.mark.integration
+async def test_anonymous_flow_sends_no_authorization_header(anon_client) -> None:
+    for text in _FLOW:
+        resp = await _turn(anon_client, text)
+        sent = {name.lower() for name in resp.request.headers}
+        assert "authorization" not in sent

--- a/apps/agent/agent/tests/integration/test_anonymous_flow_uninterrupted.py
+++ b/apps/agent/agent/tests/integration/test_anonymous_flow_uninterrupted.py
@@ -45,7 +45,9 @@ _AUTH_CHALLENGES = (401, 403)
 
 def _clarify_result() -> AgentResult:
     candidates = [
-        OrderedCandidate(id="11291", title="凉宫春日的忧郁", points_count=2, city="西宫")
+        OrderedCandidate(
+            id="11291", title="凉宫春日的忧郁", points_count=2, city="西宫"
+        )
     ]
     state = SessionState(
         pending_clarification=PendingClarification(

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -55,8 +55,10 @@ landing page and branded 404 through a Cloudflare SSR bundle. Root guide: `../..
 - `src/routeTree.gen.ts` is generated. Do not hand-edit it; oxlint and coverage ignore it. The unit
   pool runs without the TanStack Start vite plugin, so `tests/setup/generate-route-tree.ts`
   (vitest `globalSetup`) emits it before the suite; a normal build regenerates it otherwise.
-- Coverage sweeps `src/**` (routes + `router.tsx` included, per campaign plan §0.6); the floor is
-  90/90/90/90 — ratchet UP only. `routeTree.gen.ts` is the only exclusion.
+- Coverage sweeps `src/**` (routes + `router.tsx` included, per campaign plan §0.6); the enforced
+  floor is `statements 95 / branches 94 / functions 95 / lines 95`, read from `vitest.config.ts`,
+  which is the authority — ratchet UP only. `routeTree.gen.ts` is the only exclusion (plus the
+  WebGL map glue listed in the config's exclude ledger).
 - `OpenAPILink` captures `globalThis.fetch` at construction: build clients at call time (the lazy
   `catalog()` / `users()` singletons do), not at module top, or MSW patching is missed in tests.
 - A normal build must run before preview or build-output integration checks inspect `.output/`.

--- a/apps/web/src/api/hooks/use-save-route.ts
+++ b/apps/web/src/api/hooks/use-save-route.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from "react";
+import type { SaveRouteInput, UserRoute } from "@seichijunrei/contract";
+import { users } from "../orpc";
+
+/** The one transport call behind both the in-chat save and create-on-login. */
+export type SaveRouteRequest = (input: SaveRouteInput) => Promise<UserRoute>;
+
+/**
+ * `users.saveRoute` through the memoized oRPC client, so the UI never touches
+ * the transport (component -> hook -> client, per `apps/web/AGENTS.md`).
+ * Create-on-login calls this outside React, which is why it is a plain function
+ * rather than a TanStack mutation: the auth-callback replay has no provider.
+ */
+export const saveRouteRequest: SaveRouteRequest = (input) => users().saveRoute.call(input);
+
+export type SaveRouteStatus = "idle" | "saving" | "saved" | "error";
+
+export interface SaveRouteMutation {
+  readonly status: SaveRouteStatus;
+  readonly save: (input: SaveRouteInput) => Promise<boolean>;
+}
+
+type SetStatus = (status: SaveRouteStatus) => void;
+
+async function runSave(request: SaveRouteRequest, input: SaveRouteInput, setStatus: SetStatus): Promise<boolean> {
+  setStatus("saving");
+  const saved = await request(input).then(() => true, () => false);
+  setStatus(saved ? "saved" : "error");
+  return saved;
+}
+
+/** Save state for one card: a failure is retryable in place, never fatal. */
+export function useSaveRoute(request: SaveRouteRequest = saveRouteRequest): SaveRouteMutation {
+  const [status, setStatus] = useState<SaveRouteStatus>("idle");
+  const save = useCallback((input: SaveRouteInput) => runSave(request, input, setStatus), [request]);
+  return { status, save };
+}

--- a/apps/web/src/api/hooks/use-save-route.ts
+++ b/apps/web/src/api/hooks/use-save-route.ts
@@ -1,4 +1,5 @@
-import { useCallback, useState } from "react";
+import { QueryClientContext } from "@tanstack/react-query";
+import { useCallback, useContext, useRef, useState } from "react";
 import type { SaveRouteInput, UserRoute } from "@seichijunrei/contract";
 import { users } from "../orpc";
 
@@ -13,25 +14,80 @@ export type SaveRouteRequest = (input: SaveRouteInput) => Promise<UserRoute>;
  */
 export const saveRouteRequest: SaveRouteRequest = (input) => users().saveRoute.call(input);
 
-export type SaveRouteStatus = "idle" | "saving" | "saved" | "error";
+/**
+ * `unauthorized` sends the caller back through the login wall; `permanent` is a
+ * 4xx that retrying cannot fix — offering "retry" there would be a dead loop;
+ * `retryable` covers 5xx, transport failures and the transient 4xx codes.
+ */
+export type SaveRouteFailure = "unauthorized" | "permanent" | "retryable";
+export type SaveRouteStatus = "idle" | "saving" | "saved" | SaveRouteFailure;
+
+function statusOf(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const status: unknown = (error as Record<string, unknown>).status;
+  return typeof status === "number" ? status : undefined;
+}
+
+const TRANSIENT: ReadonlySet<number> = new Set([408, 425, 429]);
+
+export function classifySaveFailure(error: unknown): SaveRouteFailure {
+  const status = statusOf(error);
+  if (status === 401 || status === 403) return "unauthorized";
+  if (status === undefined || status >= 500 || TRANSIENT.has(status)) return "retryable";
+  return status >= 400 ? "permanent" : "retryable";
+}
 
 export interface SaveRouteMutation {
   readonly status: SaveRouteStatus;
-  readonly save: (input: SaveRouteInput) => Promise<boolean>;
+  readonly save: (input: SaveRouteInput) => Promise<SaveRouteStatus>;
 }
 
 type SetStatus = (status: SaveRouteStatus) => void;
 
-async function runSave(request: SaveRouteRequest, input: SaveRouteInput, setStatus: SetStatus): Promise<boolean> {
-  setStatus("saving");
-  const saved = await request(input).then(() => true, () => false);
-  setStatus(saved ? "saved" : "error");
-  return saved;
+function attempt(request: SaveRouteRequest, input: SaveRouteInput): Promise<SaveRouteStatus> {
+  return request(input).then<SaveRouteStatus, SaveRouteStatus>(
+    () => "saved",
+    (error: unknown) => classifySaveFailure(error),
+  );
 }
 
-/** Save state for one card: a failure is retryable in place, never fatal. */
+async function runSave(request: SaveRouteRequest, input: SaveRouteInput, setStatus: SetStatus): Promise<SaveRouteStatus> {
+  setStatus("saving");
+  const outcome = await attempt(request, input);
+  setStatus(outcome);
+  return outcome;
+}
+
+/** A saved route changes `listRoutes`; invalidate it when a provider is present
+ * (the chat page has one, a bare card render does not). */
+function useInvalidateRoutes(): () => void {
+  const client = useContext(QueryClientContext);
+  return useCallback(() => {
+    void client?.invalidateQueries({ queryKey: users().listRoutes.key() });
+  }, [client]);
+}
+
+/** A tap while a save is in flight is dropped rather than queued. */
+interface Busy { current: boolean }
+
+async function guardedSave(busy: Busy, run: () => Promise<SaveRouteStatus>, invalidate: () => void): Promise<SaveRouteStatus> {
+  if (busy.current) return "saving";
+  busy.current = true;
+  const outcome = await run().finally(() => { busy.current = false; });
+  if (outcome === "saved") invalidate();
+  return outcome;
+}
+
+/** Save state for one card: a failure is retryable in place, never fatal. A tap
+ * while a save is in flight is dropped, so a double click cannot create two rows
+ * against an endpoint that has no dedupe key. */
 export function useSaveRoute(request: SaveRouteRequest = saveRouteRequest): SaveRouteMutation {
   const [status, setStatus] = useState<SaveRouteStatus>("idle");
-  const save = useCallback((input: SaveRouteInput) => runSave(request, input, setStatus), [request]);
+  const busy = useRef(false);
+  const invalidate = useInvalidateRoutes();
+  const save = useCallback(
+    (input: SaveRouteInput) => guardedSave(busy, () => runSave(request, input, setStatus), invalidate),
+    [request, invalidate],
+  );
   return { status, save };
 }

--- a/apps/web/src/components/auth/AuthCallback.tsx
+++ b/apps/web/src/components/auth/AuthCallback.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from "react";
 import { useDict } from "../../i18n/context";
+import type { Dict } from "../../i18n/dictionaries";
+import type { DeferredReplayOutcome } from "../../features/chat/save/createOnLogin";
 import { getAuthToken } from "../../lib/auth/authSession";
 import { useAuthCallback } from "./useAuthCallback";
-import type { AuthCallbackState } from "./useAuthCallback";
+import type { AuthCallbackSession, AuthCallbackState } from "./useAuthCallback";
 
-type MessageState = Exclude<AuthCallbackState, "done">;
+type MessageState = Extract<AuthCallbackState, "pending" | "error">;
 
 function CallbackMessage({ state }: Readonly<{ state: MessageState }>) {
   const auth = useDict().auth;
@@ -13,16 +15,50 @@ function CallbackMessage({ state }: Readonly<{ state: MessageState }>) {
   return <p className="auth-callback__message" role={role}>{text}</p>;
 }
 
+type FailureProps = Readonly<{ auth: Dict["auth"]; session: AuthCallbackSession }>;
+
+/**
+ * The login succeeded but create-on-login did not. The intent is still on this
+ * origin, so the visitor gets a retry here plus the explicit fallback — never a
+ * silent "done" that lets the save reappear on some later login.
+ */
+function SaveFailure({ auth, session }: FailureProps) {
+  return (
+    <div className="auth-callback__save-failed" role="alert">
+      <p className="auth-callback__message">{auth.callback_save_failed}</p>
+      <button type="button" className="auth-callback__retry" onClick={session.retrySave}>
+        {auth.callback_save_retry}
+      </button>
+      <button type="button" className="auth-callback__skip" onClick={session.dismissSave}>
+        {auth.callback_save_skip}
+      </button>
+    </div>
+  );
+}
+
 export interface AuthCallbackProps {
   readonly onDone: () => void;
   readonly establish?: () => Promise<string | undefined>;
+  readonly replay?: () => Promise<DeferredReplayOutcome>;
 }
 
-/** `/auth/callback` body: redeems the session, then hands control back to the route. */
-export function AuthCallback({ onDone, establish = getAuthToken }: AuthCallbackProps) {
-  const state = useAuthCallback(establish);
+function useDoneEffect(state: AuthCallbackState, onDone: () => void): void {
   useEffect(() => {
     if (state === "done") onDone();
   }, [state, onDone]);
-  return state === "done" ? null : <CallbackMessage state={state} />;
+}
+
+function CallbackBody({ session }: Readonly<{ session: AuthCallbackSession }>) {
+  const auth = useDict().auth;
+  if (session.state === "done") return null;
+  if (session.state === "save-failed") return <SaveFailure auth={auth} session={session} />;
+  return <CallbackMessage state={session.state} />;
+}
+
+/** `/auth/callback` body: redeems the session, replays a deferred save, then
+ * hands control back to the route — unless that replay failed. */
+export function AuthCallback({ onDone, establish = getAuthToken, replay }: AuthCallbackProps) {
+  const session = useAuthCallback(establish, replay);
+  useDoneEffect(session.state, onDone);
+  return <CallbackBody session={session} />;
 }

--- a/apps/web/src/components/auth/AuthCallback.tsx
+++ b/apps/web/src/components/auth/AuthCallback.tsx
@@ -17,6 +17,12 @@ function CallbackMessage({ state }: Readonly<{ state: MessageState }>) {
 
 type FailureProps = Readonly<{ auth: Dict["auth"]; session: AuthCallbackSession }>;
 
+type ActionProps = Readonly<{ label: string; className: string; onClick: () => void }>;
+
+function CallbackAction({ label, className, onClick }: ActionProps) {
+  return <button type="button" className={className} onClick={onClick}>{label}</button>;
+}
+
 /**
  * The login succeeded but create-on-login did not. The intent is still on this
  * origin, so the visitor gets a retry here plus the explicit fallback — never a
@@ -26,12 +32,8 @@ function SaveFailure({ auth, session }: FailureProps) {
   return (
     <div className="auth-callback__save-failed" role="alert">
       <p className="auth-callback__message">{auth.callback_save_failed}</p>
-      <button type="button" className="auth-callback__retry" onClick={session.retrySave}>
-        {auth.callback_save_retry}
-      </button>
-      <button type="button" className="auth-callback__skip" onClick={session.dismissSave}>
-        {auth.callback_save_skip}
-      </button>
+      <CallbackAction label={auth.callback_save_retry} className="auth-callback__retry" onClick={session.retrySave} />
+      <CallbackAction label={auth.callback_save_skip} className="auth-callback__skip" onClick={session.dismissSave} />
     </div>
   );
 }

--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import type { ChangeEvent } from "react";
 import type { Dict } from "../../i18n/dictionaries";
 import { useDict } from "../../i18n/context";
@@ -58,9 +59,22 @@ function FormFields({ form }: { form: MagicLinkForm }) {
   </>);
 }
 
-export function LoginForm() {
+/** Announce a dispatched link exactly once: the caller uses it to tell
+ * "closed to go read the email" apart from "cancelled". */
+function useSentOnce(status: FormStatus, onSent: (() => void) | undefined): void {
+  useEffect(() => {
+    if (status === "sent") onSent?.();
+  }, [status, onSent]);
+}
+
+export interface LoginFormProps {
+  readonly onSent?: () => void;
+}
+
+export function LoginForm({ onSent }: LoginFormProps = {}) {
   const form = useMagicLinkForm();
   const auth = useDict().auth;
+  useSentOnce(form.status, onSent);
   return (
     <form className="login-form" onSubmit={form.onSubmit} noValidate aria-label={auth.title}>
       <FormFields form={form} />

--- a/apps/web/src/components/auth/LoginModal.tsx
+++ b/apps/web/src/components/auth/LoginModal.tsx
@@ -6,6 +6,9 @@ import { LoginForm } from "./LoginForm";
 interface LoginModalProps {
   open: boolean;
   onClose: () => void;
+  /** Fires when a magic link was dispatched, so a caller can tell a
+   * "closed to go read the email" dismissal apart from a cancellation. */
+  onSent?: () => void;
 }
 
 function useEscapeToClose(open: boolean, onClose: () => void): void {
@@ -19,25 +22,25 @@ function useEscapeToClose(open: boolean, onClose: () => void): void {
   }, [open, onClose]);
 }
 
-function LoginDialog({ auth, onClose }: { auth: Dict["auth"]; onClose: () => void }) {
+function LoginDialog({ auth, onClose, onSent }: { auth: Dict["auth"]; onClose: () => void; onSent?: () => void }) {
   return (
     <div className="login-modal" role="dialog" aria-modal="true" aria-label={auth.title} onClick={(event) => { event.stopPropagation(); }}>
       <button className="login-modal__close" type="button" aria-label={auth.close} onClick={onClose}>×</button>
       <h2 className="login-modal__title">{auth.title}</h2>
       <p className="login-modal__subtitle">{auth.subtitle}</p>
-      <LoginForm />
+      <LoginForm onSent={onSent} />
     </div>
   );
 }
 
 /** Magic-link login modal wired to the Neon Auth (Better Auth) client. */
-export function LoginModal({ open, onClose }: LoginModalProps) {
+export function LoginModal({ open, onClose, onSent }: LoginModalProps) {
   const auth = useDict().auth;
   useEscapeToClose(open, onClose);
   if (!open) return null;
   return (
     <div className="login-modal__mask" role="presentation" onClick={onClose}>
-      <LoginDialog auth={auth} onClose={onClose} />
+      <LoginDialog auth={auth} onClose={onClose} onSent={onSent} />
     </div>
   );
 }

--- a/apps/web/src/components/auth/useAuthCallback.ts
+++ b/apps/web/src/components/auth/useAuthCallback.ts
@@ -1,19 +1,29 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { replayDeferredSave } from "../../features/chat/save/createOnLogin";
+import type { DeferredReplayOutcome } from "../../features/chat/save/createOnLogin";
 import { getAuthToken } from "../../lib/auth/authSession";
 
-export type AuthCallbackState = "pending" | "done" | "error";
+/**
+ * `save-failed` is a *successful* login whose create-on-login replay failed. It
+ * is reported rather than folded into `done`, because the intent survives a
+ * failed replay: reporting a clean login would leave it to fire unannounced on
+ * the next login inside its TTL.
+ */
+export type AuthCallbackState = "pending" | "done" | "error" | "save-failed";
 type Establish = () => Promise<string | undefined>;
-type Replay = () => Promise<boolean>;
+type Replay = () => Promise<DeferredReplayOutcome>;
 type SetState = (state: AuthCallbackState) => void;
+
+function stateFor(outcome: DeferredReplayOutcome): AuthCallbackState {
+  return outcome === "failed" ? "save-failed" : "done";
+}
 
 /** Create-on-login: a login the save CTA started replays its deferred intent;
  * any other login (the D8/D11 banners) finds none and saves nothing. */
 async function redeem(establish: Establish, replay: Replay): Promise<AuthCallbackState> {
   const token = await establish();
   if (!token) return "error";
-  await replay();
-  return "done";
+  return stateFor(await replay());
 }
 
 /** Redeems the token once, dropping the result if the component unmounted first. */
@@ -31,16 +41,33 @@ function useEstablishOnce(establish: Establish, replay: Replay, setState: SetSta
   useEffect(() => establishEffect(establish, replay, setState), [establish, replay, setState]);
 }
 
+export interface AuthCallbackSession {
+  readonly state: AuthCallbackState;
+  /** Re-run only the create-on-login replay; the session is already redeemed. */
+  readonly retrySave: () => void;
+  /** Give up on the deferred save here; the intent stays for the chat page. */
+  readonly dismissSave: () => void;
+}
+
+function useRetrySave(replay: Replay, setState: SetState): () => void {
+  return useCallback(() => {
+    setState("pending");
+    void replay().then((outcome) => { setState(stateFor(outcome)); });
+  }, [replay, setState]);
+}
+
 /**
  * Redeems the Better Auth session cookie (set on the Neon Auth origin by the
- * magic-link verify redirect) for the app's cached bearer token. `establish`
- * is injectable for tests; production callers rely on the default.
+ * magic-link verify redirect) for the app's cached bearer token, then replays a
+ * deferred save when the login came from the 「保存する」 CTA. `establish` and
+ * `replay` are injectable for tests; production callers rely on the defaults.
  */
 export function useAuthCallback(
   establish: Establish = getAuthToken,
   replay: Replay = replayDeferredSave,
-): AuthCallbackState {
+): AuthCallbackSession {
   const [state, setState] = useState<AuthCallbackState>("pending");
   useEstablishOnce(establish, replay, setState);
-  return state;
+  const dismissSave = useCallback(() => { setState("done"); }, []);
+  return { state, retrySave: useRetrySave(replay, setState), dismissSave };
 }

--- a/apps/web/src/components/auth/useAuthCallback.ts
+++ b/apps/web/src/components/auth/useAuthCallback.ts
@@ -18,20 +18,32 @@ function stateFor(outcome: DeferredReplayOutcome): AuthCallbackState {
   return outcome === "failed" ? "save-failed" : "done";
 }
 
+/** The replay must not hold the visitor on the callback screen indefinitely: a
+ * stalled users service degrades to the same surfaced-failure path as a 5xx. */
+export const REPLAY_TIMEOUT_MS = 8_000;
+
+function withTimeout(replay: Replay, ms: number): Promise<DeferredReplayOutcome> {
+  return Promise.race([
+    replay(),
+    new Promise<DeferredReplayOutcome>((resolve) => setTimeout(() => { resolve("failed"); }, ms)),
+  ]);
+}
+
 /** Create-on-login: a login the save CTA started replays its deferred intent;
  * any other login (the D8/D11 banners) finds none and saves nothing. */
 async function redeem(establish: Establish, replay: Replay): Promise<AuthCallbackState> {
   const token = await establish();
   if (!token) return "error";
-  return stateFor(await replay());
+  return stateFor(await withTimeout(replay, REPLAY_TIMEOUT_MS));
 }
 
-/** Redeems the token once, dropping the result if the component unmounted first. */
+/** Redeems the token once, dropping the result if the component unmounted first.
+ * A rejection is a failed login, not an unhandled promise. */
 function establishEffect(establish: Establish, replay: Replay, setState: SetState): () => void {
   let active = true;
-  void redeem(establish, replay).then((state) => {
-    if (active) setState(state);
-  });
+  void redeem(establish, replay)
+    .catch((): AuthCallbackState => "error")
+    .then((state) => { if (active) setState(state); });
   return () => {
     active = false;
   };
@@ -52,7 +64,9 @@ export interface AuthCallbackSession {
 function useRetrySave(replay: Replay, setState: SetState): () => void {
   return useCallback(() => {
     setState("pending");
-    void replay().then((outcome) => { setState(stateFor(outcome)); });
+    void withTimeout(replay, REPLAY_TIMEOUT_MS)
+      .catch((): DeferredReplayOutcome => "failed")
+      .then((outcome) => { setState(stateFor(outcome)); });
   }, [replay, setState]);
 }
 

--- a/apps/web/src/components/auth/useAuthCallback.ts
+++ b/apps/web/src/components/auth/useAuthCallback.ts
@@ -1,23 +1,34 @@
 import { useEffect, useState } from "react";
+import { replayDeferredSave } from "../../features/chat/save/createOnLogin";
 import { getAuthToken } from "../../lib/auth/authSession";
 
 export type AuthCallbackState = "pending" | "done" | "error";
 type Establish = () => Promise<string | undefined>;
+type Replay = () => Promise<boolean>;
 type SetState = (state: AuthCallbackState) => void;
 
+/** Create-on-login: a login the save CTA started replays its deferred intent;
+ * any other login (the D8/D11 banners) finds none and saves nothing. */
+async function redeem(establish: Establish, replay: Replay): Promise<AuthCallbackState> {
+  const token = await establish();
+  if (!token) return "error";
+  await replay();
+  return "done";
+}
+
 /** Redeems the token once, dropping the result if the component unmounted first. */
-function establishEffect(establish: Establish, setState: SetState): () => void {
+function establishEffect(establish: Establish, replay: Replay, setState: SetState): () => void {
   let active = true;
-  void establish().then((token) => {
-    if (active) setState(token ? "done" : "error");
+  void redeem(establish, replay).then((state) => {
+    if (active) setState(state);
   });
   return () => {
     active = false;
   };
 }
 
-function useEstablishOnce(establish: Establish, setState: SetState): void {
-  useEffect(() => establishEffect(establish, setState), [establish, setState]);
+function useEstablishOnce(establish: Establish, replay: Replay, setState: SetState): void {
+  useEffect(() => establishEffect(establish, replay, setState), [establish, replay, setState]);
 }
 
 /**
@@ -25,8 +36,11 @@ function useEstablishOnce(establish: Establish, setState: SetState): void {
  * magic-link verify redirect) for the app's cached bearer token. `establish`
  * is injectable for tests; production callers rely on the default.
  */
-export function useAuthCallback(establish: Establish = getAuthToken): AuthCallbackState {
+export function useAuthCallback(
+  establish: Establish = getAuthToken,
+  replay: Replay = replayDeferredSave,
+): AuthCallbackState {
   const [state, setState] = useState<AuthCallbackState>("pending");
-  useEstablishOnce(establish, setState);
+  useEstablishOnce(establish, replay, setState);
   return state;
 }

--- a/apps/web/src/components/auth/useAuthCallback.ts
+++ b/apps/web/src/components/auth/useAuthCallback.ts
@@ -57,7 +57,8 @@ export interface AuthCallbackSession {
   readonly state: AuthCallbackState;
   /** Re-run only the create-on-login replay; the session is already redeemed. */
   readonly retrySave: () => void;
-  /** Give up on the deferred save here; the intent stays for the chat page. */
+  /** Give up on the deferred save *here*; the intent survives for the next login
+   * inside its TTL, which is what replays it. */
   readonly dismissSave: () => void;
 }
 

--- a/apps/web/src/features/chat/components/RouteCard.tsx
+++ b/apps/web/src/features/chat/components/RouteCard.tsx
@@ -6,6 +6,7 @@ import type { ChatDict } from "../i18n";
 import { resultsOf, routeOf, routeSpotsOf, SpotList } from "./cards";
 import type { IntentCardProps } from "./cards";
 import { routeStatsCopy } from "../route-copy";
+import { routeSaveTarget } from "../save/saveTarget";
 import { RouteTrailMap } from "./RouteTrailMap";
 import type { AttachBasemap } from "./SearchMap";
 import { TimedItinerary } from "./TimedItinerary";
@@ -19,11 +20,12 @@ function RouteStats({ part, dict }: Readonly<{ part: ChatDataPart; dict: ChatDic
   return <p className="chat-card__stats">{copy}</p>;
 }
 
-type GateProps = Readonly<{ itinerary: TimedItineraryModel | undefined; dict: ChatDict }>;
+type GateProps = IntentCardProps & Readonly<{ itinerary: TimedItineraryModel | undefined }>;
 
-function ItineraryGate({ itinerary, dict }: GateProps) {
+/** The card owns the part, so it derives the save payload the CTA row needs. */
+function ItineraryGate({ itinerary, part, dict }: GateProps) {
   if (!itinerary || itinerary.stops.length === 0) return null;
-  return <TimedItinerary view={itineraryView(itinerary)} dict={dict} />;
+  return <TimedItinerary view={itineraryView(itinerary)} dict={dict} save={routeSaveTarget(part, dict)} />;
 }
 
 /** Route spots in walking order, restricted to rows the map can place. */
@@ -54,7 +56,7 @@ export function RouteCard({ part, dict, attach }: RouteCardProps) {
   return (
     <div className="chat-card__body">
       <RouteStats part={part} dict={dict} />
-      <ItineraryGate itinerary={routeOf(part)?.timed_itinerary} dict={dict} />
+      <ItineraryGate itinerary={routeOf(part)?.timed_itinerary} part={part} dict={dict} />
       <TrailMapGate part={part} dict={dict} attach={attach} />
       <SpotList part={part} dict={dict} />
     </div>

--- a/apps/web/src/features/chat/components/TimedItinerary.tsx
+++ b/apps/web/src/features/chat/components/TimedItinerary.tsx
@@ -139,7 +139,7 @@ function SaveCta({ save, dict, saveDeps }: Omit<ItineraryProps, "view">) {
     <>
       <SaveButton gate={gate} dict={dict} />
       <SaveFeedback gate={gate} dict={dict} />
-      {gate.loginOpen ? <LoginModal open onClose={gate.closeLogin} /> : null}
+      {gate.loginOpen ? <LoginModal open onClose={gate.closeLogin} onSent={gate.markLinkSent} /> : null}
     </>
   );
 }

--- a/apps/web/src/features/chat/components/TimedItinerary.tsx
+++ b/apps/web/src/features/chat/components/TimedItinerary.tsx
@@ -88,7 +88,9 @@ function WalkCtaSlot({ dict }: DictProps) {
   );
 }
 
-/** A failed save stays on the card: inline copy plus a retry, never a full page. */
+/** A retryable failure stays on the card: inline copy plus a retry, never a
+ * full page. A `permanent` 4xx gets copy without a retry — offering one would
+ * be a loop that cannot succeed. */
 function SaveError({ gate, dict }: GateProps) {
   return (
     <span className="chat-cta-row__error" role="alert">
@@ -98,10 +100,22 @@ function SaveError({ gate, dict }: GateProps) {
   );
 }
 
+function SavePermanentError({ dict }: DictProps) {
+  return <span className="chat-cta-row__error" role="alert">{dict.route.savePermanentError}</span>;
+}
+
 function SaveFeedback({ gate, dict }: GateProps) {
   if (gate.status === "saved") return <span className="chat-cta-row__saved" role="status">{dict.route.saved}</span>;
-  if (gate.status !== "error") return null;
+  if (gate.status === "permanent") return <SavePermanentError dict={dict} />;
+  if (gate.status !== "retryable") return null;
   return <SaveError gate={gate} dict={dict} />;
+}
+
+/** Saving and saved are both non-actionable: the endpoint has no dedupe key, so
+ * a second tap would create a second row. `aria-busy` carries the in-flight
+ * meaning that `disabled` alone would flatten into "unavailable". */
+function saveDisabled(gate: SaveGate): boolean {
+  return gate.action === "none" || gate.status === "saving" || gate.status === "saved";
 }
 
 /**
@@ -111,8 +125,9 @@ function SaveFeedback({ gate, dict }: GateProps) {
  * P5 invariant is visible in the DOM rather than merely asserted.
  */
 function SaveButton({ gate, dict }: GateProps) {
+  const busy = gate.status === "saving";
   return (
-    <button type="button" className="chat-chip" data-cta="save" disabled={gate.action === "none"} onClick={gate.activate}>
+    <button type="button" className="chat-chip" data-cta="save" disabled={saveDisabled(gate)} aria-busy={busy} onClick={gate.activate}>
       {dict.route.saveCta}
     </button>
   );

--- a/apps/web/src/features/chat/components/TimedItinerary.tsx
+++ b/apps/web/src/features/chat/components/TimedItinerary.tsx
@@ -1,9 +1,18 @@
+import { LoginModal } from "../../../components/auth/LoginModal";
 import type { ItineraryLeg, ItineraryStation, ItineraryView } from "../../../lib/chat/itinerary";
 import type { ChatDict } from "../i18n";
 import { legCapsule } from "../route-copy";
+import { useSaveGate } from "../save/useSaveGate";
+import type { SaveGate, SaveGateOptions } from "../save/useSaveGate";
+import type { SaveTarget } from "../save/saveTarget";
+import { FallbackRetryButton } from "./ErrorStates/FallbackRetryButton";
 
 type DictProps = Readonly<{ dict: ChatDict }>;
 type ViewProps = Readonly<{ view: ItineraryView; dict: ChatDict }>;
+type GateProps = Readonly<{ gate: SaveGate; dict: ChatDict }>;
+
+/** Injectable for tests; production callers rely on the defaults. */
+export type ItineraryProps = ViewProps & Readonly<{ save?: SaveTarget; saveDeps?: SaveGateOptions }>;
 
 /** Colour alone never carries the highlight: the star names itself for AT. */
 function GoldStar({ dict }: DictProps) {
@@ -79,10 +88,52 @@ function WalkCtaSlot({ dict }: DictProps) {
   );
 }
 
-function CtaRow({ view, dict }: ViewProps) {
+/** A failed save stays on the card: inline copy plus a retry, never a full page. */
+function SaveError({ gate, dict }: GateProps) {
+  return (
+    <span className="chat-cta-row__error" role="alert">
+      {dict.route.saveError}
+      <FallbackRetryButton label={dict.route.saveRetry} onClick={gate.activate} className="chat-chip" />
+    </span>
+  );
+}
+
+function SaveFeedback({ gate, dict }: GateProps) {
+  if (gate.status === "saved") return <span className="chat-cta-row__saved" role="status">{dict.route.saved}</span>;
+  if (gate.status !== "error") return null;
+  return <SaveError gate={gate} dict={dict} />;
+}
+
+/**
+ * P5 save CTA (issue #273 S1.7). Cream, not gold: the design sync reserves the
+ * single per-screen gold CTA for しおり共有 (「永不同屏两金」), and lists 保存する
+ * under the cream press buttons. The dialog is mounted only while open, so the
+ * P5 invariant is visible in the DOM rather than merely asserted.
+ */
+function SaveButton({ gate, dict }: GateProps) {
+  return (
+    <button type="button" className="chat-chip" data-cta="save" disabled={gate.action === "none"} onClick={gate.activate}>
+      {dict.route.saveCta}
+    </button>
+  );
+}
+
+function SaveCta({ save, dict, saveDeps }: Omit<ItineraryProps, "view">) {
+  const gate = useSaveGate(save, saveDeps);
+  return (
+    <>
+      <SaveButton gate={gate} dict={dict} />
+      <SaveFeedback gate={gate} dict={dict} />
+      {gate.loginOpen ? <LoginModal open onClose={gate.closeLogin} /> : null}
+    </>
+  );
+}
+
+function CtaRow({ view, dict, save, saveDeps }: ItineraryProps) {
   return (
     <div className="chat-cta-row">
       <MapsCta view={view} dict={dict} />
+      <SaveCta save={save} dict={dict} saveDeps={saveDeps} />
       <WalkCtaSlot dict={dict} />
     </div>
   );
@@ -101,12 +152,12 @@ function Timeline({ view, dict }: ViewProps) {
  * walk capsules between stations, pacing pill, and the CTA row. The labelled
  * list doubles as the non-visual equivalent of the promoted map's track order.
  */
-export function TimedItinerary({ view, dict }: ViewProps) {
+export function TimedItinerary({ view, dict, save, saveDeps }: ItineraryProps) {
   return (
     <div className="chat-itinerary">
       <PacingPill view={view} dict={dict} />
       <Timeline view={view} dict={dict} />
-      <CtaRow view={view} dict={dict} />
+      <CtaRow view={view} dict={dict} save={save} saveDeps={saveDeps} />
     </div>
   );
 }

--- a/apps/web/src/features/chat/route-copy.ts
+++ b/apps/web/src/features/chat/route-copy.ts
@@ -10,16 +10,35 @@ export function legCapsule(dict: ChatDict, leg: ItineraryLeg): string {
 /** Localized headline stats for the route card (issue #271 S1.5). Absent
  * walking minutes render as an em dash rather than a bare "?" so the line
  * reads as copy in every locale. */
+/**
+ * Truncate to at most `max` UTF-16 units (the bound `SaveRouteInput.title`
+ * enforces) without splitting a grapheme cluster — a naive `slice` can leave a
+ * lone surrogate half, and stream-supplied work titles carry emoji and combining
+ * marks.
+ */
+function truncateGraphemes(value: string, max: number): string {
+  if (value.length <= max) return value;
+  const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+  let out = "";
+  for (const { segment } of segmenter.segment(value)) {
+    if (out.length + segment.length > max) break;
+    out += segment;
+  }
+  return out;
+}
+
 /** `SaveRouteInput.title` is required and 1-200 chars, and nothing in the chat
  * flow produces one — so the client derives it from the resolved work title
  * plus the stop count through a localized template (issue #273 S1.7, P2-4).
- * An absent work title uses the locale's own stand-in, never an English one. */
+ * An absent work title uses the locale's own stand-in, never an English one.
+ * The replacements use replacer *functions*: a work title containing `$&` or
+ * `$1` would otherwise be expanded as a replacement pattern. */
 export function saveRouteTitle(dict: ChatDict, workTitle: string | undefined, spots: number): string {
   const work = workTitle === undefined || workTitle === "" ? dict.route.saveUntitled : workTitle;
-  return dict.route.saveTitle
-    .replace("{title}", work)
-    .replace("{count}", String(spots))
-    .slice(0, 200);
+  const rendered = dict.route.saveTitle
+    .replace("{title}", () => work)
+    .replace("{count}", () => String(spots));
+  return truncateGraphemes(rendered, 200);
 }
 
 export function routeStatsCopy(dict: ChatDict, spots: number, minutes: number | undefined): string {

--- a/apps/web/src/features/chat/route-copy.ts
+++ b/apps/web/src/features/chat/route-copy.ts
@@ -10,11 +10,20 @@ export function legCapsule(dict: ChatDict, leg: ItineraryLeg): string {
 /** Localized headline stats for the route card (issue #271 S1.5). Absent
  * walking minutes render as an em dash rather than a bare "?" so the line
  * reads as copy in every locale. */
+export function routeStatsCopy(dict: ChatDict, spots: number, minutes: number | undefined): string {
+  return dict.route.stats
+    .replace("{spots}", String(spots))
+    .replace("{min}", minutes === undefined ? "—" : String(minutes));
+}
+
+/** `SaveRouteInput.title` is `min(1).max(200)`; 200 counts UTF-16 units. */
+const TITLE_MAX = 200;
+const ELLIPSIS = "…";
+
 /**
- * Truncate to at most `max` UTF-16 units (the bound `SaveRouteInput.title`
- * enforces) without splitting a grapheme cluster — a naive `slice` can leave a
- * lone surrogate half, and stream-supplied work titles carry emoji and combining
- * marks.
+ * Truncate to at most `max` UTF-16 units without splitting a grapheme cluster —
+ * a naive `slice` can leave a lone surrogate half, and stream-supplied work
+ * titles carry emoji and combining marks.
  */
 function truncateGraphemes(value: string, max: number): string {
   if (value.length <= max) return value;
@@ -27,22 +36,23 @@ function truncateGraphemes(value: string, max: number): string {
   return out;
 }
 
-/** `SaveRouteInput.title` is required and 1-200 chars, and nothing in the chat
- * flow produces one — so the client derives it from the resolved work title
- * plus the stop count through a localized template (issue #273 S1.7, P2-4).
- * An absent work title uses the locale's own stand-in, never an English one.
- * The replacements use replacer *functions*: a work title containing `$&` or
- * `$1` would otherwise be expanded as a replacement pattern. */
-export function saveRouteTitle(dict: ChatDict, workTitle: string | undefined, spots: number): string {
-  const work = workTitle === undefined || workTitle === "" ? dict.route.saveUntitled : workTitle;
-  const rendered = dict.route.saveTitle
-    .replace("{title}", () => work)
-    .replace("{count}", () => String(spots));
-  return truncateGraphemes(rendered, 200);
+/** Replacer *functions*, not strings: a work title containing `$&` or `$1`
+ * would otherwise be expanded as a replacement pattern. */
+function render(template: string, work: string, spots: number): string {
+  return template.replace("{title}", () => work).replace("{count}", () => String(spots));
 }
 
-export function routeStatsCopy(dict: ChatDict, spots: number, minutes: number | undefined): string {
-  return dict.route.stats
-    .replace("{spots}", String(spots))
-    .replace("{min}", minutes === undefined ? "—" : String(minutes));
+/**
+ * `SaveRouteInput.title` is required and nothing in the chat flow produces one,
+ * so the client derives it from the resolved work title plus the stop count
+ * through a localized template (issue #273 S1.7, P2-4). An absent work title
+ * uses the locale's own stand-in, never an English one. Over-long input trims
+ * the **work title** — never the rendered tail, which would drop the stop count.
+ */
+export function saveRouteTitle(dict: ChatDict, workTitle: string | undefined, spots: number): string {
+  const work = workTitle === undefined || workTitle === "" ? dict.route.saveUntitled : workTitle;
+  const full = render(dict.route.saveTitle, work, spots);
+  if (full.length <= TITLE_MAX) return full;
+  const budget = Math.max(TITLE_MAX - (full.length - work.length) - ELLIPSIS.length, 0);
+  return render(dict.route.saveTitle, `${truncateGraphemes(work, budget)}${ELLIPSIS}`, spots);
 }

--- a/apps/web/src/features/chat/route-copy.ts
+++ b/apps/web/src/features/chat/route-copy.ts
@@ -10,6 +10,18 @@ export function legCapsule(dict: ChatDict, leg: ItineraryLeg): string {
 /** Localized headline stats for the route card (issue #271 S1.5). Absent
  * walking minutes render as an em dash rather than a bare "?" so the line
  * reads as copy in every locale. */
+/** `SaveRouteInput.title` is required and 1-200 chars, and nothing in the chat
+ * flow produces one — so the client derives it from the resolved work title
+ * plus the stop count through a localized template (issue #273 S1.7, P2-4).
+ * An absent work title uses the locale's own stand-in, never an English one. */
+export function saveRouteTitle(dict: ChatDict, workTitle: string | undefined, spots: number): string {
+  const work = workTitle === undefined || workTitle === "" ? dict.route.saveUntitled : workTitle;
+  return dict.route.saveTitle
+    .replace("{title}", work)
+    .replace("{count}", String(spots))
+    .slice(0, 200);
+}
+
 export function routeStatsCopy(dict: ChatDict, spots: number, minutes: number | undefined): string {
   return dict.route.stats
     .replace("{spots}", String(spots))

--- a/apps/web/src/features/chat/route-i18n.ts
+++ b/apps/web/src/features/chat/route-i18n.ts
@@ -19,6 +19,8 @@ export interface ChatRouteDict {
   readonly saveUntitled: string;
   readonly saved: string;
   readonly saveError: string;
+  /** A 4xx that retrying cannot fix — no retry affordance is offered. */
+  readonly savePermanentError: string;
   readonly saveRetry: string;
   readonly timelineLabel: string;
   readonly mapLabel: string;
@@ -38,6 +40,7 @@ export const jaRoute: ChatRouteDict = {
   saveUntitled: "この作品",
   saved: "保存したよ",
   saveError: "保存できなかった…",
+  savePermanentError: "このルートは保存できないみたい。もう一度ルートを組んでみてね",
   saveRetry: "もう一度保存",
   timelineLabel: "ルートのタイムライン",
   mapLabel: "ルートマップ",
@@ -57,6 +60,7 @@ export const zhRoute: ChatRouteDict = {
   saveUntitled: "这部作品",
   saved: "已经保存好了",
   saveError: "没能保存…",
+  savePermanentError: "这条路线没法保存,重新组一次路线试试吧",
   saveRetry: "再保存一次",
   timelineLabel: "路线时间轴",
   mapLabel: "路线地图",
@@ -76,6 +80,7 @@ export const enRoute: ChatRouteDict = {
   saveUntitled: "this work",
   saved: "Saved it",
   saveError: "That didn't save…",
+  savePermanentError: "This route can't be saved. Try planning it again",
   saveRetry: "Save again",
   timelineLabel: "Route timeline",
   mapLabel: "Route map",

--- a/apps/web/src/features/chat/route-i18n.ts
+++ b/apps/web/src/features/chat/route-i18n.ts
@@ -11,6 +11,15 @@ export interface ChatRouteDict {
   readonly routePill: string;
   readonly walkCta: string;
   readonly openMaps: string;
+  /** P5 save CTA copy (issue #273 S1.7). */
+  readonly saveCta: string;
+  /** `{title}` resolved work, `{count}` stop count — the derived route title. */
+  readonly saveTitle: string;
+  /** Localized stand-in when the stream carried no resolved work title. */
+  readonly saveUntitled: string;
+  readonly saved: string;
+  readonly saveError: string;
+  readonly saveRetry: string;
   readonly timelineLabel: string;
   readonly mapLabel: string;
 }
@@ -24,6 +33,12 @@ export const jaRoute: ChatRouteDict = {
   routePill: "ルート",
   walkCta: "歩きモード(準備中)",
   openMaps: "Googleマップで開く",
+  saveCta: "保存する",
+  saveTitle: "{title}・{count}スポットの聖地巡礼",
+  saveUntitled: "この作品",
+  saved: "保存したよ",
+  saveError: "保存できなかった…",
+  saveRetry: "もう一度保存",
   timelineLabel: "ルートのタイムライン",
   mapLabel: "ルートマップ",
 };
@@ -37,6 +52,12 @@ export const zhRoute: ChatRouteDict = {
   routePill: "路线",
   walkCta: "步行模式(即将上线)",
   openMaps: "在 Google 地图打开",
+  saveCta: "保存路线",
+  saveTitle: "{title}・{count} 个地点的圣地巡礼",
+  saveUntitled: "这部作品",
+  saved: "已经保存好了",
+  saveError: "没能保存…",
+  saveRetry: "再保存一次",
   timelineLabel: "路线时间轴",
   mapLabel: "路线地图",
 };
@@ -50,6 +71,12 @@ export const enRoute: ChatRouteDict = {
   routePill: "Route",
   walkCta: "Walk mode (coming soon)",
   openMaps: "Open in Google Maps",
+  saveCta: "Save this route",
+  saveTitle: "{title} · a {count}-spot pilgrimage",
+  saveUntitled: "this work",
+  saved: "Saved it",
+  saveError: "That didn't save…",
+  saveRetry: "Save again",
   timelineLabel: "Route timeline",
   mapLabel: "Route map",
 };

--- a/apps/web/src/features/chat/save/createOnLogin.ts
+++ b/apps/web/src/features/chat/save/createOnLogin.ts
@@ -13,6 +13,14 @@ export function toSaveInput(intent: Readonly<{ pointIds: readonly string[]; titl
 }
 
 /**
+ * `none` — the login was not initiated by a save tap, so there was nothing to
+ * replay. `failed` is distinct from it precisely so the auth callback can
+ * surface a failure instead of reporting a clean login and leaving a live
+ * intent to fire, unannounced, on the next login inside the TTL.
+ */
+export type DeferredReplayOutcome = "none" | "saved" | "failed";
+
+/**
  * Replay the deferred save exactly once after a login. A login that was **not**
  * initiated by a save tap finds no intent and issues no request. The intent is
  * cleared only on success, so a failed replay is never silently dropped.
@@ -20,10 +28,10 @@ export function toSaveInput(intent: Readonly<{ pointIds: readonly string[]; titl
 export async function replayDeferredSave(
   request: SaveRouteRequest = saveRouteRequest,
   now: number = Date.now(),
-): Promise<boolean> {
+): Promise<DeferredReplayOutcome> {
   const intent = readDeferredSave(now);
-  if (intent === undefined) return false;
+  if (intent === undefined) return "none";
   const saved = await request(toSaveInput(intent)).then(() => true, () => false);
   if (saved) clearDeferredSave();
-  return saved;
+  return saved ? "saved" : "failed";
 }

--- a/apps/web/src/features/chat/save/createOnLogin.ts
+++ b/apps/web/src/features/chat/save/createOnLogin.ts
@@ -23,8 +23,9 @@ export type DeferredReplayOutcome = "none" | "saved" | "failed";
 
 /**
  * Replay the deferred save exactly once after a login. A login that was **not**
- * initiated by a save tap finds no intent and issues no request. The intent is
- * cleared only on success, so a failed replay is never silently dropped.
+ * initiated by a save tap finds no intent and issues no request. The entry is
+ * claimed (deleted) before the request goes out so two tabs cannot both save it,
+ * and restored on failure — so a failed replay is never silently dropped.
  */
 /** Claim before sending: two tabs completing a login concurrently would
  * otherwise both read the same intent and create two rows. The loser finds

--- a/apps/web/src/features/chat/save/createOnLogin.ts
+++ b/apps/web/src/features/chat/save/createOnLogin.ts
@@ -1,0 +1,29 @@
+import type { SaveRouteInput } from "@seichijunrei/contract";
+import { saveRouteRequest } from "../../../api/hooks/use-save-route";
+import type { SaveRouteRequest } from "../../../api/hooks/use-save-route";
+import { clearDeferredSave, readDeferredSave } from "./deferredSave";
+
+/**
+ * Create-on-login (OQ-9 ruling (b)): the post-login replay creates a **fresh**
+ * route from the client-held point ids. There is no claim call and no route id,
+ * so `ROUTE_NOT_OWNED` is structurally unreachable on this path.
+ */
+export function toSaveInput(intent: Readonly<{ pointIds: readonly string[]; title: string }>): SaveRouteInput {
+  return { title: intent.title, point_ids: [...intent.pointIds], status: "saved" };
+}
+
+/**
+ * Replay the deferred save exactly once after a login. A login that was **not**
+ * initiated by a save tap finds no intent and issues no request. The intent is
+ * cleared only on success, so a failed replay is never silently dropped.
+ */
+export async function replayDeferredSave(
+  request: SaveRouteRequest = saveRouteRequest,
+  now: number = Date.now(),
+): Promise<boolean> {
+  const intent = readDeferredSave(now);
+  if (intent === undefined) return false;
+  const saved = await request(toSaveInput(intent)).then(() => true, () => false);
+  if (saved) clearDeferredSave();
+  return saved;
+}

--- a/apps/web/src/features/chat/save/createOnLogin.ts
+++ b/apps/web/src/features/chat/save/createOnLogin.ts
@@ -1,7 +1,8 @@
 import type { SaveRouteInput } from "@seichijunrei/contract";
 import { saveRouteRequest } from "../../../api/hooks/use-save-route";
 import type { SaveRouteRequest } from "../../../api/hooks/use-save-route";
-import { clearDeferredSave, readDeferredSave } from "./deferredSave";
+import { clearDeferredSave, readDeferredSave, writeDeferredSave } from "./deferredSave";
+import type { DeferredSaveIntent } from "./deferredSave";
 
 /**
  * Create-on-login (OQ-9 ruling (b)): the post-login replay creates a **fresh**
@@ -25,13 +26,24 @@ export type DeferredReplayOutcome = "none" | "saved" | "failed";
  * initiated by a save tap finds no intent and issues no request. The intent is
  * cleared only on success, so a failed replay is never silently dropped.
  */
+/** Claim before sending: two tabs completing a login concurrently would
+ * otherwise both read the same intent and create two rows. The loser finds
+ * nothing. */
+function claimDeferredSave(now: number): DeferredSaveIntent | undefined {
+  const intent = readDeferredSave(now);
+  if (intent !== undefined) clearDeferredSave();
+  return intent;
+}
+
 export async function replayDeferredSave(
   request: SaveRouteRequest = saveRouteRequest,
   now: number = Date.now(),
 ): Promise<DeferredReplayOutcome> {
-  const intent = readDeferredSave(now);
+  const intent = claimDeferredSave(now);
   if (intent === undefined) return "none";
   const saved = await request(toSaveInput(intent)).then(() => true, () => false);
-  if (saved) clearDeferredSave();
+  // A failure restores the entry with its ORIGINAL timestamp, so a retry never
+  // silently extends the TTL.
+  if (!saved) writeDeferredSave(intent, intent.createdAt);
   return saved ? "saved" : "failed";
 }

--- a/apps/web/src/features/chat/save/deferredSave.ts
+++ b/apps/web/src/features/chat/save/deferredSave.ts
@@ -66,14 +66,23 @@ export function writeDeferredSave(
 }
 
 /** The live intent, or `undefined` — a missing, malformed or expired entry is
- * erased rather than replayed. */
+ * erased rather than left to accumulate on a shared device. */
 export function readDeferredSave(now: number = Date.now()): DeferredSaveIntent | undefined {
   const raw = store()?.getItem(DEFERRED_SAVE_KEY);
-  const intent = raw === null || raw === undefined ? undefined : parse(raw);
-  if (intent === undefined) return undefined;
-  if (now - intent.createdAt > DEFERRED_SAVE_TTL_MS) {
+  if (raw === null || raw === undefined) return undefined;
+  const intent = parse(raw);
+  if (intent === undefined || now - intent.createdAt > DEFERRED_SAVE_TTL_MS) {
     clearDeferredSave();
     return undefined;
   }
   return intent;
+}
+
+/**
+ * Opportunistic sweep: reading is what erases a dead entry, so an app that
+ * never reads would let an abandoned intent sit on a shared device past its
+ * TTL. Callers run this once on mount; it is a single `localStorage` read.
+ */
+export function pruneDeferredSave(now: number = Date.now()): void {
+  readDeferredSave(now);
 }

--- a/apps/web/src/features/chat/save/deferredSave.ts
+++ b/apps/web/src/features/chat/save/deferredSave.ts
@@ -1,0 +1,79 @@
+/**
+ * The P5 deferred save intent (issue #273 S1.7).
+ *
+ * A magic link is opened from an email client, i.e. a **new browsing context**,
+ * so neither React state nor `sessionStorage` survives the navigation —
+ * `sessionStorage` is tab-scoped and would simply be absent, making the deferred
+ * save fail silently. `localStorage` is origin-scoped and does survive. URL
+ * state is rejected: it would leak the point ids into the magic-link redirect,
+ * the email client and any referrer chain. The entry carries no `session_id`
+ * (the new tab has none) and a short TTL bounds an abandoned login so a stale
+ * intent cannot resurrect a save weeks later.
+ */
+
+/** Namespaced key: one origin, one versioned intent slot. */
+export const DEFERRED_SAVE_KEY = "animichi.chat.deferredSave.v1";
+
+/** Abandonment bound: an intent older than this is ignored and erased. */
+export const DEFERRED_SAVE_TTL_MS = 30 * 60_000;
+
+/** What the post-login replay needs, and nothing more. */
+export interface DeferredSaveIntent {
+  readonly pointIds: readonly string[];
+  readonly title: string;
+  readonly createdAt: number;
+}
+
+/** SSR and privacy-locked browsers have no store; both read as "no intent". */
+function store(): Storage | undefined {
+  try {
+    return globalThis.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isIntent(value: unknown): value is DeferredSaveIntent {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return isStringArray(record.pointIds) && typeof record.title === "string" && typeof record.createdAt === "number";
+}
+
+function parse(raw: string): DeferredSaveIntent | undefined {
+  try {
+    const value: unknown = JSON.parse(raw);
+    return isIntent(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function clearDeferredSave(): void {
+  store()?.removeItem(DEFERRED_SAVE_KEY);
+}
+
+/** Stash the intent behind the login wall; `now` is injectable for tests. */
+export function writeDeferredSave(
+  intent: Readonly<{ pointIds: readonly string[]; title: string }>,
+  now: number = Date.now(),
+): void {
+  const entry: DeferredSaveIntent = { pointIds: [...intent.pointIds], title: intent.title, createdAt: now };
+  store()?.setItem(DEFERRED_SAVE_KEY, JSON.stringify(entry));
+}
+
+/** The live intent, or `undefined` — a missing, malformed or expired entry is
+ * erased rather than replayed. */
+export function readDeferredSave(now: number = Date.now()): DeferredSaveIntent | undefined {
+  const raw = store()?.getItem(DEFERRED_SAVE_KEY);
+  const intent = raw === null || raw === undefined ? undefined : parse(raw);
+  if (intent === undefined) return undefined;
+  if (now - intent.createdAt > DEFERRED_SAVE_TTL_MS) {
+    clearDeferredSave();
+    return undefined;
+  }
+  return intent;
+}

--- a/apps/web/src/features/chat/save/saveTarget.ts
+++ b/apps/web/src/features/chat/save/saveTarget.ts
@@ -1,0 +1,33 @@
+import type { ChatDataPart } from "@seichijunrei/contract";
+import { routeOf } from "../components/cards";
+import type { SpotRow } from "../components/cards";
+import type { ChatDict } from "../i18n";
+import { saveRouteTitle } from "../route-copy";
+
+/** Everything create-on-login needs from a rendered route card. */
+export interface SaveTarget {
+  readonly pointIds: readonly string[];
+  readonly title: string;
+}
+
+/** Streamed routes carry points either as bare ids or as objects. */
+function idOf(point: string | SpotRow): string | undefined {
+  const id = typeof point === "string" ? point : point.id;
+  return id !== undefined && id !== "" ? id : undefined;
+}
+
+function pointIdsOf(points: readonly (string | SpotRow)[]): readonly string[] {
+  return points.map(idOf).filter((id): id is string => id !== undefined);
+}
+
+/**
+ * The save payload for one route card, or `undefined` when there is nothing to
+ * save yet — which is exactly what keeps the CTA disabled and unable to open
+ * the login wall.
+ */
+export function routeSaveTarget(part: ChatDataPart, dict: ChatDict): SaveTarget | undefined {
+  const route = routeOf(part);
+  const pointIds = pointIdsOf(route?.ordered_points ?? []);
+  if (pointIds.length === 0) return undefined;
+  return { pointIds, title: saveRouteTitle(dict, route?.anime_title, pointIds.length) };
+}

--- a/apps/web/src/features/chat/save/useSaveGate.ts
+++ b/apps/web/src/features/chat/save/useSaveGate.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState } from "react";
+import { useSaveRoute } from "../../../api/hooks/use-save-route";
+import type { SaveRouteRequest, SaveRouteStatus } from "../../../api/hooks/use-save-route";
+import { useAuthStatus } from "../../../lib/auth/session";
+import type { AuthStatus } from "../../../lib/auth/session";
+import { toSaveInput } from "./createOnLogin";
+import { writeDeferredSave } from "./deferredSave";
+import type { SaveTarget } from "./saveTarget";
+
+/** What a 「保存する」 tap does: nothing, open the login wall, or save. */
+export type SaveAction = "none" | "login" | "save";
+
+/**
+ * The **single** login-wall predicate (P5). Nothing else in the chat flow may
+ * open `LoginModal` proactively, so the invariant "no happy-path step opens the
+ * dialog before the save tap" reduces to this one function. An unresolved auth
+ * status is deliberately inert: opening the wall for a caller who turns out to
+ * be signed in would be a false interruption.
+ */
+export function saveAction(target: SaveTarget | undefined, status: AuthStatus): SaveAction {
+  if (target === undefined || target.pointIds.length === 0) return "none";
+  if (status === "authenticated") return "save";
+  return status === "anonymous" ? "login" : "none";
+}
+
+export interface SaveGate {
+  readonly action: SaveAction;
+  readonly status: SaveRouteStatus;
+  readonly loginOpen: boolean;
+  readonly activate: () => void;
+  readonly closeLogin: () => void;
+}
+
+/** Injectable for tests; production callers rely on the defaults. */
+export interface SaveGateOptions {
+  readonly authStatus?: AuthStatus;
+  readonly request?: SaveRouteRequest;
+}
+
+type Save = (input: ReturnType<typeof toSaveInput>) => Promise<boolean>;
+
+function act(action: SaveAction, target: SaveTarget | undefined, save: Save, openLogin: () => void): void {
+  if (action === "none" || target === undefined) return;
+  if (action === "save") return void save(toSaveInput(target));
+  writeDeferredSave(target);
+  openLogin();
+}
+
+function useActivate(action: SaveAction, target: SaveTarget | undefined, save: Save, openLogin: () => void) {
+  return useCallback(() => { act(action, target, save, openLogin); }, [action, target, save, openLogin]);
+}
+
+/** Save state plus the login wall for one route card. */
+export function useSaveGate(target: SaveTarget | undefined, options: SaveGateOptions = {}): SaveGate {
+  const detected = useAuthStatus();
+  const [loginOpen, setLoginOpen] = useState(false);
+  const { status, save } = useSaveRoute(options.request);
+  const action = saveAction(target, options.authStatus ?? detected);
+  const openLogin = useCallback(() => { setLoginOpen(true); }, []);
+  const closeLogin = useCallback(() => { setLoginOpen(false); }, []);
+  return { action, status, loginOpen, activate: useActivate(action, target, save, openLogin), closeLogin };
+}

--- a/apps/web/src/features/chat/save/useSaveGate.ts
+++ b/apps/web/src/features/chat/save/useSaveGate.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
 import { useSaveRoute } from "../../../api/hooks/use-save-route";
 import type { SaveRouteRequest, SaveRouteStatus } from "../../../api/hooks/use-save-route";
 import { fetchAuthStatus, useAuthStatus } from "../../../lib/auth/session";
@@ -29,6 +30,9 @@ export interface SaveGate {
   readonly loginOpen: boolean;
   readonly activate: () => void;
   readonly closeLogin: () => void;
+  /** The wall dispatched a magic link — the dismissal that follows is the user
+   * leaving to read their email, not a cancellation. */
+  readonly markLinkSent: () => void;
 }
 
 /** Injectable for tests; production callers rely on the defaults. */
@@ -70,23 +74,49 @@ function useActivate(action: SaveAction, target: SaveTarget | undefined, save: S
   return useCallback(() => { act(action, target, save, openLogin); }, [action, target, save, openLogin]);
 }
 
-/** Dismissing the wall is abandonment: drop the intent, or a later D8/D11 login
- * would silently save this card — possibly one #439 has already superseded. */
-function useCloseLogin(setLoginOpen: (open: boolean) => void): () => void {
+interface Wall {
+  readonly loginOpen: boolean;
+  readonly openLogin: () => void;
+  readonly closeLogin: () => void;
+  readonly markLinkSent: () => void;
+}
+
+/**
+ * The wall's own state. "A link went out" is a **ref**, not state: it never
+ * affects rendering, and React batches the form's effect with the dismissal
+ * click — a state value would still read `false` inside the click handler that
+ * flushed it, silently clearing an intent the user is about to use.
+ */
+function useWall(): Wall {
+  const [loginOpen, setLoginOpen] = useState(false);
+  const linkSent = useRef(false);
+  // Each fresh trip through the wall starts as "no link sent yet".
+  const openLogin = useCallback(() => { linkSent.current = false; setLoginOpen(true); }, []);
+  const markLinkSent = useCallback(() => { linkSent.current = true; }, []);
+  return { loginOpen, openLogin, markLinkSent, closeLogin: useCloseLogin(setLoginOpen, linkSent) };
+}
+
+/**
+ * Dismissal is only abandonment **before** a link goes out: closing the modal to
+ * go read the email is the mainline of the magic-link flow, and clearing there
+ * would break create-on-login silently. Once a link is dispatched the intent
+ * survives; the surprise-save risk that motivated clearing is already covered by
+ * consume-once plus the TTL.
+ */
+function useCloseLogin(setLoginOpen: (open: boolean) => void, linkSent: RefObject<boolean>): () => void {
   return useCallback(() => {
-    clearDeferredSave();
+    if (!linkSent.current) clearDeferredSave();
     setLoginOpen(false);
-  }, [setLoginOpen]);
+  }, [setLoginOpen, linkSent]);
 }
 
 /** Save state plus the login wall for one route card. */
 export function useSaveGate(target: SaveTarget | undefined, options: SaveGateOptions = {}): SaveGate {
   const detected = useResolvedAuthStatus(options.authStatus);
-  const [loginOpen, setLoginOpen] = useState(false);
+  const wall = useWall();
   const { status, save } = useSaveRoute(options.request);
   const action = saveAction(target, detected);
-  const openLogin = useCallback(() => { setLoginOpen(true); }, []);
   useEffect(() => { pruneDeferredSave(); }, []);
-  const activate = useActivate(action, target, save, openLogin);
-  return { action, status, loginOpen, activate, closeLogin: useCloseLogin(setLoginOpen) };
+  const activate = useActivate(action, target, save, wall.openLogin);
+  return { action, status, ...wall, activate };
 }

--- a/apps/web/src/features/chat/save/useSaveGate.ts
+++ b/apps/web/src/features/chat/save/useSaveGate.ts
@@ -1,10 +1,10 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useSaveRoute } from "../../../api/hooks/use-save-route";
 import type { SaveRouteRequest, SaveRouteStatus } from "../../../api/hooks/use-save-route";
-import { useAuthStatus } from "../../../lib/auth/session";
+import { fetchAuthStatus, useAuthStatus } from "../../../lib/auth/session";
 import type { AuthStatus } from "../../../lib/auth/session";
 import { toSaveInput } from "./createOnLogin";
-import { writeDeferredSave } from "./deferredSave";
+import { clearDeferredSave, pruneDeferredSave, writeDeferredSave } from "./deferredSave";
 import type { SaveTarget } from "./saveTarget";
 
 /** What a 「保存する」 tap does: nothing, open the login wall, or save. */
@@ -37,11 +37,31 @@ export interface SaveGateOptions {
   readonly request?: SaveRouteRequest;
 }
 
-type Save = (input: ReturnType<typeof toSaveInput>) => Promise<boolean>;
+/** An injected status is already the answer — don't spend a `getSession` round
+ * trip on it. Concurrent real lookups are deduped inside `fetchAuthStatus`. */
+function useResolvedAuthStatus(override: AuthStatus | undefined): AuthStatus {
+  const fetcher = useCallback(
+    () => (override === undefined ? fetchAuthStatus() : Promise.resolve(override)),
+    [override],
+  );
+  const detected = useAuthStatus(fetcher);
+  return override ?? detected;
+}
+
+type Save = (input: ReturnType<typeof toSaveInput>) => Promise<SaveRouteStatus>;
+
+/** A save rejected as unauthorized re-enters the wall with a fresh intent
+ * rather than offering a retry that would fail identically. */
+async function saveOrReWall(target: SaveTarget, save: Save, openLogin: () => void): Promise<void> {
+  const outcome = await save(toSaveInput(target));
+  if (outcome !== "unauthorized") return;
+  writeDeferredSave(target);
+  openLogin();
+}
 
 function act(action: SaveAction, target: SaveTarget | undefined, save: Save, openLogin: () => void): void {
   if (action === "none" || target === undefined) return;
-  if (action === "save") return void save(toSaveInput(target));
+  if (action === "save") return void saveOrReWall(target, save, openLogin);
   writeDeferredSave(target);
   openLogin();
 }
@@ -50,13 +70,23 @@ function useActivate(action: SaveAction, target: SaveTarget | undefined, save: S
   return useCallback(() => { act(action, target, save, openLogin); }, [action, target, save, openLogin]);
 }
 
+/** Dismissing the wall is abandonment: drop the intent, or a later D8/D11 login
+ * would silently save this card — possibly one #439 has already superseded. */
+function useCloseLogin(setLoginOpen: (open: boolean) => void): () => void {
+  return useCallback(() => {
+    clearDeferredSave();
+    setLoginOpen(false);
+  }, [setLoginOpen]);
+}
+
 /** Save state plus the login wall for one route card. */
 export function useSaveGate(target: SaveTarget | undefined, options: SaveGateOptions = {}): SaveGate {
-  const detected = useAuthStatus();
+  const detected = useResolvedAuthStatus(options.authStatus);
   const [loginOpen, setLoginOpen] = useState(false);
   const { status, save } = useSaveRoute(options.request);
-  const action = saveAction(target, options.authStatus ?? detected);
+  const action = saveAction(target, detected);
   const openLogin = useCallback(() => { setLoginOpen(true); }, []);
-  const closeLogin = useCallback(() => { setLoginOpen(false); }, []);
-  return { action, status, loginOpen, activate: useActivate(action, target, save, openLogin), closeLogin };
+  useEffect(() => { pruneDeferredSave(); }, []);
+  const activate = useActivate(action, target, save, openLogin);
+  return { action, status, loginOpen, activate, closeLogin: useCloseLogin(setLoginOpen) };
 }

--- a/apps/web/src/i18n/dictionaries/en.json
+++ b/apps/web/src/i18n/dictionaries/en.json
@@ -55,6 +55,9 @@
     "magic_link_hint": "No password — we email you a secure sign-in link.",
     "close": "Close",
     "callback_pending": "Signing you in…",
-    "callback_error": "That link has expired or was already used. Please request a new one."
+    "callback_error": "That link has expired or was already used. Please request a new one.",
+    "callback_save_failed": "You're signed in, but the route didn't save…",
+    "callback_save_retry": "Try saving again",
+    "callback_save_skip": "You can also save it again from the chat page later"
   }
 }

--- a/apps/web/src/i18n/dictionaries/ja.json
+++ b/apps/web/src/i18n/dictionaries/ja.json
@@ -55,6 +55,9 @@
     "magic_link_hint": "パスワード不要 — 安全なログインリンクをメールでお送りします。",
     "close": "閉じる",
     "callback_pending": "ログインしています…",
-    "callback_error": "リンクの有効期限が切れたか、既に使用されています。もう一度お試しください。"
+    "callback_error": "リンクの有効期限が切れたか、既に使用されています。もう一度お試しください。",
+    "callback_save_failed": "ログインはできたけど、ルートの保存に失敗しちゃった…",
+    "callback_save_retry": "もう一度保存する",
+    "callback_save_skip": "あとでチャット画面から保存し直せるよ"
   }
 }

--- a/apps/web/src/i18n/dictionaries/zh.json
+++ b/apps/web/src/i18n/dictionaries/zh.json
@@ -55,6 +55,9 @@
     "magic_link_hint": "无需密码 —— 我们会通过邮件发送安全的登录链接。",
     "close": "关闭",
     "callback_pending": "正在登录…",
-    "callback_error": "登录链接已失效或已被使用，请重新申请。"
+    "callback_error": "登录链接已失效或已被使用，请重新申请。",
+    "callback_save_failed": "登录成功了，但路线没能保存…",
+    "callback_save_retry": "再保存一次",
+    "callback_save_skip": "也可以稍后回到聊天页重新保存"
   }
 }

--- a/apps/web/src/lib/auth/session.ts
+++ b/apps/web/src/lib/auth/session.ts
@@ -9,8 +9,7 @@ function authBaseUrl(): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-/** Resolve the caller's auth status; unconfigured or failing auth is anonymous. */
-export async function fetchAuthStatus(): Promise<AuthStatus> {
+async function resolveAuthStatus(): Promise<AuthStatus> {
   const base = authBaseUrl();
   if (!base) return "anonymous";
   try {
@@ -19,6 +18,17 @@ export async function fetchAuthStatus(): Promise<AuthStatus> {
   } catch {
     return "anonymous";
   }
+}
+
+/** In-flight only: several route cards mounting together must share one
+ * `getSession` round trip, but nothing is cached past settlement, so a login
+ * is never masked by a stale value. */
+let inFlight: Promise<AuthStatus> | undefined;
+
+/** Resolve the caller's auth status; unconfigured or failing auth is anonymous. */
+export function fetchAuthStatus(): Promise<AuthStatus> {
+  inFlight ??= resolveAuthStatus().finally(() => { inFlight = undefined; });
+  return inFlight;
 }
 
 export function useAuthStatus(fetcher: () => Promise<AuthStatus> = fetchAuthStatus): AuthStatus {

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -668,14 +668,11 @@
   gap: 0.5rem;
 }
 
-/* P5 save CTA (issue #273 S1.7). The design sync assigns the card-foot CTAs as
-   「金=しおり共有(唯一) · cream=Maps/保存/歩くモード」 with the standing rule
-   「永不同屏两金」, so 保存する is a cream press button and the gold tokens stay
-   reserved for the single share CTA per screen. */
-.chat-chip[data-cta="save"] {
-  background: var(--color-card);
-  color: var(--color-fg);
-}
+/* P5 save CTA (issue #273 S1.7) carries NO tone override on purpose. The design
+   sync assigns the card-foot CTAs as 「金=しおり共有(唯一) · cream=Maps/保存/
+   歩くモード」 with the standing rule 「永不同屏两金」, so 保存する inherits the base
+   .chat-chip cream press style and the gold tokens stay reserved for the single
+   share CTA per screen. A tone rule here would be that second gold. */
 
 .chat-cta-row__saved {
   color: var(--color-primary-strong);

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -664,7 +664,29 @@
 .chat-cta-row {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 0.5rem;
+}
+
+/* P5 save CTA (issue #273 S1.7). The design sync assigns the card-foot CTAs as
+   「金=しおり共有(唯一) · cream=Maps/保存/歩くモード」 with the standing rule
+   「永不同屏两金」, so 保存する is a cream press button and the gold tokens stay
+   reserved for the single share CTA per screen. */
+.chat-chip[data-cta="save"] {
+  background: var(--color-card);
+  color: var(--color-fg);
+}
+
+.chat-cta-row__saved {
+  color: var(--color-primary-strong);
+  font-weight: 700;
+}
+
+.chat-cta-row__error {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-error-strong);
 }
 
 /* --- S1.5 promoted route map --- */

--- a/apps/web/tests/integration/create-on-login.test.ts
+++ b/apps/web/tests/integration/create-on-login.test.ts
@@ -26,7 +26,7 @@ const server = setupServer(
   http.post(ROUTES_URL, async ({ request }) => {
     const input = SaveRouteInput.parse(await request.json());
     const row = UserRoute.parse({
-      id: `11111111-1111-4111-8111-00000000000${saved.length}`,
+      id: `11111111-1111-4111-8111-00000000000${String(saved.length)}`,
       title: input.title,
       point_ids: input.point_ids,
       status: input.status,
@@ -34,7 +34,7 @@ const server = setupServer(
       updated_at: "2026-07-28T00:00:00.000Z",
     });
     saved.push(row);
-    return HttpResponse.json(row as unknown as JsonBodyType);
+    return HttpResponse.json(row);
   }),
   http.get(ROUTES_URL, () => HttpResponse.json(ListRoutesResult.parse({ routes: saved }) as JsonBodyType)),
 );
@@ -79,7 +79,7 @@ describe("create-on-login persists the deferred route and lists it back", () => 
           status: "saved",
           saved_at: null,
           updated_at: "2026-07-28T00:00:00.000Z",
-        }) as unknown as JsonBodyType);
+        }));
       }),
     );
     writeDeferredSave({ pointIds: POINT_IDS, title: TITLE });

--- a/apps/web/tests/integration/create-on-login.test.ts
+++ b/apps/web/tests/integration/create-on-login.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * AC3 (create-on-login): after a magic-link login initiated by the save tap, the
+ * deferred intent replays through `users.saveRoute` and the persisted row is
+ * visible to `users.listRoutes`. Asserted on row content, not on the call having
+ * been made — a fake that merely records the request would pass the weaker form.
+ */
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import type { JsonBodyType } from "msw";
+import { ListRoutesResult, SaveRouteInput, UserRoute } from "@seichijunrei/contract";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { users } from "../../src/api/orpc";
+import { replayDeferredSave } from "../../src/features/chat/save/createOnLogin";
+import { writeDeferredSave } from "../../src/features/chat/save/deferredSave";
+
+const ROUTES_URL = "http://localhost:3000/v1/users/routes";
+const POINT_IDS = ["uji-01", "uji-02", "uji-03"];
+const TITLE = "響け!ユーフォニアム・3スポットの聖地巡礼";
+
+/** A stateful stand-in for the users Worker: saves persist and then list. */
+const saved: UserRoute[] = [];
+
+const server = setupServer(
+  http.post(ROUTES_URL, async ({ request }) => {
+    const input = SaveRouteInput.parse(await request.json());
+    const row = UserRoute.parse({
+      id: `11111111-1111-4111-8111-00000000000${saved.length}`,
+      title: input.title,
+      point_ids: input.point_ids,
+      status: input.status,
+      saved_at: "2026-07-28T00:00:00.000Z",
+      updated_at: "2026-07-28T00:00:00.000Z",
+    });
+    saved.push(row);
+    return HttpResponse.json(row as unknown as JsonBodyType);
+  }),
+  http.get(ROUTES_URL, () => HttpResponse.json(ListRoutesResult.parse({ routes: saved }) as JsonBodyType)),
+);
+
+beforeAll(() => { server.listen({ onUnhandledRequest: "error" }); });
+afterEach(() => { server.resetHandlers(); });
+afterAll(() => { server.close(); });
+
+beforeEach(() => {
+  saved.length = 0;
+  localStorage.clear();
+});
+
+describe("create-on-login persists the deferred route and lists it back", () => {
+  it("writes a row whose point_ids are the deferred ids, in order and non-empty", async () => {
+    writeDeferredSave({ pointIds: POINT_IDS, title: TITLE });
+    expect(await replayDeferredSave()).toBe(true);
+    expect(saved).toHaveLength(1);
+    expect(saved[0]?.point_ids).toEqual(POINT_IDS);
+    expect(saved[0]?.point_ids.length).toBeGreaterThan(0);
+    expect(saved[0]?.title).toBe(TITLE);
+    expect(saved[0]?.status).toBe("saved");
+  });
+
+  it("makes the new row visible to a subsequent listRoutes for that user", async () => {
+    writeDeferredSave({ pointIds: POINT_IDS, title: TITLE });
+    await replayDeferredSave();
+    const listed = await users().listRoutes.call();
+    expect(listed.routes.map((route) => route.title)).toContain(TITLE);
+    expect(listed.routes[0]?.point_ids).toEqual(POINT_IDS);
+  });
+
+  it("creates rather than claims: no route id is ever sent, so ownership cannot be contested", async () => {
+    let sentId: unknown = "unset";
+    server.use(
+      http.post(ROUTES_URL, async ({ request }) => {
+        sentId = (await request.json() as Record<string, unknown>).id;
+        return HttpResponse.json(UserRoute.parse({
+          id: "22222222-2222-4222-8222-222222222222",
+          title: TITLE,
+          point_ids: POINT_IDS,
+          status: "saved",
+          saved_at: null,
+          updated_at: "2026-07-28T00:00:00.000Z",
+        }) as unknown as JsonBodyType);
+      }),
+    );
+    writeDeferredSave({ pointIds: POINT_IDS, title: TITLE });
+    await replayDeferredSave();
+    expect(sentId).toBeUndefined();
+  });
+
+  it("does not fire at all for a login that no save tap initiated", async () => {
+    expect(await replayDeferredSave()).toBe(false);
+    expect(saved).toHaveLength(0);
+  });
+});

--- a/apps/web/tests/integration/create-on-login.test.ts
+++ b/apps/web/tests/integration/create-on-login.test.ts
@@ -10,10 +10,14 @@ import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import type { JsonBodyType } from "msw";
 import { ListRoutesResult, SaveRouteInput, UserRoute } from "@seichijunrei/contract";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthCallback } from "../../src/components/auth/AuthCallback";
+import { LocaleProvider } from "../../src/i18n/context";
 import { users } from "../../src/api/orpc";
 import { replayDeferredSave } from "../../src/features/chat/save/createOnLogin";
-import { writeDeferredSave } from "../../src/features/chat/save/deferredSave";
+import { DEFERRED_SAVE_KEY, writeDeferredSave } from "../../src/features/chat/save/deferredSave";
 
 const ROUTES_URL = "http://localhost:3000/v1/users/routes";
 const POINT_IDS = ["uji-01", "uji-02", "uji-03"];
@@ -48,10 +52,12 @@ beforeEach(() => {
   localStorage.clear();
 });
 
+afterEach(cleanup);
+
 describe("create-on-login persists the deferred route and lists it back", () => {
   it("writes a row whose point_ids are the deferred ids, in order and non-empty", async () => {
     writeDeferredSave({ pointIds: POINT_IDS, title: TITLE });
-    expect(await replayDeferredSave()).toBe(true);
+    expect(await replayDeferredSave()).toBe("saved");
     expect(saved).toHaveLength(1);
     expect(saved[0]?.point_ids).toEqual(POINT_IDS);
     expect(saved[0]?.point_ids.length).toBeGreaterThan(0);
@@ -88,7 +94,38 @@ describe("create-on-login persists the deferred route and lists it back", () => 
   });
 
   it("does not fire at all for a login that no save tap initiated", async () => {
-    expect(await replayDeferredSave()).toBe(false);
+    expect(await replayDeferredSave()).toBe("none");
     expect(saved).toHaveLength(0);
+  });
+});
+
+describe("P1-3: the production wiring itself, with no replay injected", () => {
+  function renderCallback(onDone: () => void) {
+    const establish = () => Promise.resolve("token");
+    return render(
+      createElement(LocaleProvider, null, createElement(AuthCallback, { onDone, establish })),
+    );
+  }
+
+  it("saves through AuthCallback's own default replay and clears the intent", async () => {
+    writeDeferredSave({ pointIds: POINT_IDS, title: TITLE });
+    const onDone = vi.fn();
+    // Only `establish` is injected: `replay` keeps its production default, so a
+    // mutation that unwires it (`replay = async () => "none"`) fails here.
+    renderCallback(onDone);
+    await waitFor(() => { expect(onDone).toHaveBeenCalledTimes(1); });
+    expect(saved).toHaveLength(1);
+    expect(saved[0]?.point_ids).toEqual(POINT_IDS);
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+
+  it("surfaces the failure rather than reporting a clean login when the save 5xxs", async () => {
+    server.use(http.post(ROUTES_URL, () => new HttpResponse(null, { status: 503 })));
+    writeDeferredSave({ pointIds: POINT_IDS, title: TITLE });
+    const onDone = vi.fn();
+    renderCallback(onDone);
+    await waitFor(() => { expect(screen.getByRole("alert")).toBeTruthy(); });
+    expect(onDone).not.toHaveBeenCalled();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeTruthy();
   });
 });

--- a/apps/web/tests/msw/users.ts
+++ b/apps/web/tests/msw/users.ts
@@ -6,9 +6,10 @@ import { contractJsonHandler, orpcErrorResponse } from "./contract-handler";
 import { TEST_ORIGIN } from "./fixtures";
 
 /**
- * Contract-typed MSW swimlane for the authenticated `users.listRoutes` GET
- * route. The body is `parse()`d with the contract's `ListRoutesResult` — no
- * hand-written JSON — and the 401 handler models a logged-out caller.
+ * Contract-typed MSW swimlane for the authenticated user-route endpoints:
+ * `users.listRoutes` (GET) and `users.saveRoute` (POST). Every body is
+ * `parse()`d with the contract schema — no hand-written JSON — and the 401
+ * handler models a logged-out caller.
  */
 export const USERS_ROUTES_URL = `${TEST_ORIGIN}/v1/users/routes`;
 
@@ -37,10 +38,12 @@ export const usersRoutesUnauthorizedHandler: HttpHandler = http.get(USERS_ROUTES
   orpcErrorResponse({ code: "UNAUTHORIZED", status: 401, message: "Sign in required" }),
 );
 
-/** Saved ids: create-on-login always creates, so a fresh id per call is right. */
+/** A fixed id is enough for unit assertions; the stateful create-on-login
+ * integration swimlane (tests/integration/create-on-login.test.ts) is the one
+ * that mints a distinct id per save. */
 const SAVED_ID = "44444444-4444-4444-8444-444444444444";
 
-/** Create-on-login swimlane: `users.saveRoute` echoes the persisted row back. */
+/** `users.saveRoute` echoes the persisted row back. */
 export const usersSaveRouteHandler: HttpHandler = contractJsonHandler({
   method: "post",
   url: USERS_ROUTES_URL,

--- a/apps/web/tests/msw/users.ts
+++ b/apps/web/tests/msw/users.ts
@@ -1,8 +1,8 @@
 import { http, HttpResponse } from "msw";
 import type { HttpHandler, JsonBodyType } from "msw";
-import { ListRoutesResult } from "@seichijunrei/contract";
+import { ListRoutesResult, SaveRouteInput, UserRoute as UserRouteSchema } from "@seichijunrei/contract";
 import type { UserRoute } from "@seichijunrei/contract";
-import { orpcErrorResponse } from "./contract-handler";
+import { contractJsonHandler, orpcErrorResponse } from "./contract-handler";
 import { TEST_ORIGIN } from "./fixtures";
 
 /**
@@ -35,4 +35,28 @@ export const usersRoutesEmptyHandler: HttpHandler = http.get(USERS_ROUTES_URL, (
 
 export const usersRoutesUnauthorizedHandler: HttpHandler = http.get(USERS_ROUTES_URL, () =>
   orpcErrorResponse({ code: "UNAUTHORIZED", status: 401, message: "Sign in required" }),
+);
+
+/** Saved ids: create-on-login always creates, so a fresh id per call is right. */
+const SAVED_ID = "44444444-4444-4444-8444-444444444444";
+
+/** Create-on-login swimlane: `users.saveRoute` echoes the persisted row back. */
+export const usersSaveRouteHandler: HttpHandler = contractJsonHandler({
+  method: "post",
+  url: USERS_ROUTES_URL,
+  input: SaveRouteInput,
+  output: UserRouteSchema,
+  resolve: (input) => ({
+    id: input.id ?? SAVED_ID,
+    title: input.title,
+    point_ids: input.point_ids,
+    status: input.status,
+    saved_at: "2026-07-28T00:00:00.000Z",
+    updated_at: "2026-07-28T00:00:00.000Z",
+  }),
+});
+
+/** A users service that is down; the card must retry in place, not blow up. */
+export const usersSaveRouteOutageHandler: HttpHandler = http.post(USERS_ROUTES_URL, () =>
+  orpcErrorResponse({ code: "INTERNAL_SERVER_ERROR", status: 500, message: "users unavailable" }),
 );

--- a/apps/web/tests/unit/api/save-route.test.ts
+++ b/apps/web/tests/unit/api/save-route.test.ts
@@ -1,9 +1,13 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, expect, it } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { createElement } from "react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
 import type { SaveRouteInput } from "@seichijunrei/contract";
-import { saveRouteRequest } from "../../../src/api/hooks/use-save-route";
+import { classifySaveFailure, saveRouteRequest, useSaveRoute } from "../../../src/api/hooks/use-save-route";
 import { server } from "../../msw/node";
 import { usersSaveRouteHandler, usersSaveRouteOutageHandler } from "../../msw/users";
 
@@ -21,5 +25,53 @@ describe("saveRouteRequest goes through the contract-typed users client", () => 
   it("surfaces a users-service outage as a rejection the card can retry", async () => {
     server.use(usersSaveRouteOutageHandler);
     await expect(saveRouteRequest(INPUT)).rejects.toThrow();
+  });
+});
+
+describe("P1-1: concurrent saves collapse to one request", () => {
+  it("drops a second save issued before the first settles", async () => {
+    let release = (): void => undefined;
+    const request = vi.fn().mockImplementation(() => new Promise((resolve) => { release = () => { resolve(INPUT); }; }));
+    const { result } = renderHook(() => useSaveRoute(request));
+    const first = result.current.save(INPUT);
+    const second = result.current.save(INPUT);
+    release();
+    await Promise.all([first, second]);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("failure classification decides retry vs re-wall", () => {
+  it.each([
+    [401, "unauthorized"],
+    [403, "unauthorized"],
+    [422, "permanent"],
+    [404, "permanent"],
+    [429, "retryable"],
+    [408, "retryable"],
+    [503, "retryable"],
+  ] as const)("maps %i to %s", (status, expected) => {
+    expect(classifySaveFailure({ status })).toBe(expected);
+  });
+
+  it("treats a transport error with no status as retryable", () => {
+    expect(classifySaveFailure(new Error("network"))).toBe("retryable");
+  });
+});
+
+describe("a saved route refreshes the caller's route list", () => {
+  it("invalidates the users.listRoutes query when a provider is present", async () => {
+    const client = new QueryClient();
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    const wrapper = ({ children }: Readonly<{ children: ReactNode }>) =>
+      createElement(QueryClientProvider, { client }, children);
+    const { result } = renderHook(() => useSaveRoute(vi.fn().mockResolvedValue(INPUT)), { wrapper });
+    await act(async () => { await result.current.save(INPUT); });
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves fine with no provider at all — a bare card render must not throw", async () => {
+    const { result } = renderHook(() => useSaveRoute(vi.fn().mockResolvedValue(INPUT)));
+    await act(async () => { expect(await result.current.save(INPUT)).toBe("saved"); });
   });
 });

--- a/apps/web/tests/unit/api/save-route.test.ts
+++ b/apps/web/tests/unit/api/save-route.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from "vitest";
+import type { SaveRouteInput } from "@seichijunrei/contract";
+import { saveRouteRequest } from "../../../src/api/hooks/use-save-route";
+import { server } from "../../msw/node";
+import { usersSaveRouteHandler, usersSaveRouteOutageHandler } from "../../msw/users";
+
+const INPUT: SaveRouteInput = { title: "宇治・3スポットの聖地巡礼", point_ids: ["p1", "p2", "p3"], status: "saved" };
+
+describe("saveRouteRequest goes through the contract-typed users client", () => {
+  it("persists the point ids in order and returns the saved row", async () => {
+    server.use(usersSaveRouteHandler);
+    const route = await saveRouteRequest(INPUT);
+    expect(route.point_ids).toEqual(["p1", "p2", "p3"]);
+    expect(route.title).toBe(INPUT.title);
+    expect(route.status).toBe("saved");
+  });
+
+  it("surfaces a users-service outage as a rejection the card can retry", async () => {
+    server.use(usersSaveRouteOutageHandler);
+    await expect(saveRouteRequest(INPUT)).rejects.toThrow();
+  });
+});

--- a/apps/web/tests/unit/auth/use-auth-callback.test.tsx
+++ b/apps/web/tests/unit/auth/use-auth-callback.test.tsx
@@ -9,14 +9,14 @@ describe("useAuthCallback", () => {
   it("starts pending, then resolves to done once a token is established", async () => {
     const establish = vi.fn().mockResolvedValue("jwt-1");
     const view = renderHook(() => useAuthCallback(establish));
-    expect(view.result.current).toBe("pending");
-    await waitFor(() => { expect(view.result.current).toBe("done"); });
+    expect(view.result.current.state).toBe("pending");
+    await waitFor(() => { expect(view.result.current.state).toBe("done"); });
   });
 
   it("resolves to error when no token could be established", async () => {
     const establish = vi.fn().mockResolvedValue(undefined);
     const view = renderHook(() => useAuthCallback(establish));
-    await waitFor(() => { expect(view.result.current).toBe("error"); });
+    await waitFor(() => { expect(view.result.current.state).toBe("error"); });
   });
 
   it("ignores a late resolution after unmount", async () => {
@@ -26,6 +26,6 @@ describe("useAuthCallback", () => {
     view.unmount();
     resolve("jwt-late");
     await new Promise((r) => setTimeout(r, 10));
-    expect(view.result.current).toBe("pending");
+    expect(view.result.current.state).toBe("pending");
   });
 });

--- a/apps/web/tests/unit/chat/chat-design-css.test.ts
+++ b/apps/web/tests/unit/chat/chat-design-css.test.ts
@@ -15,16 +15,19 @@ describe("nook tri-color chip tiles", () => {
 });
 
 describe("P5 save CTA: cream, so the single gold CTA stays reserved", () => {
-  const save = '.chat-chip[data-cta="save"]';
-
-  it("paints the save CTA with the cream card token pair", () => {
-    expect(ruleDeclaration(chatCss, save, "background")).toBe("var(--color-card)");
-    expect(ruleDeclaration(chatCss, save, "color")).toBe("var(--color-fg)");
+  it("inherits the base chip's cream press style", () => {
+    expect(ruleDeclaration(chatCss, ".chat-chip", "background")).toBe("var(--color-card)");
+    expect(ruleDeclaration(chatCss, ".chat-chip", "color")).toBe("var(--color-fg)");
   });
 
-  it("never borrows a gold token — the design sync allows one gold CTA per screen", () => {
-    expect(ruleDeclaration(chatCss, save, "background")).not.toContain("gold");
-    expect(ruleDeclaration(chatCss, save, "color")).not.toContain("gold");
+  it("declares no tone override at all — a second gold is what the design forbids", () => {
+    const toneRules = [...chatCss.matchAll(/\.chat-chip\[data-cta="save"\][^{]*\{([^}]*)\}/g)];
+    expect(toneRules).toHaveLength(0);
+  });
+
+  it("keeps gold reserved: no chip rule spends a gold token", () => {
+    const chipRules = [...chatCss.matchAll(/\.chat-chip[^{]*\{([^}]*)\}/g)].map((match) => match[1] ?? "");
+    expect(chipRules.some((body) => body.includes("--color-gold"))).toBe(false);
   });
 
   it("keeps the saved confirmation and save error on semantic tokens", () => {

--- a/apps/web/tests/unit/chat/chat-design-css.test.ts
+++ b/apps/web/tests/unit/chat/chat-design-css.test.ts
@@ -14,6 +14,25 @@ describe("nook tri-color chip tiles", () => {
   });
 });
 
+describe("P5 save CTA: cream, so the single gold CTA stays reserved", () => {
+  const save = '.chat-chip[data-cta="save"]';
+
+  it("paints the save CTA with the cream card token pair", () => {
+    expect(ruleDeclaration(chatCss, save, "background")).toBe("var(--color-card)");
+    expect(ruleDeclaration(chatCss, save, "color")).toBe("var(--color-fg)");
+  });
+
+  it("never borrows a gold token — the design sync allows one gold CTA per screen", () => {
+    expect(ruleDeclaration(chatCss, save, "background")).not.toContain("gold");
+    expect(ruleDeclaration(chatCss, save, "color")).not.toContain("gold");
+  });
+
+  it("keeps the saved confirmation and save error on semantic tokens", () => {
+    expect(ruleDeclaration(chatCss, ".chat-cta-row__saved", "color")).toBe("var(--color-primary-strong)");
+    expect(ruleDeclaration(chatCss, ".chat-cta-row__error", "color")).toBe("var(--color-error-strong)");
+  });
+});
+
 describe("B2b running step: gold + shimmer", () => {
   const running = '.chat-step[data-status="running"]';
 

--- a/apps/web/tests/unit/chat/deferred-save.test.ts
+++ b/apps/web/tests/unit/chat/deferred-save.test.ts
@@ -72,15 +72,35 @@ describe("AC5: an intent older than the TTL is ignored and cleared", () => {
 describe("AC4 negative: a login not initiated by a save tap replays nothing", () => {
   it("makes no saveRoute call when no intent is present", async () => {
     const request = vi.fn();
-    expect(await replayDeferredSave(request, 1_000)).toBe(false);
+    expect(await replayDeferredSave(request, 1_000)).toBe("none");
     expect(request).not.toHaveBeenCalled();
   });
 
   it("makes no saveRoute call when the only intent has expired", async () => {
     writeDeferredSave(INTENT, 1_000);
     const request = vi.fn();
-    expect(await replayDeferredSave(request, 1_000 + DEFERRED_SAVE_TTL_MS + 1)).toBe(false);
+    expect(await replayDeferredSave(request, 1_000 + DEFERRED_SAVE_TTL_MS + 1)).toBe("none");
     expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe("P2-2: an unrelated login inside the TTL still completes the user's own save", () => {
+  it("replays a live intent even though this login was not the one that stashed it", async () => {
+    writeDeferredSave(INTENT, 1_000);
+    const request = vi.fn().mockResolvedValue({ id: "r1" });
+    // Ruled semantics: an intent can only be produced by a real 保存する tap, so
+    // replaying it within the TTL finishes a save the same user asked for. This
+    // test pins that intent so a later refactor cannot drift it silently.
+    expect(await replayDeferredSave(request, 1_000 + 60_000)).toBe("saved");
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("consumes the intent, so a second unrelated login replays nothing", async () => {
+    writeDeferredSave(INTENT, 1_000);
+    const request = vi.fn().mockResolvedValue({ id: "r1" });
+    await replayDeferredSave(request, 1_100);
+    expect(await replayDeferredSave(request, 1_200)).toBe("none");
+    expect(request).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -88,7 +108,7 @@ describe("AC3/AC7: replay semantics", () => {
   it("saves the exact deferred ids in order and clears the intent on success", async () => {
     writeDeferredSave(INTENT, 1_000);
     const request = vi.fn().mockResolvedValue({ id: "r1" });
-    expect(await replayDeferredSave(request, 1_100)).toBe(true);
+    expect(await replayDeferredSave(request, 1_100)).toBe("saved");
     expect(request).toHaveBeenCalledWith({ title: INTENT.title, point_ids: ["p1", "p2"], status: "saved" });
     expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
   });
@@ -96,7 +116,7 @@ describe("AC3/AC7: replay semantics", () => {
   it("keeps the intent after a failed replay so it is not silently dropped", async () => {
     writeDeferredSave(INTENT, 1_000);
     const request = vi.fn().mockRejectedValue(new Error("502"));
-    expect(await replayDeferredSave(request, 1_100)).toBe(false);
+    expect(await replayDeferredSave(request, 1_100)).toBe("failed");
     expect(readDeferredSave(1_100)).toBeDefined();
   });
 });

--- a/apps/web/tests/unit/chat/deferred-save.test.ts
+++ b/apps/web/tests/unit/chat/deferred-save.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFERRED_SAVE_KEY,
+  DEFERRED_SAVE_TTL_MS,
+  clearDeferredSave,
+  readDeferredSave,
+  writeDeferredSave,
+} from "../../../src/features/chat/save/deferredSave";
+import { replayDeferredSave } from "../../../src/features/chat/save/createOnLogin";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+const INTENT = { pointIds: ["p1", "p2"], title: "宇治・2スポット" } as const;
+
+describe("AC4: the deferred intent lives in namespaced localStorage", () => {
+  it("writes under a namespaced key so it survives a new browsing context", () => {
+    writeDeferredSave(INTENT, 1_000);
+    expect(DEFERRED_SAVE_KEY).toContain("animichi");
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeTruthy();
+    expect(sessionStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+
+  it("round-trips the point ids in order plus the derived title", () => {
+    writeDeferredSave(INTENT, 1_000);
+    expect(readDeferredSave(1_000)).toEqual({ ...INTENT, createdAt: 1_000 });
+  });
+
+  it("carries no session id — the magic-link tab never inherits one", () => {
+    writeDeferredSave(INTENT, 1_000);
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).not.toContain("session");
+  });
+
+  it("reads nothing when no save tap ever wrote an intent", () => {
+    expect(readDeferredSave(1_000)).toBeUndefined();
+  });
+
+  it("treats a malformed entry as absent rather than replaying garbage", () => {
+    localStorage.setItem(DEFERRED_SAVE_KEY, '{"pointIds":"nope"}');
+    expect(readDeferredSave(1_000)).toBeUndefined();
+  });
+
+  it("treats unparseable JSON as absent rather than throwing", () => {
+    localStorage.setItem(DEFERRED_SAVE_KEY, "{not json");
+    expect(readDeferredSave(1_000)).toBeUndefined();
+  });
+
+  it("clears the entry on demand", () => {
+    writeDeferredSave(INTENT, 1_000);
+    clearDeferredSave();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+});
+
+describe("AC5: an intent older than the TTL is ignored and cleared", () => {
+  it("replays an intent that is still inside the TTL window", () => {
+    writeDeferredSave(INTENT, 1_000);
+    expect(readDeferredSave(1_000 + DEFERRED_SAVE_TTL_MS - 1)).toBeDefined();
+  });
+
+  it("ignores and erases an abandoned intent past the TTL", () => {
+    writeDeferredSave(INTENT, 1_000);
+    expect(readDeferredSave(1_000 + DEFERRED_SAVE_TTL_MS + 1)).toBeUndefined();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+});
+
+describe("AC4 negative: a login not initiated by a save tap replays nothing", () => {
+  it("makes no saveRoute call when no intent is present", async () => {
+    const request = vi.fn();
+    expect(await replayDeferredSave(request, 1_000)).toBe(false);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("makes no saveRoute call when the only intent has expired", async () => {
+    writeDeferredSave(INTENT, 1_000);
+    const request = vi.fn();
+    expect(await replayDeferredSave(request, 1_000 + DEFERRED_SAVE_TTL_MS + 1)).toBe(false);
+    expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe("AC3/AC7: replay semantics", () => {
+  it("saves the exact deferred ids in order and clears the intent on success", async () => {
+    writeDeferredSave(INTENT, 1_000);
+    const request = vi.fn().mockResolvedValue({ id: "r1" });
+    expect(await replayDeferredSave(request, 1_100)).toBe(true);
+    expect(request).toHaveBeenCalledWith({ title: INTENT.title, point_ids: ["p1", "p2"], status: "saved" });
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+
+  it("keeps the intent after a failed replay so it is not silently dropped", async () => {
+    writeDeferredSave(INTENT, 1_000);
+    const request = vi.fn().mockRejectedValue(new Error("502"));
+    expect(await replayDeferredSave(request, 1_100)).toBe(false);
+    expect(readDeferredSave(1_100)).toBeDefined();
+  });
+});

--- a/apps/web/tests/unit/chat/deferred-save.test.ts
+++ b/apps/web/tests/unit/chat/deferred-save.test.ts
@@ -39,14 +39,16 @@ describe("AC4: the deferred intent lives in namespaced localStorage", () => {
     expect(readDeferredSave(1_000)).toBeUndefined();
   });
 
-  it("treats a malformed entry as absent rather than replaying garbage", () => {
+  it("treats a malformed entry as absent AND erases it", () => {
     localStorage.setItem(DEFERRED_SAVE_KEY, '{"pointIds":"nope"}');
     expect(readDeferredSave(1_000)).toBeUndefined();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
   });
 
-  it("treats unparseable JSON as absent rather than throwing", () => {
+  it("treats unparseable JSON as absent, erasing it rather than throwing", () => {
     localStorage.setItem(DEFERRED_SAVE_KEY, "{not json");
     expect(readDeferredSave(1_000)).toBeUndefined();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
   });
 
   it("clears the entry on demand", () => {
@@ -101,6 +103,25 @@ describe("P2-2: an unrelated login inside the TTL still completes the user's own
     await replayDeferredSave(request, 1_100);
     expect(await replayDeferredSave(request, 1_200)).toBe("none");
     expect(request).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("P2-3: two tabs completing a login concurrently save once", () => {
+  it("claims the intent before sending, so the second replay finds nothing", async () => {
+    writeDeferredSave(INTENT, 1_000);
+    const request = vi.fn().mockResolvedValue({ id: "r1" });
+    const outcomes = await Promise.all([replayDeferredSave(request, 1_100), replayDeferredSave(request, 1_100)]);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(outcomes.filter((outcome) => outcome === "saved")).toHaveLength(1);
+    expect(outcomes.filter((outcome) => outcome === "none")).toHaveLength(1);
+  });
+
+  it("restores a failed claim with its original timestamp, never extending the TTL", async () => {
+    writeDeferredSave(INTENT, 1_000);
+    const request = vi.fn().mockRejectedValue(new Error("502"));
+    await replayDeferredSave(request, 1_100);
+    expect(readDeferredSave(1_100)?.createdAt).toBe(1_000);
+    expect(readDeferredSave(1_000 + DEFERRED_SAVE_TTL_MS + 1)).toBeUndefined();
   });
 });
 

--- a/apps/web/tests/unit/chat/save-copy-i18n.test.ts
+++ b/apps/web/tests/unit/chat/save-copy-i18n.test.ts
@@ -42,6 +42,25 @@ describe("AC11: the save title is derived, bounded and localized", () => {
   });
 });
 
+describe("P3: the derived title is injection- and grapheme-safe", () => {
+  it("keeps a work title containing replacement patterns verbatim", () => {
+    const title = saveRouteTitle(chatDictFor("ja"), "$& $1 $` Euphonium", 3);
+    expect(title).toContain("$& $1 $` Euphonium");
+  });
+
+  it("never splits a surrogate pair when truncating a long emoji title", () => {
+    const title = saveRouteTitle(chatDictFor("ja"), "🎺".repeat(300), 3);
+    expect(title.length).toBeLessThanOrEqual(200);
+    expect([...title].every((char) => char.codePointAt(0) !== undefined)).toBe(true);
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(title)).toBe(false);
+  });
+
+  it("still produces a contract-valid title after truncation", () => {
+    const title = saveRouteTitle(chatDictFor("en"), "👨‍👩‍👧‍👦".repeat(60), 5);
+    expect(SaveRouteInput.safeParse({ title, point_ids: ["p1"] }).success).toBe(true);
+  });
+});
+
 describe("AC12: save CTA, confirmation and error copy exist in ja / zh / en", () => {
   it.each(LOCALES)("renders distinct %s save copy", (locale) => {
     const route = chatDictFor(locale).route;

--- a/apps/web/tests/unit/chat/save-copy-i18n.test.ts
+++ b/apps/web/tests/unit/chat/save-copy-i18n.test.ts
@@ -39,6 +39,9 @@ describe("AC11: the save title is derived, bounded and localized", () => {
     const title = saveRouteTitle(chatDictFor("ja"), "あ".repeat(400), 3);
     expect(SaveRouteInput.safeParse({ title, point_ids: ["p1"] }).success).toBe(true);
     expect(title.length).toBeLessThanOrEqual(200);
+    // A naive slice of the RENDERED string would amputate the tail; the trim
+    // must land on the work title so the stop count survives.
+    expect(title).toContain("3スポットの聖地巡礼");
   });
 });
 

--- a/apps/web/tests/unit/chat/save-copy-i18n.test.ts
+++ b/apps/web/tests/unit/chat/save-copy-i18n.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { SaveRouteInput } from "@seichijunrei/contract";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { saveRouteTitle } from "../../../src/features/chat/route-copy";
+import { routeSaveTarget } from "../../../src/features/chat/save/saveTarget";
+import { parsedPart, routePartRaw, ujiPoints } from "./_route-fixtures";
+
+const LOCALES = ["ja", "zh", "en"] as const;
+
+function titleIn(locale: (typeof LOCALES)[number]): string {
+  return saveRouteTitle(chatDictFor(locale), "響け!ユーフォニアム", 3);
+}
+
+describe("AC11: the save title is derived, bounded and localized", () => {
+  it("names the resolved work and its stop count", () => {
+    expect(titleIn("ja")).toContain("響け!ユーフォニアム");
+    expect(titleIn("ja")).toContain("3");
+  });
+
+  it("renders a different title in each locale — none is an untranslated fallback", () => {
+    const rendered = LOCALES.map(titleIn);
+    expect(new Set(rendered).size).toBe(LOCALES.length);
+  });
+
+  it("substitutes every template slot in every locale", () => {
+    for (const rendered of LOCALES.map(titleIn)) {
+      expect(rendered).not.toContain("{title}");
+      expect(rendered).not.toContain("{count}");
+    }
+  });
+
+  it("falls back to a localized work name rather than an empty or English one", () => {
+    const missing = LOCALES.map((locale) => saveRouteTitle(chatDictFor(locale), undefined, 2));
+    expect(new Set(missing).size).toBe(LOCALES.length);
+    for (const rendered of missing) expect(rendered.length).toBeGreaterThan(0);
+  });
+
+  it("stays inside SaveRouteInput's 1-200 bound even for a very long work title", () => {
+    const title = saveRouteTitle(chatDictFor("ja"), "あ".repeat(400), 3);
+    expect(SaveRouteInput.safeParse({ title, point_ids: ["p1"] }).success).toBe(true);
+    expect(title.length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe("AC12: save CTA, confirmation and error copy exist in ja / zh / en", () => {
+  it.each(LOCALES)("renders distinct %s save copy", (locale) => {
+    const route = chatDictFor(locale).route;
+    for (const copy of [route.saveCta, route.saved, route.saveError, route.saveRetry]) {
+      expect(copy.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps the CTA, confirmation and error strings distinct per locale", () => {
+    expect(new Set(LOCALES.map((locale) => chatDictFor(locale).route.saveCta)).size).toBe(3);
+    expect(new Set(LOCALES.map((locale) => chatDictFor(locale).route.saved)).size).toBe(3);
+    expect(new Set(LOCALES.map((locale) => chatDictFor(locale).route.saveError)).size).toBe(3);
+  });
+});
+
+describe("the save target is derived from the rendered route", () => {
+  it("carries the route's point ids in walking order plus a derived title", () => {
+    const part = parsedPart(routePartRaw([...ujiPoints()], { anime_title: "響け!ユーフォニアム" }));
+    const target = routeSaveTarget(part, chatDictFor("ja"));
+    expect(target?.pointIds).toEqual(["a", "b", "c"]);
+    expect(target?.title).toContain("響け!ユーフォニアム");
+  });
+
+  it("is undefined for a route with no placeable points, so the CTA stays disabled", () => {
+    const part = parsedPart(routePartRaw([]));
+    expect(routeSaveTarget(part, chatDictFor("ja"))).toBeUndefined();
+  });
+
+  it("accepts bare id strings and drops blank ids from the stream", () => {
+    const raw = { intent: "plan_route", success: true, status: "ok", data: { route: { ordered_points: ["x", "", "y"], point_count: 3 } } };
+    expect(routeSaveTarget(parsedPart(raw), chatDictFor("ja"))?.pointIds).toEqual(["x", "y"]);
+  });
+
+  it("is undefined for a non-route card", () => {
+    const part = parsedPart({ intent: "general_qa", success: true, status: "ok", data: {} });
+    expect(routeSaveTarget(part, chatDictFor("ja"))).toBeUndefined();
+  });
+});

--- a/apps/web/tests/unit/chat/save-copy-i18n.test.ts
+++ b/apps/web/tests/unit/chat/save-copy-i18n.test.ts
@@ -51,7 +51,6 @@ describe("P3: the derived title is injection- and grapheme-safe", () => {
   it("never splits a surrogate pair when truncating a long emoji title", () => {
     const title = saveRouteTitle(chatDictFor("ja"), "🎺".repeat(300), 3);
     expect(title.length).toBeLessThanOrEqual(200);
-    expect([...title].every((char) => char.codePointAt(0) !== undefined)).toBe(true);
     expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(title)).toBe(false);
   });
 

--- a/apps/web/tests/unit/chat/save-gate-failures.test.tsx
+++ b/apps/web/tests/unit/chat/save-gate-failures.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UserRoute } from "@seichijunrei/contract";
+import { TimedItinerary } from "../../../src/features/chat/components/TimedItinerary";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { DEFERRED_SAVE_KEY, DEFERRED_SAVE_TTL_MS, readDeferredSave, writeDeferredSave } from "../../../src/features/chat/save/deferredSave";
+import type { SaveGateOptions } from "../../../src/features/chat/save/useSaveGate";
+import { itineraryView } from "../../../src/lib/chat/itinerary";
+import { renderWithLocale, setLanguages } from "../_i18n";
+import { ujiItinerary } from "./_route-fixtures";
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+const ja = chatDictFor("ja");
+const TARGET = { pointIds: ["a", "b", "c"], title: "宇治・3スポットの聖地巡礼" } as const;
+const SAVED = { id: "r1", title: TARGET.title, point_ids: [...TARGET.pointIds], status: "saved", saved_at: null, updated_at: "" } as UserRoute;
+
+function renderCta(deps: SaveGateOptions, target: typeof TARGET | undefined) {
+  return renderWithLocale(
+    <TimedItinerary view={itineraryView(ujiItinerary())} dict={ja} save={target} saveDeps={deps} />,
+  );
+}
+
+function saveButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: ja.route.saveCta }) as HTMLButtonElement;
+}
+
+describe("P2-6: mounting a card sweeps an abandoned intent", () => {
+  it("erases an intent that outlived its TTL, so a shared device does not accumulate", () => {
+    writeDeferredSave(TARGET, Date.now() - DEFERRED_SAVE_TTL_MS - 1);
+    renderCta({ authStatus: "anonymous", request: vi.fn() }, TARGET);
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+
+  it("leaves a live intent alone", () => {
+    writeDeferredSave(TARGET, Date.now());
+    renderCta({ authStatus: "anonymous", request: vi.fn() }, TARGET);
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeTruthy();
+  });
+});
+
+describe("P1-1: a double tap cannot create two rows", () => {
+  it("issues exactly one saveRoute for two rapid clicks", async () => {
+    const request = vi.fn().mockImplementation(() => new Promise((resolve) => setTimeout(() => { resolve(SAVED); }, 20)));
+    renderCta({ authStatus: "authenticated", request }, TARGET);
+    fireEvent.click(saveButton());
+    fireEvent.click(saveButton());
+    await waitFor(() => { expect(screen.getByText(ja.route.saved)).toBeTruthy(); });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the CTA while saving and after it saved", async () => {
+    const request = vi.fn().mockResolvedValue(SAVED);
+    renderCta({ authStatus: "authenticated", request }, TARGET);
+    fireEvent.click(saveButton());
+    await waitFor(() => { expect(screen.getByText(ja.route.saved)).toBeTruthy(); });
+    expect(saveButton().disabled).toBe(true);
+    expect(saveButton().getAttribute("aria-busy")).toBe("false");
+  });
+});
+
+describe("P2-1: failures are classified, not flattened", () => {
+  it("sends a 401 back through the login wall with a fresh intent", async () => {
+    const request = vi.fn().mockRejectedValue({ status: 401 });
+    renderCta({ authStatus: "authenticated", request }, TARGET);
+    fireEvent.click(saveButton());
+    expect(await screen.findByRole("dialog")).toBeTruthy();
+    expect(readDeferredSave()?.pointIds).toEqual(["a", "b", "c"]);
+  });
+
+  it("offers no retry for a permanent 4xx", async () => {
+    const request = vi.fn().mockRejectedValue({ status: 422 });
+    renderCta({ authStatus: "authenticated", request }, TARGET);
+    fireEvent.click(saveButton());
+    expect((await screen.findByRole("alert")).textContent).toContain(ja.route.savePermanentError);
+    expect(screen.queryByRole("button", { name: ja.route.saveRetry })).toBeNull();
+  });
+
+  it("offers a retry for a 5xx", async () => {
+    const request = vi.fn().mockRejectedValue({ status: 503 });
+    renderCta({ authStatus: "authenticated", request }, TARGET);
+    fireEvent.click(saveButton());
+    expect(await screen.findByRole("button", { name: ja.route.saveRetry })).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/chat/save-gate.test.tsx
+++ b/apps/web/tests/unit/chat/save-gate.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UserRoute } from "@seichijunrei/contract";
+import { TimedItinerary } from "../../../src/features/chat/components/TimedItinerary";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { DEFERRED_SAVE_KEY, readDeferredSave } from "../../../src/features/chat/save/deferredSave";
+import { saveAction } from "../../../src/features/chat/save/useSaveGate";
+import type { SaveGateOptions } from "../../../src/features/chat/save/useSaveGate";
+import { itineraryView } from "../../../src/lib/chat/itinerary";
+import { renderWithLocale, setLanguages } from "../_i18n";
+import { ujiItinerary } from "./_route-fixtures";
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+const ja = chatDictFor("ja");
+const TARGET = { pointIds: ["a", "b", "c"], title: "宇治・3スポットの聖地巡礼" } as const;
+const SAVED = { id: "r1", title: TARGET.title, point_ids: [...TARGET.pointIds], status: "saved", saved_at: null, updated_at: "" } as UserRoute;
+
+function renderCta(deps: SaveGateOptions, target: typeof TARGET | undefined) {
+  return renderWithLocale(
+    <TimedItinerary view={itineraryView(ujiItinerary())} dict={ja} save={target} saveDeps={deps} />,
+  );
+}
+
+function saveButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: ja.route.saveCta }) as HTMLButtonElement;
+}
+
+describe("the login-wall predicate is a single rule", () => {
+  it.each([
+    ["authenticated", "save"],
+    ["anonymous", "login"],
+    ["pending", "none"],
+  ] as const)("maps a %s caller with a route to %s", (status, expected) => {
+    expect(saveAction(TARGET, status)).toBe(expected);
+  });
+
+  it.each(["authenticated", "anonymous", "pending"] as const)("never acts without a route (%s)", (status) => {
+    expect(saveAction(undefined, status)).toBe("none");
+    expect(saveAction({ pointIds: [], title: "x" }, status)).toBe("none");
+  });
+});
+
+describe("AC2: a signed-in tap saves once and never opens the dialog", () => {
+  it("calls saveRoute exactly once with the rendered stops, in order", async () => {
+    const request = vi.fn().mockResolvedValue(SAVED);
+    renderCta({ authStatus: "authenticated", request }, TARGET);
+    fireEvent.click(saveButton());
+    await waitFor(() => { expect(request).toHaveBeenCalledTimes(1); });
+    const input = request.mock.calls[0]?.[0] as { point_ids: string[]; status: string };
+    expect(input.point_ids).toEqual(["a", "b", "c"]);
+    expect(input.point_ids.length).toBeGreaterThan(0);
+    expect(input.point_ids.length).toBe(document.querySelectorAll(".chat-itinerary__stop").length);
+    expect(input.status).toBe("saved");
+  });
+
+  it("confirms on the card and leaves the login dialog unopened", async () => {
+    renderCta({ authStatus: "authenticated", request: vi.fn().mockResolvedValue(SAVED) }, TARGET);
+    fireEvent.click(saveButton());
+    expect(await screen.findByText(ja.route.saved)).toBeTruthy();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+});
+
+describe("AC1/AC4 (unit twin): an anonymous tap opens the wall and stashes the intent", () => {
+  it("opens the magic-link dialog only after the tap", async () => {
+    const request = vi.fn();
+    renderCta({ authStatus: "anonymous", request }, TARGET);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(saveButton());
+    expect(await screen.findByRole("dialog")).toBeTruthy();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("writes the point ids and derived title into the deferred intent", () => {
+    renderCta({ authStatus: "anonymous", request: vi.fn() }, TARGET);
+    fireEvent.click(saveButton());
+    expect(readDeferredSave()?.pointIds).toEqual(["a", "b", "c"]);
+    expect(readDeferredSave()?.title).toBe(TARGET.title);
+  });
+});
+
+describe("AC6: with no route generated yet the CTA is inert", () => {
+  it("renders disabled, opens nothing and writes no intent when tapped", () => {
+    const request = vi.fn();
+    renderCta({ authStatus: "anonymous", request }, undefined);
+    expect(saveButton().disabled).toBe(true);
+    fireEvent.click(saveButton());
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe("the login wall closes without saving anything", () => {
+  it("dismisses the dialog on the close button and issues no save", async () => {
+    const request = vi.fn();
+    renderCta({ authStatus: "anonymous", request }, TARGET);
+    fireEvent.click(saveButton());
+    fireEvent.click(await screen.findByRole("button", { name: "閉じる" }));
+    await waitFor(() => { expect(screen.queryByRole("dialog")).toBeNull(); });
+    expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe("AC7: a failed save is retryable in place", () => {
+  it("shows an inline error, keeps the card, and forces no logout or dialog", async () => {
+    renderCta({ authStatus: "authenticated", request: vi.fn().mockRejectedValue(new Error("502")) }, TARGET);
+    fireEvent.click(saveButton());
+    expect((await screen.findByRole("alert")).textContent).toContain(ja.route.saveError);
+    expect(screen.getByRole("list", { name: ja.route.timelineLabel })).toBeTruthy();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("retries the same save from the inline retry button", async () => {
+    const request = vi.fn().mockRejectedValueOnce(new Error("502")).mockResolvedValue(SAVED);
+    renderCta({ authStatus: "authenticated", request }, TARGET);
+    fireEvent.click(saveButton());
+    fireEvent.click(await screen.findByRole("button", { name: ja.route.saveRetry }));
+    expect(await screen.findByText(ja.route.saved)).toBeTruthy();
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/tests/unit/chat/save-gate.test.tsx
+++ b/apps/web/tests/unit/chat/save-gate.test.tsx
@@ -109,6 +109,14 @@ describe("the login wall closes without saving anything", () => {
     await waitFor(() => { expect(screen.queryByRole("dialog")).toBeNull(); });
     expect(request).not.toHaveBeenCalled();
   });
+
+  it("drops the intent on dismissal, so a later unrelated login saves nothing", async () => {
+    renderCta({ authStatus: "anonymous", request: vi.fn() }, TARGET);
+    fireEvent.click(saveButton());
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeTruthy();
+    fireEvent.click(await screen.findByRole("button", { name: "閉じる" }));
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
 });
 
 describe("AC7: a failed save is retryable in place", () => {

--- a/apps/web/tests/unit/chat/save-login-carveout.test.tsx
+++ b/apps/web/tests/unit/chat/save-login-carveout.test.tsx
@@ -1,13 +1,13 @@
 /**
  * @vitest-environment jsdom
  */
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BudgetExhausted } from "../../../src/features/chat/components/ErrorStates/BudgetExhausted";
 import { SessionExpired } from "../../../src/features/chat/components/ErrorStates/SessionExpired";
 import { chatDictFor } from "../../../src/features/chat/i18n";
 import { AuthCallback } from "../../../src/components/auth/AuthCallback";
-import { useAuthCallback } from "../../../src/components/auth/useAuthCallback";
+import { REPLAY_TIMEOUT_MS, useAuthCallback } from "../../../src/components/auth/useAuthCallback";
 import type { DeferredReplayOutcome } from "../../../src/features/chat/save/createOnLogin";
 import { DEFERRED_SAVE_KEY, writeDeferredSave } from "../../../src/features/chat/save/deferredSave";
 import { dictFor } from "../../../src/i18n/dictionaries";
@@ -87,6 +87,17 @@ describe("P2-1: a failed create-on-login is surfaced, not swallowed", () => {
     fireEvent.click(await screen.findByRole("button", { name: auth.callback_save_retry }));
     await waitFor(() => { expect(onDone).toHaveBeenCalledTimes(1); });
     expect(replay).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops waiting on a stalled replay instead of pinning the visitor on the callback", async () => {
+    vi.useFakeTimers();
+    const onDone = vi.fn();
+    const replay = vi.fn(() => new Promise<DeferredReplayOutcome>(() => undefined));
+    renderWithLocale(<AuthCallback onDone={onDone} establish={establish} replay={replay} />);
+    await act(async () => { await vi.advanceTimersByTimeAsync(REPLAY_TIMEOUT_MS + 1); });
+    expect(screen.getByText(auth.callback_save_failed)).toBeTruthy();
+    expect(onDone).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it("lets the visitor continue, keeping the intent for the chat page", async () => {

--- a/apps/web/tests/unit/chat/save-login-carveout.test.tsx
+++ b/apps/web/tests/unit/chat/save-login-carveout.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BudgetExhausted } from "../../../src/features/chat/components/ErrorStates/BudgetExhausted";
+import { SessionExpired } from "../../../src/features/chat/components/ErrorStates/SessionExpired";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { useAuthCallback } from "../../../src/components/auth/useAuthCallback";
+import { writeDeferredSave } from "../../../src/features/chat/save/deferredSave";
+import { renderWithLocale, setLanguages } from "../_i18n";
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+const ja = chatDictFor("ja");
+const states = ja.errorStates;
+
+describe("AC9: the D8/D11 recovery affordances are not P5 interruptions", () => {
+  it("D8 keeps its own user-initiated login, and opens nothing before the tap", async () => {
+    renderWithLocale(<SessionExpired dict={ja} onResume={vi.fn()} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: states.d8Login }));
+    expect(await screen.findByRole("dialog")).toBeTruthy();
+  });
+
+  it("D11 keeps its own user-initiated login, and opens nothing before the tap", async () => {
+    renderWithLocale(<BudgetExhausted dict={ja} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: states.d11Login }));
+    expect(await screen.findByRole("dialog")).toBeTruthy();
+  });
+
+  it("neither banner renders on a happy-path route card, so neither can interrupt it", () => {
+    renderWithLocale(<SessionExpired dict={ja} onResume={vi.fn()} />);
+    expect(screen.queryByText(states.d11Message)).toBeNull();
+  });
+});
+
+/** Stable identities: the production defaults are module bindings, so the
+ * redeem effect must run exactly once per mount. */
+const establish = () => Promise.resolve("token");
+
+function Callback({ replay }: Readonly<{ replay: () => Promise<boolean> }>) {
+  return <span>{useAuthCallback(establish, replay)}</span>;
+}
+
+describe("AC4 negative: only a save-initiated login replays a save", () => {
+  it("replays the stashed intent after the callback redeems the session", async () => {
+    writeDeferredSave({ pointIds: ["p1"], title: "t" });
+    const replay = vi.fn().mockResolvedValue(true);
+    render(<Callback replay={replay} />);
+    await waitFor(() => { expect(screen.getByText("done")).toBeTruthy(); });
+    expect(replay).toHaveBeenCalledTimes(1);
+  });
+
+  it("still completes the callback when no save intent was ever written", async () => {
+    const replay = vi.fn().mockResolvedValue(false);
+    render(<Callback replay={replay} />);
+    await waitFor(() => { expect(screen.getByText("done")).toBeTruthy(); });
+    expect(replay).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/unit/chat/save-login-carveout.test.tsx
+++ b/apps/web/tests/unit/chat/save-login-carveout.test.tsx
@@ -6,8 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BudgetExhausted } from "../../../src/features/chat/components/ErrorStates/BudgetExhausted";
 import { SessionExpired } from "../../../src/features/chat/components/ErrorStates/SessionExpired";
 import { chatDictFor } from "../../../src/features/chat/i18n";
+import { AuthCallback } from "../../../src/components/auth/AuthCallback";
 import { useAuthCallback } from "../../../src/components/auth/useAuthCallback";
-import { writeDeferredSave } from "../../../src/features/chat/save/deferredSave";
+import type { DeferredReplayOutcome } from "../../../src/features/chat/save/createOnLogin";
+import { DEFERRED_SAVE_KEY, writeDeferredSave } from "../../../src/features/chat/save/deferredSave";
+import { dictFor } from "../../../src/i18n/dictionaries";
 import { renderWithLocale, setLanguages } from "../_i18n";
 
 beforeEach(() => { setLanguages(["ja-JP"]); });
@@ -44,23 +47,55 @@ describe("AC9: the D8/D11 recovery affordances are not P5 interruptions", () => 
  * redeem effect must run exactly once per mount. */
 const establish = () => Promise.resolve("token");
 
-function Callback({ replay }: Readonly<{ replay: () => Promise<boolean> }>) {
-  return <span>{useAuthCallback(establish, replay)}</span>;
+function Callback({ replay }: Readonly<{ replay: () => Promise<DeferredReplayOutcome> }>) {
+  return <span>{useAuthCallback(establish, replay).state}</span>;
 }
 
 describe("AC4 negative: only a save-initiated login replays a save", () => {
   it("replays the stashed intent after the callback redeems the session", async () => {
     writeDeferredSave({ pointIds: ["p1"], title: "t" });
-    const replay = vi.fn().mockResolvedValue(true);
+    const replay = vi.fn().mockResolvedValue("saved");
     render(<Callback replay={replay} />);
     await waitFor(() => { expect(screen.getByText("done")).toBeTruthy(); });
     expect(replay).toHaveBeenCalledTimes(1);
   });
 
   it("still completes the callback when no save intent was ever written", async () => {
-    const replay = vi.fn().mockResolvedValue(false);
+    const replay = vi.fn().mockResolvedValue("none");
     render(<Callback replay={replay} />);
     await waitFor(() => { expect(screen.getByText("done")).toBeTruthy(); });
     expect(replay).toHaveBeenCalledTimes(1);
+  });
+});
+
+const auth = dictFor("ja").auth;
+
+describe("P2-1: a failed create-on-login is surfaced, not swallowed", () => {
+  it("shows the failure with a retry instead of reporting a clean login", async () => {
+    const onDone = vi.fn();
+    const replay = vi.fn().mockResolvedValue("failed");
+    renderWithLocale(<AuthCallback onDone={onDone} establish={establish} replay={replay} />);
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByText(auth.callback_save_failed)).toBeTruthy();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("retries only the save, and completes once it succeeds", async () => {
+    const onDone = vi.fn();
+    const replay = vi.fn().mockResolvedValueOnce("failed").mockResolvedValue("saved");
+    renderWithLocale(<AuthCallback onDone={onDone} establish={establish} replay={replay} />);
+    fireEvent.click(await screen.findByRole("button", { name: auth.callback_save_retry }));
+    await waitFor(() => { expect(onDone).toHaveBeenCalledTimes(1); });
+    expect(replay).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets the visitor continue, keeping the intent for the chat page", async () => {
+    const onDone = vi.fn();
+    const replay = vi.fn().mockResolvedValue("failed");
+    writeDeferredSave({ pointIds: ["p1"], title: "t" });
+    renderWithLocale(<AuthCallback onDone={onDone} establish={establish} replay={replay} />);
+    fireEvent.click(await screen.findByRole("button", { name: auth.callback_save_skip }));
+    await waitFor(() => { expect(onDone).toHaveBeenCalledTimes(1); });
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeTruthy();
   });
 });

--- a/apps/web/tests/unit/chat/save-wall-dismissal.test.tsx
+++ b/apps/web/tests/unit/chat/save-wall-dismissal.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * "Send the link, close the modal, go read the email" is the **mainline** of the
+ * magic-link flow, not a cancellation. Clearing the deferred intent on every
+ * dismissal broke create-on-login silently, so dismissal is conditional: the
+ * intent only dies if it is abandoned *before* a link goes out.
+ */
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendMagicLink } from "../../../src/lib/auth/neonAuth";
+import { LoginModal } from "../../../src/components/auth/LoginModal";
+import { TimedItinerary } from "../../../src/features/chat/components/TimedItinerary";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { DEFERRED_SAVE_KEY } from "../../../src/features/chat/save/deferredSave";
+import { itineraryView } from "../../../src/lib/chat/itinerary";
+import { renderWithLocale, setLanguages } from "../_i18n";
+import { ujiItinerary } from "./_route-fixtures";
+
+vi.mock("../../../src/lib/auth/neonAuth", () => ({ sendMagicLink: vi.fn(), isNeonAuthConfigured: () => true }));
+const send = vi.mocked(sendMagicLink);
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+const ja = chatDictFor("ja");
+const TARGET = { pointIds: ["a", "b", "c"], title: "宇治・3スポットの聖地巡礼" } as const;
+
+function openWall() {
+  renderWithLocale(
+    <TimedItinerary
+      view={itineraryView(ujiItinerary())}
+      dict={ja}
+      save={TARGET}
+      saveDeps={{ authStatus: "anonymous", request: vi.fn() }}
+    />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: ja.route.saveCta }));
+}
+
+async function sendLink(): Promise<void> {
+  send.mockResolvedValue("sent");
+  fireEvent.change(await screen.findByLabelText("メールアドレス"), { target: { value: "fan@example.com" } });
+  fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
+  await waitFor(() => { expect(screen.getByRole("status")).toBeTruthy(); });
+}
+
+function dismiss(): void {
+  fireEvent.click(screen.getByRole("button", { name: "閉じる" }));
+}
+
+describe("closing the wall before a link is sent is a cancellation", () => {
+  it("drops the intent", () => {
+    openWall();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeTruthy();
+    dismiss();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+
+  it("drops it on Escape too, so every dismissal path agrees", async () => {
+    openWall();
+    await screen.findByRole("dialog");
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+});
+
+describe("closing the wall after a link is sent is 'going to read the email'", () => {
+  it("keeps the intent so create-on-login can still replay it", async () => {
+    openWall();
+    await sendLink();
+    dismiss();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toContain("a");
+  });
+
+  it("keeps it on Escape as well", async () => {
+    openWall();
+    await sendLink();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeTruthy();
+  });
+
+  it("re-arms on the next trip: a fresh open that is cancelled clears again", async () => {
+    openWall();
+    await sendLink();
+    dismiss();
+    fireEvent.click(screen.getByRole("button", { name: ja.route.saveCta }));
+    dismiss();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+});
+
+describe("the modal reports a dispatched link to its caller", () => {
+  it("calls onSent once the magic link goes out, and not before", async () => {
+    const onSent = vi.fn();
+    renderWithLocale(<LoginModal open onClose={vi.fn()} onSent={onSent} />);
+    expect(onSent).not.toHaveBeenCalled();
+    await sendLink();
+    expect(onSent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report a failed send", async () => {
+    const onSent = vi.fn();
+    send.mockResolvedValue("error");
+    renderWithLocale(<LoginModal open onClose={vi.fn()} onSent={onSent} />);
+    fireEvent.change(screen.getByLabelText("メールアドレス"), { target: { value: "fan@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
+    await waitFor(() => { expect(screen.getByRole("alert")).toBeTruthy(); });
+    expect(onSent).not.toHaveBeenCalled();
+  });
+});

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,7 +6,7 @@
     "test:headed": "playwright test --headed",
     "test:public": "playwright test public-pages.spec.ts middleware-redirect.spec.ts login-modal.spec.ts",
     "test:auth": "playwright test auth-flow.spec.ts",
-    "test:web": "playwright test web-404.spec.ts web-chat-error-states.spec.ts web-chat-anonymous.spec.ts"
+    "test:web": "playwright test web-404.spec.ts web-chat-error-states.spec.ts web-chat-anonymous.spec.ts web-chat-save-login-wall.spec.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1"

--- a/e2e/web-chat-save-login-wall.spec.ts
+++ b/e2e/web-chat-save-login-wall.spec.ts
@@ -144,6 +144,8 @@ test("a login the save CTA never started replays nothing", async ({ page, contex
   await captureSaves(context, bodies);
   await stubAuthToken(context);
   await page.goto("/auth/callback");
-  await page.waitForTimeout(500);
+  // Deterministic signal: the callback navigates home only once the redeem —
+  // and therefore the replay decision — has completed. No arbitrary wait.
+  await page.waitForURL((url) => url.pathname === "/");
   expect(bodies).toEqual([]);
 });

--- a/e2e/web-chat-save-login-wall.spec.ts
+++ b/e2e/web-chat-save-login-wall.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from "@playwright/test";
+import type { BrowserContext, Page } from "@playwright/test";
+import { chatDictFor } from "../apps/web/src/features/chat/i18n";
+import { DEFERRED_SAVE_KEY } from "../apps/web/src/features/chat/save/deferredSave";
+import { SSE_HEADERS, chatStreamRecording, patchFinalFrame } from "./fixtures/chat-stream";
+
+/**
+ * Issue #273 (S1.7) Task 2 browser ACs: the 「保存する」 CTA is the only proactive
+ * opener of the login wall, and the deferred save intent survives the magic-link
+ * navigation.
+ *
+ * The lifecycle test deliberately uses a **second page in the same browser
+ * context** — a new tab of the same profile, sharing origin storage. A fresh
+ * Playwright `BrowserContext` would isolate `localStorage` and fail a correct
+ * implementation; a same-tab jsdom simulation would pass even for the broken,
+ * tab-scoped `sessionStorage` design this replaced.
+ *
+ * Prerequisite: `VITE_NEON_AUTH_BASE_URL` must be set for the app under test, or
+ * the auth callback cannot redeem a session and the replay never runs.
+ */
+test.use({
+  baseURL: process.env.E2E_WEB_BASE_URL ?? "http://localhost:3000",
+  locale: "ja-JP",
+});
+
+const ja = chatDictFor("ja");
+
+/** The recording carries a route but no timed itinerary; the CTA row lives on
+ * the itinerary, so inject the stops the S1.5 card renders. */
+function routeStream(): string {
+  return patchFinalFrame(chatStreamRecording("search"), (envelope) => {
+    const data = envelope.data as { route: Record<string, unknown> };
+    data.route.timed_itinerary = {
+      stops: [
+        { cluster_id: "p1", name: "宇治橋", arrive: "10:00", depart: "10:20", dwell_minutes: 20, lat: 34.891, lng: 135.807, photo_count: 4 },
+        { cluster_id: "p2", name: "京阪宇治駅", arrive: "10:32", depart: "10:52", dwell_minutes: 20, lat: 34.911, lng: 135.806, photo_count: 9 },
+      ],
+      legs: [{ from_id: "p1", to_id: "p2", mode: "walk", duration_minutes: 12, distance_m: 740 }],
+      total_minutes: 60,
+      total_distance_m: 740,
+      pacing: "chill",
+      start_time: "10:00",
+      export_google_maps_url: [],
+    };
+    return envelope;
+  });
+}
+
+async function openChat(page: Page): Promise<void> {
+  await page.route("**/healthz", (route) => route.fulfill({ json: { status: "ok" } }));
+  const hydrated = page.waitForResponse((response) => response.url().includes("/healthz"));
+  await page.goto("/chat");
+  await hydrated;
+}
+
+async function send(page: Page, text: string): Promise<void> {
+  await page.getByRole("textbox").fill(text);
+  await page.getByRole("button", { name: ja.send }).click();
+}
+
+/** Record every users.saveRoute body the app sends, answering with a saved row. */
+async function captureSaves(context: BrowserContext, bodies: unknown[]): Promise<void> {
+  await context.route("**/v1/users/routes", async (route) => {
+    if (route.request().method() !== "POST") return route.continue();
+    bodies.push(route.request().postDataJSON());
+    return route.fulfill({
+      json: {
+        id: "11111111-1111-4111-8111-111111111111",
+        title: "saved",
+        point_ids: ["p1", "p2"],
+        status: "saved",
+        saved_at: "2026-07-28T00:00:00.000Z",
+        updated_at: "2026-07-28T00:00:00.000Z",
+      },
+    });
+  });
+}
+
+async function stubAuthToken(context: BrowserContext): Promise<void> {
+  await context.route("**/token", (route) => route.fulfill({ json: { token: "e2e-token" } }));
+}
+
+async function planRoute(page: Page): Promise<void> {
+  await page.route("**/v1/chat", (route) =>
+    route.fulfill({ status: 200, headers: SSE_HEADERS, body: routeStream() }),
+  );
+  await openChat(page);
+  await send(page, "ユーフォのルートを組んで");
+  await expect(page.getByRole("list", { name: ja.route.timelineLabel })).toBeVisible();
+}
+
+test("no happy-path step opens the login dialog before the 保存する tap", async ({ page }) => {
+  await page.route("**/v1/chat", (route) =>
+    route.fulfill({ status: 200, headers: SSE_HEADERS, body: chatStreamRecording("clarify") }),
+  );
+  await openChat(page);
+  await send(page, "ユーフォ");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+
+  await page.unroute("**/v1/chat");
+  await page.route("**/v1/chat", (route) =>
+    route.fulfill({ status: 200, headers: SSE_HEADERS, body: routeStream() }),
+  );
+  await send(page, "響け!ユーフォニアム");
+  await expect(page.getByRole("list", { name: ja.route.timelineLabel })).toBeVisible();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+
+  await send(page, "もう少しゆっくりにして");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+});
+
+test("an anonymous 保存する tap opens the magic-link login dialog", async ({ page }) => {
+  await planRoute(page);
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await page.getByRole("button", { name: ja.route.saveCta }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+});
+
+test("the deferred intent survives a new tab of the same profile and replays once", async ({ page, context }) => {
+  const bodies: unknown[] = [];
+  await captureSaves(context, bodies);
+  await stubAuthToken(context);
+  await planRoute(page);
+  await page.getByRole("button", { name: ja.route.saveCta }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+
+  // Origin-scoped, not tab-scoped: sessionStorage would be empty in the new tab.
+  expect(await page.evaluate((key) => sessionStorage.getItem(key), DEFERRED_SAVE_KEY)).toBeNull();
+
+  const callbackTab = await context.newPage();
+  await callbackTab.goto("/auth/callback");
+  const stashed = await callbackTab.evaluate((key) => localStorage.getItem(key), DEFERRED_SAVE_KEY);
+  expect(stashed).toContain("p1");
+
+  await expect.poll(() => bodies.length).toBe(1);
+  expect((bodies[0] as { point_ids: string[] }).point_ids).toEqual(["p1", "p2"]);
+  await expect
+    .poll(() => callbackTab.evaluate((key) => localStorage.getItem(key), DEFERRED_SAVE_KEY))
+    .toBeNull();
+});
+
+test("a login the save CTA never started replays nothing", async ({ page, context }) => {
+  const bodies: unknown[] = [];
+  await captureSaves(context, bodies);
+  await stubAuthToken(context);
+  await page.goto("/auth/callback");
+  await page.waitForTimeout(500);
+  expect(bodies).toEqual([]);
+});

--- a/e2e/web-chat-save-login-wall.spec.ts
+++ b/e2e/web-chat-save-login-wall.spec.ts
@@ -116,6 +116,49 @@ test("an anonymous 保存する tap opens the magic-link login dialog", async ({
   await expect(page.getByRole("dialog")).toBeVisible();
 });
 
+/** The mainline: send the link, then close the modal to go read the email. */
+async function sendLinkAndDismiss(page: Page): Promise<void> {
+  await page.route("**/send-magic-link*", (route) => route.fulfill({ json: { status: true } }));
+  await page.getByRole("textbox", { name: /メール|email/i }).fill("fan@example.com");
+  await page.getByRole("button", { name: /ログインリンク|Send/i }).click();
+  await expect(page.getByRole("status")).toBeVisible();
+  await page.getByRole("button", { name: /閉じる|Close/i }).click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+}
+
+test("closing the wall after the link is sent keeps the intent — the mainline", async ({ page, context }) => {
+  const bodies: unknown[] = [];
+  await captureSaves(context, bodies);
+  await stubAuthToken(context);
+  await planRoute(page);
+  await page.getByRole("button", { name: ja.route.saveCta }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await sendLinkAndDismiss(page);
+
+  // Going to read the email is not a cancellation: the intent must still be here.
+  const stashed = await page.evaluate((key) => localStorage.getItem(key), DEFERRED_SAVE_KEY);
+  expect(stashed).toContain("p1");
+
+  const callbackTab = await context.newPage();
+  await callbackTab.goto("/auth/callback");
+  await expect.poll(() => bodies.length).toBe(1);
+});
+
+test("closing the wall before sending anything cancels the save", async ({ page, context }) => {
+  const bodies: unknown[] = [];
+  await captureSaves(context, bodies);
+  await stubAuthToken(context);
+  await planRoute(page);
+  await page.getByRole("button", { name: ja.route.saveCta }).click();
+  await page.getByRole("button", { name: /閉じる|Close/i }).click();
+  expect(await page.evaluate((key) => localStorage.getItem(key), DEFERRED_SAVE_KEY)).toBeNull();
+
+  const callbackTab = await context.newPage();
+  await callbackTab.goto("/auth/callback");
+  await callbackTab.waitForURL((url) => url.pathname === "/");
+  expect(bodies).toEqual([]);
+});
+
 test("the deferred intent survives a new tab of the same profile and replays once", async ({ page, context }) => {
   const bodies: unknown[] = [];
   await captureSaves(context, bodies);


### PR DESCRIPTION
Implements **#273 S1.7 Task 2** — the 「保存する」 CTA, the P5 login-wall trigger, the deferred save intent, and create-on-login. Spec: `docs/superpowers/specs/2026-07-28-s1.7-living-document-save-login-wall-design.md` @ `fa8d4448` (branch `docs/spec-273-s1.7`).

## AC coverage — 12/12, every AC has a test

| # | AC | Type | Test |
|---|---|---|---|
| 1 | Anonymous tap opens the magic-link `LoginModal` | browser | `e2e/web-chat-save-login-wall.spec.ts` |
| 2 | Signed-in tap: `saveRoute` once, `status: "saved"`, non-empty `point_ids` == stop count, no dialog, saved confirmation | unit | `tests/unit/chat/save-gate.test.tsx` |
| 3 | Create-on-login: row content + `listRoutes` visibility, ids in order | integration | `tests/integration/create-on-login.test.ts` |
| 4 | Deferred intent lifecycle across a real navigation in a new page of the same profile; deleted after replay; a non-save login replays nothing | browser | `e2e/web-chat-save-login-wall.spec.ts` (+ unit twins in `deferred-save.test.ts`, `save-login-carveout.test.tsx`) |
| 5 | TTL: an abandoned intent is ignored **and cleared** | unit | `tests/unit/chat/deferred-save.test.ts` |
| 6 | No route yet ⇒ CTA disabled, not actionable, opens nothing, writes nothing | unit | `tests/unit/chat/save-gate.test.tsx` |
| 7 | Network/5xx failure ⇒ inline retryable error; card survives; intent not dropped; no full-page error, no forced logout | unit | `save-gate.test.tsx`, `deferred-save.test.ts` |
| 8 | P5 trigger timing: no `role="dialog"` login node before the tap across the anonymous flow | browser | `e2e/web-chat-save-login-wall.spec.ts` |
| 9 | D8/D11 carve-out: both still open on their own tap, neither fires on a happy-path step | unit | `tests/unit/chat/save-login-carveout.test.tsx` |
| 10 | Server-side flow returns no 401/403 and carries no `Authorization` header | integration | `apps/agent/.../test_anonymous_flow_uninterrupted.py` |
| 11 | Title derivation: non-empty, within 1–200, work title + stop count, localized, no untranslated fallback | unit | `tests/unit/chat/save-copy-i18n.test.ts` |
| 12 | i18n: CTA / confirmation / error copy in ja·zh·en | unit | `tests/unit/chat/save-copy-i18n.test.ts` |

`ac_total == ac_with_test` = 12 == 12 (unit 7, integration 2, browser 3) — matches the spec's ratchet.

## Design-sync alignment

Baseline: `docs/design/2026-07-06-design-sync/Chat 完整状态.html` and `DS 补全 - Chat 桌面.html`.

- **CTA placement** — the design's card-foot CTA row is `しおりにして共有 / Mapsで開く / 保存する / 歩くモード`; 保存する lands in `TimedItinerary`'s `chat-cta-row`, between Maps and the dormant Walk seam. `RouteCard.tsx` renders no button (the spec's corrected siting).
- **CTA colour — deliberately cream, not gold.** The design稿 assigns `金=しおり共有（唯一）· cream=Maps/保存/歩くモード` with the standing rule `永不同屏两金`, and the DS token board lists 保存する under `Primary cream`. So the CTA reuses `.chat-chip`'s cream press style (`--color-card` / `--color-fg`, 3D shadow), and a CSS test asserts it never borrows a gold token. The #268 gold-CTA semantics are respected by *reserving* gold, not by spending it here. **Flagging explicitly** since the card brief mentioned a gold CTA — if the owner wants gold on 保存する, the design system requires demoting しおり共有 on the same screen.
- **Feedback states** — inline saved confirmation (`--color-primary-strong`) and an inline retryable error (`--color-error-strong`), matching the design's `ルートを保存しました ✓` toast semantics as an in-card affordance. No hardcoded palette values anywhere.
- `LoginModal` is reused as-is; it mounts only while open, so the P5 invariant is structural rather than merely asserted.

## Implementation notes

- **Deferred intent = namespaced `localStorage` + 30-min TTL** (`animichi.chat.deferredSave.v1`). `sessionStorage` is tab-scoped and is provably empty in the magic-link's new browsing context; URL state is rejected for the point-id leak into email/referrer chains. Deleted on success **or** expiry; kept on failure so a failed replay is never silently dropped.
- **One login-wall predicate** — `saveAction(target, authStatus)` in `useSaveGate.ts`. An unresolved auth status is inert (no false interruption for a signed-in caller).
- **Create-on-login, no claim** — `replayDeferredSave` calls `users.saveRoute` with the client-held ids and never sends an `id`, so `ROUTE_NOT_OWNED` is structurally unreachable. `users.claimRoutes` stays unwired.
- `use-save-route.ts` is a plain state hook rather than a TanStack mutation because the auth-callback replay runs outside any `QueryClientProvider`; the UI→hook→client direction from `apps/web/AGENTS.md` is preserved.

## Mutation verification — 10 mutants, 10 killed

| Mutation | Result |
|---|---|
| Delete the signed-in branch (wall always opens) | 5 failed |
| Delete the empty/absent-target guard | 3 failed |
| `localStorage` → `sessionStorage` (the falsified design) | 5 failed |
| Delete the TTL check | 2 failed |
| Replay even without an intent | 2 failed |
| Clear the intent after a *failed* replay | 1 failed |
| Mount `LoginModal` unconditionally | 5 failed |
| Paint the save CTA gold | 2 failed |
| Skip the replay in `useAuthCallback` | 2 failed |
| Untranslated title template | 1 failed |

## Gates

- `apps/web` typecheck ✅ · `lint:oxlint` (type-aware, deny-warnings) ✅
- `apps/web` unit: **982 passed** · coverage **98.82 / 95.27 / 99.67 / 99.82** vs floors 95/94/95/95 ✅ (new `features/chat/save` module: 95.52/96.29/100/98.03)
- `apps/web` integration: 11 passed ✅ · `pnpm run test:worker`: 97 passed ✅
- `apps/agent`: `ruff check` + `ruff format` ✅; the new integration test passes against the pinned Atlas 0.30.0 + testcontainer ✅
- `e2e`: the new spec compiles and lists 4 tests; added to `test:web`. Browser ACs are for the Tester against staging/local (`ANON_ACCESS_ENABLED=false` in production), and the lifecycle test needs `VITE_NEON_AUTH_BASE_URL` set for the callback to redeem.
- Every new test file ≤200 lines; production functions ≤10 lines; **no suppressions added**.

### Notes for the reviewer

- **Coverage ratchet not raised.** Actual coverage already sat well above the floor before this card (98.73/95.07/…), and Tasks 1 and 3 are in flight on the same base — raising the config mid-wave would break their branches on rebase. Flagging for the Coordinator to ratchet once all three land.
- **Local env caveat:** DB-backed agent integration tests need Atlas pinned to 0.30.0; this machine ships 1.2.4, which fails *all* such tests (pre-existing, reproduced on `test_conversation_hydration_contract.py`). Verified with a checksum-matched 0.30.0 binary on a temporary PATH.
- **Concurrency:** `apps/web/src/styles/chat.css`, `tests/unit/chat/chat-design-css.test.ts` and `tests/msw/users.ts` are shared with Task 1's expected edits (tray copy/CSS). Changes here are additive blocks at distinct locations. `TimedItinerary.tsx` is owned by this task per the spec's file allocation; `RouteCard.tsx` gains two lines to hand the CTA its save payload.
- **Not a bug (spec §7):** a magic link opened in a *different* browser leaves the intent behind in the originating browser's `localStorage`, so the save does not auto-fire.

Refs #273 Task 2. **Do not merge** — hand off to Reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
