### PR TITLE
fix(web): S1.4 follow-ups — real D7 mount-failure test + C3b drill-back chip (#437)

### DIFF
--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import type { ChangeEvent } from "react";
 import type { Dict } from "../../i18n/dictionaries";
 import { useDict } from "../../i18n/context";
@@ -59,22 +58,15 @@ function FormFields({ form }: { form: MagicLinkForm }) {
   </>);
 }
 
-/** Announce a dispatched link exactly once: the caller uses it to tell
- * "closed to go read the email" apart from "cancelled". */
-function useSentOnce(status: FormStatus, onSent: (() => void) | undefined): void {
-  useEffect(() => {
-    if (status === "sent") onSent?.();
-  }, [status, onSent]);
-}
-
 export interface LoginFormProps {
+  /** Announced once per dispatched link, from the send continuation itself, so
+   * the caller can tell "closed to go read the email" from "cancelled". */
   readonly onSent?: () => void;
 }
 
 export function LoginForm({ onSent }: LoginFormProps = {}) {
-  const form = useMagicLinkForm();
+  const form = useMagicLinkForm(onSent);
   const auth = useDict().auth;
-  useSentOnce(form.status, onSent);
   return (
     <form className="login-form" onSubmit={form.onSubmit} noValidate aria-label={auth.title}>
       <FormFields form={form} />

--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent } from "react";
 import type { Dict } from "../../i18n/dictionaries";
 import { useDict } from "../../i18n/context";
-import { type FormStatus, type MagicLinkForm, type ValidationKey, useMagicLinkForm } from "./useMagicLinkForm";
+import { type FormStatus, type MagicLinkForm, type SendCommitted, type ValidationKey, useMagicLinkForm } from "./useMagicLinkForm";
 
 type Auth = Dict["auth"];
 
@@ -59,13 +59,13 @@ function FormFields({ form }: { form: MagicLinkForm }) {
 }
 
 export interface LoginFormProps {
-  /** Announced once per dispatched link, from the send continuation itself, so
-   * the caller can tell "closed to go read the email" from "cancelled". */
-  readonly onSent?: () => void;
+  /** Announced once the send is dispatched, so a caller can tell "closed to go
+   * read the email" from "cancelled" — see `SendCommitted` for the timing. */
+  readonly onSendCommitted?: SendCommitted;
 }
 
-export function LoginForm({ onSent }: LoginFormProps = {}) {
-  const form = useMagicLinkForm(onSent);
+export function LoginForm({ onSendCommitted }: LoginFormProps = {}) {
+  const form = useMagicLinkForm(onSendCommitted);
   const auth = useDict().auth;
   return (
     <form className="login-form" onSubmit={form.onSubmit} noValidate aria-label={auth.title}>

--- a/apps/web/src/components/auth/LoginModal.tsx
+++ b/apps/web/src/components/auth/LoginModal.tsx
@@ -2,13 +2,14 @@ import { useEffect } from "react";
 import type { Dict } from "../../i18n/dictionaries";
 import { useDict } from "../../i18n/context";
 import { LoginForm } from "./LoginForm";
+import type { SendCommitted } from "./useMagicLinkForm";
 
 interface LoginModalProps {
   open: boolean;
   onClose: () => void;
-  /** Fires when a magic link was dispatched, so a caller can tell a
-   * "closed to go read the email" dismissal apart from a cancellation. */
-  onSent?: () => void;
+  /** Fires once the send is dispatched, so a caller can tell a "closed to go
+   * read the email" dismissal apart from a cancellation. */
+  onSendCommitted?: SendCommitted;
 }
 
 function useEscapeToClose(open: boolean, onClose: () => void): void {
@@ -22,25 +23,25 @@ function useEscapeToClose(open: boolean, onClose: () => void): void {
   }, [open, onClose]);
 }
 
-function LoginDialog({ auth, onClose, onSent }: { auth: Dict["auth"]; onClose: () => void; onSent?: () => void }) {
+function LoginDialog({ auth, onClose, onSendCommitted }: { auth: Dict["auth"]; onClose: () => void; onSendCommitted?: SendCommitted }) {
   return (
     <div className="login-modal" role="dialog" aria-modal="true" aria-label={auth.title} onClick={(event) => { event.stopPropagation(); }}>
       <button className="login-modal__close" type="button" aria-label={auth.close} onClick={onClose}>×</button>
       <h2 className="login-modal__title">{auth.title}</h2>
       <p className="login-modal__subtitle">{auth.subtitle}</p>
-      <LoginForm onSent={onSent} />
+      <LoginForm onSendCommitted={onSendCommitted} />
     </div>
   );
 }
 
 /** Magic-link login modal wired to the Neon Auth (Better Auth) client. */
-export function LoginModal({ open, onClose, onSent }: LoginModalProps) {
+export function LoginModal({ open, onClose, onSendCommitted }: LoginModalProps) {
   const auth = useDict().auth;
   useEscapeToClose(open, onClose);
   if (!open) return null;
   return (
     <div className="login-modal__mask" role="presentation" onClick={onClose}>
-      <LoginDialog auth={auth} onClose={onClose} onSent={onSent} />
+      <LoginDialog auth={auth} onClose={onClose} onSendCommitted={onSendCommitted} />
     </div>
   );
 }

--- a/apps/web/src/components/auth/useMagicLinkForm.ts
+++ b/apps/web/src/components/auth/useMagicLinkForm.ts
@@ -25,12 +25,17 @@ function callbackUrl(): string {
   return `${window.location.origin}/auth/callback`;
 }
 
-function useSendMagicLink(email: string): [FormStatus, () => Promise<void>] {
+/** `onSent` fires in this continuation, alongside the status commit — never from
+ * a passive effect, which would land a tick after the banner is observable and
+ * lose a race with an immediate dismissal (issues #437 / #465). */
+function useSendMagicLink(email: string, onSent?: () => void): [FormStatus, () => Promise<void>] {
   const [status, setStatus] = useState<FormStatus>("idle");
   const submit = useCallback(async () => {
     setStatus("submitting");
-    setStatus(await sendMagicLink({ email: email.trim().toLowerCase(), callbackURL: callbackUrl() }));
-  }, [email]);
+    const result = await sendMagicLink({ email: email.trim().toLowerCase(), callbackURL: callbackUrl() });
+    setStatus(result);
+    if (result === "sent") onSent?.();
+  }, [email, onSent]);
   return [status, submit];
 }
 
@@ -45,10 +50,10 @@ function useSubmit(email: string, setValidation: SetValidation, submit: () => Pr
   }, [email, setValidation, submit]);
 }
 
-export function useMagicLinkForm(): MagicLinkForm {
+export function useMagicLinkForm(onSent?: () => void): MagicLinkForm {
   const [email, setEmail] = useState("");
   const [validation, setValidation] = useState<ValidationKey | null>(null);
-  const [status, submit] = useSendMagicLink(email);
+  const [status, submit] = useSendMagicLink(email, onSent);
   const onSubmit = useSubmit(email, setValidation, submit);
   return { email, status, validation, setEmail, onSubmit };
 }

--- a/apps/web/src/components/auth/useMagicLinkForm.ts
+++ b/apps/web/src/components/auth/useMagicLinkForm.ts
@@ -1,4 +1,5 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import type { RefObject } from "react";
 import { type MagicLinkResult, sendMagicLink } from "../../lib/auth/neonAuth";
 
 export type ValidationKey = "email_required" | "email_invalid";
@@ -25,17 +26,31 @@ function callbackUrl(): string {
   return `${window.location.origin}/auth/callback`;
 }
 
-/** `onSent` fires in this continuation, alongside the status commit — never from
- * a passive effect, which would land a tick after the banner is observable and
- * lose a race with an immediate dismissal (issues #437 / #465). */
-function useSendMagicLink(email: string, onSent?: () => void): [FormStatus, () => Promise<void>] {
+/**
+ * Announced once per dispatched request, at the **start** of the send — the
+ * user's commitment is the click, not the server's reply. A caller that keys
+ * off dismissal (the P5 save wall) must count an in-flight request as
+ * committed, or the entire request latency is a window in which closing the
+ * modal destroys the intent. Never announced from a passive effect either:
+ * that lands a tick after the banner is observable (issues #437 / #465).
+ */
+export type SendCommitted = () => void;
+
+/** Latest-ref so a caller's inline callback cannot churn `submit`'s identity or
+ * be captured stale, mirroring `useTurnTiming`'s `reportRef`. */
+function useLatest(callback: SendCommitted | undefined): RefObject<SendCommitted | undefined> {
+  const ref = useRef(callback);
+  ref.current = callback;
+  return ref;
+}
+
+function useSendMagicLink(email: string, onCommitted: RefObject<SendCommitted | undefined>): [FormStatus, () => Promise<void>] {
   const [status, setStatus] = useState<FormStatus>("idle");
   const submit = useCallback(async () => {
     setStatus("submitting");
-    const result = await sendMagicLink({ email: email.trim().toLowerCase(), callbackURL: callbackUrl() });
-    setStatus(result);
-    if (result === "sent") onSent?.();
-  }, [email, onSent]);
+    onCommitted.current?.();
+    setStatus(await sendMagicLink({ email: email.trim().toLowerCase(), callbackURL: callbackUrl() }));
+  }, [email, onCommitted]);
   return [status, submit];
 }
 
@@ -50,10 +65,10 @@ function useSubmit(email: string, setValidation: SetValidation, submit: () => Pr
   }, [email, setValidation, submit]);
 }
 
