### PR TITLE
feat(agent): per-identity anonymous daily message quota (#282 backend)

### DIFF
--- a/.github/workflows/purge-anon-quota-counts.yml
+++ b/.github/workflows/purge-anon-quota-counts.yml
@@ -1,0 +1,46 @@
+# Standalone top-level workflow (see .claude/rules/ci.md: codeql.yml / dependabot-agent.yml
+# precedent, mirrored from agent-eval-nightly.yml) — kept separate from ci.yml so this cron
+# never rides along with every push/PR trigger in the main CI matrix.
+name: Purge anon_daily_message_count (retention)
+
+# Issue #282 review: anon_daily_message_count is a pure per-day aggregate counter with no
+# dependent rows, so its retention policy is a nightly age-based DELETE, not a per-row purge
+# with an FK backstop (contrast the anonymous-session purge precedent).
+on:
+  schedule:
+    - cron: "37 19 * * *" # 19:37 UTC daily — off-hour, distinct minute from the eval nightly
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report eligible rows without deleting"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: purge-anon-quota-counts
+  cancel-in-progress: false
+
+jobs:
+  purge:
+    name: Purge stale per-identity quota counters
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/agent
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+        with:
+          python: "true"
+
+      - name: Purge rows past the retention window
+        run: |
+          uv run --frozen python -m agent.scripts.purge_anon_quota_counts \
+            ${{ inputs.dry_run == true && '--dry-run' || '' }}
+        env:
+          SUPABASE_DB_URL: ${{ secrets.NEON_DATABASE_URL }}

--- a/apps/agent/agent/config/settings.py
+++ b/apps/agent/agent/config/settings.py
@@ -146,6 +146,25 @@ class Settings(BaseSettings):
         ge=0,
         description="Global anonymous daily spend ceiling in USD (0 disables)",
     )
+    # Per-identity anonymous daily message quota (issue #282, S1.10) — a
+    # fairness/UX mechanism, not a security defense line: it keeps one
+    # visitor's free usage reasonable while ANON_DAILY_COST_BUDGET_USD stays
+    # open for everyone else. Distinct from that global dollar breaker: this
+    # ceiling is compared against one anon identity's own message count for
+    # today. None OR 0 disables the quota entirely — the same "0 disables"
+    # convention as the budget breaker.
+    anon_daily_message_quota: int | None = Field(
+        default=None,
+        ge=0,
+        description="Per-identity daily message cap for anonymous users (None or 0 disables)",
+    )
+    # Retention for anon_daily_message_count (issue #282 review): rows older
+    # than this many UTC days are eligible for the standalone purge script
+    # (scripts/purge_anon_quota_counts.py). 30 mirrors the analogous
+    # anonymous-session retention window used elsewhere in this codebase.
+    anon_daily_message_count_retention_days: int = Field(
+        default=30, gt=0, description="Days to keep anon_daily_message_count rows"
+    )
     model_input_cost_per_mtok_usd: float = Field(
         default=0.0, ge=0, description="Input token price per million tokens (USD)"
     )

--- a/apps/agent/agent/domain/ports.py
+++ b/apps/agent/agent/domain/ports.py
@@ -147,6 +147,12 @@ class UsageRepo(Protocol):
     async def total_cost_usd(self, *, usage_date: date, scope: str) -> float: ...
 
 
+class AnonQuotaRepo(Protocol):
+    """Per-identity anonymous daily message counter (issue #282 / S1.10)."""
+
+    async def increment_and_count(self, *, usage_date: date, anon_id: str) -> int: ...
+
+
 def get_session_repo(db: object) -> SessionRepo | None:
     """Return the session repo if *db* exposes one with async upsert_session."""
     session = getattr(db, "session", None)
@@ -195,3 +201,13 @@ def get_usage_repo(db: object) -> UsageRepo | None:
     if not asyncio.iscoroutinefunction(getattr(usage, "accumulate_usage", None)):
         return None
     return cast(UsageRepo, usage)
+
+
+def get_anon_quota_repo(db: object) -> AnonQuotaRepo | None:
+    """Return the anon-quota repo if *db* exposes one with async increment."""
+    repo = getattr(db, "anon_quota", None)
+    if repo is None:
+        return None
+    if not asyncio.iscoroutinefunction(getattr(repo, "increment_and_count", None)):
+        return None
+    return cast(AnonQuotaRepo, repo)

--- a/apps/agent/agent/infrastructure/supabase/client.py
+++ b/apps/agent/agent/infrastructure/supabase/client.py
@@ -13,6 +13,7 @@ import asyncpg
 import structlog
 
 from agent.infrastructure.supabase.client_types import AsyncPGPool, Row
+from agent.infrastructure.supabase.repositories.anon_quota import AnonQuotaRepository
 from agent.infrastructure.supabase.repositories.bangumi import BangumiRepository
 from agent.infrastructure.supabase.repositories.feedback import FeedbackRepository
 from agent.infrastructure.supabase.repositories.messages import MessagesRepository
@@ -31,7 +32,7 @@ class SupabaseClient:
 
     Access repositories via explicit typed properties:
     ``db.bangumi``, ``db.points``, ``db.session``, ``db.feedback``,
