### PR TITLE
feat: arm the Turnstile gate for anonymous chat (#447)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -11,4 +11,8 @@ VITE_NEON_AUTH_BASE_URL=
 # Cloudflare Turnstile SITE key — public by design (24 characters; it ships in
 # the client bundle). The 35-character SECRET is a Worker secret binding
 # (TURNSTILE_SECRET) and must never appear here or anywhere client-side.
+# Required for PRODUCTION builds since issue #447 armed the edge gate: without
+# it the anonymous chat entry renders no widget and every anonymous turn is
+# answered 403 turnstile_required. A dev build falls back to Cloudflare's
+# always-passing test key (1x00000000000000000000AA) on its own.
 VITE_TURNSTILE_SITE_KEY=

--- a/apps/web/src/components/TurnstileGate.tsx
+++ b/apps/web/src/components/TurnstileGate.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import type { ChatDict } from "../features/chat/i18n";
-import { rememberTurnstileToken } from "../lib/turnstile/tokenStore";
+import { clearTurnstileToken, rememberTurnstileToken } from "../lib/turnstile/tokenStore";
 
 /** Cloudflare's widget loader. `async defer` per the official embed. */
 export const TURNSTILE_SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
@@ -11,13 +11,51 @@ export const TURNSTILE_ACTION = "turnstile-spin-v2";
 /** Global the widget invokes with the solved token (`data-callback`). */
 export const TURNSTILE_CALLBACK = "onAnimichiTurnstile";
 
+/**
+ * Globals for the two ways a token stops being usable: the challenge failed or
+ * the loader never came up (`data-error-callback`), and the solved token aged
+ * out (`data-expired-callback`). Both clear the store, so the next turn waits
+ * for a fresh solve instead of sending a token the edge will reject.
+ */
+export const TURNSTILE_ERROR_CALLBACK = "onAnimichiTurnstileError";
+export const TURNSTILE_EXPIRED_CALLBACK = "onAnimichiTurnstileExpired";
+
+/**
+ * The least intrusive of Turnstile's three appearances.
+ *
+ * `always` parks a permanent challenge box under the composer; `execute` needs
+ * an explicit `turnstile.execute()` handshake before a token exists, which
+ * would put a round trip in front of the very first message. `interaction-only`
+ * solves silently and renders NOTHING unless Cloudflare actually decides a
+ * human interaction is required — so the dock keeps the design's rhythm
+ * (composer + one quiet hint line) on the overwhelming majority of turns, and
+ * the challenge appears only in the rare case it is genuinely needed.
+ */
+export const TURNSTILE_APPEARANCE = "interaction-only";
+
+/** Fills the composer's width instead of a fixed 300px box when it does show. */
+export const TURNSTILE_SIZE = "flexible";
+
 /** A Turnstile site key is 24 characters; a secret is 35. */
 const SITE_KEY_LENGTH = 24;
 
 declare global {
   interface Window {
     onAnimichiTurnstile?: (token: string) => void;
+    onAnimichiTurnstileError?: () => void;
+    onAnimichiTurnstileExpired?: () => void;
+    /** Injected by api.js; only `reset` is used (re-arm after a rejection). */
+    turnstile?: { reset: (widget?: string) => void };
   }
+}
+
+/**
+ * Re-arm the widget after the edge rejected a token (403 `turnstile_required`).
+ * A Turnstile token is single-use at siteverify, so a retry that reuses the
+ * held token would be rejected again as `timeout-or-duplicate`.
+ */
+export function resetTurnstileWidget(): void {
+  window.turnstile?.reset();
 }
 
 type EnvRecord = Readonly<Record<string, string | undefined>>;
@@ -46,6 +84,35 @@ export function currentTurnstileSiteKey(): string {
   return resolveTurnstileSiteKey(import.meta.env);
 }
 
+/**
+ * Cloudflare's published always-passing TEST site key. Used only as the dev
+ * fallback below, so `pnpm dev` and the E2E run exercise the real armed path
+ * (issue #447) without anyone provisioning a widget.
+ */
+export const TURNSTILE_TEST_SITE_KEY = "1x00000000000000000000AA";
+
+/**
+ * The site key to render with, or `undefined` when this build has none.
+ *
+ * An unconfigured PRODUCTION build renders no widget rather than crashing the
+ * chat page; an unconfigured DEV build falls back to the test key, because the
+ * edge now challenges every anonymous turn and a local page with no widget
+ * could never answer. A present-but-wrong-length value still throws in both:
+ * pasting the 35-char SECRET must never reach a render.
+ */
+export function configuredTurnstileSiteKey(
+  env: EnvRecord = import.meta.env,
+  dev: boolean = import.meta.env.DEV,
+): string | undefined {
+  if ((env.VITE_TURNSTILE_SITE_KEY ?? "") !== "") return resolveTurnstileSiteKey(env);
+  return dev ? TURNSTILE_TEST_SITE_KEY : undefined;
+}
+
+/** Match the widget to the app's own day/night choice rather than the OS's. */
+function widgetTheme(): "light" | "dark" {
+  return document.documentElement.dataset.theme === "night" ? "dark" : "light";
+}
+
 /** Inject the loader once per document. */
 function useTurnstileScript(): void {
   useEffect(() => {
@@ -66,6 +133,21 @@ function useTurnstileCallback(onToken: (token: string) => void): void {
       window.onAnimichiTurnstile = undefined;
     };
   }, [onToken]);
+}
+
+function bindInvalidation(): () => void {
+  const invalidate = () => { clearTurnstileToken(); };
+  window.onAnimichiTurnstileError = invalidate;
+  window.onAnimichiTurnstileExpired = invalidate;
+  return () => {
+    window.onAnimichiTurnstileError = undefined;
+    window.onAnimichiTurnstileExpired = undefined;
+  };
+}
+
+/** Drop the held token whenever the widget says it is no longer good. */
+function useTurnstileInvalidation(): void {
+  useEffect(bindInvalidation, []);
 }
 
 type RetryProps = Readonly<{ dict: ChatDict; onRetry: () => void }>;
@@ -89,14 +171,19 @@ type Props = Readonly<{
   onToken?: (token: string) => void;
 }>;
 
+/** The attributes api.js reads that never vary between renders. */
+const WIDGET_ATTRIBUTES = {
+  "data-action": TURNSTILE_ACTION,
+  "data-callback": TURNSTILE_CALLBACK,
+  "data-error-callback": TURNSTILE_ERROR_CALLBACK,
+  "data-expired-callback": TURNSTILE_EXPIRED_CALLBACK,
+  "data-appearance": TURNSTILE_APPEARANCE,
+  "data-size": TURNSTILE_SIZE,
+} as const;
+
 function TurnstileWidget({ siteKey }: Readonly<{ siteKey: string }>) {
   return (
-    <div
-      className="cf-turnstile"
-      data-sitekey={siteKey}
-      data-action={TURNSTILE_ACTION}
-      data-callback={TURNSTILE_CALLBACK}
-    />
+    <div className="cf-turnstile" data-sitekey={siteKey} data-theme={widgetTheme()} {...WIDGET_ATTRIBUTES} />
   );
 }
 
@@ -105,9 +192,14 @@ function TurnstileWidget({ siteKey }: Readonly<{ siteKey: string }>) {
  * (`worker/turnstile.ts`) — this only collects the token and hands it to the
  * store the chat transport reads.
  */
-export function TurnstileGate({ dict, siteKey, failed = false, onRetry, onToken }: Props) {
+function useTurnstileWidget(onToken: ((token: string) => void) | undefined): void {
   useTurnstileScript();
   useTurnstileCallback(onToken ?? rememberTurnstileToken);
+  useTurnstileInvalidation();
+}
+
+export function TurnstileGate({ dict, siteKey, failed = false, onRetry, onToken }: Props) {
+  useTurnstileWidget(onToken);
   return (
     <section className="turnstile-gate" aria-label={dict.turnstile.label}>
       <TurnstileWidget siteKey={siteKey} />

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { TurnstileGate } from "../../components/TurnstileGate";
 import { useLocale } from "../../i18n/context";
-import { classifyFailure } from "../../lib/chat/errorClassifier";
+import { TURNSTILE_REQUIRED_CODE, classifyFailure } from "../../lib/chat/errorClassifier";
 import type { ChatErrorState, FailureSignal } from "../../lib/chat/errorClassifier";
 import { ChatActionsProvider } from "./chat-actions";
 import type { ChatActions } from "./chat-actions";
@@ -36,6 +37,8 @@ import { useConversationHistory } from "./use-conversation-history";
 import { useStreamRecovery } from "./use-stream-recovery";
 import { useTurnTimeout } from "./use-turn-timeout";
 import { useTurnTiming } from "./use-turn-timing";
+import { useTurnstileChallenge, useTurnstileReady } from "./use-turnstile-challenge";
+import type { TurnstileChallenge } from "./use-turnstile-challenge";
 import type { ConversationHistory } from "./use-conversation-history";
 
 export interface ChatPageProps {
@@ -49,6 +52,7 @@ type ShellProps = Readonly<{
   history: ConversationHistory;
   failure: TurnFailureView | undefined;
   recompute: RecomputeTurn;
+  challenge: TurnstileChallenge | undefined;
   onRetry: () => void;
   onSend: (text: string) => void;
   departure: DeparturePromptState;
@@ -160,6 +164,12 @@ function ComposerExtras(props: ShellProps) {
   );
 }
 
+/** The dock's hint slot: silent until Turnstile decides a human check is due. */
+function ChallengeGate({ dict, challenge }: Readonly<{ dict: ChatDict; challenge: TurnstileChallenge | undefined }>) {
+  if (challenge === undefined) return null;
+  return <TurnstileGate dict={dict} {...challenge} />;
+}
+
 /** Chips, photo upload, and the E2 tray dock between the stream and composer. */
 function ComposerDock(props: ShellProps) {
   return (
@@ -170,13 +180,23 @@ function ComposerDock(props: ShellProps) {
   );
 }
 
+/** Composer plus the quiet challenge slot beneath it (design sync `.hint`). */
+function Composer(props: ShellProps) {
+  return (
+    <>
+      <ChatInput dict={props.dict} disabled={isInputLocked(props)} onSend={props.onSend} />
+      <ChallengeGate dict={props.dict} challenge={props.challenge} />
+    </>
+  );
+}
+
 function ChatShell(props: ShellProps) {
   return (
     <main className="chat-page">
       <ShellNotices {...props} />
       <ChatBody {...props} />
       <ComposerDock {...props} />
-      <ChatInput dict={props.dict} disabled={isInputLocked(props)} onSend={props.onSend} />
+      <Composer {...props} />
     </main>
   );
 }
@@ -218,18 +238,28 @@ function isActiveTurn(status: ChatSession["status"]): boolean {
   return status === "submitted" || status === "streaming";
 }
 
-function turnFailureState(chat: ChatSession, timedOut: boolean): ChatErrorState | undefined {
+/**
+ * A challenged turn is NOT D8 — an anonymous visitor never had a session to
+ * expire — but the strip is only suppressed when a widget is actually on the
+ * page to offer the recovery. A misconfigured build (no site key, or an edge
+ * with no secret) rejects every turn with nothing to click, so there the
+ * generic failure must still render rather than the chat dying silently
+ * (issue #447 review, P1-3).
+ */
+function turnFailureState(chat: ChatSession, timedOut: boolean, challenged: boolean): ChatErrorState | undefined {
   if (isActiveTurn(chat.status)) return undefined;
   if (timedOut) return "D5";
   if (chat.error === undefined) return undefined;
-  return classifyFailure(turnFailureSignal(chat.lastHttpStatus(), chat.lastErrorCode())) ?? "D4";
+  const code = chat.lastErrorCode();
+  if (challenged && code === TURNSTILE_REQUIRED_CODE) return undefined;
+  return classifyFailure(turnFailureSignal(chat.lastHttpStatus(), code)) ?? "D4";
 }
 
 /** Compose the D4/D5/D8/D11 view: watchdog + classification + P6 recovery. */
-function useTurnFailure(chat: ChatSession, baseUrl: string): TurnFailureView | undefined {
+function useTurnFailure(chat: ChatSession, baseUrl: string, challenged: boolean): TurnFailureView | undefined {
   const timeout = useTurnTimeout(chat.status, () => void chat.stop());
   const recovery = useStreamRecovery(baseUrl, chat, chat.sessionIdOf);
-  const state = turnFailureState(chat, timeout.timedOut);
+  const state = turnFailureState(chat, timeout.timedOut, challenged);
   const onRetry = useCallback(() => { timeout.reset(); recovery.recover(); }, [timeout, recovery]);
   const onExpiredResume = useCallback(() => { timeout.reset(); recovery.recoverExpired(); }, [timeout, recovery]);
   if (state === undefined) return undefined;
@@ -246,10 +276,12 @@ function entryStateOf(search: ChatSearch, health: BackendHealth): ChatEntryState
   });
 }
 
-function useAutoSendFromQuery(search: ChatSearch, health: BackendHealth, send: (text: string) => void) {
+function useAutoSendFromQuery(
+  search: ChatSearch, health: BackendHealth, send: (text: string) => void, ready: boolean,
+) {
   useAutoSend({
     query: search.q,
-    enabled: health.healthy && !search.session,
+    enabled: health.healthy && ready && !search.session,
     send,
     sessionId: search.session,
   });
@@ -277,9 +309,9 @@ function usePhotoContext(locale: ReturnType<typeof useLocale>, chat: ChatSession
 }
 
 /** Tray state: the recompute turn, its masked failure, and the spot store. */
-function useTrayState(chat: ChatSession, baseUrl: string) {
+function useTrayState(chat: ChatSession, baseUrl: string, challenged: boolean) {
   const recompute = useRecomputeTurn(chat);
-  const failure = maskRecomputeFailure(recompute, useTurnFailure(chat, baseUrl));
+  const failure = maskRecomputeFailure(recompute, useTurnFailure(chat, baseUrl, challenged));
   const selection = useSpotSelectionState();
   return { recompute, failure, selection };
 }
@@ -297,16 +329,18 @@ function useChatPage(search: ChatSearch) {
   const { config, health, chat, history } = useChatState(search);
   const { actions, gps } = useOriginTracking(useTurnActions(chat));
   const surfaces = usePageSurfaces(chat, actions, gps);
-  const tray = useTrayState(chat, config.baseUrl);
-  useAutoSendFromQuery(search, health, actions.send);
-  return { config, health, chat, history, actions, ...surfaces, ...tray };
+  // `?q=` must not fire before the widget has a token to send (#447 review).
+  const challenge = useTurnstileChallenge(chat);
+  const tray = useTrayState(chat, config.baseUrl, challenge !== undefined);
+  useAutoSendFromQuery(search, health, actions.send, useTurnstileReady(challenge !== undefined));
+  return { config, health, chat, history, actions, challenge, ...surfaces, ...tray };
 }
 
 type PageState = ReturnType<typeof useChatPage>;
 
 function ChatPageView({ search, page }: Readonly<{ search: ChatSearch; page: PageState }>) {
   return (
-    <ChatShell entry={entryStateOf(search, page.health)} dict={page.dict} chat={page.chat} history={page.history} failure={page.failure} recompute={page.recompute} onRetry={page.health.retry} onSend={page.departure.onSend} departure={page.departure} baseUrl={page.config.baseUrl} photo={page.photo} />
+    <ChatShell entry={entryStateOf(search, page.health)} dict={page.dict} chat={page.chat} history={page.history} failure={page.failure} recompute={page.recompute} challenge={page.challenge} onRetry={page.health.retry} onSend={page.departure.onSend} departure={page.departure} baseUrl={page.config.baseUrl} photo={page.photo} />
   );
 }
 

--- a/apps/web/src/features/chat/components/PhotoSearchUpload.tsx
+++ b/apps/web/src/features/chat/components/PhotoSearchUpload.tsx
@@ -5,6 +5,7 @@ import { ChatActionsProvider, useChatActions } from "../chat-actions";
 import type { ChatActions } from "../chat-actions";
 import type { ChatDict } from "../i18n";
 import {
+  PHOTO_CHALLENGED,
   confirmPhotoSearch,
   isOversizedPhoto,
   isSupportedPhoto,
@@ -23,7 +24,7 @@ import { DataPartCard } from "./DataPartCard";
  * through DataPartCard, sharing the text-search render path; failures show
  * on-brand copy with a retry — never a stuck spinner. */
 
-type UploadError = "unsupported" | "tooLarge" | "failed";
+type UploadError = "unsupported" | "tooLarge" | "failed" | "challenge";
 
 type UploadState =
   | { readonly kind: "idle" }
@@ -42,6 +43,7 @@ function quotaCopy(dict: ChatDict, guidance: PhotoGuidance): string {
 function errorCopy(dict: ChatDict, error: UploadError): string {
   if (error === "unsupported") return dict.photo.unsupported;
   if (error === "tooLarge") return dict.photo.tooLarge;
+  if (error === "challenge") return dict.turnstile.failed;
   return dict.photo.failed;
 }
 
@@ -106,11 +108,17 @@ function settledState(outcome: PhotoSearchOutcome): UploadState {
   return outcome.kind === "quota" ? outcome : { kind: "done", part: outcome.part };
 }
 
+/** A rejected challenge reads as its own state so the visitor is told to
+ * redo the check, not that their photo was bad (issue #447 review). */
+function uploadErrorOf(cause: unknown): UploadError {
+  return cause instanceof Error && cause.message === PHOTO_CHALLENGED ? "challenge" : "failed";
+}
+
 function runUpload(baseUrl: string, file: File, context: PhotoSearchContext, setState: SetUploadState): void {
   setState({ kind: "uploading" });
   postPhotoSearch(baseUrl, file, context)
     .then((outcome) => { setState(settledState(outcome)); })
-    .catch(() => { setState({ kind: "error", error: "failed" }); });
+    .catch((cause: unknown) => { setState({ kind: "error", error: uploadErrorOf(cause) }); });
 }
 
 function preflightError(file: File): UploadError | null {

--- a/apps/web/src/features/chat/photo-search.ts
+++ b/apps/web/src/features/chat/photo-search.ts
@@ -102,9 +102,26 @@ async function quotaOutcome(response: Response): Promise<PhotoSearchOutcome> {
   return { kind: "quota", guidance: guidanceOf(await response.json()) };
 }
 
+/** The armed edge's rejection code (`worker/turnstile.ts`, #447). */
+export const PHOTO_CHALLENGED = "photo_search_challenged";
+
+async function errorCodeOf(response: Response): Promise<string | undefined> {
+  const body: unknown = await response.json().catch(() => undefined);
+  const code = fieldOf(fieldOf(body, "error"), "code");
+  return typeof code === "string" ? code : undefined;
+}
+
+/** A challenged upload is not a broken upload: #445 put photo search on the
+ * anonymous allowlist, so the armed gate rejects it exactly like a chat turn
+ * and the visitor needs the challenge copy, not "photo search failed". */
+async function rejection(response: Response): Promise<never> {
+  const code = await errorCodeOf(response);
+  throw new Error(code === "turnstile_required" ? PHOTO_CHALLENGED : "photo_search_failed");
+}
+
 async function settleResponse(response: Response): Promise<PhotoSearchOutcome> {
   if (response.status === 429) return quotaOutcome(response);
-  if (!response.ok) throw new Error("photo_search_failed");
+  if (!response.ok) return rejection(response);
   return parseOutcome(await response.json());
 }
 

--- a/apps/web/src/features/chat/session-headers.ts
+++ b/apps/web/src/features/chat/session-headers.ts
@@ -1,5 +1,6 @@
 import { authHeaders } from "../../lib/auth/authSession";
-import { turnstileHeaders } from "../../lib/turnstile/tokenStore";
+import { configuredTurnstileSiteKey } from "../../components/TurnstileGate";
+import { awaitTurnstileToken, turnstileHeaders } from "../../lib/turnstile/tokenStore";
 
 /**
  * Shared /v1 transport headers: `x-session-id` (when known) plus a Bearer
@@ -11,6 +12,25 @@ import { turnstileHeaders } from "../../lib/turnstile/tokenStore";
 export async function sessionHeaders(sessionId?: string): Promise<Record<string, string>> {
   const base: Record<string, string> = sessionId ? { "x-session-id": sessionId } : {};
   const auth = await authHeaders();
-  const challenge = auth.Authorization === undefined ? turnstileHeaders() : {};
-  return { ...base, ...challenge, ...auth };
+  if (auth.Authorization !== undefined) return { ...base, ...auth };
+  return { ...base, ...(await challengeHeaders()) };
+}
+
+/**
+ * Wait for the widget rather than walking into a 403 (issue #447 review).
+ *
+ * The edge challenges every anonymous `/v1` turn on the allowlist — chat AND
+ * photo search (#445 added `/v1/photo-search` to it) — so a request fired
+ * before the widget has solved is rejected. Chat surfaces that as a retryable
+ * challenge; photo upload has no challenge UI of its own, which is exactly why
+ * the wait lives here, in the header path both surfaces share.
+ *
+ * When this build renders no widget there is nothing to wait for, so the
+ * request goes out immediately and any rejection surfaces normally. The wait
+ * itself is bounded (`TURNSTILE_WAIT_MS`) — it delays a turn, it never hangs
+ * one.
+ */
+async function challengeHeaders(): Promise<Record<string, string>> {
+  if (configuredTurnstileSiteKey() !== undefined) await awaitTurnstileToken();
+  return turnstileHeaders();
 }

--- a/apps/web/src/features/chat/use-turnstile-challenge.ts
+++ b/apps/web/src/features/chat/use-turnstile-challenge.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { configuredTurnstileSiteKey, resetTurnstileWidget } from "../../components/TurnstileGate";
+import { getAuthToken } from "../../lib/auth/authSession";
+import {
+  awaitTurnstileToken,
+  clearTurnstileToken,
+  currentTurnstileToken,
+  onTurnstileToken,
+} from "../../lib/turnstile/tokenStore";
+import { TURNSTILE_REQUIRED_CODE } from "../../lib/chat/errorClassifier";
+import type { ChatSession } from "./use-chat-session";
+
+export interface TurnstileChallenge {
+  readonly siteKey: string;
+  readonly failed: boolean;
+  readonly onRetry: () => void;
+}
+
+/** True once we know this visitor holds no session — only anonymous turns are
+ * challenged, so a signed-in reader never loads the widget at all. */
+function trackAnonymous(setAnonymous: (anonymous: boolean) => void): () => void {
+  let live = true;
+  void getAuthToken().then((token) => {
+    if (live) setAnonymous(token === undefined);
+  });
+  return () => { live = false; };
+}
+
+function useAnonymousVisitor(): boolean {
+  const [anonymous, setAnonymous] = useState(false);
+  useEffect(() => trackAnonymous(setAnonymous), []);
+  return anonymous;
+}
+
+/**
+ * Retry the rejected turn — driven by the WIDGET, not by the click.
+ *
+ * The rejected token is spent (single-use at siteverify), so it is dropped and
+ * the widget re-armed; the resend then waits for the callback that delivers the
+ * replacement. Resending in the same tick would put a tokenless request on the
+ * wire and earn the identical 403 (issue #447 review, P1-1). The subscription
+ * is taken BEFORE the reset so a fast solve cannot land in the gap, and no
+ * token means no resend: the challenge simply stays on screen.
+ */
+function resendWhenSolved(regenerate: () => Promise<void> | void): void {
+  clearTurnstileToken();
+  const replacement = awaitTurnstileToken();
+  resetTurnstileWidget();
+  void replacement.then((token) => {
+    if (token !== undefined) void regenerate();
+  });
+}
+
+function useChallengeRetry(chat: ChatSession): () => void {
+  const { clearError, regenerate } = chat;
+  return useCallback(() => {
+    clearError();
+    resendWhenSolved(regenerate);
+  }, [clearError, regenerate]);
+}
+
+/**
+ * True once a turn may be sent without walking into a 403: either no challenge
+ * is in play on this page, or the widget has already handed over a token.
+ *
+ * `?q=` auto-send (A2) is gated on this. Firing the hero's query the instant
+ * the page mounts would race the widget's first solve, and the armed edge
+ * requires the token on the FIRST message — the visitor would land on an
+ * unrecoverable 403 (issue #447 review, P1-1).
+ */
+export function useTurnstileReady(challenged: boolean): boolean {
+  const [held, setHeld] = useState(() => currentTurnstileToken() !== undefined);
+  useEffect(() => onTurnstileToken(() => { setHeld(true); }), []);
+  return !challenged || held;
+}
+
+/**
+ * The anonymous chat entry's Turnstile state, or `undefined` when no widget
+ * belongs on the page (signed in, or no site key configured in this build).
+ */
+export function useTurnstileChallenge(chat: ChatSession): TurnstileChallenge | undefined {
+  const anonymous = useAnonymousVisitor();
+  const siteKey = useMemo(() => configuredTurnstileSiteKey(), []);
+  const onRetry = useChallengeRetry(chat);
+  if (!anonymous || siteKey === undefined) return undefined;
+  return { siteKey, failed: chat.lastErrorCode() === TURNSTILE_REQUIRED_CODE, onRetry };
+}

--- a/apps/web/src/lib/chat/errorClassifier.ts
+++ b/apps/web/src/lib/chat/errorClassifier.ts
@@ -28,10 +28,18 @@ const D1_CODE_MARKERS = ["not_found", "no_bangumi", "invalid_station"];
 /** The breaker's wire code, shared with `worker/costBreaker.ts` (S1.8 X4). */
 export const ANON_BUDGET_EXHAUSTED_CODE = "anon_budget_exhausted";
 
+/** The armed edge gate's retryable rejection (`worker/turnstile.ts`, #447). */
+export const TURNSTILE_REQUIRED_CODE = "turnstile_required";
+
 function classifyHttpStatus(status: number, code: string | undefined): ChatErrorState {
   // The budget breaker also rejects with 403, but an anonymous visitor never
   // had a session to expire — only its own code earns the D11 budget copy.
   if (status === 403 && code === ANON_BUDGET_EXHAUSTED_CODE) return "D11";
+  // Same reasoning for the Turnstile gate: a challenged visitor never had a
+  // session either. When a widget is on the page ChatPage suppresses this and
+  // the challenge owns the retry; when it is not, D4's generic retry is the
+  // honest fallback — never the login banner.
+  if (status === 403 && code === TURNSTILE_REQUIRED_CODE) return "D4";
   if (status === 401 || status === 403) return "D8";
   if (status === 429) return "D10";
   if (status === 408 || status === 504) return "D5";

--- a/apps/web/src/lib/turnstile/tokenStore.ts
+++ b/apps/web/src/lib/turnstile/tokenStore.ts
@@ -21,9 +21,23 @@ interface StoredToken {
 
 let stored: StoredToken | undefined;
 
+type TokenListener = (token: string) => void;
+const listeners = new Set<TokenListener>();
+
+/** How long a caller waits for the widget to hand over a fresh token before
+ * giving up. Solving is usually instant; an interactive challenge is not. */
+export const TURNSTILE_WAIT_MS = 15_000;
+
+/** Subscribe to solved tokens; returns the unsubscribe. */
+export function onTurnstileToken(listener: TokenListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
 /** Record a freshly solved token; an empty token clears the store. */
 export function rememberTurnstileToken(token: string, now: number = Date.now()): void {
   stored = token === "" ? undefined : { token, expiresAt: now + TURNSTILE_TOKEN_TTL_MS };
+  if (stored !== undefined) for (const listener of [...listeners]) listener(token);
 }
 
 export function currentTurnstileToken(now: number = Date.now()): string | undefined {
@@ -31,8 +45,44 @@ export function currentTurnstileToken(now: number = Date.now()): string | undefi
   return stored.token;
 }
 
+/** Waiters parked in `awaitTurnstileToken`, each with its own timeout. */
+const waiting = new Set<() => void>();
+
+/**
+ * Drop the held token and abandon anyone still waiting for one. Cancelling the
+ * waiters matters as much as clearing the token: each holds a pending timer,
+ * and a caller parked on a widget that will never solve (the page navigated
+ * away, the challenge was abandoned) would otherwise linger for the full
+ * timeout.
+ */
 export function clearTurnstileToken(): void {
   stored = undefined;
+  for (const abandon of [...waiting]) abandon();
+}
+
+function releaseWaiter(abandon: () => void, timer: ReturnType<typeof setTimeout>, stop: () => void): void {
+  stop();
+  clearTimeout(timer);
+  waiting.delete(abandon);
+}
+
+function waitForToken(timeoutMs: number, resolve: (token: string | undefined) => void): void {
+  const settle = (token: string | undefined) => { releaseWaiter(abandon, timer, stop); resolve(token); };
+  const abandon = () => { settle(undefined); };
+  const timer = setTimeout(abandon, timeoutMs);
+  const stop = onTurnstileToken(settle);
+  waiting.add(abandon);
+}
+
+/**
+ * The token to send with the next anonymous turn: the held one, or the next
+ * the widget solves, or `undefined` once the wait elapses. Callers use this so
+ * a request is never sent tokenless into an armed edge (issue #447 review).
+ */
+export function awaitTurnstileToken(timeoutMs: number = TURNSTILE_WAIT_MS): Promise<string | undefined> {
+  const held = currentTurnstileToken();
+  if (held !== undefined) return Promise.resolve(held);
+  return new Promise<string | undefined>((resolve) => { waitForToken(timeoutMs, resolve); });
 }
 
 /** `{}` unless an unexpired token is held. Anonymous turns only — the caller

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -931,3 +931,57 @@
   padding: 0.2rem 0.7rem;
   cursor: pointer;
 }
+
+/* --- S1.9 Turnstile (issue #281), armed by #447 ---
+   Lives in the dock's hint slot beneath the composer, matching the design sync
+   (`Chat 初始状态.html`: .dock > .composer + .hint). `interaction-only` means
+   the widget contributes no box at all until Cloudflare actually asks for a
+   human check, so the composer keeps its rhythm; the margin below is applied
+   only once the widget has really rendered something. */
+
+.turnstile-gate {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 48rem;
+  margin-inline: auto;
+  padding-inline: 1rem;
+  background: var(--color-card);
+}
+
+.turnstile-gate .cf-turnstile:not(:empty) {
+  margin-block: 0.75rem;
+}
+
+.turnstile-gate__error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-block: 0.5rem 0.75rem;
+  padding: 0.5rem 0.875rem;
+  border-radius: 14px;
+  background: var(--color-error-bg);
+  color: var(--color-error-strong);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.turnstile-gate__retry {
+  min-height: 36px;
+  padding: 0 0.875rem;
+  border: 0;
+  border-radius: 12px;
+  background: var(--color-primary);
+  color: var(--color-primary-fg);
+  box-shadow: 0 3px 0 var(--shadow-3d);
+  font: inherit;
+  cursor: pointer;
+}
+
+.turnstile-gate__retry:focus-visible {
+  outline: 2px solid var(--color-focus);
+}

--- a/apps/web/tests/msw/chat-handlers.ts
+++ b/apps/web/tests/msw/chat-handlers.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { http, HttpResponse } from "msw";
 import type { HttpHandler } from "msw";
+import { TURNSTILE_HEADER } from "../../src/lib/turnstile/tokenStore";
 import { TEST_ORIGIN } from "./fixtures";
 
 /**
@@ -112,6 +113,38 @@ export function chatHttpErrorHandler(status: number): HttpHandler {
 /** A JSON rejection carrying no error code — must not be promoted to D11. */
 export function chatCodelessErrorHandler(status: number): HttpHandler {
   return http.post(CHAT_URL, () => HttpResponse.json({ detail: "denied" }, { status }));
+}
+
+const TURNSTILE_REJECTION = {
+  error: { code: "turnstile_required", message: "Turnstile verification required.", retryable: true },
+};
+
+/** The armed edge gate's retryable rejection (issue #447, `worker/turnstile.ts`). */
+export function chatTurnstileRequiredHandler(spy?: (request: Request) => void): HttpHandler {
+  return http.post(CHAT_URL, ({ request }) => {
+    spy?.(request);
+    return HttpResponse.json(TURNSTILE_REJECTION, { status: 403 });
+  });
+}
+
+/**
+ * The armed edge as it actually behaves: a turn WITHOUT a solved token is
+ * challenged, a turn with one streams. A handler that answers 200 regardless
+ * cannot tell a tokenless resend from a real recovery (issue #447 review).
+ */
+export function armedChatHandler(
+  name: ChatStreamFixture,
+  seen: (string | null)[],
+  spent: readonly string[] = [],
+  options: ChatStreamOptions = {},
+): HttpHandler {
+  return http.post(CHAT_URL, ({ request }) => {
+    const token = request.headers.get(TURNSTILE_HEADER);
+    seen.push(token);
+    const usable = token !== null && token !== "" && !spent.includes(token);
+    if (!usable) return HttpResponse.json(TURNSTILE_REJECTION, { status: 403 });
+    return sseResponse(streamText(name, options));
+  });
 }
 
 /** The anonymous daily-budget breaker's rejection (issue #274 S1.8 X4 → D11). */

--- a/apps/web/tests/setup/turnstile-hermetic.ts
+++ b/apps/web/tests/setup/turnstile-hermetic.ts
@@ -1,0 +1,14 @@
+import { beforeEach, vi } from "vitest";
+import { clearTurnstileToken } from "../../src/lib/turnstile/tokenStore";
+
+// Neutralize Turnstile for every suite that is not about it (issue #447).
+// Vitest runs with `DEV === true`, which would otherwise hand the chat page the
+// dev-fallback site key, mount a widget, and make `?q=` auto-send wait for a
+// token it will never receive. Turnstile's own suites stub these back.
+beforeEach(() => {
+  // Also abandons any waiter a previous test parked on `awaitTurnstileToken`,
+  // so a pending 15s timer cannot leak into the next test's event loop.
+  clearTurnstileToken();
+  vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
+  vi.stubEnv("DEV", false);
+});

--- a/apps/web/tests/unit/chat/chat-design-css.test.ts
+++ b/apps/web/tests/unit/chat/chat-design-css.test.ts
@@ -75,3 +75,21 @@ describe("B4 settled footprint: elapsed emphasis over a semantic token", () => {
     expect(ruleDeclaration(chatCss, ".chat-settled__elapsed", "color")).toBe("var(--color-primary-strong)");
   });
 });
+
+describe("S1.9 Turnstile dock slot (issue #447)", () => {
+  it("paints the gate with the dock's own surface token, never a raw color", () => {
+    expect(ruleDeclaration(chatCss, ".turnstile-gate", "background")).toBe("var(--color-card)");
+    expect(ruleDeclaration(chatCss, ".turnstile-gate", "max-width")).toBe("48rem");
+  });
+
+  it("costs no vertical rhythm until the widget actually renders something", () => {
+    expect(ruleDeclaration(chatCss, ".turnstile-gate", "padding-block")).toBeNull();
+    expect(ruleDeclaration(chatCss, ".turnstile-gate .cf-turnstile:not(:empty)", "margin-block")).toBe("0.75rem");
+  });
+
+  it("styles the retry with the shared 3D press affordance and semantic tokens", () => {
+    expect(ruleDeclaration(chatCss, ".turnstile-gate__retry", "background")).toBe("var(--color-primary)");
+    expect(ruleDeclaration(chatCss, ".turnstile-gate__retry", "box-shadow")).toBe("0 3px 0 var(--shadow-3d)");
+    expect(ruleDeclaration(chatCss, ".turnstile-gate__error", "color")).toBe("var(--color-error-strong)");
+  });
+});

--- a/apps/web/tests/unit/chat/turnstile-armed-flow.test.tsx
+++ b/apps/web/tests/unit/chat/turnstile-armed-flow.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #447 review (P1-1): against an edge that really requires the token,
+ * not a handler that answers 200 regardless. Two failure modes are pinned here
+ * because both shipped green under a permissive handler: a retry that resends
+ * in the same tick as `turnstile.reset()` (always tokenless), and `?q=`
+ * auto-send racing the widget's first solve.
+ */
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { clearTurnstileToken, rememberTurnstileToken } from "../../../src/lib/turnstile/tokenStore";
+import { server } from "../../msw/node";
+import { armedChatHandler } from "../../msw/chat-handlers";
+import { setLanguages } from "../_i18n";
+import { chatSearch, renderChatPage } from "./_chat-page";
+
+const { getAuthToken } = vi.hoisted(() => ({ getAuthToken: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../../../src/lib/auth/authSession", () => ({
+  getAuthToken,
+  clearAuthToken: () => undefined,
+  authHeaders: () => Promise.resolve({}),
+}));
+
+const SITE_KEY = "0x4AAAAAAAsitekey24chars";
+const ja = chatDictFor("ja");
+const ANSWER = "宇治の聖地を2件、徒歩ルートにまとめました。";
+
+beforeEach(() => {
+  setLanguages(["ja"]);
+  clearTurnstileToken();
+  getAuthToken.mockReset().mockResolvedValue(undefined);
+  vi.stubEnv("VITE_TURNSTILE_SITE_KEY", SITE_KEY);
+});
+
+/**
+ * Seed the token the edge will reject. A token is single-use at siteverify, so
+ * this is the realistic way a turn earns a 403 now that the transport waits for
+ * a token before sending: the visitor holds one, it is spent or expired, and
+ * the edge says so.
+ */
+const SPENT = "spent-token";
+
+function seedSpentToken(): void {
+  rememberTurnstileToken(SPENT);
+}
+
+/** Drive the widget's own `data-callback` — the only way a token ever lands. */
+async function solve(token: string): Promise<void> {
+  await act(async () => {
+    window.onAnimichiTurnstile?.(token);
+    await Promise.resolve();
+  });
+}
+
+function sendText(text: string) {
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: text } });
+  fireEvent.click(screen.getByRole("button", { name: ja.send }));
+}
+
+async function waitForWidget(): Promise<void> {
+  await waitFor(() => {
+    expect(window.onAnimichiTurnstile).toBeTypeOf("function");
+  });
+}
+
+describe("retry after the edge challenged the turn", () => {
+  it("resends only once a replacement token has landed, and carries it", async () => {
+    const seen: (string | null)[] = [];
+    server.use(armedChatHandler("search", seen, [SPENT]));
+    renderChatPage();
+    await waitForWidget();
+    seedSpentToken();
+    sendText("ユーフォ");
+    await screen.findByText(ja.turnstile.failed);
+    fireEvent.click(screen.getByRole("button", { name: ja.turnstile.retry }));
+    await solve("fresh-token");
+    expect(await screen.findByText(ANSWER)).toBeTruthy();
+    expect(seen).toEqual(["spent-token", "fresh-token"]);
+  });
+
+  it("puts no tokenless request on the wire while the widget is still solving", async () => {
+    const seen: (string | null)[] = [];
+    server.use(armedChatHandler("search", seen, [SPENT]));
+    renderChatPage();
+    await waitForWidget();
+    seedSpentToken();
+    sendText("ユーフォ");
+    await screen.findByText(ja.turnstile.failed);
+    fireEvent.click(screen.getByRole("button", { name: ja.turnstile.retry }));
+    await act(async () => { await Promise.resolve(); });
+    expect(seen).toEqual(["spent-token"]);
+    expect(screen.getByRole("button", { name: ja.turnstile.retry })).toBeTruthy();
+  });
+
+  it("does not throw away a token the widget solved before the click", async () => {
+    const seen: (string | null)[] = [];
+    server.use(armedChatHandler("search", seen, [SPENT]));
+    renderChatPage();
+    await waitForWidget();
+    seedSpentToken();
+    sendText("ユーフォ");
+    await screen.findByText(ja.turnstile.failed);
+    fireEvent.click(screen.getByRole("button", { name: ja.turnstile.retry }));
+    await solve("second-token");
+    expect(await screen.findByText(ANSWER)).toBeTruthy();
+    expect(seen.at(-1)).toBe("second-token");
+  });
+});
+
+describe("?q= auto-send against an armed edge", () => {
+  it("waits for the first solved token instead of burning the turn on a 403", async () => {
+    const seen: (string | null)[] = [];
+    server.use(armedChatHandler("search", seen));
+    renderChatPage(chatSearch({ q: "ユーフォ" }));
+    await waitForWidget();
+    await act(async () => { await Promise.resolve(); });
+    expect(seen).toEqual([]);
+    await solve("hero-token");
+    expect(await screen.findByText(ANSWER)).toBeTruthy();
+    expect(seen).toEqual(["hero-token"]);
+  });
+
+  it("still fires immediately when no challenge is in play", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
+    vi.stubEnv("DEV", false);
+    const seen: (string | null)[] = [];
+    server.use(armedChatHandler("search", seen));
+    getAuthToken.mockResolvedValue("jwt-token");
+    renderChatPage(chatSearch({ q: "ユーフォ" }));
+    await waitFor(() => {
+      expect(seen).toEqual([null]);
+    });
+  });
+});

--- a/apps/web/tests/unit/chat/turnstile-gate.test.tsx
+++ b/apps/web/tests/unit/chat/turnstile-gate.test.tsx
@@ -5,13 +5,25 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   TURNSTILE_ACTION,
+  TURNSTILE_APPEARANCE,
   TURNSTILE_CALLBACK,
+  TURNSTILE_ERROR_CALLBACK,
+  TURNSTILE_EXPIRED_CALLBACK,
   TURNSTILE_SCRIPT_SRC,
+  TURNSTILE_SIZE,
+  TURNSTILE_TEST_SITE_KEY,
   TurnstileGate,
+  configuredTurnstileSiteKey,
   currentTurnstileSiteKey,
+  resetTurnstileWidget,
   resolveTurnstileSiteKey,
 } from "../../../src/components/TurnstileGate";
 import { chatDictFor } from "../../../src/features/chat/i18n";
+import {
+  clearTurnstileToken,
+  currentTurnstileToken,
+  rememberTurnstileToken,
+} from "../../../src/lib/turnstile/tokenStore";
 import { LOCALES } from "../../../src/i18n/locales";
 
 const SITE_KEY = "0x4AAAAAAAsitekey24chars";
@@ -19,6 +31,7 @@ const ja = chatDictFor("ja");
 
 afterEach(() => {
   cleanup();
+  clearTurnstileToken();
   vi.unstubAllEnvs();
   document.head.querySelectorAll("script").forEach((node) => {
     node.remove();
@@ -63,12 +76,92 @@ describe("site key shape assertion", () => {
   });
 });
 
+describe("optional site key (issue #447 mount decision)", () => {
+  it("reports no site key for an unconfigured production build", () => {
+    expect(configuredTurnstileSiteKey({ VITE_TURNSTILE_SITE_KEY: "" }, false)).toBeUndefined();
+    expect(configuredTurnstileSiteKey({}, false)).toBeUndefined();
+  });
+
+  it("falls back to Cloudflare's always-passing test key in dev", () => {
+    expect(configuredTurnstileSiteKey({}, true)).toBe(TURNSTILE_TEST_SITE_KEY);
+    expect(TURNSTILE_TEST_SITE_KEY).toHaveLength(24);
+  });
+
+  it("prefers a configured 24-character key over the dev fallback", () => {
+    expect(configuredTurnstileSiteKey({ VITE_TURNSTILE_SITE_KEY: SITE_KEY }, true)).toBe(SITE_KEY);
+  });
+
+  it("still throws on a secret-shaped value — a wrong key must never render", () => {
+    expect(() => configuredTurnstileSiteKey({ VITE_TURNSTILE_SITE_KEY: "x".repeat(35) }, true)).toThrow(/SECRET/);
+  });
+});
+
+describe("the widget says a token is no longer good", () => {
+  it("wires the error and expired callbacks Cloudflare invokes", () => {
+    render(<TurnstileGate dict={ja} siteKey={SITE_KEY} />);
+    expect(widget().getAttribute("data-error-callback")).toBe(TURNSTILE_ERROR_CALLBACK);
+    expect(widget().getAttribute("data-expired-callback")).toBe(TURNSTILE_EXPIRED_CALLBACK);
+  });
+
+  it("drops the held token when the challenge errors or the loader never comes up", () => {
+    render(<TurnstileGate dict={ja} siteKey={SITE_KEY} />);
+    rememberTurnstileToken("doomed-token");
+    window.onAnimichiTurnstileError?.();
+    expect(currentTurnstileToken()).toBeUndefined();
+  });
+
+  it("drops the held token once it expires, so no stale token is ever sent", () => {
+    render(<TurnstileGate dict={ja} siteKey={SITE_KEY} />);
+    rememberTurnstileToken("aged-token");
+    window.onAnimichiTurnstileExpired?.();
+    expect(currentTurnstileToken()).toBeUndefined();
+  });
+
+  it("removes both callbacks on unmount", () => {
+    render(<TurnstileGate dict={ja} siteKey={SITE_KEY} />).unmount();
+    expect(window.onAnimichiTurnstileError).toBeUndefined();
+    expect(window.onAnimichiTurnstileExpired).toBeUndefined();
+  });
+});
+
+describe("re-arming after a rejection", () => {
+  it("resets the widget so the retry does not replay a spent token", () => {
+    const reset = vi.fn();
+    window.turnstile = { reset };
+    resetTurnstileWidget();
+    expect(reset).toHaveBeenCalledTimes(1);
+    window.turnstile = undefined;
+  });
+
+  it("is a no-op before the loader has defined the global", () => {
+    window.turnstile = undefined;
+    expect(() => { resetTurnstileWidget(); }).not.toThrow();
+  });
+});
+
 describe("widget embed", () => {
   it("renders cf-turnstile with the site key and the mandatory data-action", () => {
     render(<TurnstileGate dict={ja} siteKey={SITE_KEY} />);
     expect(widget().getAttribute("data-sitekey")).toBe(SITE_KEY);
     expect(widget().getAttribute("data-action")).toBe(TURNSTILE_ACTION);
     expect(widget().getAttribute("data-callback")).toBe(TURNSTILE_CALLBACK);
+  });
+
+  it("stays out of the way until a human check is genuinely required", () => {
+    render(<TurnstileGate dict={ja} siteKey={SITE_KEY} />);
+    expect(TURNSTILE_APPEARANCE).toBe("interaction-only");
+    expect(widget().getAttribute("data-appearance")).toBe(TURNSTILE_APPEARANCE);
+    expect(widget().getAttribute("data-size")).toBe(TURNSTILE_SIZE);
+  });
+
+  it("follows the app's own day/night choice rather than the OS theme", () => {
+    document.documentElement.dataset.theme = "night";
+    render(<TurnstileGate dict={ja} siteKey={SITE_KEY} />);
+    expect(widget().getAttribute("data-theme")).toBe("dark");
+    document.documentElement.dataset.theme = "day";
+    cleanup();
+    render(<TurnstileGate dict={ja} siteKey={SITE_KEY} />);
+    expect(widget().getAttribute("data-theme")).toBe("light");
   });
 
   it("loads the official api.js once, async and deferred", () => {

--- a/apps/web/tests/unit/chat/turnstile-mount.test.tsx
+++ b/apps/web/tests/unit/chat/turnstile-mount.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #447: the widget is actually MOUNTED on the anonymous chat entry (the
+ * gate component itself is pinned by turnstile-gate.test.tsx). It sits in the
+ * dock's hint slot, only anonymous visitors load it, and the edge's retryable
+ * 403 surfaces as the challenge's own retry — never as "your session expired".
+ */
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { rememberTurnstileToken } from "../../../src/lib/turnstile/tokenStore";
+import { server } from "../../msw/node";
+import { chatStreamHandler, chatTurnstileRequiredHandler } from "../../msw/chat-handlers";
+import { setLanguages } from "../_i18n";
+import { renderChatPage } from "./_chat-page";
+
+const { getAuthToken } = vi.hoisted(() => ({ getAuthToken: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../../../src/lib/auth/authSession", () => ({
+  getAuthToken,
+  clearAuthToken: () => undefined,
+  authHeaders: async () => {
+    const token = (await getAuthToken()) as string | undefined;
+    return token === undefined ? {} : { Authorization: `Bearer ${token}` };
+  },
+}));
+
+const SITE_KEY = "0x4AAAAAAAsitekey24chars";
+const ja = chatDictFor("ja");
+
+beforeEach(() => {
+  setLanguages(["ja"]);
+  getAuthToken.mockReset().mockResolvedValue(undefined);
+  vi.stubEnv("VITE_TURNSTILE_SITE_KEY", SITE_KEY);
+});
+
+function widget(): Element | null {
+  return document.querySelector(".cf-turnstile");
+}
+
+/** Drive the widget's own `data-callback`, the only source of a token. */
+async function solve(token: string): Promise<void> {
+  await act(async () => {
+    window.onAnimichiTurnstile?.(token);
+    await Promise.resolve();
+  });
+}
+
+function sendText(text: string) {
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: text } });
+  fireEvent.click(screen.getByRole("button", { name: ja.send }));
+}
+
+describe("who gets the widget", () => {
+  it("mounts it for an anonymous visitor, carrying the configured site key", async () => {
+    renderChatPage();
+    await waitFor(() => {
+      expect(widget()).not.toBeNull();
+    });
+    expect(widget()?.getAttribute("data-sitekey")).toBe(SITE_KEY);
+  });
+
+  it("keeps it inside the dock, after the composer rather than above the thread", async () => {
+    renderChatPage();
+    await waitFor(() => {
+      expect(widget()).not.toBeNull();
+    });
+    const input = document.querySelector(".chat-input");
+    const gate = document.querySelector(".turnstile-gate");
+    expect(input?.nextElementSibling).toBe(gate);
+  });
+
+  it("never loads it for a signed-in visitor", async () => {
+    getAuthToken.mockResolvedValue("jwt-token");
+    renderChatPage();
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toBeTruthy();
+    });
+    expect(widget()).toBeNull();
+  });
+
+  it("renders nothing when a production build configured no site key", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
+    vi.stubEnv("DEV", false);
+    renderChatPage();
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toBeTruthy();
+    });
+    expect(widget()).toBeNull();
+  });
+});
+
+/**
+ * P1-3 (#447 review): suppressing the failure strip is only safe while a widget
+ * exists to offer the recovery. A misconfigured deployment — no site key, or an
+ * edge with no TURNSTILE_SECRET, both of which 403 every turn — must not leave
+ * the visitor staring at a chat that silently does nothing.
+ */
+describe("a misconfigured build still shows the failure", () => {
+  it("falls back to the generic retry strip when no widget can be rendered", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
+    vi.stubEnv("DEV", false);
+    server.use(chatTurnstileRequiredHandler());
+    renderChatPage();
+    sendText("ユーフォ");
+    expect(await screen.findByText(ja.errorStates.d4Message)).toBeTruthy();
+    expect(screen.getByRole("button", { name: ja.errorStates.d4Retry })).toBeTruthy();
+    expect(widget()).toBeNull();
+  });
+
+  it("never tells a challenged anonymous visitor their session expired", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
+    vi.stubEnv("DEV", false);
+    server.use(chatTurnstileRequiredHandler());
+    renderChatPage();
+    sendText("ユーフォ");
+    await screen.findByText(ja.errorStates.d4Message);
+    expect(screen.queryByText(ja.errorStates.d8Message)).toBeNull();
+    expect(screen.queryByRole("button", { name: ja.errorStates.d8Login })).toBeNull();
+  });
+});
+
+/** The transport waits for a token before sending, so a turn only reaches the
+ * edge's rejection when one is held — i.e. a spent or expired token. */
+function seedSpentToken(): void {
+  rememberTurnstileToken("spent-token");
+}
+
+describe("the edge rejects the turn", () => {
+  it("offers the challenge's own retry instead of the expired-session banner", async () => {
+    server.use(chatTurnstileRequiredHandler());
+    renderChatPage();
+    seedSpentToken();
+    sendText("ユーフォ");
+    expect(await screen.findByText(ja.turnstile.failed)).toBeTruthy();
+    expect(screen.queryByText(ja.errorStates.d8Message)).toBeNull();
+    expect(screen.queryByRole("button", { name: ja.errorStates.d8Login })).toBeNull();
+  });
+
+  it("resends the rejected turn once the visitor retries", async () => {
+    const seen: Request[] = [];
+    server.use(chatTurnstileRequiredHandler((request) => seen.push(request)));
+    renderChatPage();
+    seedSpentToken();
+    sendText("ユーフォ");
+    await screen.findByText(ja.turnstile.failed);
+    server.use(chatStreamHandler("search"));
+    fireEvent.click(screen.getByRole("button", { name: ja.turnstile.retry }));
+    await solve("fresh-token");
+    expect(await screen.findByText("宇治の聖地を2件、徒歩ルートにまとめました。")).toBeTruthy();
+    expect(seen).toHaveLength(1);
+  });
+
+  it("re-arms the widget on retry — a spent token would only be rejected again", async () => {
+    const reset = vi.fn();
+    window.turnstile = { reset };
+    server.use(chatTurnstileRequiredHandler());
+    renderChatPage();
+    seedSpentToken();
+    sendText("ユーフォ");
+    await screen.findByText(ja.turnstile.failed);
+    fireEvent.click(screen.getByRole("button", { name: ja.turnstile.retry }));
+    expect(reset).toHaveBeenCalledTimes(1);
+    window.turnstile = undefined;
+  });
+
+  it("clears the challenge once a turn succeeds", async () => {
+    server.use(chatTurnstileRequiredHandler());
+    renderChatPage();
+    seedSpentToken();
+    sendText("ユーフォ");
+    await screen.findByText(ja.turnstile.failed);
+    server.use(chatStreamHandler("search"));
+    fireEvent.click(screen.getByRole("button", { name: ja.turnstile.retry }));
+    await solve("fresh-token");
+    await screen.findByText("宇治の聖地を2件、徒歩ルートにまとめました。");
+    expect(screen.queryByText(ja.turnstile.failed)).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/chat/turnstile-photo-search.test.tsx
+++ b/apps/web/tests/unit/chat/turnstile-photo-search.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #447 review (merged-state blocker): #445 put `/v1/photo-search` on the
+ * anonymous allowlist, so once both land the armed gate challenges photo
+ * uploads too. Photo has no challenge UI of its own, so it must (a) wait for
+ * the widget's token like chat does, and (b) say "redo the check" rather than
+ * "photo search failed" when the edge rejects it.
+ */
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatActionsProvider } from "../../../src/features/chat/chat-actions";
+import { PhotoSearchUpload } from "../../../src/features/chat/components/PhotoSearchUpload";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { sessionHeaders } from "../../../src/features/chat/session-headers";
+import {
+  clearTurnstileToken,
+  rememberTurnstileToken,
+} from "../../../src/lib/turnstile/tokenStore";
+import { TEST_ORIGIN } from "../../msw/fixtures";
+import { server } from "../../msw/node";
+import { makeJpegWithExif } from "../shiori/_jpegFixtures";
+
+const dict = chatDictFor("ja");
+const URL = `${TEST_ORIGIN}/v1/photo-search`;
+const SITE_KEY = "0x4AAAAAAAsitekey24chars";
+const OK_ENVELOPE = { success: true, status: "ok", intent: "clarify", data: {} };
+const CHALLENGED = {
+  error: { code: "turnstile_required", message: "Turnstile verification required.", retryable: true },
+};
+
+beforeEach(() => {
+  clearTurnstileToken();
+  vi.stubEnv("VITE_TURNSTILE_SITE_KEY", SITE_KEY);
+});
+
+afterEach(() => {
+  cleanup();
+  clearTurnstileToken();
+});
+
+function renderUpload() {
+  render(
+    <ChatActionsProvider actions={{ send: vi.fn(), regenerate: vi.fn() }}>
+      <PhotoSearchUpload dict={dict} baseUrl={TEST_ORIGIN} context={{ locale: "ja" }} />
+    </ChatActionsProvider>,
+  );
+}
+
+function upload() {
+  const bytes = makeJpegWithExif() as Uint8Array<ArrayBuffer>;
+  const file = new File([bytes], "photo.jpg", { type: "image/jpeg" });
+  fireEvent.change(screen.getByLabelText(dict.photo.upload), { target: { files: [file] } });
+}
+
+/** Record the token each upload carried (null when it went out unchallenged). */
+function tokenSpy(seen: (string | null)[], body: object = OK_ENVELOPE, status = 200) {
+  server.use(
+    http.post(URL, ({ request }) => {
+      seen.push(request.headers.get("cf-turnstile-response"));
+      return HttpResponse.json(body, { status });
+    }),
+  );
+}
+
+/** Drain the microtask queue — enough turns that any promise NOT waiting on
+ * the widget would have settled. Deterministic: no clock, no timers. */
+async function flush(): Promise<void> {
+  for (let turn = 0; turn < 20; turn += 1) await Promise.resolve();
+}
+
+describe("the shared header path waits for the widget", () => {
+  // Pinned at the header layer, not through the component: an upload spends
+  // several async turns on EXIF-stripping and base64 before its headers are
+  // read, so a token solved during that window would be picked up even by a
+  // transport that never waits — the component-level test below cannot tell
+  // the two apart, and a mutation that drops the wait survives it.
+  it("does not resolve an anonymous request's headers until a token exists", async () => {
+    let settled = false;
+    const pending = sessionHeaders();
+    void pending.then(() => { settled = true; });
+    await flush();
+    expect(settled).toBe(false);
+    rememberTurnstileToken("late-token");
+    expect(await pending).toEqual({ "cf-turnstile-response": "late-token" });
+  });
+
+  it("resolves headers straight away when this build renders no widget", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
+    vi.stubEnv("DEV", false);
+    let settled = false;
+    void sessionHeaders().then(() => { settled = true; });
+    await flush();
+    expect(settled).toBe(true);
+  });
+
+});
+
+describe("an upload waits for the challenge instead of walking into a 403", () => {
+  it("holds the request until the widget has solved, then carries the token", async () => {
+    const seen: (string | null)[] = [];
+    tokenSpy(seen);
+    renderUpload();
+    upload();
+    await flush();
+    expect(seen).toEqual([]);
+    rememberTurnstileToken("photo-token");
+    await waitFor(() => {
+      expect(seen).toEqual(["photo-token"]);
+    });
+  });
+
+  it("sends immediately when a token is already held", async () => {
+    const seen: (string | null)[] = [];
+    tokenSpy(seen);
+    rememberTurnstileToken("held-token");
+    renderUpload();
+    upload();
+    await waitFor(() => {
+      expect(seen).toEqual(["held-token"]);
+    });
+  });
+
+  it("does not wait at all when this build renders no widget", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
+    vi.stubEnv("DEV", false);
+    const seen: (string | null)[] = [];
+    tokenSpy(seen);
+    renderUpload();
+    upload();
+    await waitFor(() => {
+      expect(seen).toEqual([null]);
+    });
+  });
+});
+
+describe("a challenged upload is not a broken upload", () => {
+  it("shows the redo-the-check copy, never the photo failure copy", async () => {
+    rememberTurnstileToken("stale-token");
+    tokenSpy([], CHALLENGED, 403);
+    renderUpload();
+    upload();
+    expect(await screen.findByText(dict.turnstile.failed, { exact: false })).toBeTruthy();
+    expect(screen.queryByText(dict.photo.failed, { exact: false })).toBeNull();
+  });
+
+  it("still reports a genuine backend failure as a photo failure", async () => {
+    rememberTurnstileToken("good-token");
+    tokenSpy([], { error: { code: "photo_search_unavailable" } }, 500);
+    renderUpload();
+    upload();
+    expect(await screen.findByText(dict.photo.failed, { exact: false })).toBeTruthy();
+    expect(screen.queryByText(dict.turnstile.failed, { exact: false })).toBeNull();
+  });
+
+  it("keeps the retry affordance on a challenged upload", async () => {
+    rememberTurnstileToken("stale-token");
+    tokenSpy([], CHALLENGED, 403);
+    renderUpload();
+    upload();
+    await screen.findByText(dict.turnstile.failed, { exact: false });
+    expect(screen.getByRole("button", { name: dict.photo.retry })).toBeTruthy();
+  });
+});

--- a/apps/web/tests/unit/chat/turnstile-token-store.test.ts
+++ b/apps/web/tests/unit/chat/turnstile-token-store.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   TURNSTILE_HEADER,
   TURNSTILE_TOKEN_TTL_MS,
+  awaitTurnstileToken,
   clearTurnstileToken,
   currentTurnstileToken,
+  onTurnstileToken,
   rememberTurnstileToken,
   turnstileHeaders,
 } from "../../../src/lib/turnstile/tokenStore";
@@ -81,5 +83,41 @@ describe("the cf-turnstile-response wire name", () => {
     rememberTurnstileToken("solved", 0);
     expect(turnstileHeaders(0)).toEqual({ "cf-turnstile-response": "solved" });
     clearTurnstileToken();
+  });
+});
+
+describe("waiting for a token (issue #447 review)", () => {
+  it("resolves a parked caller the moment the widget solves", async () => {
+    const pending = awaitTurnstileToken();
+    rememberTurnstileToken("late-token");
+    expect(await pending).toBe("late-token");
+  });
+
+  it("resolves immediately when a token is already held", async () => {
+    rememberTurnstileToken("held-token");
+    expect(await awaitTurnstileToken()).toBe("held-token");
+  });
+
+  it("abandons parked callers when the token is cleared, leaving no live timer", async () => {
+    const pending = awaitTurnstileToken();
+    clearTurnstileToken();
+    expect(await pending).toBeUndefined();
+  });
+
+  it("gives up once the wait elapses rather than parking forever", async () => {
+    vi.useFakeTimers();
+    const pending = awaitTurnstileToken(1_000);
+    vi.advanceTimersByTime(1_001);
+    await expect(pending).resolves.toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("notifies every subscriber and stops after unsubscribe", () => {
+    const seen: string[] = [];
+    const stop = onTurnstileToken((token) => seen.push(token));
+    rememberTurnstileToken("first");
+    stop();
+    rememberTurnstileToken("second");
+    expect(seen).toEqual(["first"]);
   });
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
     css: true,
     include: ["tests/unit/**/*.test.ts", "tests/unit/**/*.test.tsx"],
     globalSetup: ["tests/setup/generate-route-tree.ts"],
-    setupFiles: ["tests/setup/auth-hermetic.ts", "tests/setup/msw-lifecycle.ts"],
+    setupFiles: [
+      "tests/setup/auth-hermetic.ts",
+      "tests/setup/turnstile-hermetic.ts",
+      "tests/setup/msw-lifecycle.ts",
+    ],
     environmentOptions: { jsdom: { url: "http://localhost:3000" } },
     coverage: {
       provider: "istanbul",

--- a/e2e/web-chat-anonymous.spec.ts
+++ b/e2e/web-chat-anonymous.spec.ts
@@ -3,6 +3,12 @@ import type { Page } from "@playwright/test";
 import { chatDictFor } from "../apps/web/src/features/chat/i18n";
 import { SSE_HEADERS, chatStreamRecording } from "./fixtures/chat-stream";
 
+declare global {
+  interface Window {
+    onAnimichiTurnstile?: (token: string) => void;
+  }
+}
+
 /**
  * Issue #274 (S1.8) browser ACs: the whole chat round-trip is reachable without
  * a session, and the edge rate limit surfaces as in-character copy rather than
@@ -86,6 +92,17 @@ async function blockTurnstileLoader(page: Page): Promise<void> {
   await page.route("https://challenges.cloudflare.com/**", (route) => route.abort());
 }
 
+/**
+ * Hand the page a token through the widget's own callback. The transport waits
+ * for one before sending an anonymous turn, so with the real loader blocked
+ * this is what lets a turn reach the (stubbed) edge at all — and a token the
+ * edge then rejects is exactly a spent or expired one.
+ */
+async function solveChallenge(page: Page, token: string): Promise<void> {
+  await page.waitForFunction(() => typeof window.onAnimichiTurnstile === "function");
+  await page.evaluate((value) => { window.onAnimichiTurnstile?.(value); }, token);
+}
+
 test("the anonymous entry carries the challenge widget in the dock, not in the thread", async ({ page }) => {
   await blockTurnstileLoader(page);
   await openChat(page);
@@ -107,6 +124,7 @@ test("a challenged anonymous turn offers the check retry, never a login prompt",
     }),
   );
   await openChat(page);
+  await solveChallenge(page, "spent-token");
   await send(page, "ユーフォ");
   await expect(page.getByText(ja.turnstile.failed)).toBeVisible();
   await expect(page.getByRole("button", { name: ja.turnstile.retry })).toBeVisible();

--- a/e2e/web-chat-anonymous.spec.ts
+++ b/e2e/web-chat-anonymous.spec.ts
@@ -75,3 +75,41 @@ test("the anonymous budget breaker guides the visitor to login instead of failin
   await expect(page.getByRole("button", { name: states.d11Login })).toBeVisible();
   await expect(page.getByText(states.d8Message)).toHaveCount(0);
 });
+
+/**
+ * Issue #447: the edge Turnstile gate is armed on the anonymous branch, so the
+ * anonymous entry must both carry the widget and handle the edge's retryable
+ * rejection. `api.js` is blocked here — the widget's contract with the page is
+ * the `cf-turnstile` element and its data-attributes, not Cloudflare's iframe.
+ */
+async function blockTurnstileLoader(page: Page): Promise<void> {
+  await page.route("https://challenges.cloudflare.com/**", (route) => route.abort());
+}
+
+test("the anonymous entry carries the challenge widget in the dock, not in the thread", async ({ page }) => {
+  await blockTurnstileLoader(page);
+  await openChat(page);
+  const widget = page.locator(".turnstile-gate .cf-turnstile");
+  await expect(widget).toHaveAttribute("data-sitekey", /^.{24}$/);
+  await expect(widget).toHaveAttribute("data-appearance", "interaction-only");
+  await expect(page.locator(".chat-input + .turnstile-gate")).toHaveCount(1);
+});
+
+test("a challenged anonymous turn offers the check retry, never a login prompt", async ({ page }) => {
+  await blockTurnstileLoader(page);
+  await page.route("**/v1/chat", (route) =>
+    route.fulfill({
+      status: 403,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        error: { code: "turnstile_required", message: "Turnstile verification required.", retryable: true },
+      }),
+    }),
+  );
+  await openChat(page);
+  await send(page, "ユーフォ");
+  await expect(page.getByText(ja.turnstile.failed)).toBeVisible();
+  await expect(page.getByRole("button", { name: ja.turnstile.retry })).toBeVisible();
+  await expect(page.getByText(states.d8Message)).toHaveCount(0);
+  await expect(page.getByRole("button", { name: states.d8Login })).toHaveCount(0);
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:frontend": "pnpm --filter ./frontend run build",
     "deploy": "pnpm run build:frontend && npx wrangler deploy",
     "lint:oxlint": "pnpm --filter catalog --filter users --filter web run lint:oxlint",
-    "test:worker": "node --test worker/entry.test.ts worker/photoSearch.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/edgeGuard.test.ts worker/authRateLimitScope.test.ts"
+    "test:worker": "node --test worker/entry.test.ts worker/photoSearch.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/turnstileArm.test.ts worker/turnstileReplay.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/edgeGuard.test.ts worker/authRateLimitScope.test.ts"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",

--- a/worker/anonymous.test.ts
+++ b/worker/anonymous.test.ts
@@ -7,7 +7,11 @@ import { handleGuardRequest } from "./edgeGuard.ts";
 import { memoryGuardStore, type GuardStore } from "./guardStore.ts";
 
 const SECRET = "fixed-test-hmac-key-0000000000000000";
-const ANON_ENV = { ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: SECRET };
+const ANON_ENV = {
+  ANON_ACCESS_ENABLED: "true",
+  ANON_ID_SECRET: SECRET,
+  TURNSTILE_SECRET: "fixed-test-turnstile-secret-0000000",
+};
 const NOW = Date.UTC(2026, 6, 26, 12, 0, 0);
 
 const stubNext = { fetch: () => Promise.resolve(new Response("next", { status: 200 })) };
@@ -48,8 +52,17 @@ function anonEnv(captured: { requests: Request[] }, container: () => Response, g
   } as never;
 }
 
+/** These tests are about the anonymous branch itself, so the Turnstile gate
+ * (armed in #447) is stubbed to a pass. `turnstileArm.test.ts` owns the
+ * challenge behaviour. */
+const passingGate = { check: () => Promise.resolve({ ok: true, errorCodes: [] }) };
+
 function anonApp() {
-  return createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" }) });
+  return createWorkerApp({
+    nextHandler: stubNext,
+    authenticate: () => Promise.resolve({ ok: false, reason: "absent" }),
+    turnstileGate: passingGate,
+  });
 }
 
 function chat(headers: Record<string, string> = {}) {

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -20,6 +20,7 @@ import {
   checkRateLimit,
   rateLimitConfigFrom,
 } from "./rateLimiter.ts";
+import { type TurnstileGate, createTurnstileGate, guardTurnstile } from "./turnstile.ts";
 
 export interface Env {
   CATALOG: { fetch: (req: Request) => Promise<Response> };
@@ -185,12 +186,23 @@ async function anonymousForward(
  * anonymous access is not enabled (leaving the caller on the 401 path). The
  * limiter fails open — a guard outage must not take chat down — while the
  * budget breaker fails closed only on an explicit container verdict.
+ *
+ * Issue #447 arms the S1.9 Turnstile gate here, and the order is the point:
+ *  - AFTER `resolveAnonymous`, so a challenge is only ever raised for a caller
+ *    we would otherwise have served anonymously (anonymous access off still
+ *    means 401, never 403);
+ *  - BEFORE the limiter and the container, because the challenge is the outer
+ *    wall. Cookie-only identity is free to reset, which resets the per-identity
+ *    bucket with it; an unsolved turn must therefore cost neither a bucket slot
+ *    (legitimate visitors would pay for their own challenges) nor an LLM call.
  */
 export async function handleAnonymousV1(
-  env: Env, request: Request, nowMs: number,
+  env: Env, request: Request, nowMs: number, gate: TurnstileGate,
 ): Promise<Response | null> {
   const identity = await resolveAnonymous(request, env);
   if (identity === null) return null;
+  const challenged = await guardTurnstile(request, env, gate, identity.userId);
+  if (challenged !== null) return challenged;
   const limit = await checkRateLimit(env.EDGE_GUARD, identity.userId, rateLimitConfigFrom(env));
   if (limit !== null && !limit.allowed) return rateLimitedResponse(limit.retryAfterSeconds);
   const response = await anonymousForward(env, request, identity, utcDayKey(nowMs));
@@ -253,9 +265,14 @@ async function handleImageProxy(request: Request, ctx: WorkerExecutionContext): 
 export function createWorkerApp(deps: {
   nextHandler: NextHandler;
   authenticate?: (request: Request, env: Env, ctx: WorkerExecutionContext) => Promise<AuthResult>;
+  turnstileGate?: TurnstileGate;
 }): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
   const authenticate = deps.authenticate ?? ((req, env, ctx) => realAuthenticate(req, env, fetch, ctx));
+  // One gate per app instance, built outside the request handler so its
+  // short-lived pass window is shared by every request on the same isolate —
+  // that window is what stops a visitor being re-challenged per message.
+  const turnstileGate = deps.turnstileGate ?? createTurnstileGate();
   app.get("/healthz", (c) =>
     c.env.CONTAINER.get(c.env.CONTAINER.idFromName("default")).fetch(c.req.raw),
   );
@@ -278,24 +295,18 @@ export function createWorkerApp(deps: {
     if (auth.ok) {
       return authenticatedForward(c.env, c.req.raw, { userId: auth.userId, userType: auth.userType }, pathname);
     }
-    // S1.9 Turnstile (issue #281) is MERGED but still DORMANT: the gate lives in
-    // ./turnstile.ts and nothing below calls it. This branch — anonymous access
-    // (#274) — is the surface it was written to guard, and it ships
-    // ANON_ACCESS_ENABLED="false" in production precisely because until the gate
-    // is armed, dropping the `aid` cookie mints a fresh identity and resets the
-    // per-identity limiter, leaving the daily dollar breaker as the only guard.
-    // To arm it, wrap the anonymous branch:
-    //   const denied = await guardTurnstile(c.req.raw, c.env, turnstileGate);
-    //   if (denied !== null) return denied;
-    // (`turnstileGate` = module-level createTurnstileGate() from ./turnstile.ts,
-    // so its short-lived window is shared across requests on the same isolate.)
+    // S1.9 Turnstile (issue #281) is ARMED as of issue #447: `handleAnonymousV1`
+    // below challenges every anonymous turn before it can reach the limiter or
+    // the container. Without it, dropping the `aid` cookie mints a fresh
+    // identity and resets the per-identity limiter, leaving the daily dollar
+    // breaker as the only guard — i.e. a paid-for daily DoS.
     // Issue #441: only a caller who presented NO credential may be demoted to
     // an anonymous identity. A presented-but-unverifiable one (expired,
     // malformed, wrong key) falls straight through to the 401 below, which is
     // what puts the web client back on its token-refresh path.
     if (auth.reason === "invalid") return unauthorized(pathname);
     const anonymous = isAnonymousV1(pathname)
-      ? await handleAnonymousV1(c.env, c.req.raw, Date.now())
+      ? await handleAnonymousV1(c.env, c.req.raw, Date.now(), turnstileGate)
       : null;
     if (anonymous !== null) return anonymous;
     return c.json(UNAUTHORIZED_BODY, 401);

--- a/worker/authFallthrough.test.ts
+++ b/worker/authFallthrough.test.ts
@@ -115,6 +115,7 @@ function fakeGuard() {
 function anonEnv(captured: { requests: Request[] }) {
   return {
     ANON_ACCESS_ENABLED: "true",
+    TURNSTILE_SECRET: "fixed-test-turnstile-secret-0000000",
     ANON_ID_SECRET: SECRET,
     EDGE_GUARD: fakeGuard(),
     CONTAINER: {
@@ -129,8 +130,16 @@ function anonEnv(captured: { requests: Request[] }) {
   } as never;
 }
 
+/** #441 is about which credential verdict may become anonymous, so the #447
+ * Turnstile gate is stubbed to a pass here; `turnstileArm.test.ts` owns it. */
+const passingGate = { check: () => Promise.resolve({ ok: true, errorCodes: [] }) };
+
 function appWith(result: AuthResult) {
-  return createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve(result) });
+  return createWorkerApp({
+    nextHandler: stubNext,
+    authenticate: () => Promise.resolve(result),
+    turnstileGate: passingGate,
+  });
 }
 
 void test("an invalid credential 401s instead of becoming anonymous", async () => {

--- a/worker/byok.test.ts
+++ b/worker/byok.test.ts
@@ -118,9 +118,18 @@ void test("user A's burst never consumes user B's allowance", async () => {
 
 void test("an anonymous caller's allowance is unaffected by authenticated traffic", async () => {
   const guard = fakeGuard();
-  const e = env(guard, { AUTH_RATE_LIMIT: "1", ANON_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: "fixed-test-hmac-key-0000000000000000" });
+  const e = env(guard, {
+    AUTH_RATE_LIMIT: "1", ANON_RATE_LIMIT: "1", ANON_ACCESS_ENABLED: "true",
+    ANON_ID_SECRET: "fixed-test-hmac-key-0000000000000000",
+    TURNSTILE_SECRET: "fixed-test-turnstile-secret-0000000",
+  });
   await authedApp("user-a").request("/v1/chat", req("/v1/chat"), e, stubCtx);
-  const anonApp = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false, reason: "absent" } as const) });
+  // The scope under test is the rate limiter, not the #447 Turnstile gate.
+  const anonApp = createWorkerApp({
+    nextHandler: stubNext,
+    authenticate: () => Promise.resolve({ ok: false, reason: "absent" } as const),
+    turnstileGate: { check: () => Promise.resolve({ ok: true, errorCodes: [] }) },
+  });
   const res = await anonApp.request("/v1/chat", { method: "POST", headers: {} }, e, stubCtx);
   assert.equal(res.status, 200);
 });

--- a/worker/photoSearch.test.ts
+++ b/worker/photoSearch.test.ts
@@ -35,9 +35,19 @@ function fakeGuard() {
   };
 }
 
+/** #260's subject is identity + header hygiene on the photo routes, not the
+ * #447 Turnstile gate — `turnstileArm.test.ts` owns the challenge behaviour. */
+const passingGate = { check: () => Promise.resolve({ ok: true, errorCodes: [] }) };
+
 function envWith(captured: { requests: Request[] }, anonEnabled: boolean) {
   return {
-    ...(anonEnabled ? { ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: SECRET } : {}),
+    ...(anonEnabled
+      ? {
+          ANON_ACCESS_ENABLED: "true",
+          ANON_ID_SECRET: SECRET,
+          TURNSTILE_SECRET: "fixed-test-turnstile-secret-0000000",
+        }
+      : {}),
     EDGE_GUARD: fakeGuard(),
     CONTAINER: {
       idFromName: () => "id",
@@ -50,7 +60,7 @@ function envWith(captured: { requests: Request[] }, anonEnabled: boolean) {
 
 void test("authed /v1/photo-search forwards with worker identity, byok stripped, session kept", async () => {
   const authenticate = () => Promise.resolve({ ok: true, userId: "u1", userType: "human" } as const);
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate });
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate, turnstileGate: passingGate });
   const cap = { requests: [] as Request[] };
   const headers = {
     Authorization: "Bearer jwt",
@@ -70,7 +80,11 @@ void test("authed /v1/photo-search forwards with worker identity, byok stripped,
 });
 
 void test("unauthenticated /v1/photo-search with anon disabled -> 401, container not hit", async () => {
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
+  const app = createWorkerApp({
+    nextHandler: stubNext,
+    authenticate: () => Promise.resolve({ ok: false }),
+    turnstileGate: passingGate,
+  });
   const cap = { requests: [] as Request[] };
   const res = await app.request("/v1/photo-search", { method: "POST" }, envWith(cap, false), stubCtx);
   assert.equal(res.status, 401);
@@ -78,7 +92,11 @@ void test("unauthenticated /v1/photo-search with anon disabled -> 401, container
 });
 
 void test("unauthenticated /v1/photo-search with anon enabled -> minted anonymous identity", async () => {
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
+  const app = createWorkerApp({
+    nextHandler: stubNext,
+    authenticate: () => Promise.resolve({ ok: false }),
+    turnstileGate: passingGate,
+  });
   const cap = { requests: [] as Request[] };
   const res = await app.request("/v1/photo-search", { method: "POST" }, envWith(cap, true), stubCtx);
   assert.equal(await res.text(), "container");
@@ -89,7 +107,11 @@ void test("unauthenticated /v1/photo-search with anon enabled -> minted anonymou
 });
 
 void test("/v1/photo-search/confirm rides the same gate (401 when anon disabled)", async () => {
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
+  const app = createWorkerApp({
+    nextHandler: stubNext,
+    authenticate: () => Promise.resolve({ ok: false }),
+    turnstileGate: passingGate,
+  });
   const cap = { requests: [] as Request[] };
   const res = await app.request("/v1/photo-search/confirm", { method: "POST" }, envWith(cap, false), stubCtx);
   assert.equal(res.status, 401);
@@ -98,7 +120,7 @@ void test("/v1/photo-search/confirm rides the same gate (401 when anon disabled)
 
 void test("/v1/photo-search/confirm forwards for an authed caller", async () => {
   const authenticate = () => Promise.resolve({ ok: true, userId: "u1", userType: "human" } as const);
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate });
+  const app = createWorkerApp({ nextHandler: stubNext, authenticate, turnstileGate: passingGate });
   const cap = { requests: [] as Request[] };
   const res = await app.request("/v1/photo-search/confirm", { method: "POST" }, envWith(cap, false), stubCtx);
   assert.equal(await res.text(), "container");
@@ -106,7 +128,11 @@ void test("/v1/photo-search/confirm forwards for an authed caller", async () => 
 });
 
 void test("x-byok-endpoint is stripped on the anonymous path too", async () => {
-  const app = createWorkerApp({ nextHandler: stubNext, authenticate: () => Promise.resolve({ ok: false }) });
+  const app = createWorkerApp({
+    nextHandler: stubNext,
+    authenticate: () => Promise.resolve({ ok: false }),
+    turnstileGate: passingGate,
+  });
   const cap = { requests: [] as Request[] };
   await app.request(
     "/v1/photo-search",

--- a/worker/turnstile.test.ts
+++ b/worker/turnstile.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   TURNSTILE_HEADER,
+  type TurnstileResult,
   createTurnstileGate,
   guardTurnstile,
   verifySiteverify,
@@ -9,6 +10,8 @@ import {
 
 const SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
 const ENV = { TURNSTILE_SECRET: "test-secret-not-a-real-value" };
+/** The anonymous identity the pass window is scoped to (issue #447). */
+const ID = "anon_0123456789abcdef0123456789abcdef";
 
 interface Call {
   readonly url: string;
@@ -38,7 +41,7 @@ async function anonymousV1(
   gate: ReturnType<typeof createTurnstileGate>,
   forward: () => Response,
 ): Promise<Response> {
-  const denied = await guardTurnstile(req, ENV, gate);
+  const denied = await guardTurnstile(req, ENV, gate, ID);
   return denied ?? forward();
 }
 
@@ -58,7 +61,7 @@ void test("AC1: a solved token verifies at siteverify and the turn is forwarded"
 void test("AC1: the siteverify call matches the canonical contract exactly", async () => {
   const calls: Call[] = [];
   const gate = createTurnstileGate({ fetchImpl: stubFetch(calls, true), now: () => 0 });
-  await guardTurnstile(request("solved-token"), ENV, gate);
+  await guardTurnstile(request("solved-token"), ENV, gate, ID);
   const call = calls[0];
   assert.ok(call);
   assert.equal(call.url, SITEVERIFY_URL);
@@ -88,7 +91,7 @@ void test("AC3: the rejection envelope is retryable and leaks no siteverify code
     fetchImpl: stubFetch([], false, ["invalid-input-secret"]),
     now: () => 0,
   });
-  const res = await guardTurnstile(request("expired-token"), ENV, gate);
+  const res = await guardTurnstile(request("expired-token"), ENV, gate, ID);
   assert.ok(res);
   const body = await res.text();
   assert.match(body, /"code":"turnstile_required"/);
@@ -99,7 +102,7 @@ void test("AC3: the rejection envelope is retryable and leaks no siteverify code
 void test("AC3: a missing token is rejected without calling siteverify at all", async () => {
   const calls: Call[] = [];
   const gate = createTurnstileGate({ fetchImpl: stubFetch(calls, true), now: () => 0 });
-  const res = await guardTurnstile(request(), ENV, gate);
+  const res = await guardTurnstile(request(), ENV, gate, ID);
   assert.equal(res?.status, 403);
   assert.equal(calls.length, 0);
 });
@@ -117,11 +120,11 @@ void test("AC2: the same token is not re-verified for later turns inside the win
   const clock = { ms: 1_000 };
   const calls: Call[] = [];
   const gate = clockGate(clock, calls);
-  assert.equal(await guardTurnstile(request("t1"), ENV, gate), null);
+  assert.equal(await guardTurnstile(request("t1"), ENV, gate, ID), null);
   clock.ms = 30_000;
-  assert.equal(await guardTurnstile(request("t1"), ENV, gate), null);
+  assert.equal(await guardTurnstile(request("t1"), ENV, gate, ID), null);
   clock.ms = 60_000;
-  assert.equal(await guardTurnstile(request("t1"), ENV, gate), null);
+  assert.equal(await guardTurnstile(request("t1"), ENV, gate, ID), null);
   assert.equal(calls.length, 1);
 });
 
@@ -129,9 +132,9 @@ void test("AC2: once the window closes the token is verified again", async () =>
   const clock = { ms: 1_000 };
   const calls: Call[] = [];
   const gate = clockGate(clock, calls);
-  await guardTurnstile(request("t1"), ENV, gate);
+  await guardTurnstile(request("t1"), ENV, gate, ID);
   clock.ms = 61_001;
-  await guardTurnstile(request("t1"), ENV, gate);
+  await guardTurnstile(request("t1"), ENV, gate, ID);
   assert.equal(calls.length, 2);
 });
 
@@ -139,17 +142,69 @@ void test("AC2: a different token inside the window is verified on its own", asy
   const clock = { ms: 1_000 };
   const calls: Call[] = [];
   const gate = clockGate(clock, calls);
-  await guardTurnstile(request("t1"), ENV, gate);
-  await guardTurnstile(request("t2"), ENV, gate);
+  await guardTurnstile(request("t1"), ENV, gate, ID);
+  await guardTurnstile(request("t2"), ENV, gate, ID);
   assert.equal(calls.length, 2);
+});
+
+/** P1-1 (#447 review): the window must not be a cross-identity pass. */
+void test("another identity replaying the same token is verified again", async () => {
+  const clock = { ms: 1_000 };
+  const calls: Call[] = [];
+  const gate = clockGate(clock, calls);
+  assert.equal(await guardTurnstile(request("t1"), ENV, gate, ID), null);
+  await guardTurnstile(request("t1"), ENV, gate, "anon_ffffffffffffffffffffffffffffffff");
+  assert.equal(calls.length, 2);
+});
+
+void test("a replay whose siteverify verdict is timeout-or-duplicate is rejected", async () => {
+  const calls: Call[] = [];
+  const gate = createTurnstileGate({
+    fetchImpl: stubFetch(calls, false, ["timeout-or-duplicate"]),
+    now: () => 0,
+  });
+  const res = await guardTurnstile(request("t1"), ENV, gate, "anon_ffffffffffffffffffffffffffffffff");
+  assert.equal(res?.status, 403);
+});
+
+/** P2-1 (#447 review): an environment with anonymous access on and no secret
+ * rejects everyone; that must be distinguishable from a bot wave in the logs. */
+void test("a missing secret is recorded at the edge and never sent to siteverify", async () => {
+  const calls: Call[] = [];
+  const gate = createTurnstileGate({ fetchImpl: stubFetch(calls, true), now: () => 0 });
+  const records: string[] = [];
+  const original = console.error;
+  console.error = (line: unknown) => { records.push(String(line)); };
+  try {
+    const res = await guardTurnstile(request("t1"), { TURNSTILE_SECRET: "" }, gate, ID);
+    assert.equal(res?.status, 403);
+  } finally {
+    console.error = original;
+  }
+  assert.deepEqual(JSON.parse(String(records[0])), { event: "edge_turnstile_secret_missing" });
+  assert.equal(calls.length, 0);
+});
+
+void test("the missing-secret rejection still discloses nothing to the caller", async () => {
+  const gate = createTurnstileGate({ fetchImpl: stubFetch([], true), now: () => 0 });
+  const original = console.error;
+  console.error = () => undefined;
+  try {
+    const res = await guardTurnstile(request("t1"), { TURNSTILE_SECRET: "" }, gate, ID);
+    const body = await (res as Response).text();
+    assert.match(body, /"code":"turnstile_required"/);
+    assert.doesNotMatch(body, /secret/i);
+  } finally {
+    console.error = original;
+  }
 });
 
 void test("a failed verification is never cached", async () => {
   const clock = { ms: 0 };
   const calls: Call[] = [];
   const gate = createTurnstileGate({ fetchImpl: stubFetch(calls, false), now: () => clock.ms });
-  await guardTurnstile(request("t1"), ENV, gate);
-  await guardTurnstile(request("t1"), ENV, gate);
+  await guardTurnstile(request("t1"), ENV, gate, ID);
+  await guardTurnstile(request("t1"), ENV, gate, ID);
   assert.equal(calls.length, 2);
 });
 
@@ -174,7 +229,7 @@ void test("a request without CF-Connecting-IP still verifies with an empty remot
     method: "POST",
     headers: { [TURNSTILE_HEADER]: "t1" },
   });
-  await guardTurnstile(req, ENV, gate);
+  await guardTurnstile(req, ENV, gate, ID);
   assert.equal(calls[0]?.body.get("remoteip"), "");
 });
 
@@ -199,4 +254,74 @@ void test("a stringly-typed success value fails closed", async () => {
 // one side alone stays green while anonymous turns silently arrive tokenless.
 void test("the token header is literally cf-turnstile-response", () => {
   assert.equal(TURNSTILE_HEADER, "cf-turnstile-response");
+});
+
+// ── siteverify outages (issue #447 review, P1-3) ───────────────────────────
+// Before this, a rejected fetch or a 502 HTML body escaped `verifySiteverify`
+// as an unhandled rejection and every anonymous turn became a bare 500.
+
+/** Capture console.error while running an outage case. */
+async function withErrorLog(run: () => Promise<TurnstileResult | Response | null>) {
+  const records: string[] = [];
+  const original = console.error;
+  console.error = (line: unknown) => { records.push(String(line)); };
+  try {
+    return { result: await run(), records };
+  } finally {
+    console.error = original;
+  }
+}
+
+const unreachable: typeof fetch = () => Promise.reject(new Error("network down"));
+const htmlGateway: typeof fetch = () =>
+  Promise.resolve(new Response("<html>502</html>", { status: 502 }));
+
+void test("an unreachable siteverify fails OPEN rather than 500ing the turn", async () => {
+  const { result, records } = await withErrorLog(() =>
+    verifySiteverify("t1", "", ENV.TURNSTILE_SECRET, unreachable),
+  );
+  assert.deepEqual(result, { ok: true, errorCodes: ["siteverify-unavailable"] });
+  assert.deepEqual(JSON.parse(String(records[0])), {
+    event: "edge_turnstile_siteverify_unavailable",
+    reason: "unreachable",
+  });
+});
+
+void test("a non-JSON siteverify body is an outage, not an unhandled rejection", async () => {
+  const { result } = await withErrorLog(() =>
+    verifySiteverify("t1", "", ENV.TURNSTILE_SECRET, htmlGateway),
+  );
+  assert.equal((result as TurnstileResult).ok, true);
+  assert.deepEqual((result as TurnstileResult).errorCodes, ["siteverify-unavailable"]);
+});
+
+void test("an outage lets the turn through the guard instead of throwing", async () => {
+  const gate = createTurnstileGate({ fetchImpl: unreachable, now: () => 0 });
+  const { result } = await withErrorLog(() => guardTurnstile(request("t1"), ENV, gate, ID));
+  assert.equal(result, null);
+});
+
+void test("the fail-open verdict is never cached — verification resumes at once", async () => {
+  let attempts = 0;
+  const flaky: typeof fetch = (input, init) => {
+    attempts += 1;
+    return attempts === 1 ? unreachable(input, init) : Response.json({ success: false });
+  };
+  const gate = createTurnstileGate({ fetchImpl: flaky, now: () => 0 });
+  const { result } = await withErrorLog(async () => {
+    await guardTurnstile(request("t1"), ENV, gate, ID);
+    return guardTurnstile(request("t1"), ENV, gate, ID);
+  });
+  assert.equal((result as Response | null)?.status, 403);
+  assert.equal(attempts, 2);
+});
+
+void test("siteverify is called with an abort signal so a hang cannot stall a turn", async () => {
+  let signal: AbortSignal | null | undefined;
+  const capture: typeof fetch = (_input, init) => {
+    signal = init?.signal;
+    return Promise.resolve(Response.json({ success: true }));
+  };
+  await verifySiteverify("t1", "", ENV.TURNSTILE_SECRET, capture);
+  assert.ok(signal instanceof AbortSignal);
 });

--- a/worker/turnstile.ts
+++ b/worker/turnstile.ts
@@ -20,6 +20,14 @@ export const TURNSTILE_HEADER = "cf-turnstile-response";
  * Turnstile tokens are single-use at siteverify (a replay returns
  * `timeout-or-duplicate`), so caching the pass is exactly what stops an
  * anonymous user from being re-challenged on every message.
+ *
+ * The cache is keyed by token AND identity (issue #447 review): keying it by
+ * token alone would let one solved challenge cover ANY identity for its whole
+ * window, so an attacker could drop the `aid` cookie (fresh identity, fresh
+ * rate-limit bucket) and replay the same token — turning the attack this gate
+ * exists to stop into one that merely costs a challenge every few minutes.
+ * Keyed by identity, a cookie-dropper misses the cache, siteverify sees the
+ * replay, answers `timeout-or-duplicate`, and the turn is rejected.
  */
 export const TURNSTILE_WINDOW_MS = 5 * 60_000;
 
@@ -37,12 +45,36 @@ export interface TurnstileGate {
     token: string | null,
     clientIp: string,
     secret: string,
+    identity: string,
   ) => Promise<TurnstileResult>;
 }
 
 const MISSING_TOKEN: TurnstileResult = { ok: false, errorCodes: ["missing-input-response"] };
 const WINDOW_PASS: TurnstileResult = { ok: true, errorCodes: [] };
 const BAD_RESPONSE: TurnstileResult = { ok: false, errorCodes: ["bad-siteverify-response"] };
+
+/** How long siteverify gets before the call is abandoned. Verification sits in
+ * front of every anonymous turn, so it must never hang one. */
+const SITEVERIFY_TIMEOUT_MS = 5_000;
+
+/**
+ * The deliberate FAIL-OPEN verdict (issue #447 review, P1-3).
+ *
+ * When siteverify itself is unreachable — network error, timeout, a 502 whose
+ * body is HTML — the choice is between walling out every anonymous visitor for
+ * the duration of someone else's outage and letting turns through unverified.
+ * This follows the precedent already set by the edge rate limiter (#438/#451):
+ * infrastructure failure must not take chat down, and the daily-budget breaker
+ * still caps what an unverified wave can cost. It is loud (`console.error` on
+ * every occurrence) and it is deliberately NOT cached in the pass window, so
+ * verification resumes the moment siteverify does.
+ */
+const SITEVERIFY_UNAVAILABLE: TurnstileResult = { ok: true, errorCodes: ["siteverify-unavailable"] };
+
+/** Structured, credential-free record of a verification outage. */
+function logSiteverifyUnavailable(reason: string): void {
+  console.error(JSON.stringify({ event: "edge_turnstile_siteverify_unavailable", reason }));
+}
 
 function stringsOf(value: unknown): readonly string[] {
   if (!Array.isArray(value)) return [];
@@ -57,20 +89,34 @@ function readSiteverify(body: unknown): TurnstileResult {
   return { ok: record.success === true, errorCodes: stringsOf(record["error-codes"]) };
 }
 
-/** The canonical siteverify call. Pure apart from the injected `fetchImpl`. */
+function siteverifyRequest(token: string, clientIp: string, secret: string): RequestInit {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ secret, response: token, remoteip: clientIp }),
+    signal: AbortSignal.timeout(SITEVERIFY_TIMEOUT_MS),
+  };
+}
+
+/**
+ * The canonical siteverify call. Pure apart from the injected `fetchImpl`.
+ * Everything that can throw — the fetch itself, the timeout, a body that is not
+ * JSON — resolves to the fail-open verdict rather than escaping as a bare 500.
+ */
 export async function verifySiteverify(
   token: string,
   clientIp: string,
   secret: string,
   fetchImpl: typeof fetch,
 ): Promise<TurnstileResult> {
-  const response = await fetchImpl(SITEVERIFY_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({ secret, response: token, remoteip: clientIp }),
-  });
-  const body: unknown = await response.json();
-  return readSiteverify(body);
+  try {
+    const response = await fetchImpl(SITEVERIFY_URL, siteverifyRequest(token, clientIp, secret));
+    const body: unknown = await response.json();
+    return readSiteverify(body);
+  } catch {
+    logSiteverifyUnavailable("unreachable");
+    return SITEVERIFY_UNAVAILABLE;
+  }
 }
 
 export interface TurnstileGateOptions {
@@ -98,9 +144,14 @@ function toState(options: TurnstileGateOptions): GateState {
   };
 }
 
-/** True when this exact token already passed and its window is still open. */
-function isWithinWindow(state: GateState, token: string): boolean {
-  const expiresAt = state.passed.get(token);
+/** One cache entry per (identity, token) pair — never per token alone. */
+function windowKey(identity: string, token: string): string {
+  return `${identity}\n${token}`;
+}
+
+/** True when this identity already passed this token inside the open window. */
+function isWithinWindow(state: GateState, key: string): boolean {
+  const expiresAt = state.passed.get(key);
   return expiresAt !== undefined && expiresAt > state.now();
 }
 
@@ -112,24 +163,34 @@ function prune(state: GateState): void {
   }
 }
 
+/** Only a real siteverify pass earns a window slot — never the fail-open one. */
+function isVerifiedPass(result: TurnstileResult): boolean {
+  return result.ok && result.errorCodes.length === 0;
+}
+
 async function checkToken(
   state: GateState,
   token: string | null,
   clientIp: string,
   secret: string,
+  identity: string,
 ): Promise<TurnstileResult> {
   if (token === null || token === "") return MISSING_TOKEN;
-  if (isWithinWindow(state, token)) return WINDOW_PASS;
+  const key = windowKey(identity, token);
+  if (isWithinWindow(state, key)) return WINDOW_PASS;
   prune(state);
   const result = await state.verify(token, clientIp, secret, state.fetchImpl);
-  if (result.ok) state.passed.set(token, state.now() + state.windowMs);
+  if (isVerifiedPass(result)) state.passed.set(key, state.now() + state.windowMs);
   return result;
 }
 
 /** Build a gate with its own short-lived verification window. */
 export function createTurnstileGate(options: TurnstileGateOptions = {}): TurnstileGate {
   const state = toState(options);
-  return { check: (token, clientIp, secret) => checkToken(state, token, clientIp, secret) };
+  return {
+    check: (token, clientIp, secret, identity) =>
+      checkToken(state, token, clientIp, secret, identity),
+  };
 }
 
 /**
@@ -144,18 +205,36 @@ function rejection(): Response {
   );
 }
 
+/** Wire-level marker for an environment that opened anonymous access without
+ * provisioning the secret: every anonymous turn is then rejected, which would
+ * otherwise look exactly like a bot wave. Callers still get a plain 403 — the
+ * record is edge-internal and names no token, identity or secret. */
+function logMissingSecret(): void {
+  console.error(JSON.stringify({ event: "edge_turnstile_secret_missing" }));
+}
+
+function usableSecret(secret: unknown): string | null {
+  return typeof secret === "string" && secret !== "" ? secret : null;
+}
+
 /**
  * Edge guard. Returns `null` when the caller may proceed to forward the
  * request, or a 403 Response the caller MUST return without ever touching the
- * container.
+ * container. `identity` scopes the pass window — see TURNSTILE_WINDOW_MS.
  */
 export async function guardTurnstile(
   request: Request,
   env: TurnstileEnv,
   gate: TurnstileGate,
+  identity: string,
 ): Promise<Response | null> {
+  const secret = usableSecret(env.TURNSTILE_SECRET);
+  if (secret === null) {
+    logMissingSecret();
+    return rejection();
+  }
   const token = request.headers.get(TURNSTILE_HEADER);
   const clientIp = request.headers.get("CF-Connecting-IP") ?? "";
-  const result = await gate.check(token, clientIp, env.TURNSTILE_SECRET);
+  const result = await gate.check(token, clientIp, secret, identity);
   return result.ok ? null : rejection();
 }

--- a/worker/turnstileArm.test.ts
+++ b/worker/turnstileArm.test.ts
@@ -1,0 +1,230 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createWorkerApp } from "./app.ts";
+import { handleGuardRequest } from "./edgeGuard.ts";
+import { memoryGuardStore, type GuardStore } from "./guardStore.ts";
+import { TURNSTILE_HEADER, type TurnstileGate, type TurnstileResult } from "./turnstile.ts";
+
+/**
+ * Issue #447: the S1.9 gate (#436) is ARMED on the anonymous branch.
+ *
+ * `worker/turnstile.test.ts` pins the gate in isolation; this file pins the
+ * composition — that an anonymous `/v1/chat` really is challenged, in the right
+ * order relative to the 401 path, the rate limiter and the container.
+ */
+
+const SECRET = "fixed-test-hmac-key-0000000000000000";
+const TURNSTILE_SECRET = "fixed-test-turnstile-secret-0000000";
+const ANON_ENV = { ANON_ACCESS_ENABLED: "true", ANON_ID_SECRET: SECRET, TURNSTILE_SECRET };
+const NOW = Date.UTC(2026, 6, 28, 12, 0, 0);
+
+const stubNext = { fetch: () => Promise.resolve(new Response("next", { status: 200 })) };
+const stubCtx = {
+  waitUntil(promise: Promise<unknown>) { void promise; },
+  passThroughOnException() { return undefined; },
+} as unknown as ExecutionContext;
+
+interface GateCall {
+  readonly token: string | null;
+  readonly clientIp: string;
+  readonly secret: string;
+}
+
+/** A gate that records every check and passes only the token it was told to. */
+function recordingGate(calls: GateCall[], solved: string | null): TurnstileGate {
+  return {
+    check: (token, clientIp, secret): Promise<TurnstileResult> => {
+      calls.push({ token, clientIp, secret });
+      const ok = solved !== null && token === solved;
+      return Promise.resolve({ ok, errorCodes: ok ? [] : ["invalid-input-response"] });
+    },
+  };
+}
+
+function fakeGuard() {
+  const shards = new Map<string, GuardStore>();
+  const storeFor = (name: string) => {
+    const existing = shards.get(name);
+    if (existing) return existing;
+    const created = memoryGuardStore();
+    shards.set(name, created);
+    return created;
+  };
+  return {
+    idFromName: (name: string) => name as unknown as DurableObjectId,
+    get: (id: DurableObjectId) => ({
+      fetch: (request: Request) =>
+        handleGuardRequest(request, storeFor(String(id)), NOW, { limit: 20, windowSeconds: 60 }),
+    }),
+  };
+}
+
+function anonEnv(captured: { requests: Request[] }, extra: Record<string, string> = {}) {
+  return {
+    ...ANON_ENV,
+    ...extra,
+    EDGE_GUARD: fakeGuard(),
+    CONTAINER: {
+      idFromName: () => "id",
+      get: () => ({
+        fetch: (r: Request) => {
+          captured.requests.push(r);
+          return Promise.resolve(new Response("container"));
+        },
+      }),
+    },
+  } as never;
+}
+
+function armedApp(gate: TurnstileGate, authenticated = false) {
+  const auth = authenticated
+    ? () => Promise.resolve({ ok: true, userId: "u1", userType: "human" } as const)
+    : () => Promise.resolve({ ok: false, reason: "absent" } as const);
+  return createWorkerApp({ nextHandler: stubNext, authenticate: auth, turnstileGate: gate });
+}
+
+function chat(headers: Record<string, string> = {}) {
+  return { method: "POST", headers };
+}
+
+const SOLVED = "solved-token";
+const solvedHeaders = { [TURNSTILE_HEADER]: SOLVED, "CF-Connecting-IP": "203.0.113.7" };
+
+void test("a solved anonymous /v1/chat still reaches the container", async () => {
+  const captured = { requests: [] as Request[] };
+  const calls: GateCall[] = [];
+  const res = await armedApp(recordingGate(calls, SOLVED)).request(
+    "/v1/chat", chat(solvedHeaders), anonEnv(captured), stubCtx,
+  );
+  assert.equal(await res.text(), "container");
+  assert.equal(captured.requests[0]?.headers.get("X-User-Type"), "anonymous");
+});
+
+void test("the gate is handed the widget token, the client IP and the secret binding", async () => {
+  const captured = { requests: [] as Request[] };
+  const calls: GateCall[] = [];
+  await armedApp(recordingGate(calls, SOLVED)).request(
+    "/v1/chat", chat(solvedHeaders), anonEnv(captured), stubCtx,
+  );
+  assert.deepEqual(calls, [{ token: SOLVED, clientIp: "203.0.113.7", secret: TURNSTILE_SECRET }]);
+});
+
+void test("an anonymous turn with no token is challenged and never reaches the container", async () => {
+  const captured = { requests: [] as Request[] };
+  const calls: GateCall[] = [];
+  const res = await armedApp(recordingGate(calls, SOLVED)).request(
+    "/v1/chat", chat(), anonEnv(captured), stubCtx,
+  );
+  assert.equal(res.status, 403);
+  assert.equal(captured.requests.length, 0);
+  assert.equal(calls[0]?.token, null);
+});
+
+void test("a rejected challenge answers the retryable turnstile envelope", async () => {
+  const captured = { requests: [] as Request[] };
+  const res = await armedApp(recordingGate([], SOLVED)).request(
+    "/v1/chat", chat({ [TURNSTILE_HEADER]: "forged" }), anonEnv(captured), stubCtx,
+  );
+  assert.equal(res.status, 403);
+  const body = (await res.json()) as { error: { code: string; retryable: boolean } };
+  assert.equal(body.error.code, "turnstile_required");
+  assert.equal(body.error.retryable, true);
+  assert.equal(captured.requests.length, 0);
+});
+
+void test("a challenged turn does not mint an anonymous identity cookie", async () => {
+  const captured = { requests: [] as Request[] };
+  const res = await armedApp(recordingGate([], SOLVED)).request(
+    "/v1/chat", chat(), anonEnv(captured), stubCtx,
+  );
+  assert.equal(res.headers.get("Set-Cookie"), null);
+});
+
+/** A known identity is needed here: an unsolved turn mints no cookie, so two
+ * anonymous strangers never share a bucket in the first place. The budget only
+ * observably leaks when a returning visitor's own cookie is charged for a
+ * challenge they were forced to answer. */
+void test("a challenged turn does not spend the identity's burst budget", async () => {
+  const captured = { requests: [] as Request[] };
+  const env = anonEnv(captured, { ANON_RATE_LIMIT: "2" });
+  const app = armedApp(recordingGate([], SOLVED));
+  const first = await app.request("/v1/chat", chat(solvedHeaders), env, stubCtx);
+  const cookie = String(first.headers.get("Set-Cookie")).split(";")[0] ?? "";
+  const withCookie = (extra: Record<string, string>) => chat({ Cookie: cookie, ...extra });
+  const challenged = await app.request("/v1/chat", withCookie({}), env, stubCtx);
+  assert.equal(challenged.status, 403);
+  const res = await app.request("/v1/chat", withCookie(solvedHeaders), env, stubCtx);
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), "container");
+});
+
+void test("an authenticated caller is never challenged", async () => {
+  const captured = { requests: [] as Request[] };
+  const calls: GateCall[] = [];
+  const res = await armedApp(recordingGate(calls, SOLVED), true).request(
+    "/v1/chat", chat({ Authorization: "Bearer jwt" }), anonEnv(captured), stubCtx,
+  );
+  assert.equal(res.status, 200);
+  assert.equal(calls.length, 0);
+  assert.equal(captured.requests[0]?.headers.get("X-User-Type"), "human");
+});
+
+void test("with anonymous access disabled the answer stays 401, not a challenge", async () => {
+  const captured = { requests: [] as Request[] };
+  const calls: GateCall[] = [];
+  const env = { ...(anonEnv(captured) as object), ANON_ACCESS_ENABLED: "false" } as never;
+  const res = await armedApp(recordingGate(calls, SOLVED)).request("/v1/chat", chat(), env, stubCtx);
+  assert.equal(res.status, 401);
+  assert.equal(calls.length, 0);
+});
+
+void test("a non-allowlisted /v1 path 401s without ever raising a challenge", async () => {
+  const captured = { requests: [] as Request[] };
+  const calls: GateCall[] = [];
+  const res = await armedApp(recordingGate(calls, SOLVED)).request(
+    "/v1/feedback", chat(), anonEnv(captured), stubCtx,
+  );
+  assert.equal(res.status, 401);
+  assert.equal(calls.length, 0);
+});
+
+/** #445 put the photo routes on the anonymous allowlist, so the gate must
+ * cover them too — they cost a vision call, the most expensive turn there is. */
+void test("an anonymous photo upload is challenged like a chat turn", async () => {
+  const captured = { requests: [] as Request[] };
+  const calls: GateCall[] = [];
+  const res = await armedApp(recordingGate(calls, SOLVED)).request(
+    "/v1/photo-search", chat(), anonEnv(captured), stubCtx,
+  );
+  assert.equal(res.status, 403);
+  assert.equal(captured.requests.length, 0);
+  assert.equal(calls[0]?.token, null);
+});
+
+void test("a solved anonymous photo upload reaches the container", async () => {
+  const captured = { requests: [] as Request[] };
+  const res = await armedApp(recordingGate([], SOLVED)).request(
+    "/v1/photo-search", chat(solvedHeaders), anonEnv(captured), stubCtx,
+  );
+  assert.equal(res.status, 200);
+  assert.equal(captured.requests[0]?.headers.get("X-User-Type"), "anonymous");
+});
+
+void test("the confirm ping is challenged on the anonymous path too", async () => {
+  const captured = { requests: [] as Request[] };
+  const res = await armedApp(recordingGate([], SOLVED)).request(
+    "/v1/photo-search/confirm", chat(), anonEnv(captured), stubCtx,
+  );
+  assert.equal(res.status, 403);
+  assert.equal(captured.requests.length, 0);
+});
+
+void test("a public /v1 path is not challenged either", async () => {
+  const captured = { requests: [] as Request[] };
+  const calls: GateCall[] = [];
+  const res = await armedApp(recordingGate(calls, SOLVED)).request(
+    "/v1/search/preview", { method: "GET" }, anonEnv(captured), stubCtx,
+  );
+  assert.equal(res.status, 200);
+  assert.equal(calls.length, 0);
+});

--- a/worker/turnstileReplay.test.ts
+++ b/worker/turnstileReplay.test.ts
@@ -1,0 +1,137 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createWorkerApp } from "./app.ts";
+import { handleGuardRequest } from "./edgeGuard.ts";
+import { memoryGuardStore, type GuardStore } from "./guardStore.ts";
+import { TURNSTILE_HEADER, createTurnstileGate } from "./turnstile.ts";
+
+/**
+ * Issue #447 review, P1-1: the armed path exercised with the REAL gate (only
+ * the siteverify network call is stubbed), against Cloudflare's actual
+ * single-use token semantics — a replayed token answers `timeout-or-duplicate`.
+ *
+ * This is the attack the card exists to close: drop the `aid` cookie, get a
+ * fresh identity and a fresh rate-limit bucket, and replay one solved token.
+ */
+
+const ANON_ENV = {
+  ANON_ACCESS_ENABLED: "true",
+  ANON_ID_SECRET: "fixed-test-hmac-key-0000000000000000",
+  TURNSTILE_SECRET: "fixed-test-turnstile-secret-0000000",
+};
+const NOW = Date.UTC(2026, 6, 28, 12, 0, 0);
+const SOLVED = "solved-token";
+
+const stubNext = { fetch: () => Promise.resolve(new Response("next", { status: 200 })) };
+const stubCtx = {
+  waitUntil(promise: Promise<unknown>) { void promise; },
+  passThroughOnException() { return undefined; },
+} as unknown as ExecutionContext;
+
+/** Cloudflare's real contract: a token verifies once, then is a duplicate. */
+function singleUseSiteverify(calls: string[]): typeof fetch {
+  const spent = new Set<string>();
+  return (_input, init) => {
+    const token = new URLSearchParams(String(init?.body)).get("response") ?? "";
+    calls.push(token);
+    const fresh = !spent.has(token);
+    spent.add(token);
+    const body = fresh ? { success: true } : { success: false, "error-codes": ["timeout-or-duplicate"] };
+    return Promise.resolve(Response.json(body));
+  };
+}
+
+function fakeGuard() {
+  const shards = new Map<string, GuardStore>();
+  const storeFor = (name: string) => {
+    const existing = shards.get(name);
+    if (existing) return existing;
+    const created = memoryGuardStore();
+    shards.set(name, created);
+    return created;
+  };
+  return {
+    idFromName: (name: string) => name as unknown as DurableObjectId,
+    get: (id: DurableObjectId) => ({
+      fetch: (request: Request) =>
+        handleGuardRequest(request, storeFor(String(id)), NOW, { limit: 20, windowSeconds: 60 }),
+    }),
+  };
+}
+
+function anonEnv(captured: { requests: Request[] }) {
+  return {
+    ...ANON_ENV,
+    EDGE_GUARD: fakeGuard(),
+    CONTAINER: {
+      idFromName: () => "id",
+      get: () => ({
+        fetch: (r: Request) => {
+          captured.requests.push(r);
+          return Promise.resolve(new Response("container"));
+        },
+      }),
+    },
+  } as never;
+}
+
+/** The real gate, wired exactly as `createWorkerApp` builds its default. */
+function realGateApp(calls: string[]) {
+  return createWorkerApp({
+    nextHandler: stubNext,
+    authenticate: () => Promise.resolve({ ok: false, reason: "absent" } as const),
+    turnstileGate: createTurnstileGate({ fetchImpl: singleUseSiteverify(calls) }),
+  });
+}
+
+function chat(headers: Record<string, string> = {}) {
+  return { method: "POST", headers };
+}
+
+const solved = { [TURNSTILE_HEADER]: SOLVED, "CF-Connecting-IP": "203.0.113.7" };
+
+void test("a genuinely solved token verifies once and the turn is forwarded", async () => {
+  const calls: string[] = [];
+  const captured = { requests: [] as Request[] };
+  const res = await realGateApp(calls).request("/v1/chat", chat(solved), anonEnv(captured), stubCtx);
+  assert.equal(res.status, 200);
+  assert.deepEqual(calls, [SOLVED]);
+  assert.equal(captured.requests.length, 1);
+});
+
+void test("the same visitor's follow-up turn rides the window without re-verifying", async () => {
+  const calls: string[] = [];
+  const captured = { requests: [] as Request[] };
+  const env = anonEnv(captured);
+  const app = realGateApp(calls);
+  const first = await app.request("/v1/chat", chat(solved), env, stubCtx);
+  const cookie = String(first.headers.get("Set-Cookie")).split(";")[0] ?? "";
+  const second = await app.request("/v1/chat", chat({ ...solved, Cookie: cookie }), env, stubCtx);
+  assert.equal(second.status, 200);
+  assert.deepEqual(calls, [SOLVED]);
+  assert.equal(captured.requests.length, 2);
+});
+
+void test("replaying the token from a dropped cookie is rejected, not waved through", async () => {
+  const calls: string[] = [];
+  const captured = { requests: [] as Request[] };
+  const env = anonEnv(captured);
+  const app = realGateApp(calls);
+  await app.request("/v1/chat", chat(solved), env, stubCtx);
+  const replay = await app.request("/v1/chat", chat(solved), env, stubCtx);
+  assert.equal(replay.status, 403);
+  assert.deepEqual(calls, [SOLVED, SOLVED], "the replay must reach siteverify, not the local window");
+  assert.equal(captured.requests.length, 1);
+});
+
+void test("the cookie-drop replay stays rejected however often it is retried", async () => {
+  const calls: string[] = [];
+  const captured = { requests: [] as Request[] };
+  const env = anonEnv(captured);
+  const app = realGateApp(calls);
+  await app.request("/v1/chat", chat(solved), env, stubCtx);
+  await app.request("/v1/chat", chat(solved), env, stubCtx);
+  const third = await app.request("/v1/chat", chat(solved), env, stubCtx);
+  assert.equal(third.status, 403);
+  assert.equal(captured.requests.length, 1);
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -31,6 +31,12 @@
 # until BOTH of these are present:
 #   ANON_ACCESS_ENABLED        — "true" to open /v1/chat to anonymous callers ([vars] below)
 #   ANON_ID_SECRET             — HMAC key for the signed anonymous-id cookie (wrangler secret put)
+#   TURNSTILE_SECRET           — REQUIRED once ANON_ACCESS_ENABLED="true" (issue #447): every
+#                                anonymous /v1/chat turn is verified at siteverify before it can
+#                                reach the limiter or the container, so an environment with
+#                                anonymous access on and no secret answers 403 turnstile_required
+#                                to everyone. Local/dev may use Cloudflare's always-passing test
+#                                pair (site 1x00000000000000000000AA / secret 1x0000000000000000000000000000000AA).
 #
 # Frontend build-time envs (injected by GitHub Actions):
 #   NEXT_PUBLIC_SUPABASE_URL


### PR DESCRIPTION
Arms the dormant S1.9 Turnstile gate (#436) on the anonymous `/v1/chat` branch and gives the web app the widget that feeds it. Closes the "paid-for daily DoS" hole in #447: until now, dropping the `aid` cookie minted a fresh anonymous identity and reset the per-identity limiter, leaving the daily dollar breaker as the only guard.

`ANON_ACCESS_ENABLED` is untouched everywhere — flipping prod is the owner's separate call after deploy validation.

> **Review rounds 2 and 3 are folded in.** Round 2 (Fable + Opus) found five holes — two of them (the token-keyed pass window, the same-tick retry) meant the first cut did not actually close the attack it was written for. Round 3 covered the merged state with #445 (photo search) plus two polish items. The mutation table marks them all.

## 1. Edge wiring (`worker/app.ts`, `worker/turnstile.ts`)

`guardTurnstile` runs inside `handleAnonymousV1`, positioned deliberately:

- **after `resolveAnonymous`** — a challenge is only raised for a caller we would otherwise serve anonymously, so anonymous-access-off still answers 401, never 403;
- **before the limiter and the container** — an unsolved turn costs neither a bucket slot nor an LLM call.

**Pass window keyed by (identity, token)** *(review P1-1, Fable)*. Keyed by token alone, one solved challenge covered **any** identity for its whole window: drop the cookie → fresh identity, fresh rate-limit bucket, replay the same token. The attack merely got a price tag of one challenge per five minutes. Keyed by identity, a cookie-dropper misses the cache, siteverify sees the replay and answers `timeout-or-duplicate` → 403.

**siteverify outages no longer 500 the chat** *(review P1-3, Opus)*. `verifySiteverify` had no try/catch and no timeout: a rejected fetch or a 502 HTML body escaped as an unhandled rejection and every anonymous turn became a bare 500. It now uses `AbortSignal.timeout(5s)` and, on any infrastructure failure, **fails open** with `console.error({event:"edge_turnstile_siteverify_unavailable"})` on every occurrence, and that verdict is **never cached** so verification resumes the instant siteverify does.
  > **Tradeoff, flagged for the owner:** fail-open on a security gate means a siteverify outage reopens the anonymous path unverified. It follows the precedent already set by the edge rate limiter (#438/#451) — infrastructure failure must not take chat down — and the daily-budget breaker still caps what an unverified wave can cost. If you'd rather fail closed, it is a one-constant change plus its two tests.

**A missing `TURNSTILE_SECRET` is now visible** *(review P2-1 / P1-4)*. It previously reached Cloudflare as the literal string `"undefined"` and 403'd everyone with zero logging — indistinguishable from a bot wave. Now an explicit edge-internal record; callers still get a plain 403 disclosing nothing.

## 2. Widget (`apps/web`)

The token store and transport header shipped in #436; nothing rendered a widget. `TurnstileGate` is now mounted from `ChatPage` via `useTurnstileChallenge`:

- **Placement** — the dock's hint slot, directly after the composer, matching `docs/design/2026-07-06-design-sync/Chat 初始状态.html` (`.dock > .composer + .hint`). Never in the thread.
- **Mode: `interaction-only`** (the least intrusive of the three). `always` parks a permanent challenge box under the composer; `execute` needs a `turnstile.execute()` handshake before a token exists. `interaction-only` solves silently and renders **nothing** unless Cloudflare decides a human interaction is genuinely required. `data-size="flexible"`; `data-theme` follows the app's own day/night choice, not the OS.
- **Anonymous-only** — a signed-in visitor never loads api.js.
- **Retry is driven by the widget, not by the click** *(review P1-1, Opus)*. The old handler cleared the token, called the async `turnstile.reset()` and resent in the same tick — the resend was reliably tokenless and ate the identical 403, and a token that landed first was thrown away. Now: clear the spent token → subscribe → reset → resend **only** when the replacement callback fires. No token, no resend; the challenge just stays on screen.
- **`?q=` auto-send waits for the first token** *(same review item)*. A visitor arriving from the hero would otherwise race the widget's first solve and land on an unrecoverable 403 on the very first turn.
- **403 `turnstile_required` is not D8** — an anonymous visitor never had a session to expire — **but only when a widget is on the page** *(review P1-3, Fable)*. A build with no site key, or an edge with no secret, 403s every turn; suppressing the strip there left the chat silently dead. Now the generic D4 retry renders instead.
- **Styling** — semantic tokens only, pinned by CSS tests; no hardcoded palette.
- **Dev/E2E** — an unconfigured **production** build renders no widget (no crash); an unconfigured **dev** build falls back to Cloudflare's always-passing test key `1x00000000000000000000AA`. A wrong-length value still throws — pasting the 35-char SECRET must never reach a render.

## 2b. Photo search — the merged-state blocker (round 3)

#445 put `/v1/photo-search` and `/v1/photo-search/confirm` on `ANON_V1`, so after the merge the gate challenges photo uploads too — and photo has no challenge UI, so an unsolved upload would have thrown `photo_search_failed`: a generic failure with no challenge and no retry.

- **The wait moved into the shared header path.** `session-headers.ts` (which #445 extracted for exactly this reason — chat and photo hit the edge with identical identity semantics) now waits for the widget's token on anonymous requests before resolving. One mechanism covers chat, photo upload and the confirm ping. It is bounded by `TURNSTILE_WAIT_MS`, it only engages when this build actually renders a widget, and it never drops a held token when it does not.
- **A challenged upload reads as a challenge.** `photo-search.ts` inspects the rejection code and `PhotoSearchUpload` renders `dict.turnstile.failed` (localized, already shipped) instead of the photo-failure copy; a genuine backend failure still reads as one.
- **Worker side**: both photo routes are covered in `turnstileArm.test.ts` (challenged unsolved, forwarded solved, confirm ping challenged).
- **Still open, tracked in #471**: photo has no challenge *recovery* — its retry resets the uploader, so the visitor re-picks the file. Chat's re-arm/resend handshake should be reused there. Low urgency: with the readiness wait in place, a challenged upload now only happens when a held token is spent or expired.

## 2c. Two polish items (round 3)

- **`data-error-callback` + `data-expired-callback`** are now wired: a dead loader or an aged-out token clears the store, so no stale token is sent to be rejected. Previously a failed api.js load left the page silently stuck.
- **`remoteip` was already sent** — `guardTurnstile` reads `CF-Connecting-IP` and `verifySiteverify` puts it in the siteverify body; `turnstile.test.ts` pins both the populated and the header-absent case. No change needed.
- **A leak found while fixing the above:** each parked waiter held a pending 15s timer, and abandoned ones starved the whole vitest pool (unrelated suites timing out at 5s+). `clearTurnstileToken()` now abandons waiters, and the hermetic setup clears between tests. Two consecutive clean full runs since.

## 3. Tests

| Layer | File | Covers |
|---|---|---|
| worker unit | `worker/turnstile.test.ts` (+9) | identity-scoped window · `timeout-or-duplicate` replay · missing secret logged + not sent · outage fails open, logs, is not cached, and carries an abort signal |
| worker integration | `worker/turnstileReplay.test.ts` (4, new) | the **real gate** against Cloudflare's single-use semantics: solved turn forwards · same visitor rides the window without re-verifying · **cookie-drop replay rejected** · stays rejected on repeat |
| worker integration | `worker/turnstileArm.test.ts` (10, new) | composition: gate receives token/IP/secret · no token → 403, container untouched · retryable envelope · no cookie minted on a challenge · challenge does not spend the burst budget · authed never challenged · anon-off stays 401 · non-allowlisted and public `/v1` never challenged |
| web unit | `turnstile-armed-flow.test.tsx` (5, new) | against a handler that **rejects tokenless turns**: retry resends only with the replacement token · no tokenless request while solving · a token solved before the click is not discarded · `?q=` waits for the first token · ungated when no challenge is in play |
| web unit | `turnstile-mount.test.tsx` (10, new) | mounts for anonymous · sits after `.chat-input` · never for signed-in · nothing for an unconfigured prod build · **misconfigured build still shows the generic failure** · 403 shows the check retry not the login banner · retry resends · retry re-arms the widget · challenge clears on success |
| web unit | `turnstile-gate.test.tsx` (+7), `chat-design-css.test.ts` (+3) | appearance/size/theme attributes · optional + dev-fallback key resolution · `resetTurnstileWidget` · dock tokens, zero vertical cost until rendered, 3D retry affordance |
| web unit | `turnstile-photo-search.test.tsx` (8, new) | the header path does not resolve until a token exists (deterministic, no clock) and resolves at once when no widget is configured · upload holds, then carries the token · challenged upload shows the redo-the-check copy, a real failure still shows the photo copy · retry affordance survives |
| web unit | `turnstile-token-store.test.ts` (+5), `turnstile-gate.test.tsx` (+4) | parked waiter resolves on solve / on clear / on timeout · error + expired callbacks wired and dropping the token |
| worker integration | `turnstileArm.test.ts` (+3) | photo upload challenged · solved upload forwarded · confirm ping challenged |
| E2E | `e2e/web-chat-anonymous.spec.ts` (+2) | widget present in the dock with a 24-char key and `interaction-only` · a challenged turn shows the retry, never the login prompt |

`tests/setup/turnstile-hermetic.ts` neutralizes Turnstile for every suite that is not about it (vitest runs with `DEV === true`, which would otherwise mount a widget under every chat test and stall `?q=`).

## 4. Mutation evidence

| Mutation | Result |
|---|---|
| remove the `guardTurnstile` call | 4 worker tests fail |
| guard **before** `resolveAnonymous` | anon-off-stays-401 + entry 401 fail |
| guard **after** the rate limiter | burst-budget test fails |
| **window keyed by token alone** (the shipped P1-1 bug) | 3 replay tests fail |
| **no try/catch around siteverify** (the shipped P1-3 bug) | 4 outage tests fail |
| **missing secret not detected** | 2 tests fail |
| **retry resends in the same tick** (the shipped P1-1 bug) | tokenless-resend test fails |
| **auto-send not gated on readiness** | `?q=` test fails |
| **unconditional D8 suppression** (the shipped P1-3 bug) | 2 misconfiguration tests fail |
| **photo path does not wait for a token** (the merged-state gap) | header-layer test fails |
| **challenged upload reported as a photo failure** | 2 photo tests fail |
| error/expired callbacks unwired · cleared token does not abandon waiters | respective tests fail |
| unmount `<ChallengeGate>` / signed-in widget / `appearance: always` / retry without reset | respective tests fail |

**Three** tests were rewritten after **surviving** a mutation: the burst-budget one (vacuous — unsolved turns mint no cookie, so strangers never share a bucket), the widget re-arm, and the photo readiness one. The last is worth calling out: an upload spends several async turns on EXIF-stripping and base64 before its headers are read, so a token solved during that window is picked up even by a transport that never waits — the component-level test could not tell the two apart. It is now pinned deterministically at the header layer (microtask drain, no clock).

## 5. Gates

*(re-run after rebasing onto #445/#461 — the `ComposerDock` refactor)*

- `pnpm run test:worker` — **176 pass / 0 fail**
- `apps/web`: `typecheck` clean · `lint:oxlint --deny-warnings` clean (no suppressions) · `pnpm test` **166 files / 1072 tests**, coverage **98.68 stmts / 95.12 branches / 99.08 funcs / 99.56 lines** (floors 95/94/95/95). Run twice back-to-back clean after the timer-leak fix.
- E2E `web-chat-anonymous.spec.ts` — 5/5 against a live `apps/web` dev server

## 6. Honest scope of the E2E, and the staging prerequisite

Both new browser specs **stub `/v1/chat` and block `challenges.cloudflare.com`** — they pin the page's contract (widget present in the dock, rejection handled), *not* a live edge. The armed path end-to-end is covered hermetically at the worker level (`turnstileReplay.test.ts` drives the real gate against real single-use semantics with only the network stubbed), but **no test in this PR exercises a real Cloudflare challenge against a real Worker.**

**Prerequisite before `ANON_ACCESS_ENABLED` is flipped anywhere:** a manual smoke on staging with a real site key + secret — one anonymous turn succeeds, and a turn with a stripped `cf-turnstile-response` header is 403'd.

## 7. Operator + merge notes

1. **`TURNSTILE_SECRET` is now required wherever `ANON_ACCESS_ENABLED="true"`** (documented in `wrangler.toml` and `apps/web/.env.example`). **Staging runs with anon on** — its secret must be in place before this lands there, or every anonymous turn 403s. `VITE_TURNSTILE_SITE_KEY` is likewise required for production web builds.
2. **#445 interaction — handled**, see §2b. The remaining recovery gap is tracked in **#471**.
3. **Rebases absorbed:** #451, #458, #273 T1, and **#445/#461** (the challenge slot assembles into the new `ComposerDock`/`Composer` split). Base tests that send an anonymous `/v1` request and expect a 200 (`byok.test.ts`, `authFallthrough.test.ts`, `photoSearch.test.ts`) were given the passing-gate injection the other non-Turnstile suites use — their subject is limiter scoping, credential verdicts and header hygiene, not the challenge.
4. Manual sends **are** now gated, via the shared header wait added in round 3 — the earlier caveat no longer applies.

Refs #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