-export function useMagicLinkForm(onSent?: () => void): MagicLinkForm {
+export function useMagicLinkForm(onSendCommitted?: SendCommitted): MagicLinkForm {
   const [email, setEmail] = useState("");
   const [validation, setValidation] = useState<ValidationKey | null>(null);
-  const [status, submit] = useSendMagicLink(email, onSent);
+  const [status, submit] = useSendMagicLink(email, useLatest(onSendCommitted));
   const onSubmit = useSubmit(email, setValidation, submit);
   return { email, status, validation, setEmail, onSubmit };
 }

--- a/apps/web/src/features/chat/components/SearchMap.tsx
+++ b/apps/web/src/features/chat/components/SearchMap.tsx
@@ -8,6 +8,7 @@ import type { BasemapStatus, MountBasemapOptions } from "../../bubble-map/bubble
 import { clusterName, spotCountBadge } from "../search-copy";
 import type { ChatDict } from "../i18n";
 import { MapFallback } from "./ErrorStates/MapFallback";
+import { useAutoFocus } from "./useAutoFocus";
 
 /** Injectable mount so tests (and D7 simulations) never touch WebGL. */
 export type AttachBasemap = (options: MountBasemapOptions) => () => void;
@@ -105,11 +106,12 @@ function bubbleStyle(placement: BubblePlacement): CSSProperties {
   return { width: size, height: size, ...percentStyle(placement) };
 }
 
-type BubbleProps = Readonly<{ placement: BubblePlacement; dict: ChatDict; onClick: () => void }>;
+type BubbleProps = Readonly<{ placement: BubblePlacement; dict: ChatDict; onClick: () => void; refocus: boolean }>;
 
-function ClusterBubble({ placement, dict, onClick }: BubbleProps) {
+function ClusterBubble({ placement, dict, onClick, refocus }: BubbleProps) {
+  const ref = useAutoFocus<HTMLButtonElement>(refocus);
   return (
-    <button type="button" className="chat-map-bubble" style={bubbleStyle(placement)} onClick={onClick}>
+    <button ref={ref} type="button" className="chat-map-bubble" style={bubbleStyle(placement)} onClick={onClick}>
       <span className="chat-map-bubble__name">{placement.region}</span>
       <span className="chat-map-bubble__count">{spotCountBadge(placement.count, dict)}</span>
     </button>
@@ -120,7 +122,9 @@ type BubbleMapProps = Readonly<{
   clusters: readonly SpotCluster[];
   dict: ChatDict;
   attach: AttachBasemap;
-  onSelect: (cluster: SpotCluster) => void;
+  onSelect: (cluster: SpotCluster, index: number) => void;
+  /** Index of the bubble a drill was just backed out of; it reclaims focus. */
+  refocusIndex: number | null;
 }>;
 
 type OverlayProps = Omit<BubbleMapProps, "attach">;
@@ -134,30 +138,41 @@ function toCircle(cluster: SpotCluster, index: number, dict: ChatDict) {
   };
 }
 
-function selectAt(clusters: readonly SpotCluster[], index: number, onSelect: (cluster: SpotCluster) => void): void {
+function selectAt(clusters: readonly SpotCluster[], index: number, onSelect: BubbleMapProps["onSelect"]): void {
   const cluster = clusters[index];
-  if (cluster) onSelect(cluster);
+  if (cluster) onSelect(cluster, index);
 }
 
-function BubbleOverlay({ clusters, dict, onSelect }: OverlayProps) {
+function BubbleOverlay({ clusters, dict, onSelect, refocusIndex }: OverlayProps) {
   const circles = clusters.map((cluster, index) => toCircle(cluster, index, dict));
   const bubbles = bubblePlacements(circles).map((placement, index) => (
     // Keyed by position, not by region name: two clusters >50km apart can share
     // a city name (府中市 exists in both Tokyo and Hiroshima), and a duplicate
     // key silently drops one bubble.
-    <ClusterBubble key={index} placement={placement} dict={dict} onClick={() => { selectAt(clusters, index, onSelect); }} />
+    <ClusterBubble key={index} placement={placement} dict={dict} refocus={index === refocusIndex} onClick={() => { selectAt(clusters, index, onSelect); }} />
   ));
   return <div className="chat-search-map__overlay chat-search-map__overlay--bubbles">{bubbles}</div>;
 }
 
+type BubbleFallbackProps = Readonly<{ dict: ChatDict; center?: LatLng; refocus: boolean }>;
+
+/** D7 overview: no bubble survives to take focus, so the placeholder takes it. */
+function BubbleMapFallback({ dict, center, refocus }: BubbleFallbackProps) {
+  const ref = useAutoFocus<HTMLDivElement>(refocus);
+  return (
+    <div ref={ref} tabIndex={-1} className="chat-search-map__fallback">
+      <MapFallback dict={dict} lat={center?.lat} lng={center?.lng} />
+    </div>
+  );
+}
+
 /** C3b overview: bubbles only (area ∝ count) — this zoom never draws pins. */
-export function ClusterBubbleMap({ clusters, dict, attach, onSelect }: BubbleMapProps) {
+export function ClusterBubbleMap({ clusters, dict, attach, onSelect, refocusIndex }: BubbleMapProps) {
   const basemap = useBasemap(clusters.map((cluster) => cluster.center), attach);
-  const first = clusters[0];
-  if (basemap.status === "fallback") return <MapFallback dict={dict} lat={first?.center.lat} lng={first?.center.lng} />;
+  if (basemap.status === "fallback") return <BubbleMapFallback dict={dict} center={clusters[0]?.center} refocus={refocusIndex !== null} />;
   return (
     <MapFrame basemap={basemap} role="group" label={dict.search.mapLabel}>
-      <BubbleOverlay clusters={clusters} dict={dict} onSelect={onSelect} />
+      <BubbleOverlay clusters={clusters} dict={dict} onSelect={onSelect} refocusIndex={refocusIndex} />
     </MapFrame>
   );
 }

--- a/apps/web/src/features/chat/components/SearchResult.tsx
+++ b/apps/web/src/features/chat/components/SearchResult.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { MAX_MAP_PINS, searchMapView, topSpots } from "../../../lib/chat/spotClusters";
 import type { SearchSpot, SpotCluster } from "../../../lib/chat/spotClusters";
 import { attachBasemap } from "../../bubble-map/bubbleMapController";
@@ -9,6 +9,7 @@ import { EnvelopeFallback } from "./ErrorStates/EnvelopeFallback";
 import { SceneThumb } from "./ErrorStates/SceneThumb";
 import { ClusterBubbleMap, StaticSpotMap } from "./SearchMap";
 import type { AttachBasemap } from "./SearchMap";
+import { useAutoFocus } from "./useAutoFocus";
 
 type SpotProps = Readonly<{ spot: SearchSpot; dict: ChatDict }>;
 type GridProps = Readonly<{ spots: readonly SearchSpot[]; dict: ChatDict }>;
@@ -59,14 +60,34 @@ function SingleClusterView({ cluster, dict, attach }: ClusterProps) {
 type DrillProps = ClusterProps & Readonly<{ onBack: () => void }>;
 
 /** C3b→C3a keeps a way back to the 圏 overview, so the drill is not a dead end
- * (issue #437 item 2); the funnel in the S1.4 spec reads in both directions. */
+ * (issue #437 item 2); the funnel in the S1.4 spec reads in both directions.
+ * The chip also takes focus, since the view it replaced held it. */
 function DrilledClusterView({ cluster, dict, attach, onBack }: DrillProps) {
+  const ref = useAutoFocus<HTMLButtonElement>(true);
   return (
     <div className="chat-drill">
-      <button type="button" className="chat-chip chat-drill__back" onClick={onBack}>{dict.search.backToOverview}</button>
+      <button ref={ref} type="button" className="chat-chip chat-drill__back" onClick={onBack}>{dict.search.backToOverview}</button>
       <SingleClusterView cluster={cluster} dict={dict} attach={attach} />
     </div>
   );
+}
+
+type Drill = Readonly<{ cluster: SpotCluster; index: number }>;
+
+interface DrillNav {
+  readonly drill: Drill | null;
+  /** Set only while returning, so a fresh drill never steals focus back. */
+  readonly refocusIndex: number | null;
+  readonly select: (cluster: SpotCluster, index: number) => void;
+  readonly back: () => void;
+}
+
+function useDrillNav(): DrillNav {
+  const [drill, setDrill] = useState<Drill | null>(null);
+  const [refocusIndex, setRefocus] = useState<number | null>(null);
+  const select = useCallback((cluster: SpotCluster, index: number) => { setRefocus(null); setDrill({ cluster, index }); }, []);
+  const back = useCallback(() => { setRefocus(drill?.index ?? null); setDrill(null); }, [drill]);
+  return { drill, refocusIndex, select, back };
 }
 
 /** No locatable spot: the D2 state (issue #272 S1.6), never a silently empty map. */
@@ -88,9 +109,9 @@ type SearchResultProps = Readonly<{ spots: readonly SearchSpot[]; dict: ChatDict
  */
 export function SearchResult({ spots, dict, attach = attachBasemap }: SearchResultProps) {
   const view = searchMapView(spots);
-  const [drill, setDrill] = useState<SpotCluster | null>(null);
+  const nav = useDrillNav();
   if (view.kind === "empty") return <EmptyMapState spots={spots} dict={dict} />;
   if (view.kind === "single") return <SingleClusterView cluster={view.cluster} dict={dict} attach={attach} />;
-  if (drill !== null) return <DrilledClusterView cluster={drill} dict={dict} attach={attach} onBack={() => { setDrill(null); }} />;
-  return <ClusterBubbleMap clusters={view.clusters} dict={dict} attach={attach} onSelect={setDrill} />;
+  if (nav.drill !== null) return <DrilledClusterView cluster={nav.drill.cluster} dict={dict} attach={attach} onBack={nav.back} />;
+  return <ClusterBubbleMap clusters={view.clusters} dict={dict} attach={attach} onSelect={nav.select} refocusIndex={nav.refocusIndex} />;
 }

--- a/apps/web/src/features/chat/components/SearchResult.tsx
+++ b/apps/web/src/features/chat/components/SearchResult.tsx
@@ -56,6 +56,19 @@ function SingleClusterView({ cluster, dict, attach }: ClusterProps) {
   );
 }
 
+type DrillProps = ClusterProps & Readonly<{ onBack: () => void }>;
+
+/** C3b→C3a keeps a way back to the 圏 overview, so the drill is not a dead end
+ * (issue #437 item 2); the funnel in the S1.4 spec reads in both directions. */
+function DrilledClusterView({ cluster, dict, attach, onBack }: DrillProps) {
+  return (
+    <div className="chat-drill">
+      <button type="button" className="chat-chip chat-drill__back" onClick={onBack}>{dict.search.backToOverview}</button>
+      <SingleClusterView cluster={cluster} dict={dict} attach={attach} />
+    </div>
+  );
+}
+
 /** No locatable spot: the D2 state (issue #272 S1.6), never a silently empty map. */
 function EmptyMapState({ spots, dict }: GridProps) {
   return (
@@ -78,6 +91,6 @@ export function SearchResult({ spots, dict, attach = attachBasemap }: SearchResu
   const [drill, setDrill] = useState<SpotCluster | null>(null);
   if (view.kind === "empty") return <EmptyMapState spots={spots} dict={dict} />;
   if (view.kind === "single") return <SingleClusterView cluster={view.cluster} dict={dict} attach={attach} />;
-  if (drill !== null) return <SingleClusterView cluster={drill} dict={dict} attach={attach} />;
+  if (drill !== null) return <DrilledClusterView cluster={drill} dict={dict} attach={attach} onBack={() => { setDrill(null); }} />;
   return <ClusterBubbleMap clusters={view.clusters} dict={dict} attach={attach} onSelect={setDrill} />;
 }

--- a/apps/web/src/features/chat/components/TimedItinerary.tsx
+++ b/apps/web/src/features/chat/components/TimedItinerary.tsx
@@ -139,7 +139,7 @@ function SaveCta({ save, dict, saveDeps }: Omit<ItineraryProps, "view">) {
     <>
       <SaveButton gate={gate} dict={dict} />
       <SaveFeedback gate={gate} dict={dict} />
-      {gate.loginOpen ? <LoginModal open onClose={gate.closeLogin} onSent={gate.markLinkSent} /> : null}
+      {gate.loginOpen ? <LoginModal open onClose={gate.closeLogin} onSendCommitted={gate.markSendCommitted} /> : null}
     </>
   );
 }

--- a/apps/web/src/features/chat/components/useAutoFocus.ts
+++ b/apps/web/src/features/chat/components/useAutoFocus.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+
+/**
+ * Move focus onto an element the moment it becomes the view's entry point.
+ *
+ * The C3b drill swaps one view for another rather than navigating, so without
+ * this the focused control is unmounted and focus falls to `<body>` — keyboard
+ * and screen-reader users land back at the top of the document with nothing
+ * announced (issue #437 item 2).
+ */
+export function useAutoFocus<T extends HTMLElement>(active: boolean): RefObject<T | null> {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    if (active) ref.current?.focus();
+  }, [active]);
+  return ref;
+}

--- a/apps/web/src/features/chat/save/useSaveGate.ts
+++ b/apps/web/src/features/chat/save/useSaveGate.ts
@@ -30,9 +30,9 @@ export interface SaveGate {
   readonly loginOpen: boolean;
   readonly activate: () => void;
   readonly closeLogin: () => void;
-  /** The wall dispatched a magic link — the dismissal that follows is the user
+  /** The wall dispatched a send — any dismissal that follows is the user
    * leaving to read their email, not a cancellation. */
-  readonly markLinkSent: () => void;
+  readonly markSendCommitted: () => void;
 }
 
 /** Injectable for tests; production callers rely on the defaults. */
@@ -78,36 +78,41 @@ interface Wall {
   readonly loginOpen: boolean;
   readonly openLogin: () => void;
   readonly closeLogin: () => void;
-  readonly markLinkSent: () => void;
+  readonly markSendCommitted: () => void;
 }
 
 /**
- * The wall's own state. "A link went out" is a **ref**, not state: it never
- * affects rendering, and React batches the form's effect with the dismissal
- * click — a state value would still read `false` inside the click handler that
- * flushed it, silently clearing an intent the user is about to use.
+ * The wall's own state. "The user committed to a send" is a **ref**, not state:
+ * it never affects rendering, and `markSendCommitted` fires synchronously as
+ * the request is dispatched. A state value would only reach the *next* render's
+ * closures, so the dismissal handler already created for the current render
+ * would still read `false` — silently clearing an intent the user is about to
+ * use. The flag is set at dispatch, not on the reply, so the request's own
+ * latency is not a window in which closing the modal destroys the intent.
  */
 function useWall(): Wall {
   const [loginOpen, setLoginOpen] = useState(false);
-  const linkSent = useRef(false);
-  // Each fresh trip through the wall starts as "no link sent yet".
-  const openLogin = useCallback(() => { linkSent.current = false; setLoginOpen(true); }, []);
-  const markLinkSent = useCallback(() => { linkSent.current = true; }, []);
-  return { loginOpen, openLogin, markLinkSent, closeLogin: useCloseLogin(setLoginOpen, linkSent) };
+  const committed = useRef(false);
+  // Each fresh trip through the wall starts as "nothing committed yet".
+  const openLogin = useCallback(() => { committed.current = false; setLoginOpen(true); }, []);
+  const markSendCommitted = useCallback(() => { committed.current = true; }, []);
+  return { loginOpen, openLogin, markSendCommitted, closeLogin: useCloseLogin(setLoginOpen, committed) };
 }
 
 /**
- * Dismissal is only abandonment **before** a link goes out: closing the modal to
- * go read the email is the mainline of the magic-link flow, and clearing there
- * would break create-on-login silently. Once a link is dispatched the intent
- * survives; the surprise-save risk that motivated clearing is already covered by
- * consume-once plus the TTL.
+ * Dismissal is only abandonment **before** a send is dispatched: closing the
+ * modal to go read the email is the mainline of the magic-link flow, and
+ * clearing there would break create-on-login silently. Once a request is out
+ * the intent survives — including while it is still in flight, and including a
+ * send that ultimately failed, since keeping a stale intent costs nothing
+ * (consume-once plus the TTL bound it) while clearing a live one loses the
+ * user's work.
  */
-function useCloseLogin(setLoginOpen: (open: boolean) => void, linkSent: RefObject<boolean>): () => void {
+function useCloseLogin(setLoginOpen: (open: boolean) => void, committed: RefObject<boolean>): () => void {
   return useCallback(() => {
-    if (!linkSent.current) clearDeferredSave();
+    if (!committed.current) clearDeferredSave();
     setLoginOpen(false);
-  }, [setLoginOpen, linkSent]);
+  }, [setLoginOpen, committed]);
 }
 
 /** Save state plus the login wall for one route card. */

--- a/apps/web/src/features/chat/search-i18n.ts
+++ b/apps/web/src/features/chat/search-i18n.ts
@@ -5,6 +5,7 @@ export interface ChatSearchDict {
   readonly spotCount: string;
   readonly areaFallback: string;
   readonly mapLabel: string;
+  readonly backToOverview: string;
   readonly trayChanged: string;
   readonly trayMinimum: string;
   readonly traySelected: string;
@@ -19,6 +20,7 @@ export const jaSearch: ChatSearchDict = {
   spotCount: "{count}件",
   areaFallback: "エリア{n}",
   mapLabel: "聖地マップ",
+  backToOverview: "← 全体にもどる",
   trayChanged: "スポットの選択が変わりました",
   trayMinimum: "2件以上選んでください",
   traySelected: "{count}件選択中",
@@ -33,6 +35,7 @@ export const zhSearch: ChatSearchDict = {
   spotCount: "{count} 处",
   areaFallback: "区域{n}",
   mapLabel: "圣地地图",
+  backToOverview: "← 返回全部区域",
   trayChanged: "圣地的选择有变化",
   trayMinimum: "请至少选择 2 处",
   traySelected: "已选 {count} 处",
@@ -47,6 +50,7 @@ export const enSearch: ChatSearchDict = {
   spotCount: "{count} spots",
   areaFallback: "Area {n}",
   mapLabel: "Spot map",
+  backToOverview: "← Back to all areas",
   trayChanged: "Your spot selection changed",
   trayMinimum: "Select at least 2 spots",
   traySelected: "{count} selected",

--- a/apps/web/src/features/chat/search-i18n.ts
+++ b/apps/web/src/features/chat/search-i18n.ts
@@ -20,7 +20,7 @@ export const jaSearch: ChatSearchDict = {
   spotCount: "{count}件",
   areaFallback: "エリア{n}",
   mapLabel: "聖地マップ",
-  backToOverview: "← 全体にもどる",
+  backToOverview: "← 全体に戻る",
   trayChanged: "スポットの選択が変わりました",
   trayMinimum: "2件以上選んでください",
   traySelected: "{count}件選択中",

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -499,6 +499,20 @@
   gap: 0.75rem;
 }
 
+/* C3b -> C3a drill: the way back to the 圏 overview (issue #437) */
+
+.chat-drill {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Layout only: the cream press style and tokens come from .chat-chip. */
+.chat-drill__back {
+  align-self: flex-start;
+  font-size: 0.8125rem;
+}
+
 .chat-spot-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));

--- a/apps/web/tests/unit/chat/basemap-mount-failure.test.tsx
+++ b/apps/web/tests/unit/chat/basemap-mount-failure.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #437 item 1: the `.catch` in `attachBasemap` was only reachable through a
+ * real WebGL/import failure, and every other suite injects a fake `attach`. Here the
+ * maplibre module itself is stubbed so the real controller runs and its failure path
+ * drives the D7 placeholder.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { attachBasemap } from "../../../src/features/bubble-map/bubbleMapController";
+import { SearchResult } from "../../../src/features/chat/components/SearchResult";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { toSearchSpots } from "../../../src/lib/chat/spotClusters";
+import type { SpotRowLike } from "../../../src/lib/chat/spotClusters";
+
+vi.mock("pmtiles", () => ({ Protocol: class { readonly tile = () => undefined; } }));
+
+// Stands in for a browser without a WebGL context: constructing the map throws.
+vi.mock("maplibre-gl", () => ({
+  addProtocol: () => undefined,
+  Map: function MapStub(): never { throw new Error("WebGL context unavailable"); },
+}));
+
+afterEach(cleanup);
+
+const dict = chatDictFor("ja");
+
+const ONE_CLUSTER: readonly SpotRowLike[] = [
+  { id: "u1", name: "宇治橋", lat: 34.89, lng: 135.8, city: "宇治市", screenshot_url: "/s.webp" },
+  { id: "u2", name: "宇治川", lat: 34.9, lng: 135.81, city: "宇治市", screenshot_url: "/s.webp" },
+];
+
+/** The mount awaits two dynamic imports before it throws; drain past both. */
+const settleMount = async (): Promise<void> => {
+  for (let tick = 0; tick < 5; tick += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
+describe("real basemap mount failure (issue #437 item 1)", () => {
+  it("renders the D7 doodle and map-app link instead of a blank map frame", async () => {
+    render(<SearchResult spots={toSearchSpots(ONE_CLUSTER)} dict={dict} />);
+    await vi.waitFor(() => {
+      expect(document.querySelector(".chat-map-fallback__doodle")).not.toBeNull();
+    });
+    expect(screen.getByText(dict.errorStates.d7Message)).toBeTruthy();
+    expect(screen.getByRole("link", { name: dict.errorStates.d7Open }).getAttribute("href")).toContain("34.89,135.8");
+    expect(document.querySelector(".chat-search-map__gl")).toBeNull();
+  });
+
+  it("stays silent when the effect is cleaned up before the mount rejects", async () => {
+    const onStatus = vi.fn();
+    const detach = attachBasemap({ container: document.createElement("div"), points: [{ lat: 34.89, lng: 135.8 }], onStatus });
+    detach();
+    await settleMount();
+    expect(onStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/chat/chat-design-css.test.ts
+++ b/apps/web/tests/unit/chat/chat-design-css.test.ts
@@ -125,6 +125,14 @@ describe("B4 settled footprint: elapsed emphasis over a semantic token", () => {
   });
 });
 
+describe("C3b drill-back chip (issue #437)", () => {
+  it("carries layout only, so the cream chip tokens stay the single source", () => {
+    expect(ruleDeclaration(chatCss, ".chat-drill__back", "align-self")).toBe("flex-start");
+    expect(ruleDeclaration(chatCss, ".chat-drill__back", "background")).toBeNull();
+    expect(ruleDeclaration(chatCss, ".chat-drill__back", "color")).toBeNull();
+  });
+});
+
 describe("S1.9 Turnstile dock slot (issue #447)", () => {
   it("paints the gate with the dock's own surface token, never a raw color", () => {
     expect(ruleDeclaration(chatCss, ".turnstile-gate", "background")).toBe("var(--color-card)");

--- a/apps/web/tests/unit/chat/save-wall-dismissal.test.tsx
+++ b/apps/web/tests/unit/chat/save-wall-dismissal.test.tsx
@@ -84,6 +84,17 @@ describe("closing the wall after a link is sent is 'going to read the email'", (
     expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeTruthy();
   });
 
+  /** The whole request latency used to be a window in which closing the modal
+   * destroyed the intent — the commit is the click, not the server's reply. */
+  it("keeps the intent when the wall is closed while the request is still in flight", () => {
+    send.mockReturnValue(new Promise(() => undefined));
+    openWall();
+    fireEvent.change(screen.getByLabelText("メールアドレス"), { target: { value: "fan@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
+    dismiss();
+    expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toContain("a");
+  });
+
   it("re-arms on the next trip: a fresh open that is cancelled clears again", async () => {
     openWall();
     await sendLink();
@@ -94,22 +105,24 @@ describe("closing the wall after a link is sent is 'going to read the email'", (
   });
 });
 
-describe("the modal reports a dispatched link to its caller", () => {
-  it("calls onSent once the magic link goes out, and not before", async () => {
-    const onSent = vi.fn();
-    renderWithLocale(<LoginModal open onClose={vi.fn()} onSent={onSent} />);
-    expect(onSent).not.toHaveBeenCalled();
+describe("the modal reports a dispatched send to its caller", () => {
+  it("calls onSendCommitted once the request goes out, and not before", async () => {
+    const onSendCommitted = vi.fn();
+    renderWithLocale(<LoginModal open onClose={vi.fn()} onSendCommitted={onSendCommitted} />);
+    expect(onSendCommitted).not.toHaveBeenCalled();
     await sendLink();
-    expect(onSent).toHaveBeenCalledTimes(1);
+    expect(onSendCommitted).toHaveBeenCalledTimes(1);
   });
 
-  it("does not report a failed send", async () => {
-    const onSent = vi.fn();
+  /** A failed send still counts: the user asked for a link and may retry, and a
+   * kept intent is bounded by consume-once + TTL while a cleared one is lost. */
+  it("still reports a send that came back as an error", async () => {
+    const onSendCommitted = vi.fn();
     send.mockResolvedValue("error");
-    renderWithLocale(<LoginModal open onClose={vi.fn()} onSent={onSent} />);
+    renderWithLocale(<LoginModal open onClose={vi.fn()} onSendCommitted={onSendCommitted} />);
     fireEvent.change(screen.getByLabelText("メールアドレス"), { target: { value: "fan@example.com" } });
     fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
     await waitFor(() => { expect(screen.getByRole("alert")).toBeTruthy(); });
-    expect(onSent).not.toHaveBeenCalled();
+    expect(onSendCommitted).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/unit/chat/search-card-c3a.test.tsx
+++ b/apps/web/tests/unit/chat/search-card-c3a.test.tsx
@@ -61,4 +61,11 @@ describe("C3a static map (AC: static map with ≤50 pins)", () => {
     renderSingle(Array.from({ length: 60 }, (_, index) => ujiRow(index, "/s.webp")));
     expect(document.querySelectorAll(".chat-map-pin")).toHaveLength(50);
   });
+
+  // Issue #437 item 2: the back chip belongs to a drill, not to a natively
+  // single-cluster result — there is no overview to return to here.
+  it("offers no drill-back chip when the result was single-cluster to begin with", () => {
+    renderSingle([ujiRow(1, "/s1.webp")]);
+    expect(screen.queryByRole("button", { name: dict.search.backToOverview })).toBeNull();
+  });
 });

--- a/apps/web/tests/unit/chat/search-card-c3b.test.tsx
+++ b/apps/web/tests/unit/chat/search-card-c3b.test.tsx
@@ -98,4 +98,26 @@ describe("C3b drill-down back affordance (issue #437)", () => {
     fireEvent.click(screen.getByRole("button", { name: /新宿区/ }));
     expect(screen.getAllByRole("checkbox")).toHaveLength(2);
   });
+
+  // A view swap that leaves focus on <body> strands keyboard and screen-reader
+  // users at the top of the document with no announcement of what changed.
+  it("moves focus onto the back chip when a cluster is drilled into", () => {
+    renderMulti();
+    fireEvent.click(screen.getByRole("button", { name: /宇治市/ }));
+    expect(document.activeElement).toBe(back());
+  });
+
+  it("returns focus to the bubble that was drilled into", () => {
+    renderMulti();
+    fireEvent.click(screen.getByRole("button", { name: /宇治市/ }));
+    fireEvent.click(back());
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: /宇治市/ }));
+  });
+
+  it("returns focus to the bubble actually chosen, not simply the first one", () => {
+    renderMulti();
+    fireEvent.click(screen.getByRole("button", { name: /新宿区/ }));
+    fireEvent.click(back());
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: /新宿区/ }));
+  });
 });

--- a/apps/web/tests/unit/chat/search-card-c3b.test.tsx
+++ b/apps/web/tests/unit/chat/search-card-c3b.test.tsx
@@ -67,3 +67,35 @@ describe("C3b bubble overview (AC: bubbles only, area ∝ count, badge)", () => 
     expect(document.querySelectorAll(".chat-map-pin")).toHaveLength(3);
   });
 });
+
+/** Issue #437 item 2: the drill used to be a dead end with no route back. */
+describe("C3b drill-down back affordance (issue #437)", () => {
+  const back = (): HTMLElement => screen.getByRole("button", { name: dict.search.backToOverview });
+
+  it("offers no back affordance while the overview itself is showing", () => {
+    renderMulti();
+    expect(screen.queryByRole("button", { name: dict.search.backToOverview })).toBeNull();
+  });
+
+  it("shows the back chip once a cluster is drilled into", () => {
+    renderMulti();
+    fireEvent.click(screen.getByRole("button", { name: /宇治市/ }));
+    expect(back().className).toContain("chat-drill__back");
+  });
+
+  it("returns to the bubble overview when the back chip is pressed", () => {
+    renderMulti();
+    fireEvent.click(screen.getByRole("button", { name: /宇治市/ }));
+    fireEvent.click(back());
+    expect(document.querySelectorAll(".chat-map-bubble")).toHaveLength(2);
+    expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+  });
+
+  it("lets a second cluster be drilled into after coming back", () => {
+    renderMulti();
+    fireEvent.click(screen.getByRole("button", { name: /宇治市/ }));
+    fireEvent.click(back());
+    fireEvent.click(screen.getByRole("button", { name: /新宿区/ }));
+    expect(screen.getAllByRole("checkbox")).toHaveLength(2);
+  });
+});

--- a/apps/web/tests/unit/chat/search-copy-i18n.test.ts
+++ b/apps/web/tests/unit/chat/search-copy-i18n.test.ts
@@ -13,7 +13,7 @@ function cluster(city?: string): SpotCluster {
 
 function searchValuesOf(locale: (typeof LOCALES)[number]): readonly string[] {
   const search = chatDictFor(locale).search;
-  return [search.select, search.spotCount, search.areaFallback, search.mapLabel];
+  return [search.select, search.spotCount, search.areaFallback, search.mapLabel, search.backToOverview];
 }
 
 describe("cluster names across locales (AC: i18n)", () => {
@@ -37,6 +37,12 @@ describe("count badges across locales (AC: i18n)", () => {
     expect(spotCountBadge(12, chatDictFor("ja"))).toBe("12件");
     expect(spotCountBadge(12, chatDictFor("zh"))).toBe("12 处");
     expect(spotCountBadge(12, chatDictFor("en"))).toBe("12 spots");
+  });
+
+  it("translates the C3b drill-back chip per locale (issue #437)", () => {
+    const labels = LOCALES.map((locale) => chatDictFor(locale).search.backToOverview);
+    expect(new Set(labels).size).toBe(LOCALES.length);
+    expect(labels.every((label) => label.startsWith("←"))).toBe(true);
   });
 
   it.each(LOCALES)("keeps every %s search string non-empty", (locale) => {

--- a/apps/web/tests/unit/login-form.test.tsx
+++ b/apps/web/tests/unit/login-form.test.tsx
@@ -68,32 +68,49 @@ describe("LoginForm submission", () => {
 });
 
 /**
- * Issue #437 / #465: `onSent` used to fire from a passive effect, so it landed a
- * scheduler tick *after* the "sent" banner reached the DOM. A caller that waits
- * on the banner and then acts (the P5 save wall's dismissal) could therefore run
- * before it was told a link went out — a 1-in-6 flake under load, and the same
- * race a fast human click would hit. It must fire in the send continuation.
+ * Issue #437 / #465: the notification used to fire from a passive effect, so it
+ * landed a scheduler tick *after* the "sent" banner reached the DOM. A caller
+ * that waits on the banner and then acts (the P5 save wall's dismissal) could
+ * run before it was told — a 1-in-6 flake under load, and the same race a fast
+ * human click would hit. The invariant asserted here is an **ordering** one:
+ * the caller is never told later than the banner is observable.
  */
-describe("LoginForm sent notification timing", () => {
-  it("notifies the caller in the send continuation, not in a later effect", async () => {
-    const onSent = vi.fn();
-    let resolve!: (value: "sent") => void;
-    send.mockReturnValue(new Promise((r) => { resolve = r; }));
-    renderWithLocale(<LoginForm onSent={onSent} />);
+describe("LoginForm send-committed notification timing", () => {
+  function submitLogin(onSendCommitted: () => void): void {
+    renderWithLocale(<LoginForm onSendCommitted={onSendCommitted} />);
     fireEvent.change(screen.getByLabelText("メールアドレス"), { target: { value: "fan@example.com" } });
     fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
-    resolve("sent");
-    await Promise.resolve();
-    expect(onSent).toHaveBeenCalledTimes(1);
+  }
+
+  it("fires before any feedback banner is observable", () => {
+    const seenBanner: (Element | null)[] = [];
+    send.mockResolvedValue("sent");
+    submitLogin(() => { seenBanner.push(screen.queryByRole("status"), screen.queryByRole("alert")); });
+    expect(seenBanner).toEqual([null, null]);
   });
 
-  it("stays silent when the send did not produce a link", async () => {
-    const onSent = vi.fn();
-    send.mockResolvedValue("error");
-    renderWithLocale(<LoginForm onSent={onSent} />);
-    fireEvent.change(screen.getByLabelText("メールアドレス"), { target: { value: "fan@example.com" } });
+  it("has already fired by the time the sent banner renders", async () => {
+    const onSendCommitted = vi.fn();
+    send.mockResolvedValue("sent");
+    submitLogin(onSendCommitted);
+    await waitFor(() => { expect(screen.getByRole("status")).toBeTruthy(); });
+    expect(onSendCommitted).toHaveBeenCalledTimes(1);
+  });
+
+  // The commitment is the click, not the reply: a caller keying dismissal off
+  // this must not have a window the width of the request's latency.
+  it("fires while the request is still in flight", () => {
+    const onSendCommitted = vi.fn();
+    send.mockReturnValue(new Promise(() => undefined));
+    submitLogin(onSendCommitted);
+    expect(onSendCommitted).toHaveBeenCalledTimes(1);
+  });
+
+  it("never fires for input the form rejects before dispatching", () => {
+    const onSendCommitted = vi.fn();
+    renderWithLocale(<LoginForm onSendCommitted={onSendCommitted} />);
     fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
-    await waitFor(() => { expect(screen.getByRole("alert")).toBeTruthy(); });
-    expect(onSent).not.toHaveBeenCalled();
+    expect(onSendCommitted).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/unit/login-form.test.tsx
+++ b/apps/web/tests/unit/login-form.test.tsx
@@ -66,3 +66,34 @@ describe("LoginForm submission", () => {
     resolve("sent");
   });
 });
+
+/**
+ * Issue #437 / #465: `onSent` used to fire from a passive effect, so it landed a
+ * scheduler tick *after* the "sent" banner reached the DOM. A caller that waits
+ * on the banner and then acts (the P5 save wall's dismissal) could therefore run
+ * before it was told a link went out — a 1-in-6 flake under load, and the same
+ * race a fast human click would hit. It must fire in the send continuation.
+ */
+describe("LoginForm sent notification timing", () => {
+  it("notifies the caller in the send continuation, not in a later effect", async () => {
+    const onSent = vi.fn();
+    let resolve!: (value: "sent") => void;
+    send.mockReturnValue(new Promise((r) => { resolve = r; }));
+    renderWithLocale(<LoginForm onSent={onSent} />);
+    fireEvent.change(screen.getByLabelText("メールアドレス"), { target: { value: "fan@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
+    resolve("sent");
+    await Promise.resolve();
+    expect(onSent).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent when the send did not produce a link", async () => {
+    const onSent = vi.fn();
+    send.mockResolvedValue("error");
+    renderWithLocale(<LoginForm onSent={onSent} />);
+    fireEvent.change(screen.getByLabelText("メールアドレス"), { target: { value: "fan@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
+    await waitFor(() => { expect(screen.getByRole("alert")).toBeTruthy(); });
+    expect(onSent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -46,6 +46,8 @@ export default defineConfig({
       // freshly merged BYOK/Turnstile code dilutes the global ratio below the
       // 99 this branch measured pre-rebase, and inventing coverage for other
       // people's code to hold a number is not a ratchet. Ratchet UP only.
+      // #437 landed on the same 94 -> 95 independently (measured 95.25), so the
+      // floor below is a converged value, not one branch's number.
       thresholds: { statements: 98, branches: 95, functions: 98, lines: 99 },
     },
   },


### PR DESCRIPTION
Closes the still-live parts of #437 (follow-ups deferred from the Fable review of #435 / #261 S1.4). Each item was audited against the current tree first — one of the four was already fixed by later work and is **not** redone here; another turned out to be a real product race, not just a slow test.

## Audit result

| # | Item | Verdict |
|---|---|---|
| 1 | `.catch` → D7 path untested | **Still live → fixed here** |
| 2 | C3b drill-down is one-way | **Still live → fixed here** |
| 3 | Spot-card checkbox wired to nothing | **Already covered by #461** — evidence on the issue, no rework |
| 4 | Unreproduced web-suite flake | **Reproduced, named, root-caused, fixed** — same bug as #465 |

---

## 1 — the real mount-failure → D7 path is now exercised

`attachBasemap`'s `.catch` was only reachable through a genuine dynamic-import / WebGL failure, and every other suite injects a fake `attach`, so nothing ran it. `tests/unit/chat/basemap-mount-failure.test.tsx` stubs the `maplibre-gl` module itself so its `Map` constructor throws — the *real* controller then runs, rejects, and drives the placeholder. Two assertions:

- a `SearchResult` rendered with the default (real) `attach` shows the D7 doodle + `地図アプリで開く` link carrying the spot's coordinates, and **no** `.chat-search-map__gl` frame;
- cleaning up before the mount rejects leaves `onStatus` uncalled (the `attachment.active` guard).

The coverage exclude-ledger is untouched — `bubbleMapController.ts` stays excluded; this is a behavioural test, not a coverage move.

## 2 — the drill is no longer a dead end

Selecting a cluster bubble set `drill` and swapped to the C3a view with nothing to press to get back. `SearchResult` now renders `DrilledClusterView`, which prepends a back chip; pressing it clears `drill` and restores the bubble overview, and a second cluster can then be drilled into.

Design alignment: the chip reuses `.chat-chip` outright, inheriting the 動森 cream surface, `0 3px 0 var(--shadow-3d)` press, 12px radius and 44px hit target — `.chat-drill__back` carries **layout only**, asserted in the CSS test so a future raw colour regresses loudly. Copy is trilingual and follows the design-sync `← …に戻る` pattern from `Chat 状态总览.html`: `← 全体に戻る` / `← 返回全部区域` / `← Back to all areas`.

## 4 — the flake: reproduced, then fixed at the source

A 6× full-suite sweep (coverage on) reproduced it at **1-in-6**, matching #465's reported rate:

```
run 5 exit=1  Tests  1 failed | 1243 passed (1244)   (runs 1-4, 6 green)

FAIL tests/unit/chat/save-wall-dismissal.test.tsx
  > keeps the intent so create-on-login can still replay it
  expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toContain("a")   // was null
```

**Root cause.** `LoginForm` announced a dispatched magic link from a *passive effect* (`useEffect(… status === "sent" …)`). The confirmation banner reaches the DOM in the status commit, but the effect calling the caller ran a scheduler tick later. The test helper waits on the banner, then dismisses; under load the dismissal beat the notification, so the P5 save gate read it as a **cancellation** and cleared the deferred intent.

Round-2 review then found the window was **wider than the flake showed**: the gate only counted a *completed* send, so the entire request latency — not just one scheduler tick — was a period in which closing the modal destroyed the intent. That part was deterministically reproducible, not a race at all.

**Fix.** The notification is now `onSendCommitted`, fired at the **start** of the send:

```ts
setStatus("submitting");
onCommitted.current?.();
setStatus(await sendMagicLink({ … }));
```

The user's commitment is the click, not the server's reply, so there is no longer any interval — tick-sized or latency-sized — in which the modal is dismissable but the caller has not been told. A send that comes back as an error also counts as committed: a kept intent is bounded by consume-once + TTL, while a cleared one is lost work.

The callback is held in a latest-ref (the `useTurnTiming` precedent), so an inline caller callback can neither churn `submit`'s identity nor be captured stale. This also removes a latent bug in the old effect: with a non-memoized callback, its `[status, onSent]` deps re-fired on every parent render while status stayed `"sent"`.

**Focus management (P2).** The C3b drill swapped views without moving focus, stranding keyboard and screen-reader users on `<body>`. The back chip now takes focus on drill-in, the originating bubble reclaims it on back (the one actually chosen, not index 0), and the D7 placeholder is the fallback target when no bubble survives.

---

## Mutation evidence

| Mutation | Result |
|---|---|
| delete the `.catch` from `attachBasemap` | D7 test fails (`expected null not to be null`) |
| drop the `if (attachment.active)` guard | cleanup test fails (`onStatus` called once) |
| make `onBack` a no-op | 2 drill tests fail |
| delete the back chip from the JSX | 3 drill tests fail |
| drop `align-self` from `.chat-drill__back` | CSS token test fails |
| notify on the send's reply instead of at dispatch | 4 tests fail (banner-ordering, in-flight, wall-dismissal, error-send) |
| always `clearDeferredSave()` on dismiss | 3 wall-dismissal tests fail |
| drop the back chip's autofocus | drill-in focus test fails |
| refocus bubble 0 instead of the chosen index | "not simply the first one" test fails |

The cleanup-guard test *survived* its first mutation (microtask flush too shallow to get past two dynamic imports) and was strengthened until the mutant died. The flake regression test was written red-first against the old effect-based code.

## Gates (`apps/web`)

- `pnpm run typecheck` — exit 0
- `pnpm run lint:oxlint` (type-aware, `--deny-warnings`) — exit 0
- `pnpm test` — 182 files / **1252 passed**, coverage **98.57 / 95.24 / 98.99 / 99.47**. Branches ratcheted **94 → 95** on the measured 95.24; statements/functions/lines left at 98/98/99 (they dipped a hair versus the S1.3 measurement, so raising them would be brittle). Never lowered.
- **Confirmation sweep after the flake fix: 8× full suite, all green.**

No suppressions; production functions stay ≤10 lines and every touched test file stays well under 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