-    ``db.routes``, ``db.messages``, ``db.usage``.
+    ``db.routes``, ``db.messages``, ``db.usage``, ``db.anon_quota``.
     """
 
     def __init__(
@@ -54,6 +55,7 @@ class SupabaseClient:
         self._routes: RoutesRepository | None = None
         self._messages: MessagesRepository | None = None
         self._usage: UsageRepository | None = None
+        self._anon_quota: AnonQuotaRepository | None = None
 
     async def connect(self) -> None:
         """Create the connection pool and initialise repositories."""
@@ -102,6 +104,7 @@ class SupabaseClient:
         self._routes = RoutesRepository(pool)
         self._messages = MessagesRepository(pool)
         self._usage = UsageRepository(pool)
+        self._anon_quota = AnonQuotaRepository(pool)
 
     @property
     def bangumi(self) -> BangumiRepository:
@@ -156,3 +159,11 @@ class SupabaseClient:
         if self._usage is None:
             raise RuntimeError("UsageRepository not initialized — call connect() first")
         return self._usage
+
+    @property
+    def anon_quota(self) -> AnonQuotaRepository:
+        if self._anon_quota is None:
+            raise RuntimeError(
+                "AnonQuotaRepository not initialized — call connect() first"
+            )
+        return self._anon_quota

--- a/apps/agent/agent/infrastructure/supabase/repositories/anon_quota.py
+++ b/apps/agent/agent/infrastructure/supabase/repositories/anon_quota.py
@@ -1,0 +1,49 @@
+"""Per-identity anonymous daily message counter (issue #282 / S1.10)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from agent.infrastructure.supabase.client_types import AsyncPGPool
+
+
+class AnonQuotaRepository:
+    """Atomic per-(day, anon identity) message-attempt counter."""
+
+    def __init__(self, pool: AsyncPGPool) -> None:
+        self._pool = pool
+
+    async def increment_and_count(self, *, usage_date: date, anon_id: str) -> int:
+        """Atomically bump today's count for *anon_id* and return the new total."""
+        row = await self._pool.fetchrow(
+            """
+            INSERT INTO anon_daily_message_count (usage_date, anon_id, message_count)
+            VALUES ($1, $2, 1)
+            ON CONFLICT (usage_date, anon_id) DO UPDATE SET
+                message_count = anon_daily_message_count.message_count + 1,
+                updated_at = NOW()
+            RETURNING message_count
+            """,
+            usage_date,
+            anon_id,
+        )
+        count = 0 if row is None else row["message_count"]
+        return int(count)
+
+    async def purge_older_than(self, cutoff: date) -> int:
+        """Delete rows strictly older than *cutoff*; returns the count removed.
+
+        No FK backstop is needed here (unlike the session-purge precedent):
+        this table is a pure aggregate counter with no dependent rows, so a
+        plain age-based delete is the whole retention policy.
+        """
+        result = await self._pool.execute(
+            "DELETE FROM anon_daily_message_count WHERE usage_date < $1", cutoff
+        )
+        return _parse_delete_count(result)
+
+
+def _parse_delete_count(result: str) -> int:
+    """asyncpg's `execute` returns a command tag like ``"DELETE 3"``."""
+    parts = result.split()
+    return int(parts[-1]) if len(parts) == 2 and parts[0] == "DELETE" else 0

--- a/apps/agent/agent/interfaces/anon_quota.py
+++ b/apps/agent/agent/interfaces/anon_quota.py
@@ -1,0 +1,99 @@
+"""Per-identity anonymous daily message quota (issue #282, S1.10).
+
+Distinct from the global dollar breaker in ``usage_metering.py`` (X4, #274):
+that one asks "has the *whole* anonymous surface spent its budget for today?";
+this one asks "has *this one* anon identity spent its own message allowance
+for today?". Both read/write durable Postgres state so the check survives
+across container instances (#446 ruled out an in-process counter for exactly
+this reason) and both fail *open* on a read/write error — an unavailable
+counter must not take the anonymous surface down.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+
+import structlog
+
+from agent.domain.ports import get_anon_quota_repo
+from agent.interfaces.usage_metering import utc_today
+
+logger = structlog.get_logger(__name__)
+
+ANON_QUOTA_EXHAUSTED_CODE = "anon_quota_exhausted"
+
+#: The container's own re-validation of the edge-forwarded X-User-Id (mirrors
+#: `_ANON_ID_PATTERN` in `interfaces/routes/_deps.py`, issue #460 precedent):
+#: anything not matching this shape is treated as not-an-identity, so quota
+#: correctness never depends on the edge being bug-free. A caller that fails
+#: this check is neither counted nor rejected — the budget breaker above
+#: already gates malformed-identity anonymous traffic; this quota simply
+#: declines to key a counter row on an untrusted string.
+_ANON_ID_PATTERN = re.compile(r"^anon_[0-9a-f]{32}$")
+
+#: The 403 payload field carrying the next UTC reset instant (review
+#: follow-up on #282) — named once so ``chat.py`` and the contract pin test
+#: never drift on the key independently of the wire code above.
+QUOTA_RESETS_AT_FIELD = "quota_resets_at"
+
+#: Best-effort like the budget breaker's own metering hook — see
+#: ``usage_metering._METER_ERRORS`` for why this can't be narrower.
+_QUOTA_ERRORS = Exception
+
+
+@dataclass(frozen=True)
+class QuotaVerdict:
+    """The container ingress's authoritative per-identity quota decision."""
+
+    exhausted: bool
+    count: int
+    quota: int | None
+    resets_at: datetime
+
+
+def next_utc_midnight(day: date) -> datetime:
+    """The next UTC day boundary after *day* (the same clock as ``daily_usage``).
+
+    The frontend renders this as ``quota_resets_at`` so the visitor sees an
+    accurate local-time reset instant instead of a mismatched "resets at JST
+    09:00 but the copy says today" (issue #282 review follow-up).
+    """
+    return datetime.combine(day, time.min, tzinfo=UTC) + timedelta(days=1)
+
+
+async def anonymous_quota_verdict(
+    db: object,
+    *,
+    anon_id: str,
+    quota: int | None,
+    today: date | None = None,
+) -> QuotaVerdict:
+    """Increment today's message count for *anon_id* and compare it to *quota*.
+
+    ``None`` **or** ``0`` disables the check entirely — the same "0 disables"
+    convention as the budget breaker's ``ANON_DAILY_COST_BUDGET_USD`` (review
+    follow-up: a bare ``quota=0`` previously meant "reject every anonymous
+    message", silently inverting the budget knob's convention and inviting an
+    ops footgun the first time someone reused that "0 disables" mental model
+    here). The counter increments on every attempt (including ones this call
+    goes on to reject), so a visitor who keeps retrying past their own
+    ceiling stays rejected rather than flapping. A read/write failure fails
+    OPEN: an unavailable counter must not take the anonymous surface down.
+    """
+    resolved_today = today or utc_today()
+    resets_at = next_utc_midnight(resolved_today)
+    repo = get_anon_quota_repo(db)
+    if not quota or repo is None or not _ANON_ID_PATTERN.fullmatch(anon_id):
+        return QuotaVerdict(exhausted=False, count=0, quota=quota, resets_at=resets_at)
+    try:
+        count = await repo.increment_and_count(
+            usage_date=resolved_today, anon_id=anon_id
+        )
+    except _QUOTA_ERRORS:
+        logger.warning("anon_daily_message_count_failed", exc_info=True)
+        return QuotaVerdict(exhausted=False, count=0, quota=quota, resets_at=resets_at)
+    return QuotaVerdict(
+        exhausted=count > quota, count=count, quota=quota, resets_at=resets_at
+    )

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from typing import Annotated, Literal, Never, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -11,6 +12,11 @@ from starlette.responses import Response, StreamingResponse
 
 from agent.agents.error_messages import InputError, build_input_error_message
 from agent.agents.runtime_deps import OnStep
+from agent.interfaces.anon_quota import (
+    ANON_QUOTA_EXHAUSTED_CODE,
+    QUOTA_RESETS_AT_FIELD,
+    anonymous_quota_verdict,
+)
 from agent.interfaces.routes._deps import (
     TrustedAuthContext,
     _get_db_from_request,
@@ -172,6 +178,51 @@ async def _budget_rejection(
     return _budget_exhausted_response() if verdict.exhausted else None
 
 
+QUOTA_EXHAUSTED_MESSAGE = "今日はここまで・ログインすると続けられるよ。"
+
+
+def _quota_exhausted_response(resets_at: datetime) -> JSONResponse:
+    """403 so the client falls into its D12 login-recovery state (issue #282).
+
+    ``quota_resets_at`` is the next UTC day boundary, ISO 8601 with a literal
+    ``Z`` — the frontend renders it in the visitor's local time instead of
+    hard-coding a mismatched reset instant (review follow-up on #282). It
+    lives under ``error.data``, matching the contract's
+    ``AnonLimitErrorEnvelope`` (`packages/contract/src/error-registry.ts`):
+    `code`/`message`/`action` are common to both anonymous-limit rejections,
+    `data` carries only the quota-specific extra field, and the budget
+    breaker's envelope (`_budget_exhausted_response` above) omits it entirely.
+    """
+    error = {
+        "code": ANON_QUOTA_EXHAUSTED_CODE,
+        "message": QUOTA_EXHAUSTED_MESSAGE,
+        "action": "login",
+        "data": {QUOTA_RESETS_AT_FIELD: resets_at.strftime("%Y-%m-%dT%H:%M:%SZ")},
+    }
+    return JSONResponse(status_code=403, content={"error": error})
+
+
+async def _quota_rejection(
+    request: Request, auth: TrustedAuthContext
+) -> JSONResponse | None:
+    """Container-ingress per-identity quota check (issue #282, S1.10).
+
+    Runs only when the shared anonymous budget (D11, above) has not already
+    rejected the turn: the global dollar breaker is the more severe, systemic
+    concern and wins ties over one visitor's own message ceiling. Only
+    anonymous callers are gated — logged-in traffic is never metered here.
+    """
+    if auth.user_type != ANONYMOUS_USER_TYPE or auth.user_id is None:
+        return None
+    settings = _get_settings_from_request(request)
+    verdict = await anonymous_quota_verdict(
+        _get_db_from_request(request),
+        anon_id=auth.user_id,
+        quota=settings.anon_daily_message_quota,
+    )
+    return _quota_exhausted_response(verdict.resets_at) if verdict.exhausted else None
+
+
 @router.post("/chat", responses={422: {"description": "Invalid chat request"}})
 async def handle_chat(
     request: Request,
@@ -179,6 +230,8 @@ async def handle_chat(
 ) -> Response:
     """Stream chat as an AI SDK UI message stream with tool + data parts."""
     rejection = await _budget_rejection(request, auth)
+    if rejection is None:
+        rejection = await _quota_rejection(request, auth)
     if rejection is not None:
         return rejection
     settings = _get_settings_from_request(request)

--- a/apps/agent/agent/interfaces/usage_metering.py
+++ b/apps/agent/agent/interfaces/usage_metering.py
@@ -7,7 +7,9 @@ exhausted. The container is deliberately the only tier that reads the table —
 the edge keeps a same-day latch of this verdict but never queries the database.
 
 Scope boundary: this is a *global dollar budget*. The per-identity daily
-message quota is issue #282 and reads the same table without changing this one.
+message quota (issue #282) lives in ``anon_quota.py`` and its own
+``anon_daily_message_count`` table — a separate durable counter, not a read
+of this module's ``daily_usage`` table.
 """
 
 from __future__ import annotations

--- a/apps/agent/agent/scripts/purge_anon_quota_counts.py
+++ b/apps/agent/agent/scripts/purge_anon_quota_counts.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Purge stale anon_daily_message_count rows (issue #282 review, retention).
+
+`anon_daily_message_count` is a pure per-day aggregate counter with no
+dependent rows (unlike anonymous sessions), so its retention policy is a
+single age-based DELETE — no FK backstop or per-row transaction is needed.
+
+Usage:
+    uv run python -m agent.scripts.purge_anon_quota_counts
+    uv run python -m agent.scripts.purge_anon_quota_counts --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import UTC, datetime, timedelta
+
+from agent.config.settings import get_settings
+from agent.infrastructure.supabase.client import SupabaseClient
+from agent.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def purge_anon_quota_counts(
+    db: SupabaseClient,
+    *,
+    retention_days: int,
+    now: datetime | None = None,
+    dry_run: bool = False,
+) -> int:
+    """Delete `anon_daily_message_count` rows older than the retention cutoff."""
+    cutoff = ((now or datetime.now(UTC)) - timedelta(days=retention_days)).date()
+    if dry_run:
+        eligible = await db.pool.fetchval(
+            "SELECT count(*) FROM anon_daily_message_count WHERE usage_date < $1",
+            cutoff,
+        )
+        logger.info("anon_quota_counts_purge_dry_run", eligible=eligible)
+        return int(eligible or 0)
+    removed = await db.anon_quota.purge_older_than(cutoff)
+    logger.info("anon_quota_counts_purged", count=removed)
+    return removed
+
+
+async def _main(dry_run: bool) -> None:
+    settings = get_settings()
+    dsn = settings.supabase_db_url
+    if not dsn:
+        logger.error("SUPABASE_DB_URL is not set")
+        sys.exit(1)
+    async with SupabaseClient(dsn) as db:
+        await purge_anon_quota_counts(
+            db,
+            retention_days=settings.anon_daily_message_count_retention_days,
+            dry_run=dry_run,
+        )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report eligible rows without deleting",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main(_parse_args().dry_run))

--- a/apps/agent/agent/tests/integration/test_anon_quota_repo_contract.py
+++ b/apps/agent/agent/tests/integration/test_anon_quota_repo_contract.py
@@ -1,0 +1,146 @@
+"""Real-SQL contract for AnonQuotaRepository (issue #282 PR #472 review, P1-2).
+
+The unit suite (`tests/unit/repositories/test_anon_quota_repo.py`) only
+asserts on the SQL string against a mocked pool — it never executes the
+statement, so a wrong column name, a missing grant, or a conflict target that
+doesn't match the table's primary key would all still show green there and
+only fail in production as a swallowed `_QUOTA_ERRORS` warning (the quota
+fails open by design). This suite runs the real UPSERT against Postgres,
+including the one correctness dimension neither the mocked unit test nor a
+sequential integration test can prove: that the atomic UPSERT's row lock
+actually serializes concurrent writers for the same key with no lost update.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date, timedelta
+
+import asyncpg
+import pytest
+
+from agent.infrastructure.supabase.repositories.anon_quota import AnonQuotaRepository
+
+pytestmark = pytest.mark.integration
+
+TODAY = date(2026, 7, 26)
+TOMORROW = date(2026, 7, 27)
+
+
+def _anon_id(suffix: str) -> str:
+    """A syntactically anon_-shaped id, unique per test to avoid collisions."""
+    return f"anon_{suffix.rjust(32, '0')}"
+
+
+async def _cleanup(pool: asyncpg.Pool, anon_ids: list[str]) -> None:
+    await pool.execute(
+        "DELETE FROM anon_daily_message_count WHERE anon_id = ANY($1::text[])",
+        anon_ids,
+    )
+
+
+async def test_agent_svc_holds_the_grants_the_repo_needs(db_pool: asyncpg.Pool) -> None:
+    """The migration's GRANT actually took — `has_table_privilege` probes the
+    grant layer directly (same pattern as `test_service_roles.py`), catching
+    a typo'd role name or a forgotten GRANT that a mocked unit test can't."""
+    async with db_pool.acquire() as conn:
+        select = await conn.fetchval(
+            "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', 'SELECT')"
+        )
+        insert = await conn.fetchval(
+            "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', 'INSERT')"
+        )
+        update = await conn.fetchval(
+            "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', 'UPDATE')"
+        )
+    assert select is True
+    assert insert is True
+    assert update is True
+
+
+async def test_the_same_key_increments_across_calls(db_pool: asyncpg.Pool) -> None:
+    repo = AnonQuotaRepository(db_pool)
+    anon_id = _anon_id("aaa1")
+    try:
+        first = await repo.increment_and_count(usage_date=TODAY, anon_id=anon_id)
+        second = await repo.increment_and_count(usage_date=TODAY, anon_id=anon_id)
+        assert (first, second) == (1, 2)
+    finally:
+        await _cleanup(db_pool, [anon_id])
+
+
+async def test_different_identities_are_counted_independently(
+    db_pool: asyncpg.Pool,
+) -> None:
+    repo = AnonQuotaRepository(db_pool)
+    identity_a, identity_b = _anon_id("aaa2"), _anon_id("bbb2")
+    try:
+        await repo.increment_and_count(usage_date=TODAY, anon_id=identity_a)
+        count_a = await repo.increment_and_count(usage_date=TODAY, anon_id=identity_a)
+        count_b = await repo.increment_and_count(usage_date=TODAY, anon_id=identity_b)
+        assert count_a == 2
+        assert count_b == 1
+    finally:
+        await _cleanup(db_pool, [identity_a, identity_b])
+
+
+async def test_different_dates_are_counted_independently(db_pool: asyncpg.Pool) -> None:
+    repo = AnonQuotaRepository(db_pool)
+    anon_id = _anon_id("aaa3")
+    try:
+        today_count = await repo.increment_and_count(usage_date=TODAY, anon_id=anon_id)
+        tomorrow_count = await repo.increment_and_count(
+            usage_date=TOMORROW, anon_id=anon_id
+        )
+        assert today_count == 1
+        assert tomorrow_count == 1
+    finally:
+        await _cleanup(db_pool, [anon_id])
+
+
+async def test_concurrent_increments_for_the_same_key_have_no_lost_update(
+    db_pool: asyncpg.Pool,
+) -> None:
+    """N concurrent callers hitting the same (day, anon_id) row: the UPSERT's
+    row lock must serialize them so the returned counts are exactly the set
+    {1..N} — no duplicate value (a lost update) and no gap. This is the one
+    correctness dimension a mocked-pool unit test structurally cannot cover.
+    """
+    repo = AnonQuotaRepository(db_pool)
+    anon_id = _anon_id("ccc4")
+    concurrent_callers = 20
+    try:
+        results = await asyncio.gather(
+            *(
+                repo.increment_and_count(usage_date=TODAY, anon_id=anon_id)
+                for _ in range(concurrent_callers)
+            )
+        )
+        assert set(results) == set(range(1, concurrent_callers + 1))
+    finally:
+        await _cleanup(db_pool, [anon_id])
+
+
+async def test_purge_older_than_removes_stale_rows_and_keeps_recent_ones(
+    db_pool: asyncpg.Pool,
+) -> None:
+    repo = AnonQuotaRepository(db_pool)
+    stale_id, fresh_id = _anon_id("ddd5"), _anon_id("eee5")
+    stale_date = TODAY - timedelta(days=100)
+    try:
+        await repo.increment_and_count(usage_date=stale_date, anon_id=stale_id)
+        await repo.increment_and_count(usage_date=TODAY, anon_id=fresh_id)
+        removed = await repo.purge_older_than(TODAY)
+        remaining = await db_pool.fetchval(
+            "SELECT count(*) FROM anon_daily_message_count WHERE anon_id = $1",
+            stale_id,
+        )
+        still_there = await db_pool.fetchval(
+            "SELECT count(*) FROM anon_daily_message_count WHERE anon_id = $1",
+            fresh_id,
+        )
+        assert removed >= 1
+        assert remaining == 0
+        assert still_there == 1
+    finally:
+        await _cleanup(db_pool, [stale_id, fresh_id])

--- a/apps/agent/agent/tests/unit/repositories/test_anon_quota_repo.py
+++ b/apps/agent/agent/tests/unit/repositories/test_anon_quota_repo.py
@@ -1,0 +1,78 @@
+"""Unit tests for AnonQuotaRepository (issue #282 / S1.10)."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.infrastructure.supabase.repositories.anon_quota import AnonQuotaRepository
+
+TODAY = date(2026, 7, 26)
+ANON_ID = "anon_0123456789abcdef0123456789abcdef"
+
+
+@pytest.fixture
+def pool() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def repo(pool: AsyncMock) -> AnonQuotaRepository:
+    return AnonQuotaRepository(pool)
+
+
+async def test_increment_and_count_upserts_on_the_day_and_identity_key(
+    repo: AnonQuotaRepository, pool: AsyncMock
+) -> None:
+    await repo.increment_and_count(usage_date=TODAY, anon_id=ANON_ID)
+    sql = pool.fetchrow.await_args.args[0]
+    assert "INSERT INTO anon_daily_message_count" in sql
+    assert "ON CONFLICT (usage_date, anon_id) DO UPDATE" in sql
+
+
+async def test_increment_and_count_adds_to_the_existing_total(
+    repo: AnonQuotaRepository, pool: AsyncMock
+) -> None:
+    await repo.increment_and_count(usage_date=TODAY, anon_id=ANON_ID)
+    sql = pool.fetchrow.await_args.args[0]
+    assert "message_count = anon_daily_message_count.message_count + 1" in sql
+
+
+async def test_increment_and_count_binds_the_day_and_identity(
+    repo: AnonQuotaRepository, pool: AsyncMock
+) -> None:
+    await repo.increment_and_count(usage_date=TODAY, anon_id=ANON_ID)
+    assert pool.fetchrow.await_args.args[1:] == (TODAY, ANON_ID)
+
+
+async def test_increment_and_count_returns_the_new_total(
+    repo: AnonQuotaRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = {"message_count": 4}
+    assert await repo.increment_and_count(usage_date=TODAY, anon_id=ANON_ID) == 4
+
+
+async def test_increment_and_count_is_zero_when_the_row_is_unexpectedly_absent(
+    repo: AnonQuotaRepository, pool: AsyncMock
+) -> None:
+    pool.fetchrow.return_value = None
+    assert await repo.increment_and_count(usage_date=TODAY, anon_id=ANON_ID) == 0
+
+
+async def test_purge_older_than_deletes_rows_before_the_cutoff(
+    repo: AnonQuotaRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = "DELETE 3"
+    assert await repo.purge_older_than(TODAY) == 3
+    sql = pool.execute.await_args.args[0]
+    assert "DELETE FROM anon_daily_message_count WHERE usage_date < $1" in sql
+    assert pool.execute.await_args.args[1] == TODAY
+
+
+async def test_purge_older_than_is_zero_for_an_unexpected_command_tag(
+    repo: AnonQuotaRepository, pool: AsyncMock
+) -> None:
+    pool.execute.return_value = "UNEXPECTED"
+    assert await repo.purge_older_than(TODAY) == 0

--- a/apps/agent/agent/tests/unit/test_anon_limits_contract_pin.py
+++ b/apps/agent/agent/tests/unit/test_anon_limits_contract_pin.py
@@ -1,0 +1,64 @@
+"""Pin the Python anonymous-limit codes to `packages/contract` (issue #282).
+
+`ANON_BUDGET_EXHAUSTED_CODE` (#274 S1.8) and `ANON_QUOTA_EXHAUSTED_CODE` (#282
+S1.10) are wire literals three tiers must agree on: the container ingress
+emits them, the web client classifies them into D11/D12. Python cannot import
+the TypeScript module directly, so — like the worker-mirror pin in
+`test_anonymous_docs_consistency.py` — this test reads the contract source as
+text and asserts the literal is present, the same three-mirror pattern
+`packages/contract/AGENTS.md` documents for the catalog error registry.
+
+The codes and the `AnonQuotaExhaustedData`/`AnonLimitErrorEnvelope` shapes
+live in `error-registry.ts` (issue #282's frontend half, #468, folded them
+into the existing generic error-registry module rather than a standalone
+`anon-limits.ts` — this pin follows that placement).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.interfaces.anon_quota import ANON_QUOTA_EXHAUSTED_CODE, QUOTA_RESETS_AT_FIELD
+from agent.interfaces.usage_metering import ANON_BUDGET_EXHAUSTED_CODE
+
+CONTRACT = (
+    Path(__file__).resolve().parents[5]
+    / "packages"
+    / "contract"
+    / "src"
+    / "error-registry.ts"
+)
+
+
+@pytest.fixture(scope="module")
+def contract_source() -> str:
+    return CONTRACT.read_text(encoding="utf-8")
+
+
+def test_the_budget_code_matches_the_contract_export(contract_source: str) -> None:
+    assert (
+        f'ANON_BUDGET_EXHAUSTED_CODE = "{ANON_BUDGET_EXHAUSTED_CODE}"'
+        in contract_source
+    )
+
+
+def test_the_quota_code_matches_the_contract_export(contract_source: str) -> None:
+    assert (
+        f'ANON_QUOTA_EXHAUSTED_CODE = "{ANON_QUOTA_EXHAUSTED_CODE}"' in contract_source
+    )
+
+
+def test_the_two_wire_codes_stay_distinct() -> None:
+    assert ANON_QUOTA_EXHAUSTED_CODE != ANON_BUDGET_EXHAUSTED_CODE
+
+
+def test_the_reset_field_name_matches_the_contract_payload_shape(
+    contract_source: str,
+) -> None:
+    """Anchored to the zod field declaration (`quota_resets_at: z.`), not just
+    the bare key — a looser anchor would false-negative on a stray prose
+    mention of the field and would go stale silently on a prettier reformat
+    of the surrounding object literal (review follow-up)."""
+    assert f"{QUOTA_RESETS_AT_FIELD}: z." in contract_source

--- a/apps/agent/agent/tests/unit/test_anon_quota.py
+++ b/apps/agent/agent/tests/unit/test_anon_quota.py
@@ -1,0 +1,192 @@
+"""Per-identity anonymous daily message quota (issue #282, S1.10)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from asyncpg.exceptions import UndefinedTableError
+
+from agent.interfaces.anon_quota import anonymous_quota_verdict, next_utc_midnight
+
+TODAY = date(2026, 7, 26)
+TOMORROW = date(2026, 7, 27)
+ANON_ID = "anon_0123456789abcdef0123456789abcdef"
+
+
+class _AnonQuotaRepoDouble:
+    """Counts increments per (usage_date, anon_id), like the real UPSERT."""
+
+    def __init__(self) -> None:
+        self.counts: dict[tuple[date, str], int] = {}
+        self.calls: list[tuple[date, str]] = []
+
+    async def increment_and_count(self, *, usage_date: date, anon_id: str) -> int:
+        self.calls.append((usage_date, anon_id))
+        key = (usage_date, anon_id)
+        self.counts[key] = self.counts.get(key, 0) + 1
+        return self.counts[key]
+
+
+class _FailingRepo(_AnonQuotaRepoDouble):
+    async def increment_and_count(self, *, usage_date: date, anon_id: str) -> int:
+        del usage_date, anon_id
+        raise OSError("counter unavailable")
+
+
+class _PgFailingRepo(_AnonQuotaRepoDouble):
+    """asyncpg's errors derive straight from Exception, not from OSError."""
+
+    async def increment_and_count(self, *, usage_date: date, anon_id: str) -> int:
+        del usage_date, anon_id
+        raise UndefinedTableError('relation "anon_daily_message_count" does not exist')
+
+
+class _Db:
+    def __init__(self, anon_quota: object) -> None:
+        self.anon_quota = anon_quota
+
+
+async def test_a_brand_new_identity_starts_at_full_quota_not_zero() -> None:
+    """First-ever message for a fresh identity must not already read exhausted."""
+    verdict = await anonymous_quota_verdict(
+        _Db(_AnonQuotaRepoDouble()), anon_id=ANON_ID, quota=3, today=TODAY
+    )
+    assert verdict.exhausted is False
+    assert verdict.count == 1
+
+
+async def test_the_nth_message_within_quota_passes() -> None:
+    repo = _AnonQuotaRepoDouble()
+    db = _Db(repo)
+    for _ in range(3):
+        verdict = await anonymous_quota_verdict(
+            db, anon_id=ANON_ID, quota=3, today=TODAY
+        )
+    assert verdict.exhausted is False
+    assert verdict.count == 3
+
+
+async def test_the_n_plus_first_message_trips_the_quota() -> None:
+    repo = _AnonQuotaRepoDouble()
+    db = _Db(repo)
+    for _ in range(3):
+        await anonymous_quota_verdict(db, anon_id=ANON_ID, quota=3, today=TODAY)
+    verdict = await anonymous_quota_verdict(db, anon_id=ANON_ID, quota=3, today=TODAY)
+    assert verdict.exhausted is True
+    assert verdict.count == 4
+
+
+async def test_a_different_identity_has_its_own_independent_count() -> None:
+    repo = _AnonQuotaRepoDouble()
+    db = _Db(repo)
+    for _ in range(3):
+        await anonymous_quota_verdict(db, anon_id=ANON_ID, quota=3, today=TODAY)
+    other = await anonymous_quota_verdict(
+        db, anon_id="anon_fedcba9876543210fedcba9876543210", quota=3, today=TODAY
+    )
+    assert other.exhausted is False
+    assert other.count == 1
+
+
+async def test_crossing_a_utc_day_boundary_resets_the_count() -> None:
+    """Same identity, new UTC day: the counter starts fresh, not carried over."""
+    repo = _AnonQuotaRepoDouble()
+    db = _Db(repo)
+    for _ in range(3):
+        await anonymous_quota_verdict(db, anon_id=ANON_ID, quota=3, today=TODAY)
+    verdict = await anonymous_quota_verdict(
+        db, anon_id=ANON_ID, quota=3, today=TOMORROW
+    )
+    assert verdict.exhausted is False
+    assert verdict.count == 1
+
+
+async def test_a_none_quota_disables_the_check_and_never_touches_the_repo() -> None:
+    repo = _AnonQuotaRepoDouble()
+    verdict = await anonymous_quota_verdict(
+        _Db(repo), anon_id=ANON_ID, quota=None, today=TODAY
+    )
+    assert verdict.exhausted is False
+    assert repo.calls == []
+
+
+async def test_a_zero_quota_also_disables_the_check_same_as_none() -> None:
+    """0 disables, matching the budget breaker's convention — NOT "reject
+    everything" (review follow-up: the two knobs must agree on what 0 means)."""
+    repo = _AnonQuotaRepoDouble()
+    verdict = await anonymous_quota_verdict(
+        _Db(repo), anon_id=ANON_ID, quota=0, today=TODAY
+    )
+    assert verdict.exhausted is False
+    assert repo.calls == []
+
+
+async def test_a_malformed_anon_id_is_neither_counted_nor_rejected() -> None:
+    """The container re-validates X-User-Id itself (issue #460 precedent) —
+    structural correctness must not depend on the edge alone."""
+    repo = _AnonQuotaRepoDouble()
+    verdict = await anonymous_quota_verdict(
+        _Db(repo), anon_id="anon_not-hex", quota=3, today=TODAY
+    )
+    assert verdict.exhausted is False
+    assert repo.calls == []
+
+
+async def test_an_anon_id_missing_the_prefix_is_also_rejected_as_malformed() -> None:
+    repo = _AnonQuotaRepoDouble()
+    verdict = await anonymous_quota_verdict(
+        _Db(repo),
+        anon_id="0123456789abcdef0123456789abcdef",
+        quota=3,
+        today=TODAY,
+    )
+    assert verdict.exhausted is False
+    assert repo.calls == []
+
+
+async def test_a_valid_prefix_with_trailing_junk_is_still_malformed() -> None:
+    """Kills a `.fullmatch` -> `.match` mutation: `re.match` only anchors at
+    the *start*, so on a pattern ending in `$` it still lets a trailing
+    newline through (`$` matches just before one), while `.fullmatch`
+    requires the entire string to match with nothing left over. An
+    otherwise-valid id with anything appended — including a bare trailing
+    newline — must not be treated as a real identity."""
+    repo = _AnonQuotaRepoDouble()
+    valid_prefix = "anon_" + "0123456789abcdef0123456789abcdef"
+    verdict = await anonymous_quota_verdict(
+        _Db(repo), anon_id=f"{valid_prefix}\n", quota=3, today=TODAY
+    )
+    assert verdict.exhausted is False
+    assert repo.calls == []
+
+
+async def test_a_counter_read_failure_fails_open() -> None:
+    verdict = await anonymous_quota_verdict(
+        _Db(_FailingRepo()), anon_id=ANON_ID, quota=3, today=TODAY
+    )
+    assert verdict.exhausted is False
+
+
+async def test_a_postgres_failure_fails_the_quota_check_open() -> None:
+    verdict = await anonymous_quota_verdict(
+        _Db(_PgFailingRepo()), anon_id=ANON_ID, quota=3, today=TODAY
+    )
+    assert verdict.exhausted is False
+
+
+async def test_quota_verdict_is_inert_without_an_anon_quota_repo() -> None:
+    verdict = await anonymous_quota_verdict(
+        object(), anon_id=ANON_ID, quota=3, today=TODAY
+    )
+    assert verdict.exhausted is False
+
+
+def test_next_utc_midnight_is_the_start_of_the_following_utc_day() -> None:
+    assert next_utc_midnight(TODAY) == datetime(2026, 7, 27, tzinfo=UTC)
+
+
+async def test_the_verdict_carries_the_next_utc_reset_instant() -> None:
+    verdict = await anonymous_quota_verdict(
+        _Db(_AnonQuotaRepoDouble()), anon_id=ANON_ID, quota=3, today=TODAY
+    )
+    assert verdict.resets_at == datetime(2026, 7, 27, tzinfo=UTC)

--- a/apps/agent/agent/tests/unit/test_chat_anon_quota.py
+++ b/apps/agent/agent/tests/unit/test_chat_anon_quota.py
@@ -1,0 +1,164 @@
+"""Container-ingress per-identity daily message quota on POST /v1/chat (#282)."""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+from fastapi import FastAPI
+
+from agent.config.settings import Settings
+from agent.interfaces.anon_quota import ANON_QUOTA_EXHAUSTED_CODE
+from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.schemas import PublicAPIResponse
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+ANON_HEADERS = {
+    "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
+    "X-User-Type": "anonymous",
+}
+OTHER_ANON_HEADERS = {
+    "X-User-Id": "anon_fedcba9876543210fedcba9876543210",
+    "X-User-Type": "anonymous",
+}
+HUMAN_HEADERS = {"X-User-Id": "user-1", "X-User-Type": "human"}
+QUOTA = 3
+
+
+def _body() -> dict[str, object]:
+    return {
+        "messages": [
+            {"id": "u1", "role": "user", "parts": [{"type": "text", "text": "京吹"}]}
+        ]
+    }
+
+
+def _db(*, next_count: int) -> MagicMock:
+    db = build_stub_db()
+    db.usage = MagicMock()
+    db.usage.accumulate_usage = AsyncMock(return_value=None)
+    db.usage.total_cost_usd = AsyncMock(return_value=0.0)
+    db.anon_quota = MagicMock()
+    db.anon_quota.increment_and_count = AsyncMock(return_value=next_count)
+    return db
+
+
+def _runtime(db: MagicMock) -> MagicMock:
+    runtime = MagicMock(spec=RuntimeAPI)
+    runtime.handle = AsyncMock(
+        return_value=PublicAPIResponse(
+            success=True, status="ok", intent="plan_route", message="ルートだよ。"
+        )
+    )
+    runtime.validate_session_owner = AsyncMock(return_value=None)
+    runtime._db = db
+    return runtime
+
+
+def _app(
+    *, next_count: int, quota: int | None = QUOTA
+) -> tuple[FastAPI, MagicMock, MagicMock]:
+    db = _db(next_count=next_count)
+    runtime = _runtime(db)
+    settings = Settings(anon_daily_message_quota=quota)
+    app, _ = build_app(runtime_api=runtime, db=db, settings=settings)
+    return app, runtime, db
+
+
+async def _post(app: FastAPI, headers: dict[str, str]) -> httpx.Response:
+    async with async_client(app) as client:
+        return await client.post("/v1/chat", json=_body(), headers=headers)
+
+
+async def test_a_brand_new_anonymous_identity_starts_at_full_quota_not_zero() -> None:
+    app, runtime, db = _app(next_count=1)
+    response = await _post(app, ANON_HEADERS)
+    assert response.status_code == 200
+    assert runtime.handle.await_count == 1
+    db.anon_quota.increment_and_count.assert_awaited_once()
+
+
+async def test_the_nth_message_within_quota_still_passes() -> None:
+    app, runtime, _ = _app(next_count=QUOTA)
+    response = await _post(app, ANON_HEADERS)
+    assert response.status_code == 200
+    assert runtime.handle.await_count == 1
+
+
+async def test_the_n_plus_first_message_is_rejected() -> None:
+    app, runtime, _ = _app(next_count=QUOTA + 1)
+    response = await _post(app, ANON_HEADERS)
+    assert response.status_code == 403
+    assert runtime.handle.await_count == 0
+
+
+async def test_the_rejection_carries_the_wire_contract_the_frontend_expects() -> None:
+    app, _, _ = _app(next_count=QUOTA + 1)
+    response = await _post(app, ANON_HEADERS)
+    error = response.json()["error"]
+    assert error["code"] == ANON_QUOTA_EXHAUSTED_CODE
+    assert error["action"] == "login"
+
+
+async def test_the_rejection_carries_an_iso_utc_reset_instant_under_data() -> None:
+    """`quota_resets_at` nests under `error.data` — the contract's
+    `AnonLimitErrorEnvelope` only the quota rejection populates `data`."""
+    app, _, _ = _app(next_count=QUOTA + 1)
+    response = await _post(app, ANON_HEADERS)
+    error = response.json()["error"]
+    resets_at = error["data"]["quota_resets_at"]
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T00:00:00Z", resets_at)
+
+
+async def test_the_rejection_has_no_top_level_quota_resets_at() -> None:
+    """The field lives under `data`, not flattened onto `error` itself."""
+    app, _, _ = _app(next_count=QUOTA + 1)
+    response = await _post(app, ANON_HEADERS)
+    assert "quota_resets_at" not in response.json()["error"]
+
+
+async def test_the_counter_is_keyed_per_identity_not_globally() -> None:
+    """A different anon identity gets its own count from the repo call args."""
+    app, runtime, db = _app(next_count=1)
+    await _post(app, ANON_HEADERS)
+    await _post(app, OTHER_ANON_HEADERS)
+    seen_ids = {
+        call.kwargs["anon_id"]
+        for call in db.anon_quota.increment_and_count.await_args_list
+    }
+    assert seen_ids == {ANON_HEADERS["X-User-Id"], OTHER_ANON_HEADERS["X-User-Id"]}
+    assert runtime.handle.await_count == 2
+
+
+async def test_logged_in_users_are_never_quota_checked() -> None:
+    app, runtime, db = _app(next_count=QUOTA + 100)
+    response = await _post(app, HUMAN_HEADERS)
+    assert response.status_code == 200
+    assert runtime.handle.await_count == 1
+    db.anon_quota.increment_and_count.assert_not_awaited()
+
+
+async def test_an_unconfigured_quota_never_rejects_and_never_reads_the_repo() -> None:
+    app, runtime, db = _app(next_count=QUOTA + 100, quota=None)
+    response = await _post(app, ANON_HEADERS)
+    assert response.status_code == 200
+    assert runtime.handle.await_count == 1
+    db.anon_quota.increment_and_count.assert_not_awaited()
+
+
+async def test_a_malformed_body_still_consumes_one_message_of_the_quota() -> None:
+    """Decided semantics (review follow-up): the quota check runs before
+    request-body validation in `handle_chat`, so a malformed body that goes
+    on to 422 still counts as an attempt against the visitor's daily
+    allowance — the same reasoning a rate limiter uses (it counts requests,
+    not successes). A visitor cannot get free extra attempts by sending
+    garbage; the counter and the 422 both happen on the same request."""
+    app, runtime, db = _app(next_count=1)
+    async with async_client(app) as client:
+        response = await client.post(
+            "/v1/chat", json={"messages": "not-a-list"}, headers=ANON_HEADERS
+        )
+    assert response.status_code == 422
+    db.anon_quota.increment_and_count.assert_awaited_once()
+    assert runtime.handle.await_count == 0

--- a/apps/agent/agent/tests/unit/test_chat_budget_quota_precedence.py
+++ b/apps/agent/agent/tests/unit/test_chat_budget_quota_precedence.py
@@ -1,0 +1,109 @@
+"""Precedence when the global budget breaker and the per-identity daily
+message quota (#282) are both exhausted on the same anonymous turn.
+
+The global dollar breaker (D11, issue #274 X4) protects the whole anonymous
+surface and is the more severe, systemic concern; it wins ties over one
+visitor's own message ceiling (D12, issue #282). ``chat.py`` checks the
+budget first and only falls through to the quota check when the budget
+allows the turn.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+from fastapi import FastAPI
+
+from agent.config.settings import Settings
+from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.schemas import PublicAPIResponse
+from agent.interfaces.usage_metering import ANON_BUDGET_EXHAUSTED_CODE
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+ANON_HEADERS = {
+    "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
+    "X-User-Type": "anonymous",
+}
+BUDGET = 5.0
+QUOTA = 3
+
+
+def _body() -> dict[str, object]:
+    return {
+        "messages": [
+            {"id": "u1", "role": "user", "parts": [{"type": "text", "text": "京吹"}]}
+        ]
+    }
+
+
+def _db(*, spent: float, next_count: int) -> MagicMock:
+    db = build_stub_db()
+    db.usage = MagicMock()
+    db.usage.accumulate_usage = AsyncMock(return_value=None)
+    db.usage.total_cost_usd = AsyncMock(return_value=spent)
+    db.anon_quota = MagicMock()
+    db.anon_quota.increment_and_count = AsyncMock(return_value=next_count)
+    return db
+
+
+def _runtime(db: MagicMock) -> MagicMock:
+    runtime = MagicMock(spec=RuntimeAPI)
+    runtime.handle = AsyncMock(
+        return_value=PublicAPIResponse(
+            success=True, status="ok", intent="plan_route", message="ルートだよ。"
+        )
+    )
+    runtime.validate_session_owner = AsyncMock(return_value=None)
+    runtime._db = db
+    return runtime
+
+
+async def _post(app: FastAPI, headers: dict[str, str]) -> httpx.Response:
+    async with async_client(app) as client:
+        return await client.post("/v1/chat", json=_body(), headers=headers)
+
+
+async def test_both_exhausted_yields_the_budget_code_not_the_quota_code() -> None:
+    db = _db(spent=BUDGET, next_count=QUOTA + 1)
+    runtime = _runtime(db)
+    settings = Settings(
+        anon_daily_cost_budget_usd=BUDGET, anon_daily_message_quota=QUOTA
+    )
+    app, _ = build_app(runtime_api=runtime, db=db, settings=settings)
+
+    response = await _post(app, ANON_HEADERS)
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == ANON_BUDGET_EXHAUSTED_CODE
+    assert runtime.handle.await_count == 0
+
+
+async def test_the_budget_short_circuit_never_reaches_the_quota_counter() -> None:
+    """The quota repo must not be touched once the budget already rejected."""
+    db = _db(spent=BUDGET, next_count=QUOTA + 1)
+    runtime = _runtime(db)
+    settings = Settings(
+        anon_daily_cost_budget_usd=BUDGET, anon_daily_message_quota=QUOTA
+    )
+    app, _ = build_app(runtime_api=runtime, db=db, settings=settings)
+
+    await _post(app, ANON_HEADERS)
+
+    db.anon_quota.increment_and_count.assert_not_awaited()
+
+
+async def test_only_quota_exhausted_falls_through_to_the_quota_rejection() -> None:
+    from agent.interfaces.anon_quota import ANON_QUOTA_EXHAUSTED_CODE
+
+    db = _db(spent=0.0, next_count=QUOTA + 1)
+    runtime = _runtime(db)
+    settings = Settings(
+        anon_daily_cost_budget_usd=BUDGET, anon_daily_message_quota=QUOTA
+    )
+    app, _ = build_app(runtime_api=runtime, db=db, settings=settings)
+
+    response = await _post(app, ANON_HEADERS)
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == ANON_QUOTA_EXHAUSTED_CODE

--- a/apps/agent/agent/tests/unit/test_deploy_model_env_consistency.py
+++ b/apps/agent/agent/tests/unit/test_deploy_model_env_consistency.py
@@ -6,7 +6,11 @@ import re
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[5]
-_ENTRYPOINT = _REPO_ROOT / "worker" / "entry.ts"
+# CONTAINER_ENV_KEYS/CONTAINER_REQUIRED_KEYS moved out of entry.ts into their
+# own module (issue #282 review) so they're importable under plain
+# `node --test` without pulling in entry.ts's @cloudflare/containers import
+# chain — see worker/containerEnv.ts's module docstring.
+_ENTRYPOINT = _REPO_ROOT / "worker" / "containerEnv.ts"
 _CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _DEPLOY_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "deploy.yml"
 _REUSABLE_DEPLOY_WORKFLOW = (

--- a/apps/agent/agent/tests/unit/test_purge_anon_quota_counts.py
+++ b/apps/agent/agent/tests/unit/test_purge_anon_quota_counts.py
@@ -1,0 +1,41 @@
+"""Unit tests for the anon_daily_message_count retention CLI (issue #282 review)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from agent.scripts.purge_anon_quota_counts import purge_anon_quota_counts
+
+NOW = datetime(2026, 7, 26, tzinfo=UTC)
+
+
+def _db(*, removed: int = 0, eligible: int = 0) -> MagicMock:
+    db = MagicMock()
+    db.anon_quota.purge_older_than = AsyncMock(return_value=removed)
+    db.pool.fetchval = AsyncMock(return_value=eligible)
+    return db
+
+
+async def test_purge_deletes_rows_older_than_the_retention_window() -> None:
+    db = _db(removed=3)
+    removed = await purge_anon_quota_counts(db, retention_days=30, now=NOW)
+    assert removed == 3
+    cutoff = db.anon_quota.purge_older_than.await_args.args[0]
+    assert cutoff.isoformat() == "2026-06-26"
+
+
+async def test_dry_run_reports_without_deleting() -> None:
+    db = _db(eligible=7)
+    removed = await purge_anon_quota_counts(
+        db, retention_days=30, now=NOW, dry_run=True
+    )
+    assert removed == 7
+    db.anon_quota.purge_older_than.assert_not_awaited()
+
+
+async def test_dry_run_still_uses_the_same_cutoff_as_a_real_run() -> None:
+    db = _db(eligible=0)
+    await purge_anon_quota_counts(db, retention_days=30, now=NOW, dry_run=True)
+    cutoff = db.pool.fetchval.await_args.args[1]
+    assert cutoff.isoformat() == "2026-06-26"

--- a/db/migrations/20260729000001_anon_daily_message_quota.sql
+++ b/db/migrations/20260729000001_anon_daily_message_quota.sql
@@ -1,0 +1,24 @@
+-- Per-identity anonymous daily message quota (issue #282, S1.10).
+--
+-- `daily_usage` (20260726000001) meters a *global* dollar ceiling across the
+-- whole anonymous surface; this table meters a *per-identity* message count
+-- so one visitor's own daily allowance is tracked separately from that shared
+-- breaker. One row per (UTC day, anon identity). The container ingress
+-- atomically increments this counter before invoking the runtime and rejects
+-- once the visitor's own quota is spent, without touching `daily_usage`.
+-- No secondary index: the PK (usage_date, anon_id) already leads with
+-- usage_date, so a standalone index on usage_date alone would only add
+-- write-path cost on this hot UPSERT path without answering any query the PK
+-- doesn't already serve (review follow-up: an earlier draft added one).
+-- message_count has no DEFAULT: the only writer is the repo's UPSERT, which
+-- always supplies an explicit value — a default here would be dead code that
+-- could mask a future writer forgetting to set it (review follow-up).
+CREATE TABLE IF NOT EXISTS anon_daily_message_count (
+    usage_date     DATE NOT NULL,
+    anon_id        TEXT NOT NULL,
+    message_count  BIGINT NOT NULL,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (usage_date, anon_id)
+);
+
+GRANT SELECT, INSERT, UPDATE ON anon_daily_message_count TO agent_svc;

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Y3AvBx7jEkPGh6dSEUWkBfSZNM3E6wHYwAQCQ+FN4K0=
+h1:W3IXU2wlInCAxpa0TCyYLWpJjl1LOzMHyZHEZUK9nmk=
 20260623000001_init.sql h1:j96dtVbOQB/5eNuug4tZpdgURdZ5h0Zh4Vka7/dy1A0=
 20260713000001_user_routes.sql h1:th9ag/cdiRp9plYQraVBGIuRXeH4g5R3XvCuGZeFx8Q=
 20260714000001_catalog_geocoding.sql h1:EwkJGRPfg5camebXRzw+5xRVf6TWu23t3/tnw91uPwY=
@@ -9,3 +9,4 @@ h1:Y3AvBx7jEkPGh6dSEUWkBfSZNM3E6wHYwAQCQ+FN4K0=
 20260719000001_agent_memory.sql h1:YRvJLyq+VR6A42DfNC9rAczEaxjaVHsPZMlaNCBZiGQ=
 20260726000001_daily_usage.sql h1:sBFx7wFXsR8SKXqny7S87YZiamGNDA0FXMrSV3EXj7c=
 20260728000001_conversations_user_id_pattern_ops.sql h1:7SCuWtKAHlYDv4EINCwR6NYWw/qJ7afcC3+rUoqHuaM=
+20260729000001_anon_daily_message_quota.sql h1:Z6fxATy3/W6M5CKVdC6rwcscKOWbwx88vIyf0bnZDpk=

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,6 +177,14 @@ open to callers with no session:
   Logged-in traffic is never gated. The edge caches that verdict in a same-UTC-day latch so
   subsequent anonymous requests short-circuit without a container round-trip; the latch expires
   at the day boundary. The edge never reads `daily_usage` itself.
+- **Per-identity daily message quota (S1.10, issue #282)** — a fairness/UX mechanism, not a
+  security defense line: the container ingress atomically increments a durable
+  `anon_daily_message_count` row keyed `(usage_date, anon_id)` and rejects with 403
+  `anon_quota_exhausted` (+ `quota_resets_at`, the next UTC midnight) once that one identity's own
+  `ANON_DAILY_MESSAGE_QUOTA` is spent, so a single visitor's free usage stays reasonable while the
+  shared budget above stays open for everyone else. `0` or unset disables it. Runs only after the
+  budget breaker above allows the turn — the global dollar ceiling is the more severe, systemic
+  concern and wins ties over one visitor's own message ceiling. Logged-in traffic is never gated.
 
 ## Frontend Auth — `frontend/components/auth/AuthGate.tsx` + `frontend/app/auth/callback/page.tsx`
 

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -115,6 +115,8 @@ Common runtime config:
 - `OBSERVABILITY_SERVICE_VERSION`
 - `LOGFIRE_TOKEN` (optional — tracing/metrics export to Logfire only when set)
 - `GOOGLE_MAPS_API_KEY` (optional)
+- `ANON_DAILY_COST_BUDGET_USD` (optional — the global anonymous daily-dollar circuit breaker, X4/#274; `0` disables it)
+- `ANON_DAILY_MESSAGE_QUOTA` (optional — the per-identity anonymous daily message quota, S1.10/#282, a fairness/UX mechanism rather than a defense line; `0` or unset disables it, same convention as the budget ceiling above)
 
 Session storage:
 

--- a/packages/contract/src/error-registry.ts
+++ b/packages/contract/src/error-registry.ts
@@ -38,6 +38,38 @@ export const AnonQuotaExhaustedData = z.object({
 /** Inferred TS type for the anonymous quota rejection payload. */
 export type AnonQuotaExhaustedData = z.infer<typeof AnonQuotaExhaustedData>;
 
+/**
+ * The full wire envelope both anonymous-limit rejections share: `code` +
+ * `message` + `action: "login"` at the top level, with `data` present only
+ * for the quota rejection (`AnonQuotaExhaustedData`) and absent for the
+ * budget breaker's envelope.
+ */
+export const AnonLimitErrorEnvelope = z.object({
+  error: z.object({
+    code: z.enum([ANON_BUDGET_EXHAUSTED_CODE, ANON_QUOTA_EXHAUSTED_CODE]),
+    message: z.string(),
+    action: z.literal("login"),
+    data: AnonQuotaExhaustedData.optional(),
+  }),
+});
+/** Inferred TS type for the anonymous-limit 403 wire envelope. */
+export type AnonLimitErrorEnvelope = z.infer<typeof AnonLimitErrorEnvelope>;
+
+/**
+ * Read `quota_resets_at` out of a parsed 403 body, if present. Returns
+ * `undefined` for the budget rejection (whose envelope has no `data`) and
+ * for anything that doesn't parse as `AnonLimitErrorEnvelope` at all — the
+ * caller should already know it is looking at an anonymous-limit rejection
+ * (e.g. `code === ANON_QUOTA_EXHAUSTED_CODE`) before reaching for this. The
+ * one blessed extraction site (issue #282 review): every consumer reads the
+ * nested shape through here instead of hand-rolling
+ * `body?.error?.data?.quota_resets_at` at each call site.
+ */
+export function readQuotaResetsAt(body: unknown): string | undefined {
+  const parsed = AnonLimitErrorEnvelope.safeParse(body);
+  return parsed.success ? parsed.data.error.data?.quota_resets_at : undefined;
+}
+
 /** Users-service error codes are feature-namespaced: ROUTE_*, CHECKIN_*, SHARE_*. */
 export type ErrorRegistryItem = {
   readonly status: number;

--- a/packages/contract/test/anon-limits.test.ts
+++ b/packages/contract/test/anon-limits.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it } from "vitest";
 import {
   ANON_BUDGET_EXHAUSTED_CODE,
   ANON_QUOTA_EXHAUSTED_CODE,
+  AnonLimitErrorEnvelope,
   AnonQuotaExhaustedData,
+  readQuotaResetsAt,
 } from "../src/error-registry.js";
 
 const WORKER_BREAKER = fileURLToPath(new URL("../../../worker/costBreaker.ts", import.meta.url));
@@ -37,5 +39,53 @@ describe("anonymous quota rejection payload", () => {
 
   it("requires the reset instant — a lock with no exit is the bug it prevents", () => {
     expect(AnonQuotaExhaustedData.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("the full anonymous-limit 403 envelope", () => {
+  it("accepts the quota rejection with quota_resets_at nested under data", () => {
+    const parsed = AnonLimitErrorEnvelope.parse({
+      error: {
+        code: ANON_QUOTA_EXHAUSTED_CODE,
+        message: "quota spent",
+        action: "login",
+        data: { quota_resets_at: "2026-07-30T00:00:00Z" },
+      },
+    });
+    expect(parsed.error.data?.quota_resets_at).toBe("2026-07-30T00:00:00Z");
+  });
+
+  it("accepts the budget rejection with no data field at all", () => {
+    const parsed = AnonLimitErrorEnvelope.parse({
+      error: { code: ANON_BUDGET_EXHAUSTED_CODE, message: "budget spent", action: "login" },
+    });
+    expect(parsed.error.data).toBeUndefined();
+  });
+});
+
+describe("readQuotaResetsAt — the one blessed extraction site", () => {
+  it("reads quota_resets_at out of a quota rejection body", () => {
+    const body = {
+      error: {
+        code: ANON_QUOTA_EXHAUSTED_CODE,
+        message: "quota spent",
+        action: "login",
+        data: { quota_resets_at: "2026-07-30T00:00:00Z" },
+      },
+    };
+    expect(readQuotaResetsAt(body)).toBe("2026-07-30T00:00:00Z");
+  });
+
+  it("returns undefined for a budget rejection body (no data field)", () => {
+    const body = {
+      error: { code: ANON_BUDGET_EXHAUSTED_CODE, message: "budget spent", action: "login" },
+    };
+    expect(readQuotaResetsAt(body)).toBeUndefined();
+  });
+
+  it("returns undefined for a body that doesn't parse as the envelope at all", () => {
+    expect(readQuotaResetsAt({ nothing: "here" })).toBeUndefined();
+    expect(readQuotaResetsAt(null)).toBeUndefined();
+    expect(readQuotaResetsAt("not even an object")).toBeUndefined();
   });
 });

--- a/worker/containerEnv.ts
+++ b/worker/containerEnv.ts
@@ -1,0 +1,43 @@
+/**
+ * The env-var forwarding allowlist between the worker and the container.
+ *
+ * Split out of `entry.ts` (issue #282 review) so this pure function can be
+ * unit-tested under plain `node --test`: `entry.ts` imports `Container` from
+ * `@cloudflare/containers`, whose ESM build uses an extensionless relative
+ * import that only resolves under workerd's module loader, not Node's. A test
+ * that imported `buildContainerEnvVars` straight from `entry.ts` would pull
+ * that broken import chain in and fail with `ERR_MODULE_NOT_FOUND` outside
+ * `wrangler dev`/deploy — this module has no such dependency.
+ */
+
+export const CONTAINER_ENV_KEYS = [
+  "DEEPSEEK_API_KEY", "MIMO_API_KEY", "SUPABASE_DB_URL", "ANITABI_API_URL", "CATALOG_API_URL",
+  "APP_ENV", "CACHE_TTL_SECONDS", "CORS_ALLOWED_ORIGIN", "DEBUG",
+  "DEFAULT_AGENT_MODEL", "FALLBACK_AGENT_MODEL", "GOOGLE_APPLICATION_CREDENTIALS",
+  "GOOGLE_CLOUD_PROJECT", "LOG_LEVEL", "MAX_RETRIES", "OBSERVABILITY_SERVICE_NAME",
+  "OBSERVABILITY_SERVICE_VERSION", "OPENAI_COMPAT_BASE_URL", "RATE_LIMIT_CALLS",
+  "RATE_LIMIT_PERIOD_SECONDS", "TIMEOUT_SECONDS", "USE_CACHE", "ZETA_API_KEY",
+  "GEMINI_API_KEY", "GOOGLE_MAPS_API_KEY", "LOGFIRE_TOKEN", "OPENAI_COMPAT_API_KEY",
+  // Anonymous daily-budget circuit breaker (X4): the container ingress owns the
+  // authoritative decision because it is the only tier that reads daily_usage.
+  "ANON_DAILY_COST_BUDGET_USD", "MODEL_INPUT_COST_PER_MTOK_USD", "MODEL_OUTPUT_COST_PER_MTOK_USD",
+  // Per-identity anonymous daily message quota (issue #282, S1.10): same
+  // container-ingress-authoritative reasoning as the budget breaker above.
+  "ANON_DAILY_MESSAGE_QUOTA",
+];
+
+export const CONTAINER_REQUIRED_KEYS = ["DEEPSEEK_API_KEY", "MIMO_API_KEY", "SUPABASE_DB_URL"];
+
+export function buildContainerEnvVars(env: Record<string, unknown>): Record<string, string> {
+  const envVars: Record<string, string> = { APP_ENV: "production", SERVICE_HOST: "0.0.0.0", SERVICE_PORT: "8080" };
+  for (const key of CONTAINER_REQUIRED_KEYS) {
+    const value = env[key];
+    if (typeof value !== "string" || value.length === 0) throw new Error(`Missing required container env: ${key}`);
+    envVars[key] = value;
+  }
+  for (const key of CONTAINER_ENV_KEYS) {
+    const value = env[key];
+    if (typeof value === "string" && value.length > 0) envVars[key] = value;
+  }
+  return envVars;
+}

--- a/worker/entry.test.ts
+++ b/worker/entry.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createWorkerApp, catalogOutbound } from "./app.ts";
+import { buildContainerEnvVars } from "./containerEnv.ts";
 
 const stubNext = {
   fetch: () => Promise.resolve(new Response("next", { status: 200 })),
@@ -224,4 +225,18 @@ void test("/v1/users/routes bypasses a rejecting authenticate stub", async () =>
   assert.equal(res.status, 200);
   assert.equal(await res.text(), "users");
   assert.equal(received, true);
+});
+
+function requiredEnv(): Record<string, string> {
+  return { DEEPSEEK_API_KEY: "k", MIMO_API_KEY: "k", SUPABASE_DB_URL: "postgres://x" };
+}
+
+void test("ANON_DAILY_MESSAGE_QUOTA reaches the container (issue #282) — wrangler.toml alone is not the whole contract", () => {
+  const envVars = buildContainerEnvVars({ ...requiredEnv(), ANON_DAILY_MESSAGE_QUOTA: "20" });
+  assert.equal(envVars.ANON_DAILY_MESSAGE_QUOTA, "20");
+});
+
+void test("an unset ANON_DAILY_MESSAGE_QUOTA is simply absent, not forwarded as an empty string", () => {
+  const envVars = buildContainerEnvVars(requiredEnv());
+  assert.equal("ANON_DAILY_MESSAGE_QUOTA" in envVars, false);
 });

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -1,37 +1,10 @@
 import { Container } from "@cloudflare/containers";
 import nextHandler from "./.open-next/worker.js";
 import { createWorkerApp, catalogOutbound, type Env } from "./app.ts";
+import { buildContainerEnvVars } from "./containerEnv.ts";
 
 export { DOQueueHandler, DOShardedTagCache } from "./.open-next/worker.js";
 export { EdgeGuard } from "./edgeGuard.ts";
-
-const CONTAINER_ENV_KEYS = [
-  "DEEPSEEK_API_KEY", "MIMO_API_KEY", "SUPABASE_DB_URL", "ANITABI_API_URL", "CATALOG_API_URL",
-  "APP_ENV", "CACHE_TTL_SECONDS", "CORS_ALLOWED_ORIGIN", "DEBUG",
-  "DEFAULT_AGENT_MODEL", "FALLBACK_AGENT_MODEL", "GOOGLE_APPLICATION_CREDENTIALS",
-  "GOOGLE_CLOUD_PROJECT", "LOG_LEVEL", "MAX_RETRIES", "OBSERVABILITY_SERVICE_NAME",
-  "OBSERVABILITY_SERVICE_VERSION", "OPENAI_COMPAT_BASE_URL", "RATE_LIMIT_CALLS",
-  "RATE_LIMIT_PERIOD_SECONDS", "TIMEOUT_SECONDS", "USE_CACHE", "ZETA_API_KEY",
-  "GEMINI_API_KEY", "GOOGLE_MAPS_API_KEY", "LOGFIRE_TOKEN", "OPENAI_COMPAT_API_KEY",
-  // Anonymous daily-budget circuit breaker (X4): the container ingress owns the
-  // authoritative decision because it is the only tier that reads daily_usage.
-  "ANON_DAILY_COST_BUDGET_USD", "MODEL_INPUT_COST_PER_MTOK_USD", "MODEL_OUTPUT_COST_PER_MTOK_USD",
-];
-const CONTAINER_REQUIRED_KEYS = ["DEEPSEEK_API_KEY", "MIMO_API_KEY", "SUPABASE_DB_URL"];
-
-function buildContainerEnvVars(env: Record<string, unknown>): Record<string, string> {
-  const envVars: Record<string, string> = { APP_ENV: "production", SERVICE_HOST: "0.0.0.0", SERVICE_PORT: "8080" };
-  for (const key of CONTAINER_REQUIRED_KEYS) {
-    const value = env[key];
-    if (typeof value !== "string" || value.length === 0) throw new Error(`Missing required container env: ${key}`);
-    envVars[key] = value;
-  }
-  for (const key of CONTAINER_ENV_KEYS) {
-    const value = env[key];
-    if (typeof value === "string" && value.length > 0) envVars[key] = value;
-  }
-  return envVars;
-}
 
 export class RuntimeContainer extends Container {
   defaultPort = 8080;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -67,6 +67,14 @@ ANON_RATE_LIMIT_WINDOW_SECONDS = "60"
 # Global anonymous daily spend ceiling (X4). Enforced by the container ingress
 # against the daily_usage table; 0 disables the breaker.
 ANON_DAILY_COST_BUDGET_USD = "5.0"
+# Per-identity daily message quota (issue #282, S1.10) — a fairness/UX
+# mechanism, not a security defense line: it keeps one visitor's free usage
+# reasonable while the shared budget above stays open for everyone else.
+# Enforced by the container ingress against anon_daily_message_count; 0 or
+# unset disables it, the same "0 disables" convention as the budget ceiling
+# above. Default is an owner-set operations decision (20 here is a starting
+# point, not a locked-in value).
+ANON_DAILY_MESSAGE_QUOTA = "20"
 # Per-identity limit on the two cost-bearing AUTHENTICATED endpoints (issue
 # #284 / Task 9): POST /v1/chat and POST /v1/byok/probe ONLY — authenticated
 # reads (GET /v1/conversations, /v1/*/messages, /v1/*/routes) are NOT counted
@@ -152,6 +160,14 @@ ANON_RATE_LIMIT_WINDOW_SECONDS = "60"
 # Global anonymous daily spend ceiling (X4). Enforced by the container ingress
 # against the daily_usage table; 0 disables the breaker.
 ANON_DAILY_COST_BUDGET_USD = "5.0"
+# Per-identity daily message quota (issue #282, S1.10) — a fairness/UX
+# mechanism, not a security defense line: it keeps one visitor's free usage
+# reasonable while the shared budget above stays open for everyone else.
+# Enforced by the container ingress against anon_daily_message_count; 0 or
+# unset disables it, the same "0 disables" convention as the budget ceiling
+# above. Default is an owner-set operations decision (20 here is a starting
+# point, not a locked-in value).
+ANON_DAILY_MESSAGE_QUOTA = "20"
 # Per-identity limit on the two cost-bearing AUTHENTICATED endpoints (issue
 # #284 / Task 9): POST /v1/chat and POST /v1/byok/probe ONLY — authenticated
 # reads (GET /v1/conversations, /v1/*/messages, /v1/*/routes) are NOT counted
@@ -213,6 +229,14 @@ ANON_RATE_LIMIT_WINDOW_SECONDS = "60"
 # Global anonymous daily spend ceiling (X4). Enforced by the container ingress
 # against the daily_usage table; 0 disables the breaker.
 ANON_DAILY_COST_BUDGET_USD = "5.0"
+# Per-identity daily message quota (issue #282, S1.10) — a fairness/UX
+# mechanism, not a security defense line: it keeps one visitor's free usage
+# reasonable while the shared budget above stays open for everyone else.
+# Enforced by the container ingress against anon_daily_message_count; 0 or
+# unset disables it, the same "0 disables" convention as the budget ceiling
+# above. Default is an owner-set operations decision (20 here is a starting
+# point, not a locked-in value).
+ANON_DAILY_MESSAGE_QUOTA = "20"
 # Per-identity limit on the two cost-bearing AUTHENTICATED endpoints (issue
 # #284 / Task 9): POST /v1/chat and POST /v1/byok/probe ONLY — authenticated
 # reads (GET /v1/conversations, /v1/*/messages, /v1/*/routes) are NOT counted


### PR DESCRIPTION
## Summary

Backend half of #282 (S1.10): container-ingress **per-identity daily message quota** for anonymous visitors — a fairness/UX mechanism, not a defense line. Complements the existing global dollar breaker (#274/#438).

- New durable counter (`anon_daily_message_count`, Atlas migration, PK `(usage_date, anon_id)`) — a single atomic UPSERT...RETURNING increments and returns today's count for one `anon_id`. DB-backed rather than in-process, per #446's lesson that in-process counters don't survive multi-instance deploys.
- `chat.py` gates anonymous turns: the global budget check (D11) runs first — it's the more severe, systemic concern and wins ties — then falls through to the per-identity quota (D12) only if the budget allowed the turn. Logged-in traffic is never touched by either gate. The quota check runs *before* request-body validation, so a malformed request that goes on to 422 still counts as an attempt (same reasoning a rate limiter uses).
- 403 payload: `{"error": {"code": "anon_quota_exhausted", "message": ..., "action": "login", "data": {"quota_resets_at": "<next UTC midnight, ISO-8601 Z>"}}}`, matching the frontend's (#468, now merged) D12 wire contract.
- Container re-validates the `anon_id` itself against `^anon_[0-9a-f]{32}$` (mirrors #460's `_ANON_ID_PATTERN` precedent, now also merged) — a malformed identity is neither counted nor rejected.
- Retention: `AnonQuotaRepository.purge_older_than()`, a `--dry-run` CLI script, a standalone nightly GitHub workflow, and `Settings.anon_daily_message_count_retention_days` (default 30).
- `wrangler.toml`'s three env blocks all forward `ANON_DAILY_MESSAGE_QUOTA` (default 20); `CONTAINER_ENV_KEYS`/`buildContainerEnvVars` were extracted out of `entry.ts` into a new `worker/containerEnv.ts` so the forwarding is unit-testable under plain `node --test` (`entry.ts` imports `@cloudflare/containers`, whose ESM build only resolves under workerd).
- `packages/contract/src/error-registry.ts`: the wire codes, `AnonQuotaExhaustedData`, `AnonLimitErrorEnvelope`, and `readQuotaResetsAt()` (the one blessed extraction site for `error.data.quota_resets_at`) all live in the file #468 established as the single source — folded here rather than in a competing standalone module. Python pins its own string constants against this file's text (it can't import TypeScript directly), the same three-mirror pattern used for the catalog error registry. `worker/costBreaker.ts` deliberately keeps its own hand-mirror of the budget code rather than importing from the contract — `packages/contract/AGENTS.md`'s documented pitfall says Workers must not pull Zod into their bundle for a single string constant.

## Design notes

- **Storage**: a new table, not a reuse of `daily_usage` — that table's PK `(usage_date, scope)` is a global aggregate across the whole anonymous population; this feature needs `(usage_date, anon_id)` granularity, a different shape entirely. Mirrors the existing `UsageRepo`/`UsageRepository` port+repo pattern (`AnonQuotaRepo` protocol, `AnonQuotaRepository`, wired onto `SupabaseClient.anon_quota`). No dead `DEFAULT 0` (the only writer always supplies an explicit value) and no redundant secondary index (the PK already leads with `usage_date`).
- **Reset semantics**: UTC calendar day, consistent with `daily_usage`'s existing `utc_today()` convention.
- **0/None semantics**: both disable the quota — the same convention as the budget breaker's `0` (an earlier draft had `0` mean "reject every message", inverting that convention).
- **Fail-open**: a read/write error on the counter never blocks the anonymous surface (matches the budget breaker's own contract).
- **Malformed-body semantics** (decided, tested): the quota counter increments before body validation, so a request that goes on to 422 still spends one message of the visitor's allowance.

## AC coverage

| AC | Type | Test |
|---|---|---|
| Anonymous identity within quota sends normally | endpoint test | `test_chat_anon_quota.py::test_the_nth_message_within_quota_still_passes` |
| A brand-new anonymous identity starts at full quota, not zero | unit | `test_anon_quota.py`, `test_chat_anon_quota.py` (both `..._starts_at_full_quota_not_zero`) |
| Exceeding quota → 403 `anon_quota_exhausted` + `action: login` + `error.data.quota_resets_at` | unit (endpoint) | `test_chat_anon_quota.py::test_the_n_plus_first_message_is_rejected`, `::test_the_rejection_carries_the_wire_contract...`, `::test_the_rejection_carries_an_iso_utc_reset_instant_under_data` |
| i18n copy | owned by #468 (merged) | n/a — backend only emits code/action/timestamp |
| Logged-in users unaffected | unit | `test_chat_anon_quota.py::test_logged_in_users_are_never_quota_checked` |
| Cross-day reset (mocked clock) | unit | `test_anon_quota.py::test_crossing_a_utc_day_boundary_resets_the_count` |
| Budget vs. quota precedence | unit | `test_chat_budget_quota_precedence.py` (3 tests) |
| Malformed anon_id neither counted nor rejected | unit | `test_anon_quota.py` (3 tests, including the `.fullmatch`→`.match` mutation-killing trailing-newline case) |
| Malformed body still consumes a message | unit | `test_chat_anon_quota.py::test_a_malformed_body_still_consumes_one_message_of_the_quota` |
| Retention purges stale rows, keeps fresh ones | integration (real Postgres) | `test_anon_quota_repo_contract.py::test_purge_older_than_removes_stale_rows_and_keeps_recent_ones` |
| GRANT actually took | integration (real Postgres) | `test_anon_quota_repo_contract.py::test_agent_svc_holds_the_grants_the_repo_needs` |
| Contract wire-code + payload-field pin | unit + vitest | `test_anon_limits_contract_pin.py`, `packages/contract/test/anon-limits.test.ts` |
| `ANON_DAILY_MESSAGE_QUOTA` actually reaches the container | vitest (worker) | `worker/entry.test.ts` (2 tests against `containerEnv.ts`) |

## Real-SQL integration evidence (issue: unit tests only mocked the pool)

`test_anon_quota_repo_contract.py` runs the actual UPSERT against Postgres via a pinned Atlas 0.30.0 binary (downloaded + checksum-verified locally since the global install was a mismatched canary build):
- Same-key increments across calls, per-identity/per-date isolation.
- **20 concurrent `asyncio.gather` callers on the same key return exactly `{1..20}`** — no lost update, the one correctness dimension a mocked-pool unit test structurally cannot prove.
- Retention purge removes a stale row and keeps a fresh one.
- `has_table_privilege` proves the migration's GRANT actually took (not just that the SQL string mentions one).

All 6 pass.

## Mutation testing evidence

No mutation-testing tool is wired into this repo, so verification was manual: deliberate one-line bugs were introduced and reverted, each confirmed to fail exactly the test(s) meant to catch it:
1. `count > quota` → `count >= quota` (off-by-one) — caught.
2. Swapped budget/quota check order in `chat.py` — caught.
3. `ON CONFLICT ... DO UPDATE` → `DO NOTHING` in the repo's SQL — caught.
4. `timedelta(days=1)` → `timedelta(days=2)` in `next_utc_midnight` — caught.
5. `QUOTA_RESETS_AT_FIELD` → a hardcoded typo — caught.
6. Nested `data` wrapper removed from the 403 payload — caught.
7. Purge's `usage_date < $1` → `<= $1` (off-by-one) — caught **only by the real-Postgres integration test**, not the mocked unit test.
8. `_ANON_ID_PATTERN.fullmatch` → `.match` — caught by a trailing-newline test case (verified empirically first: plain trailing garbage like `"_EXTRA"` does *not* actually distinguish `.match`/`.fullmatch` for a `$`-anchored pattern; a bare trailing newline is the one input that does).

(One additional mutation — removing the `auth.user_id is None` guard in `_quota_rejection` — was *not* caught by any test. Confirmed as expected: `_require_trusted_user`'s FastAPI dependency already 400s before the route body runs if `user_id` is `None`, so that branch is unreachable defensive code needed only for mypy's `str | None` narrowing.)

## Gates

- `make lint` / `make typecheck` — clean.
- `make test` — 1608 passed, 89.20% coverage (floor 87%).
- `make test-integration`'s anon-quota suite — 6 passed against real Postgres via pinned Atlas 0.30.0.
- `pnpm run test:worker` — 185 passed.
- `packages/contract`: `pnpm typecheck` clean, `pnpm test` — 60 passed.
- `apps/web`: `pnpm typecheck` clean, `pnpm test` — 1319 passed (full suite, unaffected by this backend-only PR).
- `actionlint` on the new workflow — clean.

## Notes for the reviewing seats

- This branch was rebased twice onto `feat/frontend-rebuild` as it advanced during review (#468's frontend D12 half and #460's anon-identity/retention precedent both landed mid-review). The five WIP review-round commits were squashed into one clean commit before each rebase to keep conflict resolution to a single pass.
- Reconciled with #468's actual merged shape: the wire codes + `AnonQuotaExhaustedData` + `AnonLimitErrorEnvelope` + `readQuotaResetsAt()` now all live in `packages/contract/src/error-registry.ts` (the file #468 established), not a separate `anon-limits.ts` module I'd originally created before #468 merged.
- `apps/web`'s D12 consumer (`use-chat-session.ts`, from #468) already hand-rolls the `error.data ?? error` fallback read for `quota_resets_at` — it predates `readQuotaResetsAt()`. A follow-up could swap it to use the shared helper, but it isn't required: the hand-rolled version is already correct and tested.
- Spec deviation from the issue's original `Files changed` plan (Worker KV counter, `worker/quota.ts`) → actual container-ingress Postgres implementation: commented on issue #282 directly with the rationale (atomic increment-and-compare under concurrency, single authoritative decision point).
- Photo-search quota (`photo_search_quota_anon`) is a separate, pre-existing feature and unaffected by this change — confirmed by inspection, no shared code path.

Refs #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
