### PR TITLE
feat(web): BYOK storage wrapper + header wiring (#284 Task 6, storage half)

### DIFF
--- a/apps/web/src/features/chat/byok-i18n.ts
+++ b/apps/web/src/features/chat/byok-i18n.ts
@@ -1,0 +1,104 @@
+/**
+ * BYOK settings panel copy (issue #284 Task 6).
+ *
+ * Covers the three-family selector, the model field (required for
+ * openai-compatible, pre-filled elsewhere), the base_url helper, the vision
+ * badge, and every error code the container/edge can surface for a BYOK
+ * turn. Kept feature-local and split out of `i18n.ts`, same as
+ * `route-i18n.ts` / `search-i18n.ts`.
+ */
+export interface ChatByokDict {
+  readonly title: string;
+  readonly familyLabel: string;
+  readonly familyOpenaiCompatible: string;
+  readonly familyAnthropic: string;
+  readonly familyGemini: string;
+  readonly apiKeyLabel: string;
+  readonly modelLabel: string;
+  readonly modelRequired: string;
+  readonly baseUrlLabel: string;
+  readonly baseUrlHelp: string;
+  readonly save: string;
+  readonly clear: string;
+  readonly maskedSummary: string;
+  readonly visionBadge: string;
+  readonly errorCredentialRejected: string;
+  readonly errorRequiresLogin: string;
+  readonly errorInvalidRequest: string;
+  readonly errorEgressBlocked: string;
+  readonly notAccepted: string;
+  readonly anonymousTeaser: string;
+  readonly signInToSetUp: string;
+}
+
+export const jaByok: ChatByokDict = {
+  title: "自分のAPIキーを使う",
+  familyLabel: "サービスをえらんでね",
+  familyOpenaiCompatible: "OpenAI互換",
+  familyAnthropic: "Anthropic",
+  familyGemini: "Gemini",
+  apiKeyLabel: "APIキー",
+  modelLabel: "モデル名",
+  modelRequired: "モデル名を入力してね",
+  baseUrlLabel: "接続先URL",
+  baseUrlHelp: "https:// から始まるURLを入れてね",
+  save: "保存する",
+  clear: "解除する",
+  maskedSummary: "登録ずみ(キーはひみつ)",
+  visionBadge: "✓ 画像対応",
+  errorCredentialRejected: "このキーは使えなかったみたい。もう一度確かめてね",
+  errorRequiresLogin: "自分のキーを使うにはログインしてね",
+  errorInvalidRequest: "入力に不備があるみたい。確認してね",
+  errorEgressBlocked: "その接続先には安全のためつなげられないよ",
+  notAccepted: "キーが受け付けられなかったよ。標準のモードでは続けないから、直してね",
+  anonymousTeaser: "自分のAPIキーを使うと、待たずにたくさん話せるよ",
+  signInToSetUp: "ログインして設定する",
+};
+
+export const zhByok: ChatByokDict = {
+  title: "使用你自己的 API 密钥",
+  familyLabel: "选择服务商",
+  familyOpenaiCompatible: "OpenAI 兼容",
+  familyAnthropic: "Anthropic",
+  familyGemini: "Gemini",
+  apiKeyLabel: "API 密钥",
+  modelLabel: "模型名称",
+  modelRequired: "请填写模型名称",
+  baseUrlLabel: "接口地址",
+  baseUrlHelp: "请填写以 https:// 开头的地址",
+  save: "保存",
+  clear: "清除",
+  maskedSummary: "已保存(密钥已隐藏)",
+  visionBadge: "✓ 支持图片",
+  errorCredentialRejected: "这个密钥没能用,请再检查一下",
+  errorRequiresLogin: "使用自己的密钥需要先登录",
+  errorInvalidRequest: "填写的内容好像不对,请检查一下",
+  errorEgressBlocked: "出于安全考虑,无法连接这个地址",
+  notAccepted: "密钥没有被接受。不会用默认模式继续,请先修正",
+  anonymousTeaser: "用你自己的密钥,就不用受限额限制啦",
+  signInToSetUp: "登录后设置",
+};
+
+export const enByok: ChatByokDict = {
+  title: "Use your own API key",
+  familyLabel: "Choose a provider",
+  familyOpenaiCompatible: "OpenAI-compatible",
+  familyAnthropic: "Anthropic",
+  familyGemini: "Gemini",
+  apiKeyLabel: "API key",
+  modelLabel: "Model name",
+  modelRequired: "Please enter a model name",
+  baseUrlLabel: "Base URL",
+  baseUrlHelp: "Enter a URL starting with https://",
+  save: "Save",
+  clear: "Clear",
+  maskedSummary: "Saved (key hidden)",
+  visionBadge: "✓ Image support",
+  errorCredentialRejected: "That key wasn't accepted. Please double-check it",
+  errorRequiresLogin: "Sign in to use your own key",
+  errorInvalidRequest: "Something in that entry looks off — please check it",
+  errorEgressBlocked: "That address can't be reached for safety reasons",
+  notAccepted: "Your key was not accepted. We won't continue on the standard mode — please fix it",
+  anonymousTeaser: "Bring your own key to chat without the daily limit",
+  signInToSetUp: "Sign in to set up",
+};

--- a/apps/web/src/features/chat/byok-i18n.ts
+++ b/apps/web/src/features/chat/byok-i18n.ts
@@ -20,6 +20,7 @@ export interface ChatByokDict {
   readonly modelRequired: string;
   readonly baseUrlLabel: string;
   readonly baseUrlHelp: string;
+  readonly baseUrlInvalid: string;
   readonly save: string;
   readonly clear: string;
   readonly maskedSummary: string;
@@ -46,6 +47,7 @@ export const jaByok: ChatByokDict = {
   modelRequired: "モデル名を入力してね",
   baseUrlLabel: "接続先URL",
   baseUrlHelp: "https:// から始まるURLを入れてね",
+  baseUrlInvalid: "そのURLは使えない文字が入ってるみたい。ローマ字のアドレスを試してね",
   save: "保存する",
   clear: "解除する",
   maskedSummary: "登録ずみ(キーはひみつ)",
@@ -72,6 +74,7 @@ export const zhByok: ChatByokDict = {
   modelRequired: "请填写模型名称",
   baseUrlLabel: "接口地址",
   baseUrlHelp: "请填写以 https:// 开头的地址",
+  baseUrlInvalid: "这个地址里有不能使用的字符,请换成英文/数字格式的地址试试",
   save: "保存",
   clear: "清除",
   maskedSummary: "已保存(密钥已隐藏)",
@@ -98,6 +101,7 @@ export const enByok: ChatByokDict = {
   modelRequired: "Please enter a model name",
   baseUrlLabel: "Base URL",
   baseUrlHelp: "Enter a URL starting with https://",
+  baseUrlInvalid: "That URL contains characters that can't be used — try an ASCII/punycode address",
   save: "Save",
   clear: "Clear",
   maskedSummary: "Saved (key hidden)",

--- a/apps/web/src/features/chat/byok-i18n.ts
+++ b/apps/web/src/features/chat/byok-i18n.ts
@@ -14,6 +14,8 @@ export interface ChatByokDict {
   readonly familyAnthropic: string;
   readonly familyGemini: string;
   readonly apiKeyLabel: string;
+  readonly apiKeyRequired: string;
+  readonly apiKeyInvalid: string;
   readonly modelLabel: string;
   readonly modelRequired: string;
   readonly baseUrlLabel: string;
@@ -38,6 +40,8 @@ export const jaByok: ChatByokDict = {
   familyAnthropic: "Anthropic",
   familyGemini: "Gemini",
   apiKeyLabel: "APIキー",
+  apiKeyRequired: "APIキーを入力してね",
+  apiKeyInvalid: "そのAPIキーは使えない文字が入ってるみたい。確認してね",
   modelLabel: "モデル名",
   modelRequired: "モデル名を入力してね",
   baseUrlLabel: "接続先URL",
@@ -62,6 +66,8 @@ export const zhByok: ChatByokDict = {
   familyAnthropic: "Anthropic",
   familyGemini: "Gemini",
   apiKeyLabel: "API 密钥",
+  apiKeyRequired: "请填写 API 密钥",
+  apiKeyInvalid: "这个 API 密钥里有不能使用的字符,请检查一下",
   modelLabel: "模型名称",
   modelRequired: "请填写模型名称",
   baseUrlLabel: "接口地址",
@@ -86,6 +92,8 @@ export const enByok: ChatByokDict = {
   familyAnthropic: "Anthropic",
   familyGemini: "Gemini",
   apiKeyLabel: "API key",
+  apiKeyRequired: "Please enter an API key",
+  apiKeyInvalid: "That API key contains characters that can't be used — please check it",
   modelLabel: "Model name",
   modelRequired: "Please enter a model name",
   baseUrlLabel: "Base URL",

--- a/apps/web/src/features/chat/i18n.ts
+++ b/apps/web/src/features/chat/i18n.ts
@@ -1,4 +1,6 @@
 import type { Locale } from "../../i18n/locales";
+import { enByok, jaByok, zhByok } from "./byok-i18n";
+import type { ChatByokDict } from "./byok-i18n";
 import {
   enClarify,
   enDeparture,
@@ -28,6 +30,7 @@ import type { ChatSearchDict } from "./search-i18n";
 
 export type { ChatRouteDict } from "./route-i18n";
 export type { ChatSearchDict } from "./search-i18n";
+export type { ChatByokDict } from "./byok-i18n";
 export type {
   ChatClarifyDict,
   ChatDepartureDict,
@@ -120,6 +123,7 @@ export interface ChatDict {
   readonly departure: ChatDepartureDict;
   readonly location: ChatLocationDict;
   readonly photo: ChatPhotoDict;
+  readonly byok: ChatByokDict;
 }
 
 const jaToolSteps: ChatToolStepsDict = {
@@ -193,6 +197,7 @@ const ja: ChatDict = {
   departure: jaDeparture,
   location: jaLocation,
   photo: jaPhoto,
+  byok: jaByok,
 };
 
 const zh: ChatDict = {
@@ -220,6 +225,7 @@ const zh: ChatDict = {
   departure: zhDeparture,
   location: zhLocation,
   photo: zhPhoto,
+  byok: zhByok,
 };
 
 const en: ChatDict = {
@@ -251,6 +257,7 @@ const en: ChatDict = {
   departure: enDeparture,
   location: enLocation,
   photo: enPhoto,
+  byok: enByok,
 };
 
 const CHAT_DICTIONARIES: Record<Locale, ChatDict> = { ja, zh, en };

--- a/apps/web/src/features/chat/session-headers.ts
+++ b/apps/web/src/features/chat/session-headers.ts
@@ -1,5 +1,6 @@
-import { authHeaders } from "../../lib/auth/authSession";
 import { configuredTurnstileSiteKey } from "../../components/TurnstileGate";
+import { authHeaders } from "../../lib/auth/authSession";
+import { byokHeaders } from "../../lib/byok/byokStorage";
 import { awaitTurnstileToken, turnstileHeaders } from "../../lib/turnstile/tokenStore";
 
 /**
@@ -8,12 +9,23 @@ import { awaitTurnstileToken, turnstileHeaders } from "../../lib/turnstile/token
  * carry the held Turnstile token (S1.9 #281) — one solved challenge covers
  * every turn in its window. Used by the chat transport and photo search so
  * both surfaces hit the edge with identical identity semantics.
+ *
+ * A saved BYOK credential (#284 Task 6) adds its `X-BYOK-*` headers on top of
+ * every caller of this function — deliberately, not by omission. Photo
+ * search's vision probe/badge (Task 5, D5) exists precisely so a BYOK user's
+ * image turns are answered by their own key; T9 requires a BYOK turn to
+ * never silently fall back to the platform key, so photo search inheriting
+ * the same headers as chat is the correct semantics, not an accident of
+ * sharing this module. `byokHeaders()` returns `{}` with nothing saved, so
+ * this is a no-op for every caller until a credential exists. It is read
+ * synchronously and does not participate in the Turnstile wait below in any
+ * way — its ordering relative to that wait has no observable effect.
  */
 export async function sessionHeaders(sessionId?: string): Promise<Record<string, string>> {
   const base: Record<string, string> = sessionId ? { "x-session-id": sessionId } : {};
   const auth = await authHeaders();
-  if (auth.Authorization !== undefined) return { ...base, ...auth };
-  return { ...base, ...(await challengeHeaders()) };
+  const challenge = await challengeHeaders(auth);
+  return { ...base, ...challenge, ...auth, ...byokHeaders() };
 }
 
 /**
@@ -23,14 +35,17 @@ export async function sessionHeaders(sessionId?: string): Promise<Record<string,
  * photo search (#445 added `/v1/photo-search` to it) — so a request fired
  * before the widget has solved is rejected. Chat surfaces that as a retryable
  * challenge; photo upload has no challenge UI of its own, which is exactly why
- * the wait lives here, in the header path both surfaces share.
+ * the wait lives here, in the header path both surfaces share. Skipped
+ * entirely once authenticated — the same short-circuit the pre-wait version
+ * of this function had.
  *
  * When this build renders no widget there is nothing to wait for, so the
  * request goes out immediately and any rejection surfaces normally. The wait
  * itself is bounded (`TURNSTILE_WAIT_MS`) — it delays a turn, it never hangs
  * one.
  */
-async function challengeHeaders(): Promise<Record<string, string>> {
+async function challengeHeaders(auth: Record<string, string>): Promise<Record<string, string>> {
+  if (auth.Authorization !== undefined) return {};
   if (configuredTurnstileSiteKey() !== undefined) await awaitTurnstileToken();
   return turnstileHeaders();
 }

--- a/apps/web/src/lib/byok/byokStorage.ts
+++ b/apps/web/src/lib/byok/byokStorage.ts
@@ -35,7 +35,7 @@ export interface ByokConfig {
   readonly baseUrl?: string;
 }
 
-export type ByokSaveError = "model_required" | "key_required" | "key_invalid";
+export type ByokSaveError = "model_required" | "key_required" | "key_invalid" | "base_url_invalid";
 export type ByokSaveResult = { readonly ok: true } | { readonly ok: false; readonly error: ByokSaveError };
 
 const CONFIG_KEY = "animichi.byok.config";
@@ -137,10 +137,28 @@ function keyInvalid(config: ByokConfig): boolean {
   return !HEADER_SAFE.test(config.apiKey);
 }
 
+/** Character-unsafe in EVERY family, not just openai-compatible: a Japanese
+ * model name on anthropic/gemini, or a CRLF-injected model on any family,
+ * would otherwise save successfully and only crash `Headers()`/`fetch()`
+ * later, at turn time — the same sticky-TypeError shape `keyInvalid` guards
+ * against, just on a different field. */
 function modelInvalid(config: ByokConfig): boolean {
-  const required = config.provider === "openai-compatible";
-  if (!required) return false;
-  return config.model.trim() === "" || !HEADER_SAFE.test(config.model);
+  const { provider, model } = config;
+  const trimmed = model.trim();
+  if (provider === "openai-compatible" && trimmed === "") return true;
+  return trimmed !== "" && !HEADER_SAFE.test(model);
+}
+
+/** openai-compatible only; empty/whitespace is absent, not invalid (P3). An
+ * internationalized domain (e.g. `https://例え.jp/v1`) fails this check —
+ * deliberately: rather than punycode-encode it here (a second, untested
+ * encoding step this module would then own), reject non-ASCII outright and
+ * let the settings panel prompt for an A-label/ASCII host, matching what
+ * the egress guard (Task 1) already expects on the wire. */
+function baseUrlInvalid(config: ByokConfig): boolean {
+  if (config.provider !== "openai-compatible") return false;
+  const baseUrl = config.baseUrl ?? "";
+  return baseUrl.trim() !== "" && !HEADER_SAFE.test(baseUrl);
 }
 
 /** Pure validation the settings panel can call before (and instead of)
@@ -149,6 +167,7 @@ export function validateByokConfig(config: ByokConfig): ByokSaveResult {
   if (keyMissing(config)) return { ok: false, error: "key_required" };
   if (keyInvalid(config)) return { ok: false, error: "key_invalid" };
   if (modelInvalid(config)) return { ok: false, error: "model_required" };
+  if (baseUrlInvalid(config)) return { ok: false, error: "base_url_invalid" };
   return { ok: true };
 }
 

--- a/apps/web/src/lib/byok/byokStorage.ts
+++ b/apps/web/src/lib/byok/byokStorage.ts
@@ -1,12 +1,27 @@
 /**
  * Session-scoped BYOK credential storage (issue #284 Task 6, X10).
  *
- * `sessionStorage` only — never `localStorage` — so closing the tab drops
- * the key. This module is the **only** place allowed to touch
- * `sessionStorage` for BYOK; a repo-wide grep test enforces that no
- * component calls it directly. SSR-safe: no `window` access at import time,
- * and every accessor checks availability first and degrades to "no
- * credential" rather than throwing.
+ * `sessionStorage` only — never `localStorage`. This bounds the credential to
+ * the current browser session; it is not a hard per-tab boundary (a
+ * duplicated tab or a restored session can carry `sessionStorage` along, per
+ * the browser's own semantics — see threat T11), but it drops the key far
+ * sooner than `localStorage` would. This module is the **only** place
+ * allowed to touch `sessionStorage` for BYOK; a repo-wide grep test enforces
+ * that no component calls it directly. SSR-safe: no `window` access at
+ * import time, and every accessor checks availability first and degrades to
+ * "no credential" rather than throwing.
+ *
+ * Every storage access is wrapped in `try`/`catch`, not just guarded by a
+ * `typeof` check: **reading `window.sessionStorage` itself can throw** —
+ * Safari (and other browsers' partitioned/blocked storage modes) implement
+ * it as an accessor that raises a `SecurityError` on access, not merely on
+ * `.getItem`/`.setItem`. Without the `try`/`catch` here, that exception would
+ * propagate out of `byokHeaders()` and fail every chat turn for a user who
+ * has never touched BYOK at all.
+ *
+ * Naming note: the spec prose refers to the read accessor as
+ * "readByokConfig" — this module exports it as `getByokConfig`, matching the
+ * `getX`/`setX`/`clearX` naming already used by `tokenStore.ts`/`authSession.ts`.
  */
 
 /** The three model families the credential boundary (Task 3) accepts. */
@@ -20,7 +35,7 @@ export interface ByokConfig {
   readonly baseUrl?: string;
 }
 
-export type ByokSaveError = "model_required";
+export type ByokSaveError = "model_required" | "key_required" | "key_invalid";
 export type ByokSaveResult = { readonly ok: true } | { readonly ok: false; readonly error: ByokSaveError };
 
 const CONFIG_KEY = "animichi.byok.config";
@@ -34,8 +49,15 @@ export const BYOK_DEFAULT_MODEL: Readonly<Record<"anthropic" | "gemini", string>
   gemini: "gemini-2.5-flash",
 };
 
-function hasSessionStorage(): boolean {
-  return typeof window === "undefined" ? false : typeof window.sessionStorage !== "undefined";
+/** `undefined` if `window` doesn't exist (SSR) or reading the accessor threw
+ * (partitioned/blocked storage) — never lets either failure mode escape. */
+function trySessionStorage(): Storage | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return undefined;
+  }
 }
 
 function isByokProvider(value: unknown): value is ByokProvider {
@@ -53,9 +75,35 @@ function isByokConfig(value: unknown): value is ByokConfig {
   );
 }
 
-function readRaw(key: string): string | null {
-  if (!hasSessionStorage()) return null;
-  return window.sessionStorage.getItem(key);
+function safeGet(key: string): string | null {
+  const storage = trySessionStorage();
+  if (storage === undefined) return null;
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  const storage = trySessionStorage();
+  if (storage === undefined) return;
+  try {
+    storage.setItem(key, value);
+  } catch {
+    // Storage unavailable, partitioned, or over quota — degrade silently;
+    // the credential simply won't be there on the next read.
+  }
+}
+
+function safeRemove(key: string): void {
+  const storage = trySessionStorage();
+  if (storage === undefined) return;
+  try {
+    storage.removeItem(key);
+  } catch {
+    // Same rationale as safeSet.
+  }
 }
 
 function parseConfig(raw: string | null): ByokConfig | null {
@@ -68,57 +116,82 @@ function parseConfig(raw: string | null): ByokConfig | null {
   }
 }
 
-/** `null` when absent, during SSR, or the stored value is corrupt/non-JSON. */
+/** `null` when absent, during SSR, storage is blocked, or the stored value
+ * is corrupt/non-JSON. */
 export function getByokConfig(): ByokConfig | null {
-  return parseConfig(readRaw(CONFIG_KEY));
+  return parseConfig(safeGet(CONFIG_KEY));
+}
+
+/** Printable ASCII only. Rejects both the `\r`/`\n` that make `Headers()`
+ * throw a `TypeError` on the value, and non-Latin-1 characters that `fetch`
+ * would otherwise reject deep inside the transport — either would otherwise
+ * turn into an opaque, per-turn-sticky crash instead of a validation
+ * rejection surfaced once at save time. */
+const HEADER_SAFE = /^[\x20-\x7E]+$/u;
+
+function keyMissing(config: ByokConfig): boolean {
+  return config.apiKey.trim() === "";
+}
+
+function keyInvalid(config: ByokConfig): boolean {
+  return !HEADER_SAFE.test(config.apiKey);
+}
+
+function modelInvalid(config: ByokConfig): boolean {
+  const required = config.provider === "openai-compatible";
+  if (!required) return false;
+  return config.model.trim() === "" || !HEADER_SAFE.test(config.model);
 }
 
 /** Pure validation the settings panel can call before (and instead of)
  * attempting a save, to render its inline message synchronously. */
 export function validateByokConfig(config: ByokConfig): ByokSaveResult {
-  const modelMissing = config.provider === "openai-compatible" && config.model.trim() === "";
-  return modelMissing ? { ok: false, error: "model_required" } : { ok: true };
+  if (keyMissing(config)) return { ok: false, error: "key_required" };
+  if (keyInvalid(config)) return { ok: false, error: "key_invalid" };
+  if (modelInvalid(config)) return { ok: false, error: "model_required" };
+  return { ok: true };
 }
 
 /**
  * Persists the config and clears any vision flag left over from a prior
  * credential — a new key's vision support is unknown until it is re-probed.
- * A no-op during SSR. Rejects (without writing) when validation fails.
+ * A no-op during SSR or if storage is unavailable. Rejects (without
+ * writing) when validation fails.
  */
 export function saveByokConfig(config: ByokConfig): ByokSaveResult {
   const result = validateByokConfig(config);
   if (!result.ok) return result;
-  if (hasSessionStorage()) {
-    window.sessionStorage.setItem(CONFIG_KEY, JSON.stringify(config));
-    window.sessionStorage.removeItem(VISION_KEY);
-  }
+  safeSet(CONFIG_KEY, JSON.stringify(config));
+  safeRemove(VISION_KEY);
   return result;
 }
 
 /** Drops the credential and its vision flag together — never one without
  * the other, so a stale vision badge can never outlive its key. */
 export function clearByokConfig(): void {
-  if (!hasSessionStorage()) return;
-  window.sessionStorage.removeItem(CONFIG_KEY);
-  window.sessionStorage.removeItem(VISION_KEY);
+  safeRemove(CONFIG_KEY);
+  safeRemove(VISION_KEY);
 }
 
 /** Records the outcome of a `/v1/byok/probe` call (Task 5) against the
- * currently saved credential. */
+ * currently saved credential. A no-op with no config saved — otherwise a
+ * probe that resolves after the credential was cleared (or before one was
+ * ever saved) would leave an orphaned vision flag with nothing to attach to,
+ * which a subsequently-saved unrelated credential could then inherit. */
 export function setByokVisionSupported(supported: boolean): void {
-  if (!hasSessionStorage()) return;
-  window.sessionStorage.setItem(VISION_KEY, supported ? "true" : "false");
+  if (getByokConfig() === null) return;
+  safeSet(VISION_KEY, supported ? "true" : "false");
 }
 
 /** `null` when no probe has run yet for the current credential. */
 export function getByokVisionSupported(): boolean | null {
-  const raw = readRaw(VISION_KEY);
+  const raw = safeGet(VISION_KEY);
   return raw === null ? null : raw === "true";
 }
 
 function baseUrlHeader(config: ByokConfig): Record<string, string> {
   const { provider, baseUrl } = config;
-  if (provider !== "openai-compatible" || baseUrl === undefined) return {};
+  if (provider !== "openai-compatible" || baseUrl === undefined || baseUrl.trim() === "") return {};
   return { "X-BYOK-Base-Url": baseUrl };
 }
 
@@ -131,8 +204,9 @@ function byokHeadersFor(config: ByokConfig): Record<string, string> {
   };
 }
 
-/** `{}` when no config is saved (or during SSR); the full BYOK header set
- * otherwise — spread into the chat transport's outgoing request headers. */
+/** `{}` when no config is saved (or during SSR, or storage is blocked); the
+ * full BYOK header set otherwise — spread into the chat transport's
+ * outgoing request headers. */
 export function byokHeaders(): Record<string, string> {
   const config = getByokConfig();
   return config === null ? {} : byokHeadersFor(config);

--- a/apps/web/src/lib/byok/byokStorage.ts
+++ b/apps/web/src/lib/byok/byokStorage.ts
@@ -1,0 +1,139 @@
+/**
+ * Session-scoped BYOK credential storage (issue #284 Task 6, X10).
+ *
+ * `sessionStorage` only — never `localStorage` — so closing the tab drops
+ * the key. This module is the **only** place allowed to touch
+ * `sessionStorage` for BYOK; a repo-wide grep test enforces that no
+ * component calls it directly. SSR-safe: no `window` access at import time,
+ * and every accessor checks availability first and degrades to "no
+ * credential" rather than throwing.
+ */
+
+/** The three model families the credential boundary (Task 3) accepts. */
+export type ByokProvider = "openai-compatible" | "anthropic" | "gemini";
+
+export interface ByokConfig {
+  readonly provider: ByokProvider;
+  readonly apiKey: string;
+  readonly model: string;
+  /** openai-compatible only. */
+  readonly baseUrl?: string;
+}
+
+export type ByokSaveError = "model_required";
+export type ByokSaveResult = { readonly ok: true } | { readonly ok: false; readonly error: ByokSaveError };
+
+const CONFIG_KEY = "animichi.byok.config";
+const VISION_KEY = "animichi.byok.vision";
+
+/** Named default models (OQ-1): pre-filled by the settings panel and
+ * user-overridable. Only the openai-compatible family has no sane default,
+ * since it has no fixed catalog of model names. */
+export const BYOK_DEFAULT_MODEL: Readonly<Record<"anthropic" | "gemini", string>> = {
+  anthropic: "claude-sonnet-4-5",
+  gemini: "gemini-2.5-flash",
+};
+
+function hasSessionStorage(): boolean {
+  return typeof window === "undefined" ? false : typeof window.sessionStorage !== "undefined";
+}
+
+function isByokProvider(value: unknown): value is ByokProvider {
+  return value === "openai-compatible" || value === "anthropic" || value === "gemini";
+}
+
+function isByokConfig(value: unknown): value is ByokConfig {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    isByokProvider(record.provider) &&
+    typeof record.apiKey === "string" &&
+    typeof record.model === "string" &&
+    (record.baseUrl === undefined || typeof record.baseUrl === "string")
+  );
+}
+
+function readRaw(key: string): string | null {
+  if (!hasSessionStorage()) return null;
+  return window.sessionStorage.getItem(key);
+}
+
+function parseConfig(raw: string | null): ByokConfig | null {
+  if (raw === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isByokConfig(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** `null` when absent, during SSR, or the stored value is corrupt/non-JSON. */
+export function getByokConfig(): ByokConfig | null {
+  return parseConfig(readRaw(CONFIG_KEY));
+}
+
+/** Pure validation the settings panel can call before (and instead of)
+ * attempting a save, to render its inline message synchronously. */
+export function validateByokConfig(config: ByokConfig): ByokSaveResult {
+  const modelMissing = config.provider === "openai-compatible" && config.model.trim() === "";
+  return modelMissing ? { ok: false, error: "model_required" } : { ok: true };
+}
+
+/**
+ * Persists the config and clears any vision flag left over from a prior
+ * credential — a new key's vision support is unknown until it is re-probed.
+ * A no-op during SSR. Rejects (without writing) when validation fails.
+ */
+export function saveByokConfig(config: ByokConfig): ByokSaveResult {
+  const result = validateByokConfig(config);
+  if (!result.ok) return result;
+  if (hasSessionStorage()) {
+    window.sessionStorage.setItem(CONFIG_KEY, JSON.stringify(config));
+    window.sessionStorage.removeItem(VISION_KEY);
+  }
+  return result;
+}
+
+/** Drops the credential and its vision flag together — never one without
+ * the other, so a stale vision badge can never outlive its key. */
+export function clearByokConfig(): void {
+  if (!hasSessionStorage()) return;
+  window.sessionStorage.removeItem(CONFIG_KEY);
+  window.sessionStorage.removeItem(VISION_KEY);
+}
+
+/** Records the outcome of a `/v1/byok/probe` call (Task 5) against the
+ * currently saved credential. */
+export function setByokVisionSupported(supported: boolean): void {
+  if (!hasSessionStorage()) return;
+  window.sessionStorage.setItem(VISION_KEY, supported ? "true" : "false");
+}
+
+/** `null` when no probe has run yet for the current credential. */
+export function getByokVisionSupported(): boolean | null {
+  const raw = readRaw(VISION_KEY);
+  return raw === null ? null : raw === "true";
+}
+
+function baseUrlHeader(config: ByokConfig): Record<string, string> {
+  const { provider, baseUrl } = config;
+  if (provider !== "openai-compatible" || baseUrl === undefined) return {};
+  return { "X-BYOK-Base-Url": baseUrl };
+}
+
+function byokHeadersFor(config: ByokConfig): Record<string, string> {
+  return {
+    "X-BYOK-Provider": config.provider,
+    "X-BYOK-Key": config.apiKey,
+    "X-BYOK-Model": config.model,
+    ...baseUrlHeader(config),
+  };
+}
+
+/** `{}` when no config is saved (or during SSR); the full BYOK header set
+ * otherwise — spread into the chat transport's outgoing request headers. */
+export function byokHeaders(): Record<string, string> {
+  const config = getByokConfig();
+  return config === null ? {} : byokHeadersFor(config);
+}

--- a/apps/web/tests/unit/byokStorage-field-safety.test.ts
+++ b/apps/web/tests/unit/byokStorage-field-safety.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * `HEADER_SAFE` character-safety extended to the model field (every family,
+ * not just openai-compatible) and to base_url (Opus P2① follow-up, second
+ * round). Split out of byokStorage-validation.test.ts to keep each file
+ * under the repo's ~200-line budget.
+ *
+ * Five probes, per review: a Japanese model name on anthropic/gemini, a
+ * CRLF-injected model, an internationalized-domain base_url, a CRLF in
+ * base_url, and a regression confirming a plain ASCII base_url still saves.
+ * Each of these previously saved successfully and only crashed
+ * `Headers()`/`fetch()` later, at turn time, exactly the failure shape
+ * `keyInvalid` already guards the key field against.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BYOK_DEFAULT_MODEL,
+  byokHeaders,
+  clearByokConfig,
+  getByokConfig,
+  saveByokConfig,
+  validateByokConfig,
+} from "../../src/lib/byok/byokStorage";
+import type { ByokConfig } from "../../src/lib/byok/byokStorage";
+
+const OPENAI_CONFIG: ByokConfig = {
+  provider: "openai-compatible",
+  apiKey: "sk-test-key",
+  model: "gpt-5",
+  baseUrl: "https://api.example.com/v1",
+};
+
+const ANTHROPIC_CONFIG: ByokConfig = {
+  provider: "anthropic",
+  apiKey: "anthropic-key",
+  model: BYOK_DEFAULT_MODEL.anthropic,
+};
+
+afterEach(() => {
+  clearByokConfig();
+});
+
+describe("model character safety — every family (probes 1-2)", () => {
+  it("probe 1: rejects a Japanese model name on anthropic as model_required", () => {
+    expect(validateByokConfig({ ...ANTHROPIC_CONFIG, model: "クロード・ソネット" })).toEqual({
+      ok: false,
+      error: "model_required",
+    });
+  });
+
+  it("probe 2: rejects a CRLF-injected model name on gemini as model_required", () => {
+    expect(
+      validateByokConfig({ ...ANTHROPIC_CONFIG, provider: "gemini", model: "gemini-2.5\r\nX-Injected: x" }),
+    ).toEqual({ ok: false, error: "model_required" });
+  });
+
+  it("still accepts the named default model for anthropic/gemini (regression)", () => {
+    expect(validateByokConfig(ANTHROPIC_CONFIG)).toEqual({ ok: true });
+  });
+
+  it("refuses to save (and does not touch storage) an unsafe model on a non-openai-compatible family", () => {
+    const result = saveByokConfig({ ...ANTHROPIC_CONFIG, model: "日本語モデル" });
+    expect(result).toEqual({ ok: false, error: "model_required" });
+    expect(getByokConfig()).toBeNull();
+  });
+});
+
+describe("base_url character safety — openai-compatible only (probes 3-4)", () => {
+  it("probe 3: rejects an internationalized-domain base_url as base_url_invalid", () => {
+    // Deliberately not punycode-decoded here — see the module doc comment.
+    // The settings panel is expected to prompt for an ASCII/A-label host.
+    expect(validateByokConfig({ ...OPENAI_CONFIG, baseUrl: "https://例え.jp/v1" })).toEqual({
+      ok: false,
+      error: "base_url_invalid",
+    });
+  });
+
+  it("probe 4: rejects a CRLF-injected base_url as base_url_invalid", () => {
+    expect(validateByokConfig({ ...OPENAI_CONFIG, baseUrl: "https://api.example.com\r\nX-Injected: x" })).toEqual({
+      ok: false,
+      error: "base_url_invalid",
+    });
+  });
+
+  it("probe 5 (regression): still accepts a plain ASCII base_url", () => {
+    expect(validateByokConfig(OPENAI_CONFIG)).toEqual({ ok: true });
+  });
+
+  it("does not check base_url character safety for anthropic/gemini (the field is unused there)", () => {
+    expect(validateByokConfig({ ...ANTHROPIC_CONFIG, baseUrl: "not a url at all\r\n" })).toEqual({ ok: true });
+  });
+
+  it("refuses to save (and does not emit the header) an unsafe base_url", () => {
+    const result = saveByokConfig({ ...OPENAI_CONFIG, baseUrl: "https://例え.jp/v1" });
+    expect(result).toEqual({ ok: false, error: "base_url_invalid" });
+    expect(getByokConfig()).toBeNull();
+    expect(byokHeaders()).toEqual({});
+  });
+});

--- a/apps/web/tests/unit/byokStorage-security-error.test.ts
+++ b/apps/web/tests/unit/byokStorage-security-error.test.ts
@@ -56,6 +56,17 @@ function blockGetItem(): void {
   });
 }
 
+/** The `safeSet` counterpart: Safari private-mode quota exhaustion throws
+ * `QuotaExceededError` from `.setItem()` itself, property access unaffected.
+ * Without this test, `safeSet`'s catch block was only "covered" by an
+ * accessor-level block that never reaches the method call — a false-positive
+ * signal, per review. */
+function blockSetItem(): void {
+  vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    throw new DOMException("quota exceeded", "QuotaExceededError");
+  });
+}
+
 afterEach(() => {
   restoreSessionStorage();
   vi.restoreAllMocks();
@@ -94,5 +105,25 @@ describe("SecurityError from a storage method call, distinct from the accessor (
     blockGetItem();
     expect(() => getByokConfig()).not.toThrow();
     expect(getByokConfig()).toBeNull();
+  });
+});
+
+describe("QuotaExceededError from .setItem() itself (P3 — genuine safeSet catch coverage)", () => {
+  it("saveByokConfig() reports ok:true (validation passed) but does not throw when the write itself fails", () => {
+    blockSetItem();
+    expect(() => saveByokConfig(OPENAI_CONFIG)).not.toThrow();
+    expect(saveByokConfig(OPENAI_CONFIG)).toEqual({ ok: true });
+    expect(getByokConfig()).toBeNull();
+  });
+
+  it("setByokVisionSupported() degrades to a no-op instead of throwing when .setItem() fails", () => {
+    // Requires a config already in storage (see the orphan-flag guard), so
+    // block .setItem() only after a real save has already succeeded.
+    saveByokConfig(OPENAI_CONFIG);
+    blockSetItem();
+    expect(() => {
+      setByokVisionSupported(true);
+    }).not.toThrow();
+    expect(getByokVisionSupported()).toBeNull();
   });
 });

--- a/apps/web/tests/unit/byokStorage-security-error.test.ts
+++ b/apps/web/tests/unit/byokStorage-security-error.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Reproduces Safari's partitioned/blocked-storage behaviour: reading the
+ * `sessionStorage` *property* (not just calling `.getItem`) throws. This is
+ * exactly the shape a `typeof window.sessionStorage` check would already
+ * have evaluated — so guarding only the subsequent method calls would not
+ * have caught it. Without a try/catch around the property read itself, this
+ * would previously have propagated out of `byokHeaders()` and failed every
+ * chat turn for a user who has never touched BYOK (Opus P1-2).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  byokHeaders,
+  clearByokConfig,
+  getByokConfig,
+  getByokVisionSupported,
+  saveByokConfig,
+  setByokVisionSupported,
+} from "../../src/lib/byok/byokStorage";
+import type { ByokConfig } from "../../src/lib/byok/byokStorage";
+
+const OPENAI_CONFIG: ByokConfig = {
+  provider: "openai-compatible",
+  apiKey: "sk-test-key",
+  model: "gpt-5",
+};
+
+const original = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+
+function blockSessionStorage(): void {
+  Object.defineProperty(window, "sessionStorage", {
+    configurable: true,
+    get(): Storage {
+      throw new DOMException("blocked", "SecurityError");
+    },
+  });
+}
+
+function restoreSessionStorage(): void {
+  if (original) Object.defineProperty(window, "sessionStorage", original);
+}
+
+/**
+ * A distinct failure shape from `blockSessionStorage()`: the property itself
+ * is readable (a real `Storage`), but the method call throws — e.g. a
+ * quota/security restriction enforced per-operation rather than on access.
+ * jsdom's `Storage` intercepts all property access through its own
+ * mechanism, so overriding the instance's `.getItem` directly is silently
+ * ignored — spying on `Storage.prototype.getItem` is what actually takes
+ * effect.
+ */
+function blockGetItem(): void {
+  vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+    throw new DOMException("blocked", "SecurityError");
+  });
+}
+
+afterEach(() => {
+  restoreSessionStorage();
+  vi.restoreAllMocks();
+  clearByokConfig();
+});
+
+describe("SecurityError from the sessionStorage accessor itself (Opus P1-2)", () => {
+  it("getByokConfig() returns null instead of throwing", () => {
+    blockSessionStorage();
+    expect(() => getByokConfig()).not.toThrow();
+    expect(getByokConfig()).toBeNull();
+  });
+
+  it("byokHeaders() returns {} instead of throwing — the failure mode this guard exists for", () => {
+    blockSessionStorage();
+    expect(() => byokHeaders()).not.toThrow();
+    expect(byokHeaders()).toEqual({});
+  });
+
+  it("saveByokConfig()/clearByokConfig()/setByokVisionSupported() degrade to no-ops instead of throwing", () => {
+    blockSessionStorage();
+    expect(() => saveByokConfig(OPENAI_CONFIG)).not.toThrow();
+    expect(saveByokConfig(OPENAI_CONFIG)).toEqual({ ok: true });
+    expect(() => {
+      clearByokConfig();
+    }).not.toThrow();
+    expect(() => {
+      setByokVisionSupported(true);
+    }).not.toThrow();
+    expect(getByokVisionSupported()).toBeNull();
+  });
+});
+
+describe("SecurityError from a storage method call, distinct from the accessor (Opus P1-2)", () => {
+  it("getByokConfig() returns null instead of throwing when .getItem() itself throws", () => {
+    blockGetItem();
+    expect(() => getByokConfig()).not.toThrow();
+    expect(getByokConfig()).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/byokStorage-source-guard.test.ts
+++ b/apps/web/tests/unit/byokStorage-source-guard.test.ts
@@ -12,6 +12,12 @@
  * guard unnoticed. A full-tree recursive `readdirSync` costs single-digit
  * milliseconds on this codebase's `src/` (verified locally), so there is no
  * reason to keep the narrower scan.
+ *
+ * #463 rebase follow-up: a bare substring match false-positived on
+ * `deferredSave.ts`, whose doc comment *describes* `sessionStorage`
+ * (explaining why the P5 deferred-save feature deliberately does NOT use it)
+ * without ever touching the API. Comments are stripped before matching so
+ * only real usage counts.
  */
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -40,8 +46,18 @@ function readSource(root: string, relativePath: string): string {
   return readFileSync(`${root}/${relativePath}`, "utf8");
 }
 
+/** Strips `/** ... *\/` block comments and `//` line comments — a doc
+ * comment merely *mentioning* `sessionStorage` (e.g. to explain why a
+ * feature avoids it) must not count as usage. Naive w.r.t. `//` inside a
+ * string literal, an acceptable trade-off for this narrow guard. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//gu, "").replace(/\/\/.*$/gmu, "");
+}
+
 function filesUsingSessionStorage(root: string): readonly string[] {
-  return walkSourceFiles(root).filter((relativePath) => readSource(root, relativePath).includes("sessionStorage"));
+  return walkSourceFiles(root).filter((relativePath) =>
+    withoutComments(readSource(root, relativePath)).includes("sessionStorage"),
+  );
 }
 
 describe("no component calls sessionStorage directly for BYOK (AC1 lint-level grep, full src/ tree)", () => {

--- a/apps/web/tests/unit/byokStorage-source-guard.test.ts
+++ b/apps/web/tests/unit/byokStorage-source-guard.test.ts
@@ -4,47 +4,55 @@
  * against the configured jsdom page URL rather than a real `file://` path
  * (vitest.config.ts's `environmentOptions.jsdom.url`), which breaks
  * `node:fs` reads. This file uses the default (node) environment instead.
+ *
+ * P1 review follow-up: the grep now walks the **entire** `src/` tree instead
+ * of two flat directories — the AC says "no component", not "no component in
+ * these two folders", and a component anywhere else reaching past
+ * `byokStorage.ts` into `sessionStorage` would previously have passed this
+ * guard unnoticed. A full-tree recursive `readdirSync` costs single-digit
+ * milliseconds on this codebase's `src/` (verified locally), so there is no
+ * reason to keep the narrower scan.
  */
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-const BYOK_DIR = fileURLToPath(new URL("../../src/lib/byok/", import.meta.url));
-const CHAT_COMPONENTS_DIR = fileURLToPath(new URL("../../src/features/chat/components/", import.meta.url));
+const SRC_DIR = fileURLToPath(new URL("../../src/", import.meta.url));
+const BYOK_STORAGE_RELATIVE = "lib/byok/byokStorage.ts";
+const SOURCE_EXTENSIONS = [".ts", ".tsx"];
 
-/** File names (not full paths) under a directory, non-recursive — every
- * BYOK-adjacent source file lives flat in these two directories today. */
-function fileNamesIn(dir: string): readonly string[] {
-  return readdirSync(dir, { withFileTypes: true })
-    .filter((entry) => entry.isFile())
-    .map((entry) => entry.name);
+function isSourceFile(name: string): boolean {
+  return SOURCE_EXTENSIONS.some((ext) => name.endsWith(ext)) && !name.endsWith(".gen.ts");
 }
 
-function readSource(dir: string, name: string): string {
-  return readFileSync(`${dir}/${name}`, "utf8");
-}
-
-function sourceFilesUsingSessionStorage(dir: string): readonly string[] {
-  return fileNamesIn(dir).filter((name) => readSource(dir, name).includes("sessionStorage"));
-}
-
-describe("no component calls sessionStorage directly for BYOK (AC1 lint-level grep)", () => {
-  it("finds sessionStorage used only inside byokStorage.ts, not in any BYOK-lib sibling", () => {
-    expect(sourceFilesUsingSessionStorage(BYOK_DIR)).toEqual(["byokStorage.ts"]);
+/** Relative (`dir/file.ts`) paths of every source file under `root`,
+ * recursing into subdirectories — the whole `src/` tree, not a flat list. */
+function walkSourceFiles(root: string, relativeDir = ""): readonly string[] {
+  const absoluteDir = `${root}/${relativeDir}`;
+  return readdirSync(absoluteDir, { withFileTypes: true }).flatMap((entry) => {
+    const relativePath = relativeDir === "" ? entry.name : `${relativeDir}/${entry.name}`;
+    if (entry.isDirectory()) return walkSourceFiles(root, relativePath);
+    return isSourceFile(entry.name) ? [relativePath] : [];
   });
+}
 
-  it("finds no direct sessionStorage usage among the chat components directory", () => {
-    // ByokSettings.tsx / ChatInput.tsx land here in the UI half of Task 6;
-    // this guard holds today (the directory has no BYOK files yet) and must
-    // keep holding once they land — a component reaching past byokStorage
-    // straight into sessionStorage would fail this test immediately.
-    expect(sourceFilesUsingSessionStorage(CHAT_COMPONENTS_DIR)).toEqual([]);
+function readSource(root: string, relativePath: string): string {
+  return readFileSync(`${root}/${relativePath}`, "utf8");
+}
+
+function filesUsingSessionStorage(root: string): readonly string[] {
+  return walkSourceFiles(root).filter((relativePath) => readSource(root, relativePath).includes("sessionStorage"));
+}
+
+describe("no component calls sessionStorage directly for BYOK (AC1 lint-level grep, full src/ tree)", () => {
+  it("finds sessionStorage used only inside byokStorage.ts across the whole src/ tree", () => {
+    expect(filesUsingSessionStorage(SRC_DIR)).toEqual([BYOK_STORAGE_RELATIVE]);
   });
 });
 
 describe("byokStorage.ts never accesses `window` at module (top) scope", () => {
   it("only references `window.` inside function bodies, never at column 0", () => {
-    const source = readSource(BYOK_DIR, "byokStorage.ts");
+    const source = readSource(SRC_DIR, BYOK_STORAGE_RELATIVE);
     const topLevelLines = source.split("\n").filter((line) => !/^\s/.test(line) && !line.startsWith("}"));
     const windowAtTopLevel = topLevelLines.some((line) => line.includes("window."));
     expect(windowAtTopLevel).toBe(false);

--- a/apps/web/tests/unit/byokStorage-source-guard.test.ts
+++ b/apps/web/tests/unit/byokStorage-source-guard.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Source-level guards for the BYOK storage boundary (issue #284 Task 6,
+ * AC1). Deliberately NOT jsdom: under jsdom, `import.meta.url` resolves
+ * against the configured jsdom page URL rather than a real `file://` path
+ * (vitest.config.ts's `environmentOptions.jsdom.url`), which breaks
+ * `node:fs` reads. This file uses the default (node) environment instead.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const BYOK_DIR = fileURLToPath(new URL("../../src/lib/byok/", import.meta.url));
+const CHAT_COMPONENTS_DIR = fileURLToPath(new URL("../../src/features/chat/components/", import.meta.url));
+
+/** File names (not full paths) under a directory, non-recursive — every
+ * BYOK-adjacent source file lives flat in these two directories today. */
+function fileNamesIn(dir: string): readonly string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name);
+}
+
+function readSource(dir: string, name: string): string {
+  return readFileSync(`${dir}/${name}`, "utf8");
+}
+
+function sourceFilesUsingSessionStorage(dir: string): readonly string[] {
+  return fileNamesIn(dir).filter((name) => readSource(dir, name).includes("sessionStorage"));
+}
+
+describe("no component calls sessionStorage directly for BYOK (AC1 lint-level grep)", () => {
+  it("finds sessionStorage used only inside byokStorage.ts, not in any BYOK-lib sibling", () => {
+    expect(sourceFilesUsingSessionStorage(BYOK_DIR)).toEqual(["byokStorage.ts"]);
+  });
+
+  it("finds no direct sessionStorage usage among the chat components directory", () => {
+    // ByokSettings.tsx / ChatInput.tsx land here in the UI half of Task 6;
+    // this guard holds today (the directory has no BYOK files yet) and must
+    // keep holding once they land — a component reaching past byokStorage
+    // straight into sessionStorage would fail this test immediately.
+    expect(sourceFilesUsingSessionStorage(CHAT_COMPONENTS_DIR)).toEqual([]);
+  });
+});
+
+describe("byokStorage.ts never accesses `window` at module (top) scope", () => {
+  it("only references `window.` inside function bodies, never at column 0", () => {
+    const source = readSource(BYOK_DIR, "byokStorage.ts");
+    const topLevelLines = source.split("\n").filter((line) => !/^\s/.test(line) && !line.startsWith("}"));
+    const windowAtTopLevel = topLevelLines.some((line) => line.includes("window."));
+    expect(windowAtTopLevel).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/byokStorage-ssr.test.ts
+++ b/apps/web/tests/unit/byokStorage-ssr.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment node
+ *
+ * No `window` global exists in this environment (unlike jsdom), so this
+ * pins the SSR half of the AC: importing byokStorage.ts and calling every
+ * exported accessor must not throw, and every read must degrade to the
+ * "no credential" answer rather than crash the render.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  byokHeaders,
+  clearByokConfig,
+  getByokConfig,
+  getByokVisionSupported,
+  saveByokConfig,
+  setByokVisionSupported,
+} from "../../src/lib/byok/byokStorage";
+
+describe("SSR safety — no window global available", () => {
+  it("importing the module does not throw", () => {
+    expect(typeof getByokConfig).toBe("function");
+  });
+
+  it("getByokConfig() returns null instead of throwing", () => {
+    expect(getByokConfig()).toBeNull();
+  });
+
+  it("byokHeaders() returns {} instead of throwing", () => {
+    expect(byokHeaders()).toEqual({});
+  });
+
+  it("saveByokConfig() succeeds as a no-op write instead of throwing", () => {
+    expect(
+      saveByokConfig({ provider: "anthropic", apiKey: "k", model: "claude-sonnet-4-5" }),
+    ).toEqual({ ok: true });
+    expect(getByokConfig()).toBeNull();
+  });
+
+  it("clearByokConfig() and the vision accessors are no-ops instead of throwing", () => {
+    expect(() => {
+      clearByokConfig();
+    }).not.toThrow();
+    expect(() => {
+      setByokVisionSupported(true);
+    }).not.toThrow();
+    expect(getByokVisionSupported()).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/byokStorage-validation.test.ts
+++ b/apps/web/tests/unit/byokStorage-validation.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * validateByokConfig() rules: model requirement (OQ-1) and key requirement
+ * (P1 review follow-up — Fable + Opus). Split out of byokStorage.test.ts to
+ * keep each test file under the repo's ~200-line budget.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BYOK_DEFAULT_MODEL,
+  byokHeaders,
+  clearByokConfig,
+  getByokConfig,
+  saveByokConfig,
+  validateByokConfig,
+} from "../../src/lib/byok/byokStorage";
+import type { ByokConfig } from "../../src/lib/byok/byokStorage";
+
+const OPENAI_CONFIG: ByokConfig = {
+  provider: "openai-compatible",
+  apiKey: "sk-test-key",
+  model: "gpt-5",
+  baseUrl: "https://api.example.com/v1",
+};
+
+const ANTHROPIC_CONFIG: ByokConfig = {
+  provider: "anthropic",
+  apiKey: "anthropic-key",
+  model: BYOK_DEFAULT_MODEL.anthropic,
+};
+
+const GEMINI_CONFIG: ByokConfig = {
+  provider: "gemini",
+  apiKey: "gemini-key",
+  model: BYOK_DEFAULT_MODEL.gemini,
+};
+
+afterEach(() => {
+  clearByokConfig();
+});
+
+describe("happy path (OQ-1) — model requirement by family", () => {
+  it("requires a model for openai-compatible", () => {
+    expect(validateByokConfig({ ...OPENAI_CONFIG, model: "" })).toEqual({
+      ok: false,
+      error: "model_required",
+    });
+    expect(validateByokConfig({ ...OPENAI_CONFIG, model: "   " })).toEqual({
+      ok: false,
+      error: "model_required",
+    });
+  });
+
+  it("does not require a model for anthropic or gemini", () => {
+    expect(validateByokConfig({ ...ANTHROPIC_CONFIG, model: "" })).toEqual({ ok: true });
+    expect(validateByokConfig({ ...GEMINI_CONFIG, model: "" })).toEqual({ ok: true });
+  });
+
+  it("exposes a named default model constant for anthropic and gemini", () => {
+    expect(BYOK_DEFAULT_MODEL.anthropic.length).toBeGreaterThan(0);
+    expect(BYOK_DEFAULT_MODEL.gemini.length).toBeGreaterThan(0);
+  });
+
+  it("refuses to save (and does not touch storage) when the model is missing", () => {
+    const result = saveByokConfig({ ...OPENAI_CONFIG, model: "" });
+    expect(result).toEqual({ ok: false, error: "model_required" });
+    expect(getByokConfig()).toBeNull();
+  });
+});
+
+describe("key requirement — every family (P1 review follow-up)", () => {
+  it("rejects an empty or whitespace-only key regardless of family", () => {
+    expect(validateByokConfig({ ...OPENAI_CONFIG, apiKey: "" })).toEqual({
+      ok: false,
+      error: "key_required",
+    });
+    expect(validateByokConfig({ ...ANTHROPIC_CONFIG, apiKey: "   " })).toEqual({
+      ok: false,
+      error: "key_required",
+    });
+  });
+
+});
+
+describe("key character safety — Headers()/fetch-breaking values (Opus P2①)", () => {
+  it("rejects a key containing a newline as key_invalid, which would otherwise throw a generic TypeError from Headers()", () => {
+    expect(validateByokConfig({ ...OPENAI_CONFIG, apiKey: "sk-abc\ninjected: x" })).toEqual({
+      ok: false,
+      error: "key_invalid",
+    });
+    expect(validateByokConfig({ ...OPENAI_CONFIG, apiKey: "sk-abc\r\ninjected" })).toEqual({
+      ok: false,
+      error: "key_invalid",
+    });
+  });
+
+  it("rejects a key containing non-Latin-1 characters as key_invalid, which fetch would otherwise reject deep in the transport", () => {
+    expect(validateByokConfig({ ...OPENAI_CONFIG, apiKey: "sk-abcéè" })).toEqual({
+      ok: false,
+      error: "key_invalid",
+    });
+    expect(validateByokConfig({ ...OPENAI_CONFIG, apiKey: "sk-😀-abc" })).toEqual({
+      ok: false,
+      error: "key_invalid",
+    });
+  });
+
+  it("accepts a plain ASCII key with punctuation", () => {
+    expect(validateByokConfig({ ...OPENAI_CONFIG, apiKey: "sk-Ab12_-.:" })).toEqual({ ok: true });
+  });
+
+  it("refuses to save (and does not touch storage, does not emit an empty X-BYOK-Key header) when the key is blank", () => {
+    const result = saveByokConfig({ ...OPENAI_CONFIG, apiKey: "   " });
+    expect(result).toEqual({ ok: false, error: "key_required" });
+    expect(getByokConfig()).toBeNull();
+    expect(byokHeaders()).toEqual({});
+  });
+
+  it("prioritizes key_required over model_required when both are invalid", () => {
+    expect(validateByokConfig({ ...OPENAI_CONFIG, apiKey: "", model: "" })).toEqual({
+      ok: false,
+      error: "key_required",
+    });
+  });
+
+  it("prioritizes key_invalid over model_required when both are invalid", () => {
+    expect(validateByokConfig({ ...OPENAI_CONFIG, apiKey: "sk-abc\ninjected", model: "" })).toEqual({
+      ok: false,
+      error: "key_invalid",
+    });
+  });
+});

--- a/apps/web/tests/unit/byokStorage.test.ts
+++ b/apps/web/tests/unit/byokStorage.test.ts
@@ -1,0 +1,198 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BYOK_DEFAULT_MODEL,
+  byokHeaders,
+  clearByokConfig,
+  getByokConfig,
+  getByokVisionSupported,
+  saveByokConfig,
+  setByokVisionSupported,
+  validateByokConfig,
+} from "../../src/lib/byok/byokStorage";
+import type { ByokConfig } from "../../src/lib/byok/byokStorage";
+
+const OPENAI_CONFIG: ByokConfig = {
+  provider: "openai-compatible",
+  apiKey: "sk-test-key",
+  model: "gpt-5",
+  baseUrl: "https://api.example.com/v1",
+};
+
+const ANTHROPIC_CONFIG: ByokConfig = {
+  provider: "anthropic",
+  apiKey: "anthropic-key",
+  model: BYOK_DEFAULT_MODEL.anthropic,
+};
+
+const GEMINI_CONFIG: ByokConfig = {
+  provider: "gemini",
+  apiKey: "gemini-key",
+  model: BYOK_DEFAULT_MODEL.gemini,
+};
+
+afterEach(() => {
+  clearByokConfig();
+});
+
+describe("happy path — persistence (X10)", () => {
+  it("saves and reads back an openai-compatible config", () => {
+    expect(saveByokConfig(OPENAI_CONFIG)).toEqual({ ok: true });
+    expect(getByokConfig()).toEqual(OPENAI_CONFIG);
+  });
+
+  it("routes the write through sessionStorage only, never localStorage", () => {
+    window.localStorage.clear();
+    saveByokConfig(OPENAI_CONFIG);
+    expect(window.sessionStorage.getItem("animichi.byok.config")).not.toBeNull();
+    expect(window.localStorage.length).toBe(0);
+  });
+});
+
+describe("happy path — sessionHeaders() header emission", () => {
+  it("emits Provider/Key/Model/Base-Url for openai-compatible", () => {
+    saveByokConfig(OPENAI_CONFIG);
+    expect(byokHeaders()).toEqual({
+      "X-BYOK-Provider": "openai-compatible",
+      "X-BYOK-Key": "sk-test-key",
+      "X-BYOK-Model": "gpt-5",
+      "X-BYOK-Base-Url": "https://api.example.com/v1",
+    });
+  });
+
+  it("omits Base-Url for anthropic", () => {
+    saveByokConfig(ANTHROPIC_CONFIG);
+    expect(byokHeaders()).toEqual({
+      "X-BYOK-Provider": "anthropic",
+      "X-BYOK-Key": "anthropic-key",
+      "X-BYOK-Model": BYOK_DEFAULT_MODEL.anthropic,
+    });
+  });
+
+  it("omits Base-Url for gemini", () => {
+    saveByokConfig(GEMINI_CONFIG);
+    expect(byokHeaders()).toEqual({
+      "X-BYOK-Provider": "gemini",
+      "X-BYOK-Key": "gemini-key",
+      "X-BYOK-Model": BYOK_DEFAULT_MODEL.gemini,
+    });
+  });
+
+  it("omits Base-Url for anthropic even if a stray baseUrl value is present", () => {
+    // Guards the provider check independently of "baseUrl happens to be
+    // undefined" — a config object could carry a baseUrl for the wrong
+    // family, and the header must still be family-gated, not just
+    // presence-gated.
+    saveByokConfig({ ...ANTHROPIC_CONFIG, baseUrl: "https://sneaky.example.com" });
+    expect(byokHeaders()).toEqual({
+      "X-BYOK-Provider": "anthropic",
+      "X-BYOK-Key": "anthropic-key",
+      "X-BYOK-Model": BYOK_DEFAULT_MODEL.anthropic,
+    });
+  });
+
+  it("emits {} with no config saved", () => {
+    expect(byokHeaders()).toEqual({});
+  });
+});
+
+describe("happy path — vision flag lockstep with clearByokConfig()", () => {
+  it("keeps a set vision flag until an explicit clear", () => {
+    saveByokConfig(OPENAI_CONFIG);
+    setByokVisionSupported(true);
+    expect(getByokVisionSupported()).toBe(true);
+    clearByokConfig();
+    expect(getByokVisionSupported()).toBeNull();
+  });
+
+  it("clears the vision flag when the config is overwritten with a new key", () => {
+    saveByokConfig(OPENAI_CONFIG);
+    setByokVisionSupported(true);
+    saveByokConfig({ ...OPENAI_CONFIG, apiKey: "sk-different-key" });
+    expect(getByokVisionSupported()).toBeNull();
+  });
+
+  it("distinguishes an unprobed credential (null) from a probed-false one", () => {
+    saveByokConfig(OPENAI_CONFIG);
+    expect(getByokVisionSupported()).toBeNull();
+    setByokVisionSupported(false);
+    expect(getByokVisionSupported()).toBe(false);
+  });
+});
+
+describe("happy path (OQ-1) — model requirement by family", () => {
+  it("requires a model for openai-compatible", () => {
+    expect(validateByokConfig({ ...OPENAI_CONFIG, model: "" })).toEqual({
+      ok: false,
+      error: "model_required",
+    });
+    expect(validateByokConfig({ ...OPENAI_CONFIG, model: "   " })).toEqual({
+      ok: false,
+      error: "model_required",
+    });
+  });
+
+  it("does not require a model for anthropic or gemini", () => {
+    expect(validateByokConfig({ ...ANTHROPIC_CONFIG, model: "" })).toEqual({ ok: true });
+    expect(validateByokConfig({ ...GEMINI_CONFIG, model: "" })).toEqual({ ok: true });
+  });
+
+  it("exposes a named default model constant for anthropic and gemini", () => {
+    expect(BYOK_DEFAULT_MODEL.anthropic.length).toBeGreaterThan(0);
+    expect(BYOK_DEFAULT_MODEL.gemini.length).toBeGreaterThan(0);
+  });
+
+  it("refuses to save (and does not touch storage) when the model is missing", () => {
+    const result = saveByokConfig({ ...OPENAI_CONFIG, model: "" });
+    expect(result).toEqual({ ok: false, error: "model_required" });
+    expect(getByokConfig()).toBeNull();
+  });
+});
+
+describe("null/empty — SSR safety and corrupt storage", () => {
+  it("returns null for an absent config", () => {
+    expect(getByokConfig()).toBeNull();
+  });
+
+  it("returns null for non-JSON stored garbage", () => {
+    window.sessionStorage.setItem("animichi.byok.config", "not json{{");
+    expect(getByokConfig()).toBeNull();
+  });
+
+  it("returns null for well-formed JSON missing required fields", () => {
+    window.sessionStorage.setItem("animichi.byok.config", JSON.stringify({ provider: "anthropic" }));
+    expect(getByokConfig()).toBeNull();
+  });
+
+  it("returns null for an unknown provider value", () => {
+    window.sessionStorage.setItem(
+      "animichi.byok.config",
+      JSON.stringify({ provider: "made-up", apiKey: "k", model: "m" }),
+    );
+    expect(getByokConfig()).toBeNull();
+  });
+
+  it("returns null when the stored value is valid JSON but not an object (a bare number)", () => {
+    window.sessionStorage.setItem("animichi.byok.config", "42");
+    expect(getByokConfig()).toBeNull();
+  });
+
+  it("returns null when the stored value is valid JSON `null`", () => {
+    window.sessionStorage.setItem("animichi.byok.config", "null");
+    expect(getByokConfig()).toBeNull();
+  });
+
+  it("byokHeaders() returns {} when the stored value is corrupt", () => {
+    window.sessionStorage.setItem("animichi.byok.config", "not json{{");
+    expect(byokHeaders()).toEqual({});
+  });
+});
+
+// The module-source guards (no top-level `window` access, no other file
+// touching `sessionStorage` for BYOK) live in byokStorage-source-guard.test.ts:
+// under jsdom, `import.meta.url` resolves against the configured jsdom page
+// URL rather than a real file:// path (see vitest.config.ts's
+// environmentOptions.jsdom.url), so `node:fs` reads need the plain node
+// environment instead.

--- a/apps/web/tests/unit/byokStorage.test.ts
+++ b/apps/web/tests/unit/byokStorage.test.ts
@@ -1,11 +1,10 @@
 /**
  * @vitest-environment jsdom
  *
- * Core persistence, header emission, and vision-flag lockstep. Validation
- * rules (model/key requirements) live in byokStorage-validation.test.ts;
- * the SecurityError/partitioned-storage failure mode lives in
- * byokStorage-security-error.test.ts — split out to keep each file under
- * the repo's ~200-line test-file budget (P2③ review follow-up).
+ * Core persistence, header emission, vision-flag lockstep. Validation and
+ * field-safety rules live in byokStorage-validation.test.ts /
+ * byokStorage-field-safety.test.ts; storage-failure modes live in
+ * byokStorage-security-error.test.ts (split for the ~200-line file budget).
  */
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -194,9 +193,7 @@ describe("null/empty — SSR safety and corrupt storage", () => {
   });
 });
 
-// The module-source guards (no top-level `window` access, no other file
-// touching `sessionStorage` for BYOK) live in byokStorage-source-guard.test.ts:
-// under jsdom, `import.meta.url` resolves against the configured jsdom page
-// URL rather than a real file:// path (see vitest.config.ts's
-// environmentOptions.jsdom.url), so `node:fs` reads need the plain node
-// environment instead.
+// Module-source guards (no top-level `window` access, no cross-file
+// `sessionStorage` use) live in byokStorage-source-guard.test.ts — a plain
+// node environment, since jsdom rewrites `import.meta.url` away from a real
+// `file://` path (vitest.config.ts's `environmentOptions.jsdom.url`).

--- a/apps/web/tests/unit/byokStorage.test.ts
+++ b/apps/web/tests/unit/byokStorage.test.ts
@@ -1,5 +1,11 @@
 /**
  * @vitest-environment jsdom
+ *
+ * Core persistence, header emission, and vision-flag lockstep. Validation
+ * rules (model/key requirements) live in byokStorage-validation.test.ts;
+ * the SecurityError/partitioned-storage failure mode lives in
+ * byokStorage-security-error.test.ts — split out to keep each file under
+ * the repo's ~200-line test-file budget (P2③ review follow-up).
  */
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -10,7 +16,6 @@ import {
   getByokVisionSupported,
   saveByokConfig,
   setByokVisionSupported,
-  validateByokConfig,
 } from "../../src/lib/byok/byokStorage";
 import type { ByokConfig } from "../../src/lib/byok/byokStorage";
 
@@ -98,6 +103,23 @@ describe("happy path — sessionHeaders() header emission", () => {
   });
 });
 
+describe("happy path — Base-Url edge cases", () => {
+  it("omits Base-Url for openai-compatible when baseUrl is empty/whitespace (P3)", () => {
+    saveByokConfig({ ...OPENAI_CONFIG, baseUrl: "" });
+    expect(byokHeaders()).toEqual({
+      "X-BYOK-Provider": "openai-compatible",
+      "X-BYOK-Key": "sk-test-key",
+      "X-BYOK-Model": "gpt-5",
+    });
+    saveByokConfig({ ...OPENAI_CONFIG, baseUrl: "   " });
+    expect(byokHeaders()).toEqual({
+      "X-BYOK-Provider": "openai-compatible",
+      "X-BYOK-Key": "sk-test-key",
+      "X-BYOK-Model": "gpt-5",
+    });
+  });
+});
+
 describe("happy path — vision flag lockstep with clearByokConfig()", () => {
   it("keeps a set vision flag until an explicit clear", () => {
     saveByokConfig(OPENAI_CONFIG);
@@ -120,34 +142,16 @@ describe("happy path — vision flag lockstep with clearByokConfig()", () => {
     setByokVisionSupported(false);
     expect(getByokVisionSupported()).toBe(false);
   });
-});
 
-describe("happy path (OQ-1) — model requirement by family", () => {
-  it("requires a model for openai-compatible", () => {
-    expect(validateByokConfig({ ...OPENAI_CONFIG, model: "" })).toEqual({
-      ok: false,
-      error: "model_required",
-    });
-    expect(validateByokConfig({ ...OPENAI_CONFIG, model: "   " })).toEqual({
-      ok: false,
-      error: "model_required",
-    });
-  });
-
-  it("does not require a model for anthropic or gemini", () => {
-    expect(validateByokConfig({ ...ANTHROPIC_CONFIG, model: "" })).toEqual({ ok: true });
-    expect(validateByokConfig({ ...GEMINI_CONFIG, model: "" })).toEqual({ ok: true });
-  });
-
-  it("exposes a named default model constant for anthropic and gemini", () => {
-    expect(BYOK_DEFAULT_MODEL.anthropic.length).toBeGreaterThan(0);
-    expect(BYOK_DEFAULT_MODEL.gemini.length).toBeGreaterThan(0);
-  });
-
-  it("refuses to save (and does not touch storage) when the model is missing", () => {
-    const result = saveByokConfig({ ...OPENAI_CONFIG, model: "" });
-    expect(result).toEqual({ ok: false, error: "model_required" });
-    expect(getByokConfig()).toBeNull();
+  it("does not write an orphaned vision flag when no config is saved (probe-after-clear race, Opus P1-2)", () => {
+    // A probe that resolves after clearByokConfig() (or before any config was
+    // ever saved) must not leave a vision flag with nothing to attach to —
+    // otherwise a later, unrelated saveByokConfig() could inherit a stale
+    // "vision supported" flag it never earned.
+    setByokVisionSupported(true);
+    expect(getByokVisionSupported()).toBeNull();
+    saveByokConfig(OPENAI_CONFIG);
+    expect(getByokVisionSupported()).toBeNull();
   });
 });
 

--- a/apps/web/tests/unit/chat/byok-i18n.test.ts
+++ b/apps/web/tests/unit/chat/byok-i18n.test.ts
@@ -23,6 +23,8 @@ function allStrings(dict: ChatByokDict): readonly string[] {
     dict.familyAnthropic,
     dict.familyGemini,
     dict.apiKeyLabel,
+    dict.apiKeyRequired,
+    dict.apiKeyInvalid,
     dict.modelLabel,
     dict.modelRequired,
     dict.baseUrlLabel,
@@ -56,6 +58,9 @@ describe("BYOK panel copy (issue #284 Task 6)", () => {
     }
   });
 
+});
+
+describe("BYOK panel copy — field/message distinctness", () => {
   it("covers all three family selector labels distinctly per locale", () => {
     for (const locale of LOCALES) {
       const dict = chatDictFor(locale).byok;
@@ -68,6 +73,20 @@ describe("BYOK panel copy (issue #284 Task 6)", () => {
     for (const locale of LOCALES) {
       const dict = chatDictFor(locale).byok;
       expect(dict.modelRequired).not.toBe(dict.modelLabel);
+    }
+  });
+
+  it("keeps the key-required validation message distinct from the label", () => {
+    for (const locale of LOCALES) {
+      const dict = chatDictFor(locale).byok;
+      expect(dict.apiKeyRequired).not.toBe(dict.apiKeyLabel);
+    }
+  });
+
+  it("keeps the key-invalid message distinct from the key-required message", () => {
+    for (const locale of LOCALES) {
+      const dict = chatDictFor(locale).byok;
+      expect(dict.apiKeyInvalid).not.toBe(dict.apiKeyRequired);
     }
   });
 

--- a/apps/web/tests/unit/chat/byok-i18n.test.ts
+++ b/apps/web/tests/unit/chat/byok-i18n.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { ChatByokDict } from "../../../src/features/chat/i18n";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { LOCALES } from "../../../src/i18n/locales";
+
+/** Every raw key name that must never leak into user-facing copy. */
+const RAW_KEY_NAMES = [
+  "X-BYOK-Provider",
+  "X-BYOK-Key",
+  "X-BYOK-Model",
+  "X-BYOK-Base-Url",
+  "byok_credential_rejected",
+  "byok_requires_login",
+  "invalid_request",
+  "egress_blocked",
+];
+
+function allStrings(dict: ChatByokDict): readonly string[] {
+  return [
+    dict.title,
+    dict.familyLabel,
+    dict.familyOpenaiCompatible,
+    dict.familyAnthropic,
+    dict.familyGemini,
+    dict.apiKeyLabel,
+    dict.modelLabel,
+    dict.modelRequired,
+    dict.baseUrlLabel,
+    dict.baseUrlHelp,
+    dict.save,
+    dict.clear,
+    dict.maskedSummary,
+    dict.visionBadge,
+    dict.errorCredentialRejected,
+    dict.errorRequiresLogin,
+    dict.errorInvalidRequest,
+    dict.errorEgressBlocked,
+    dict.notAccepted,
+    dict.anonymousTeaser,
+    dict.signInToSetUp,
+  ];
+}
+
+describe("BYOK panel copy (issue #284 Task 6)", () => {
+  it.each(LOCALES)("resolves every key with non-empty copy for %s", (locale) => {
+    for (const value of allStrings(chatDictFor(locale).byok)) {
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(LOCALES)("never leaks a raw header name or wire error code in %s copy", (locale) => {
+    for (const value of allStrings(chatDictFor(locale).byok)) {
+      for (const rawName of RAW_KEY_NAMES) {
+        expect(value).not.toContain(rawName);
+      }
+    }
+  });
+
+  it("covers all three family selector labels distinctly per locale", () => {
+    for (const locale of LOCALES) {
+      const dict = chatDictFor(locale).byok;
+      const labels = [dict.familyOpenaiCompatible, dict.familyAnthropic, dict.familyGemini];
+      expect(new Set(labels).size).toBe(3);
+    }
+  });
+
+  it("keeps the model-required validation message distinct from the label", () => {
+    for (const locale of LOCALES) {
+      const dict = chatDictFor(locale).byok;
+      expect(dict.modelRequired).not.toBe(dict.modelLabel);
+    }
+  });
+
+  it("provides distinct copy for every BYOK-specific error code across locales", () => {
+    const ja = chatDictFor("ja").byok;
+    const zh = chatDictFor("zh").byok;
+    const en = chatDictFor("en").byok;
+    expect(ja.errorCredentialRejected).not.toBe(en.errorCredentialRejected);
+    expect(zh.errorCredentialRejected).not.toBe(en.errorCredentialRejected);
+    expect(ja.errorRequiresLogin).not.toBe(en.errorRequiresLogin);
+  });
+
+  it("provides base_url helper copy distinct from its label", () => {
+    for (const locale of LOCALES) {
+      const dict = chatDictFor(locale).byok;
+      expect(dict.baseUrlHelp).not.toBe(dict.baseUrlLabel);
+    }
+  });
+});

--- a/apps/web/tests/unit/chat/byok-i18n.test.ts
+++ b/apps/web/tests/unit/chat/byok-i18n.test.ts
@@ -29,6 +29,7 @@ function allStrings(dict: ChatByokDict): readonly string[] {
     dict.modelRequired,
     dict.baseUrlLabel,
     dict.baseUrlHelp,
+    dict.baseUrlInvalid,
     dict.save,
     dict.clear,
     dict.maskedSummary,
@@ -103,6 +104,13 @@ describe("BYOK panel copy — field/message distinctness", () => {
     for (const locale of LOCALES) {
       const dict = chatDictFor(locale).byok;
       expect(dict.baseUrlHelp).not.toBe(dict.baseUrlLabel);
+    }
+  });
+
+  it("provides base_url-invalid copy distinct from its helper text", () => {
+    for (const locale of LOCALES) {
+      const dict = chatDictFor(locale).byok;
+      expect(dict.baseUrlInvalid).not.toBe(dict.baseUrlHelp);
     }
   });
 });

--- a/apps/web/tests/unit/chat/photo-search-client.test.ts
+++ b/apps/web/tests/unit/chat/photo-search-client.test.ts
@@ -2,7 +2,8 @@
  * @vitest-environment jsdom
  */
 import { http, HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearByokConfig, saveByokConfig } from "../../../src/lib/byok/byokStorage";
 import {
   MAX_PHOTO_BYTES,
   confirmPhotoSearch,
@@ -15,6 +16,10 @@ import type { PhotoSearchContext } from "../../../src/features/chat/photo-search
 import { TEST_ORIGIN } from "../../msw/fixtures";
 import { server } from "../../msw/node";
 import { bytesToText, makeJpegWithExif } from "../shiori/_jpegFixtures";
+
+afterEach(() => {
+  clearByokConfig();
+});
 
 const URL = `${TEST_ORIGIN}/v1/photo-search`;
 const CONFIRM_URL = `${TEST_ORIGIN}/v1/photo-search/confirm`;
@@ -89,6 +94,38 @@ describe("photo-search transport (P1-1/P1-4)", () => {
     expect(bodies[1]).not.toHaveProperty("gps");
   });
 
+});
+
+describe("BYOK headers on photo search (#284 P1-2 — deliberate, not inherited by accident)", () => {
+  // Ruling: photo search sharing `sessionHeaders()` with chat means a saved
+  // BYOK credential's headers reach the vision turn too. This is the
+  // *correct* semantics, not a side effect to suppress — the vision
+  // probe/badge (Task 5, D5) exists precisely so a BYOK user's image turns
+  // are answered by their own key, and T9 requires a BYOK turn to never
+  // silently fall back to the platform key. Photo search is a BYOK turn
+  // like any other, so it must carry the same headers chat does.
+  it("carries the full X-BYOK-* set on the upload request", async () => {
+    saveByokConfig({
+      provider: "openai-compatible",
+      apiKey: "sk-vision-key",
+      model: "gpt-5-vision",
+      baseUrl: "https://api.example.com/v1",
+    });
+    const headers: Headers[] = [];
+    capture([], headers);
+    await postPhotoSearch(TEST_ORIGIN, jpegFile(), CTX);
+    expect(headers[0]?.get("x-byok-provider")).toBe("openai-compatible");
+    expect(headers[0]?.get("x-byok-key")).toBe("sk-vision-key");
+    expect(headers[0]?.get("x-byok-model")).toBe("gpt-5-vision");
+    expect(headers[0]?.get("x-byok-base-url")).toBe("https://api.example.com/v1");
+  });
+
+  it("carries no X-BYOK-* headers when nothing is saved", async () => {
+    const headers: Headers[] = [];
+    capture([], headers);
+    await postPhotoSearch(TEST_ORIGIN, jpegFile(), CTX);
+    expect(headers[0]?.get("x-byok-provider")).toBeNull();
+  });
 });
 
 describe("photo-search outcomes", () => {

--- a/apps/web/tests/unit/chat/session-headers.test.ts
+++ b/apps/web/tests/unit/chat/session-headers.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * `sessionHeaders()` (issue #260/#445 shared-module extraction) is the single
+ * injection point for both the chat transport and photo search. This file
+ * pins its BYOK header behaviour (#284 Task 6) directly at the function,
+ * independent of either caller — see also `photo-search-client.test.ts`'s
+ * "BYOK headers on photo search (#284 P1-2)" describe block, which asserts
+ * the same semantics survive through that specific transport.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearByokConfig, saveByokConfig } from "../../../src/lib/byok/byokStorage";
+import { sessionHeaders } from "../../../src/features/chat/session-headers";
+
+const { authHeaders } = vi.hoisted(() => ({ authHeaders: vi.fn().mockResolvedValue({}) }));
+vi.mock("../../../src/lib/auth/authSession", () => ({ authHeaders }));
+
+afterEach(() => {
+  authHeaders.mockReset().mockResolvedValue({});
+  clearByokConfig();
+});
+
+describe("sessionHeaders() identity headers (regression, pre-BYOK behaviour)", () => {
+  it("emits x-session-id only when a session id is known", async () => {
+    expect(await sessionHeaders("s-1")).toMatchObject({ "x-session-id": "s-1" });
+    expect(await sessionHeaders()).not.toHaveProperty("x-session-id");
+  });
+
+  it("injects the Bearer token in place of a Turnstile header once signed in", async () => {
+    authHeaders.mockResolvedValue({ Authorization: "Bearer jwt" });
+    expect(await sessionHeaders()).toMatchObject({ Authorization: "Bearer jwt" });
+  });
+});
+
+describe("sessionHeaders() BYOK injection (#284 Task 6)", () => {
+  it("emits exactly today's header set when nothing is saved", async () => {
+    expect(await sessionHeaders("s-1")).toEqual({ "x-session-id": "s-1" });
+  });
+
+  it("adds the full X-BYOK-* set for openai-compatible on top of the identity headers", async () => {
+    authHeaders.mockResolvedValue({ Authorization: "Bearer jwt" });
+    saveByokConfig({
+      provider: "openai-compatible",
+      apiKey: "sk-test",
+      model: "gpt-5",
+      baseUrl: "https://api.example.com/v1",
+    });
+    expect(await sessionHeaders("s-1")).toEqual({
+      "x-session-id": "s-1",
+      Authorization: "Bearer jwt",
+      "X-BYOK-Provider": "openai-compatible",
+      "X-BYOK-Key": "sk-test",
+      "X-BYOK-Model": "gpt-5",
+      "X-BYOK-Base-Url": "https://api.example.com/v1",
+    });
+  });
+
+  it("omits X-BYOK-Base-Url for anthropic/gemini", async () => {
+    saveByokConfig({ provider: "anthropic", apiKey: "ak", model: "claude-sonnet-4-5" });
+    const headers = await sessionHeaders();
+    expect(headers["X-BYOK-Base-Url"]).toBeUndefined();
+    expect(headers["X-BYOK-Provider"]).toBe("anthropic");
+  });
+
+  it("adds BYOK headers to an anonymous (no-Authorization) turn too — the container is the authority on rejecting it, not the client", async () => {
+    saveByokConfig({ provider: "gemini", apiKey: "gk", model: "gemini-2.5-flash" });
+    const headers = await sessionHeaders();
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers["X-BYOK-Provider"]).toBe("gemini");
+  });
+});

--- a/apps/web/tests/unit/chat/session-headers.test.ts
+++ b/apps/web/tests/unit/chat/session-headers.test.ts
@@ -11,6 +11,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearByokConfig, saveByokConfig } from "../../../src/lib/byok/byokStorage";
 import { sessionHeaders } from "../../../src/features/chat/session-headers";
+import { clearTurnstileToken, rememberTurnstileToken } from "../../../src/lib/turnstile/tokenStore";
+
+/** 24 characters — the shape `configuredTurnstileSiteKey()` accepts as a real
+ * public key (see turnstile-armed-flow.test.tsx). The global
+ * `turnstile-hermetic.ts` setup stubs the site key empty for every other
+ * describe block in this file; these tests deliberately re-arm it. */
+const SITE_KEY = "0x4AAAAAAAsitekey24chars";
 
 const { authHeaders } = vi.hoisted(() => ({ authHeaders: vi.fn().mockResolvedValue({}) }));
 vi.mock("../../../src/lib/auth/authSession", () => ({ authHeaders }));
@@ -67,5 +74,38 @@ describe("sessionHeaders() BYOK injection (#284 Task 6)", () => {
     const headers = await sessionHeaders();
     expect(headers.Authorization).toBeUndefined();
     expect(headers["X-BYOK-Provider"]).toBe("gemini");
+  });
+});
+
+describe("sessionHeaders() BYOK headers vs the armed Turnstile wait (#463 rebase follow-up)", () => {
+  afterEach(() => {
+    clearTurnstileToken();
+  });
+
+  it("applies BYOK headers on top once an awaited, late-arriving challenge resolves", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", SITE_KEY);
+    saveByokConfig({ provider: "gemini", apiKey: "gk", model: "gemini-2.5-flash" });
+    const pending = sessionHeaders("s-armed");
+    await Promise.resolve();
+    rememberTurnstileToken("late-token");
+    expect(await pending).toEqual({
+      "x-session-id": "s-armed",
+      "cf-turnstile-response": "late-token",
+      "X-BYOK-Provider": "gemini",
+      "X-BYOK-Key": "gk",
+      "X-BYOK-Model": "gemini-2.5-flash",
+    });
+  });
+
+  it("skips the wait once authenticated, and still applies BYOK headers", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", SITE_KEY);
+    authHeaders.mockResolvedValue({ Authorization: "Bearer jwt" });
+    saveByokConfig({ provider: "anthropic", apiKey: "ak", model: "claude-sonnet-4-5" });
+    expect(await sessionHeaders()).toEqual({
+      Authorization: "Bearer jwt",
+      "X-BYOK-Provider": "anthropic",
+      "X-BYOK-Key": "ak",
+      "X-BYOK-Model": "claude-sonnet-4-5",
+    });
   });
 });

--- a/apps/web/tests/unit/chat/use-chat-session.test.tsx
+++ b/apps/web/tests/unit/chat/use-chat-session.test.tsx
@@ -3,7 +3,6 @@
  */
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { clearByokConfig, saveByokConfig } from "../../../src/lib/byok/byokStorage";
 import { useChatSession } from "../../../src/features/chat/use-chat-session";
 import { server } from "../../msw/node";
 import {
@@ -20,7 +19,6 @@ vi.mock("../../../src/lib/auth/authSession", () => ({ authHeaders }));
 
 afterEach(() => {
   authHeaders.mockReset().mockResolvedValue({});
-  clearByokConfig();
 });
 
 type Props = Readonly<{ sessionId?: string }>;
@@ -187,52 +185,5 @@ describe("auth header injection", () => {
     const view = renderSession("auth-1");
     await sendAndSettle(view, "ユーフォ");
     expect(seen).toEqual(["Bearer jwt-chat"]);
-  });
-});
-
-describe("BYOK header injection (issue #284 Task 6)", () => {
-  function byokSpyingHandler(seen: Record<string, string | null>[]) {
-    return chatStreamHandler("search", {
-      spy: (request) =>
-        seen.push({
-          provider: request.headers.get("x-byok-provider"),
-          key: request.headers.get("x-byok-key"),
-          model: request.headers.get("x-byok-model"),
-          baseUrl: request.headers.get("x-byok-base-url"),
-        }),
-    });
-  }
-
-  it("adds X-BYOK-* headers when a config is saved", async () => {
-    saveByokConfig({
-      provider: "openai-compatible",
-      apiKey: "sk-test",
-      model: "gpt-5",
-      baseUrl: "https://api.example.com/v1",
-    });
-    const seen: Record<string, string | null>[] = [];
-    server.use(byokSpyingHandler(seen));
-    const view = renderSession("byok-1");
-    await sendAndSettle(view, "ユーフォ");
-    expect(seen).toEqual([
-      { provider: "openai-compatible", key: "sk-test", model: "gpt-5", baseUrl: "https://api.example.com/v1" },
-    ]);
-  });
-
-  it("emits exactly today's header set (no X-BYOK-*) when nothing is saved", async () => {
-    const seen: Record<string, string | null>[] = [];
-    server.use(byokSpyingHandler(seen));
-    const view = renderSession("byok-2");
-    await sendAndSettle(view, "ユーフォ");
-    expect(seen).toEqual([{ provider: null, key: null, model: null, baseUrl: null }]);
-  });
-
-  it("omits X-BYOK-Base-Url for a non-openai-compatible family", async () => {
-    saveByokConfig({ provider: "anthropic", apiKey: "ak", model: "claude-sonnet-4-5" });
-    const seen: Record<string, string | null>[] = [];
-    server.use(byokSpyingHandler(seen));
-    const view = renderSession("byok-3");
-    await sendAndSettle(view, "ユーフォ");
-    expect(seen).toEqual([{ provider: "anthropic", key: "ak", model: "claude-sonnet-4-5", baseUrl: null }]);
   });
 });

--- a/apps/web/tests/unit/chat/use-chat-session.test.tsx
+++ b/apps/web/tests/unit/chat/use-chat-session.test.tsx
@@ -3,6 +3,7 @@
  */
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearByokConfig, saveByokConfig } from "../../../src/lib/byok/byokStorage";
 import { useChatSession } from "../../../src/features/chat/use-chat-session";
 import { server } from "../../msw/node";
 import {
@@ -19,6 +20,7 @@ vi.mock("../../../src/lib/auth/authSession", () => ({ authHeaders }));
 
 afterEach(() => {
   authHeaders.mockReset().mockResolvedValue({});
+  clearByokConfig();
 });
 
 type Props = Readonly<{ sessionId?: string }>;
@@ -185,5 +187,52 @@ describe("auth header injection", () => {
     const view = renderSession("auth-1");
     await sendAndSettle(view, "ユーフォ");
     expect(seen).toEqual(["Bearer jwt-chat"]);
+  });
+});
+
+describe("BYOK header injection (issue #284 Task 6)", () => {
+  function byokSpyingHandler(seen: Record<string, string | null>[]) {
+    return chatStreamHandler("search", {
+      spy: (request) =>
+        seen.push({
+          provider: request.headers.get("x-byok-provider"),
+          key: request.headers.get("x-byok-key"),
+          model: request.headers.get("x-byok-model"),
+          baseUrl: request.headers.get("x-byok-base-url"),
+        }),
+    });
+  }
+
+  it("adds X-BYOK-* headers when a config is saved", async () => {
+    saveByokConfig({
+      provider: "openai-compatible",
+      apiKey: "sk-test",
+      model: "gpt-5",
+      baseUrl: "https://api.example.com/v1",
+    });
+    const seen: Record<string, string | null>[] = [];
+    server.use(byokSpyingHandler(seen));
+    const view = renderSession("byok-1");
+    await sendAndSettle(view, "ユーフォ");
+    expect(seen).toEqual([
+      { provider: "openai-compatible", key: "sk-test", model: "gpt-5", baseUrl: "https://api.example.com/v1" },
+    ]);
+  });
+
+  it("emits exactly today's header set (no X-BYOK-*) when nothing is saved", async () => {
+    const seen: Record<string, string | null>[] = [];
+    server.use(byokSpyingHandler(seen));
+    const view = renderSession("byok-2");
+    await sendAndSettle(view, "ユーフォ");
+    expect(seen).toEqual([{ provider: null, key: null, model: null, baseUrl: null }]);
+  });
+
+  it("omits X-BYOK-Base-Url for a non-openai-compatible family", async () => {
+    saveByokConfig({ provider: "anthropic", apiKey: "ak", model: "claude-sonnet-4-5" });
+    const seen: Record<string, string | null>[] = [];
+    server.use(byokSpyingHandler(seen));
+    const view = renderSession("byok-3");
+    await sendAndSettle(view, "ユーフォ");
+    expect(seen).toEqual([{ provider: "anthropic", key: "ak", model: "claude-sonnet-4-5", baseUrl: null }]);
   });
 });


### PR DESCRIPTION
## Summary

Implements the **storage/non-render half** of Task 6 from the BYOK spec (#284, `docs/superpowers/specs/2026-07-28-284-byok-design.md`, revision efc0abaa). Per the split with the UI wave:

**In this PR (non-UI):**
- `apps/web/src/lib/byok/byokStorage.ts` — session-scoped BYOK credential storage. SSR-safe and Safari-partitioned-storage-safe (every `sessionStorage` access, **including the property read itself**, is wrapped in `try`/`catch`; see "Review round 2" below). Exposes `saveByokConfig`/`getByokConfig`/`clearByokConfig`, `validateByokConfig` (model required for openai-compatible only, per OQ-1; key required + character-safety validated for every family), `byokHeaders()` (`X-BYOK-Provider/Key/Model/Base-Url`), vision-flag accessors cleared in lockstep with the credential.
- `apps/web/src/features/chat/session-headers.ts` — the shared `sessionHeaders()` (extracted by #445, used by both chat and photo search) now spreads `byokHeaders()` on top of auth/turnstile headers.
- `apps/web/src/features/chat/byok-i18n.ts` (new) + `i18n.ts` wiring — ja/zh/en BYOK panel copy, including key-required/key-invalid/model-required validation messages.
- Tests: see "Test plan" below.

**Left for the UI wave** (explicitly noted here): `ByokSettings.tsx`, `ChatInput.tsx` entry point, `chat.css` design tokens, and the browser-level ACs that need those components to exist (inline error render, "key not accepted" state, vision badge render, design-token grep).

## Review round 2 — rebase + Fable/Opus follow-up

Both review seats (Fable, Opus) returned `request_changes` against the first revision (base `fa3f2385`, before #445 landed). This revision addresses both in one pass:

**Rebase (Fable P1-1).** #445 merged and extracted the shared `sessionHeaders()` out of `use-chat-session.ts` into `apps/web/src/features/chat/session-headers.ts` (used by both chat and the new photo-search feature). Rebased onto current `feat/frontend-rebuild`; the BYOK header injection point moved to `session-headers.ts` instead of re-adding it to `use-chat-session.ts`, with a new dedicated `session-headers.test.ts`.

**Photo-search BYOK semantics — explicit ruling (Fable P1-2, Fable architecture seat).** Because photo search now shares `sessionHeaders()` with chat, a saved BYOK credential's headers reach photo search's upload request too. **Ruling: this is the correct semantics, not an accident of sharing a module.** The vision-capability probe/badge (Task 5, D5) exists precisely so a BYOK user's image turns are answered by their own key, and Task 9 (per-identity rate limiting) requires a BYOK turn to never silently fall back to the platform key — photo search is a BYOK turn like any other. Documented in `session-headers.ts`'s doc comment and covered by a dedicated "BYOK headers on photo search" describe block in `photo-search-client.test.ts` (asserts the full header set present when a credential is saved, and absent when none is).

**Opus P1-2 — SecurityError from the `sessionStorage` accessor itself (reproduced).** `typeof window.sessionStorage` **evaluates the accessor**, not just a type check — Safari's partitioned/blocked-storage mode (and similar restrictions) implements `sessionStorage` as a getter that throws `SecurityError` on read, not merely on `.getItem()`/`.setItem()`. Before this fix, that would have propagated out of `byokHeaders()` and failed **every chat turn for a user who has never touched BYOK**. Fixed: `trySessionStorage()` wraps the property read itself in `try`/`catch`, and every storage operation (`safeGet`/`safeSet`/`safeRemove`) independently wraps its call too (a `.getItem()`-level throw is a distinct failure mode from an accessor-level throw). Reproduced in jsdom via `Object.defineProperty(window, "sessionStorage", { get() { throw ... } })` (accessor-level) and `vi.spyOn(Storage.prototype, "getItem")` (method-level — jsdom's `Storage` silently ignores a direct instance-property override, so the prototype spy is what actually takes effect) in `byokStorage-security-error.test.ts`.

**P2 follow-ups (Fable + Opus, merged into one pass):**
1. **Key validation extended.** `validateByokConfig` now rejects an empty/whitespace key (`key_required` — previously this would have shipped `X-BYOK-Key: ""` and relied on a guaranteed 400 downstream) and a key containing `\r`/`\n` or any non-Latin-1/control character (`key_invalid` — previously this would have thrown an opaque, per-turn-**sticky** `TypeError` from `Headers()`/`fetch()` deep in the transport instead of a validation rejection surfaced once at save time). New `apiKeyRequired`/`apiKeyInvalid` i18n copy added.
2. **Orphaned vision flag fixed.** `setByokVisionSupported()` is now a no-op when no config is saved, closing a probe-after-clear race: a vision probe that resolves after `clearByokConfig()` (or before any config was ever saved) could previously leave a vision flag with nothing to attach to, which a later, unrelated `saveByokConfig()` call would then silently inherit.
3. **AC1 grep upgraded to full-tree.** The "no component touches `sessionStorage` directly" guard now recursively walks all of `apps/web/src/` (excluding `byokStorage.ts`) instead of two flat directories — the AC says "no component", not "no component in these two folders". Verified this costs single-digit milliseconds locally; no reason to keep the narrower scan.
4. **Test-file budget.** `byokStorage.test.ts` (was 333 lines) split into `byokStorage.test.ts` / `byokStorage-validation.test.ts` / `byokStorage-security-error.test.ts`; oversized `describe` blocks in `byokStorage.test.ts`, `byokStorage-validation.test.ts`, and `byok-i18n.test.ts` split further to satisfy the repo's 50-line-per-function lint rule on test bodies. The originally-flagged 238-line `use-chat-session.test.tsx` addition was removed entirely once the injection point moved to `session-headers.ts` (no BYOK-specific changes remain in that file — it's back to its pre-this-PR state).
5. **P3 (baseUrl / naming):** `baseUrl` of `""` or whitespace-only is now treated as absent for header purposes, same as `undefined`. Added a one-line jsdoc note reconciling the spec prose's "readByokConfig" with this module's `getByokConfig` export name.

**Threat-model wording corrected.** `byokStorage.ts`'s header comment previously implied `sessionStorage` was a hard per-tab boundary. It isn't (per threat T11): a duplicated tab or a browser-restored session can carry `sessionStorage` along. Wording now says the credential is bounded to the browser session, not to a single tab — no design change, just an accuracy fix.

**Residual risk tracked separately.** OQ-6 (a CSP for `apps/web` as BYOK residual-XSS hardening) and OQ-7 (retrofitting the SSRF egress guard onto pre-existing egress paths like `web_tools`/image proxy) are out of Task 6's scope and tracked as #469 and #470 respectively.

## Task 6 AC coverage (9 total)

| # | AC | Status |
|---|---|---|
| 1 | No component calls `sessionStorage` directly (spy + grep) | ✅ storage half done; grep test now walks the full `src/` tree |
| 2 | `sessionHeaders()` emits the right X-BYOK-* set / `{}` set when unsaved | ✅ done + tested (now at the `session-headers.ts` injection point) |
| 3 | Vision badge write/clear lockstep with `clearByokConfig()` | ✅ storage lockstep done (incl. the orphan-flag race fix); the visible badge render is UI-wave |
| 4 | Model required for openai-compatible; pre-filled default for anthropic/gemini | ✅ `validateByokConfig` + `BYOK_DEFAULT_MODEL` done; the inline validation message *render* is UI-wave |
| 5 | SSR-safe, corrupt/absent → null, `byokHeaders()` → `{}` | ✅ done + tested, now also covering Safari-partitioned-storage `SecurityError` |
| 6 | Inline error inside settings panel, no raw key in DOM | ⏳ UI-wave (browser AC, needs the component) |
| 7 | Rejected credential doesn't silently continue on platform key | ⏳ UI-wave (browser AC) |
| 8 | i18n: every BYOK string resolves ja/zh/en, no leaked keys | ✅ done + tested |
| 9 | Design tokens grep (no `bg-white`/`bg-gray-`/hardcoded palette) | ⏳ UI-wave (no CSS touched yet) |

## Mutation testing evidence

No mutation-testing tool is configured in the repo. Verified by hand across both review rounds — introduced and reverted each mutation, re-running the relevant unit suite:

Round 1:
1. Inverted the openai-compatible model-required condition → **caught**
2. Stopped clearing the vision flag on save/clear → **caught**
3. Dropped the provider gate on the `X-BYOK-Base-Url` header → **initially survived** — added a test asserting the header stays omitted for anthropic even with a stray `baseUrl` present, re-ran: **caught**
4. Forced `hasSessionStorage()` to always return `true` (breaks SSR safety) → **caught**
5. Made `isByokProvider` accept any string → **caught**

Round 2 (this revision):
6. Dropped the `try`/`catch` around the `sessionStorage` property read (reverting to a bare `typeof` guard) → **caught** by `byokStorage-security-error.test.ts`
7. Weakened `HEADER_SAFE` to only reject `\r`/`\n`, allowing non-Latin-1 through → **caught** by `byokStorage-validation.test.ts`
8. Removed the orphaned-vision-flag guard (`setByokVisionSupported` writing with no config saved) → **caught**
9. Removed the `try`/`catch` inside `safeGet` around `.getItem()` (keeping only the property-level guard) → **caught** by the `Storage.prototype.getItem` spy test — confirming the two guard layers are independently load-bearing

All mutations reverted; working tree confirmed clean after each sweep.

## Gates

- `pnpm test` (apps/web, full suite): **1090 tests, all passing** (`Test Files 170 passed`, `Tests 1090 passed`)
- Coverage: `src/lib/byok/byokStorage.ts` at 100% stmts/branches/funcs/lines (fully covered — no longer listed in the istanbul non-100% report); overall apps/web coverage 98.7% stmts / 95.13% branches / 99.16% funcs / 99.56% lines, well above the 90/90/90/90 floor in `apps/web/AGENTS.md`
- `pnpm run typecheck`: clean
- `pnpm run lint:oxlint` (type-aware, `--deny-warnings`): clean
- No `eslint-disable`/`@ts-ignore`/suppression added

## Test plan

- [x] `apps/web/tests/unit/byokStorage.test.ts` — persistence, header emission (incl. Base-Url edge cases), vision lockstep (incl. orphan-flag fix), null/corrupt storage
- [x] `apps/web/tests/unit/byokStorage-validation.test.ts` — model-required (OQ-1) and key-required/key-invalid (character-safety) validation rules
- [x] `apps/web/tests/unit/byokStorage-security-error.test.ts` — SecurityError from both the `sessionStorage` accessor and a method call, reproduced in jsdom
- [x] `apps/web/tests/unit/byokStorage-ssr.test.ts` — node-environment SSR safety (no `window` global)
- [x] `apps/web/tests/unit/byokStorage-source-guard.test.ts` — AC1 full-tree grep guard + no top-level `window` access
- [x] `apps/web/tests/unit/chat/byok-i18n.test.ts` — ja/zh/en copy resolves, no leaked raw keys/header names
- [x] `apps/web/tests/unit/chat/session-headers.test.ts` — the shared injection point directly: identity headers (regression) + BYOK header combinations
- [x] `apps/web/tests/unit/chat/photo-search-client.test.ts` — new "BYOK headers on photo search" describe block asserting the deliberate semantics

References issue #284, Task 6 of `docs/superpowers/specs/2026-07-28-284-byok-design.md` (rev4, efc0abaa). Residual risk tracked as #469 (CSP/OQ-6) and #470 (egress-guard retrofit/OQ-7). Not merging per instructions — for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 3 pushed — SHA `fb975550061a527c1d7b07d2f3c45705809475fb`

Addressed both approval-gated follow-ups from round 2's sign-off:

**P2 — HEADER_SAFE extended to model (all families) and base_url.** Previously `model`'s character-safety check only ran for the openai-compatible family, and `base_url` had no character check at all — so a Japanese model name on anthropic/gemini, a CRLF-injected model on any family, or an internationalized-domain (non-ASCII) `base_url` would all have saved successfully and only crashed `Headers()`/`fetch()` later, at turn time (a sticky per-turn `TypeError`). Both now go through `HEADER_SAFE`, with a new `base_url_invalid` error code (IDN hosts are rejected outright rather than punycode-decoded here — the settings panel is expected to prompt for an ASCII/A-label host, matching what the Task 1 egress guard already expects on the wire). Five probes added in `byokStorage-field-safety.test.ts`: Japanese model on anthropic, CRLF-injected model on gemini, IDN base_url, CRLF-injected base_url, and an ASCII base_url regression. New `baseUrlInvalid` i18n copy (ja/zh/en).

**P3 — genuine safeSet catch coverage.** The `safeSet` catch block previously showed 100% coverage only via an accessor-level `SecurityError` block, which short-circuits before ever reaching `.setItem()` — a false-positive signal, exactly as flagged. Added a `Storage.prototype.setItem`-throwing (`QuotaExceededError`, reproducing Safari private-mode) test exercising `saveByokConfig()` and `setByokVisionSupported()` through the actual catch path in `byokStorage-security-error.test.ts`. Verified by mutation: removing the `try`/`catch` around `.setItem()` makes both new tests fail.

Also trimmed `byokStorage.test.ts`'s comments (202 → 199 lines) to clear the ~200-line test-file budget.

Gates: `pnpm test` 1102 tests passing, `byokStorage.ts` at 100% coverage, typecheck clean, `lint:oxlint --deny-warnings` clean. 2 new mutations (model-family restriction, dropped base_url check) + the safeSet-catch mutation all caught; working tree confirmed clean after each sweep.

Aware I'm queued behind #463 in the merge order and may need a rebase once that lands (Turnstile wait-logic changes to `session-headers.ts`) — will handle when it's my turn.
