### PR TITLE
feat(#273 T5): compaction-time verbatim entity retention (OQ-8(c))

### DIFF
--- a/apps/agent/agent/agents/animichi_agent.py
+++ b/apps/agent/agent/agents/animichi_agent.py
@@ -487,10 +487,15 @@ def _compaction_retention_context(ledger: RetainedEntityLedger) -> list[str]:
     """Named consumption point for Task 5's compaction-retained entities
     (OQ-8(c)): a compacted tool call's rescued entity string is surfaced
     here so it stays a live prompt-injection consumer, not dead scaffolding.
+
+    The value is wrapped in closing brackets (`「」`) rather than concatenated
+    bare onto the same line, so a value engineered to look like trailing
+    instruction text cannot blend into the directive sentence that follows it.
     """
     return [
         f"Verbatim entity retained from an earlier {entity.tool_name} call: "
-        f"{entity.value}."
+        f"「{entity.value}」. This was compacted out of the raw conversation; "
+        "still treat it as valid context for anaphora and follow-up."
         for entity in ledger.entities
     ]
 

--- a/apps/agent/agent/agents/animichi_agent.py
+++ b/apps/agent/agent/agents/animichi_agent.py
@@ -43,6 +43,7 @@ from agent.agents.runtime_models import (
 from agent.agents.session_state import SessionState
 from agent.agents.tool_outcomes import ResolveAmbiguous, ResolveNotFound
 from agent.agents.web_tools import TOOLS as WEB_TOOLS
+from agent.domain.compaction_retention import RetainedEntityLedger
 from agent.domain.fact_ledger import FactLedger
 from agent.infrastructure.observability import (
     record_agent_run_error,
@@ -459,6 +460,7 @@ def trusted_session_context(deps: RuntimeDeps) -> str:
             f"candidate_ids={pending.candidate_ids}."
         )
     parts.extend(_fact_ledger_context(session.fact_ledger))
+    parts.extend(_compaction_retention_context(session.compaction_retained_entities))
     return "[Trusted runtime context]\n" + "\n".join(parts)
 
 
@@ -479,6 +481,18 @@ def _fact_ledger_context(ledger: FactLedger) -> list[str]:
             "questions this session."
         )
     return parts
+
+
+def _compaction_retention_context(ledger: RetainedEntityLedger) -> list[str]:
+    """Named consumption point for Task 5's compaction-retained entities
+    (OQ-8(c)): a compacted tool call's rescued entity string is surfaced
+    here so it stays a live prompt-injection consumer, not dead scaffolding.
+    """
+    return [
+        f"Verbatim entity retained from an earlier {entity.tool_name} call: "
+        f"{entity.value}."
+        for entity in ledger.entities
+    ]
 
 
 _REPEAT_GUARD_HINT = (

--- a/apps/agent/agent/agents/history_compaction.py
+++ b/apps/agent/agent/agents/history_compaction.py
@@ -13,6 +13,8 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelRequestPart,
+    ModelResponse,
+    ToolCallPart,
     ToolReturnPart,
 )
 from pydantic_ai_harness.compaction import (
@@ -22,6 +24,7 @@ from pydantic_ai_harness.compaction import (
 )
 
 from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.session_state import SessionState
 
 HISTORY_MAX_TOKENS = 5_500
 HISTORY_KEEP_TOKENS = 1_100
@@ -44,6 +47,50 @@ Respond only with the compact continuation context.
 """
 
 ToolSummary = Callable[[str, object], str]
+
+# Task 5 (OQ-8(c)): tool arguments that carry a literal, user-supplied entity
+# string worth rescuing verbatim across compaction — an anime title or a
+# place name, keyed by the tool call's own argument name.
+_ENTITY_ARG_FIELDS: dict[str, str] = {
+    "resolve_anime": "title",
+    "search_nearby": "location",
+}
+
+
+def _entity_from_call_args(tool_name: str, args: Mapping[str, object]) -> str | None:
+    field = _ENTITY_ARG_FIELDS.get(tool_name)
+    if field is None:
+        return None
+    value = args.get(field)
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _call_args_by_id(messages: list[ModelMessage]) -> dict[str, Mapping[str, object]]:
+    """Map each tool call's id to its own arguments, read from `ModelResponse`
+    parts. `CompactToolReturns` otherwise only sees the paired `ModelRequest`
+    tool-return message, which carries the (compact) result, not the call."""
+    lookup: dict[str, Mapping[str, object]] = {}
+    for message in messages:
+        if not isinstance(message, ModelResponse):
+            continue
+        for part in message.parts:
+            if isinstance(part, ToolCallPart):
+                lookup[part.tool_call_id] = part.args_as_dict()
+    return lookup
+
+
+def _session_of(ctx: object) -> SessionState | None:
+    """Best-effort, exception-free lookup of the live session from `ctx.deps`.
+
+    Degrades to `None` for any shape that isn't a real production
+    `RunContext[RuntimeDeps]` (including the `None` sentinel some tests pass
+    for `ctx`), matching the error-path AC: a lookup miss never raises out of
+    the compaction tier.
+    """
+    deps = getattr(ctx, "deps", None)
+    tool_state = getattr(deps, "tool_state", None)
+    session = getattr(tool_state, "session", None)
+    return session if isinstance(session, SessionState) else None
 
 
 def _mapping(content: object) -> Mapping[str, object] | None:
@@ -79,27 +126,59 @@ class CompactToolReturns(Generic[AgentDepsT]):
     async def compact(
         self, messages: list[ModelMessage], ctx: RunContext[AgentDepsT]
     ) -> list[ModelMessage]:
-        del ctx
         cutoff = max(0, len(messages) - self.keep_recent)
+        call_args = _call_args_by_id(messages)
+        session = _session_of(ctx)
         return [
-            self._compact_message(message, i < cutoff)
+            self._compact_message(message, i < cutoff, call_args, session)
             for i, message in enumerate(messages)
         ]
 
-    def _compact_message(self, message: ModelMessage, old: bool) -> ModelMessage:
+    def _compact_message(
+        self,
+        message: ModelMessage,
+        old: bool,
+        call_args: dict[str, Mapping[str, object]],
+        session: SessionState | None,
+    ) -> ModelMessage:
         if not old or not isinstance(message, ModelRequest):
             return message
-        parts = [self._compact_return(part) for part in message.parts]
+        parts = [
+            self._compact_return(part, call_args, session) for part in message.parts
+        ]
         return replace(message, parts=parts)
 
-    def _compact_return(self, part: ModelRequestPart) -> ModelRequestPart:
+    def _compact_return(
+        self,
+        part: ModelRequestPart,
+        call_args: dict[str, Mapping[str, object]],
+        session: SessionState | None,
+    ) -> ModelRequestPart:
         if (
             not isinstance(part, ToolReturnPart)
             or len(str(part.content)) <= TOOL_RETURN_MAX_CHARS
         ):
             return part
+        self._retain_entity(part, call_args, session)
         summary = self._summary(part.tool_name, part.content)
         return replace(part, content=summary)
+
+    def _retain_entity(
+        self,
+        part: ToolReturnPart,
+        call_args: dict[str, Mapping[str, object]],
+        session: SessionState | None,
+    ) -> None:
+        """Task 5 (OQ-8(c)): rescue a literal call argument verbatim into
+        session state before this tool return is shrunk to a summary."""
+        if session is None:
+            return
+        args = call_args.get(part.tool_call_id)
+        if args is None:
+            return
+        value = _entity_from_call_args(part.tool_name, args)
+        if value is not None:
+            session.compaction_retained_entities.record(part.tool_name, value)
 
     def _summary(self, tool_name: str, content: object) -> str:
         candidates = (

--- a/apps/agent/agent/agents/history_compaction.py
+++ b/apps/agent/agent/agents/history_compaction.py
@@ -57,12 +57,21 @@ _ENTITY_ARG_FIELDS: dict[str, str] = {
 }
 
 
-def _entity_from_call_args(tool_name: str, args: Mapping[str, object]) -> str | None:
+def _entity_from_call_args(tool_name: str, args: object) -> str | None:
+    """Extract the literal entity argument, if any. `args` may be `None`
+    (no matching `ToolCallPart`, e.g. an orphaned or already-compacted-away
+    call) — that is folded in here rather than guarded separately upstream."""
     field = _ENTITY_ARG_FIELDS.get(tool_name)
-    if field is None:
+    if field is None or not isinstance(args, Mapping):
         return None
     value = args.get(field)
     return value if isinstance(value, str) and value.strip() else None
+
+
+def _tool_calls_in(message: ModelMessage) -> list[ToolCallPart]:
+    if not isinstance(message, ModelResponse):
+        return []
+    return [part for part in message.parts if isinstance(part, ToolCallPart)]
 
 
 def _call_args_by_id(messages: list[ModelMessage]) -> dict[str, Mapping[str, object]]:
@@ -71,26 +80,25 @@ def _call_args_by_id(messages: list[ModelMessage]) -> dict[str, Mapping[str, obj
     tool-return message, which carries the (compact) result, not the call."""
     lookup: dict[str, Mapping[str, object]] = {}
     for message in messages:
-        if not isinstance(message, ModelResponse):
-            continue
-        for part in message.parts:
-            if isinstance(part, ToolCallPart):
-                lookup[part.tool_call_id] = part.args_as_dict()
+        for call in _tool_calls_in(message):
+            lookup[call.tool_call_id] = call.args_as_dict()
     return lookup
 
 
 def _session_of(ctx: object) -> SessionState | None:
-    """Best-effort, exception-free lookup of the live session from `ctx.deps`.
+    """Exception-free lookup of the live session from `ctx.deps`.
 
     Degrades to `None` for any shape that isn't a real production
-    `RunContext[RuntimeDeps]` (including the `None` sentinel some tests pass
-    for `ctx`), matching the error-path AC: a lookup miss never raises out of
-    the compaction tier.
+    `RunContext[RuntimeDeps]` (including the `None` sentinel some other
+    compaction unit tests pass for `ctx`), matching the error-path AC: a
+    lookup miss never raises out of the compaction tier.
     """
     deps = getattr(ctx, "deps", None)
-    tool_state = getattr(deps, "tool_state", None)
-    session = getattr(tool_state, "session", None)
-    return session if isinstance(session, SessionState) else None
+    return deps.tool_state.session if isinstance(deps, RuntimeDeps) else None
+
+
+def _current_anime_title(session: SessionState) -> str | None:
+    return session.current_anime.title if session.current_anime is not None else None
 
 
 def _mapping(content: object) -> Mapping[str, object] | None:
@@ -118,7 +126,19 @@ def _candidate_summary(content: object) -> str | None:
 
 @dataclass(frozen=True)
 class CompactToolReturns(Generic[AgentDepsT]):
-    """Deterministically shrink old tool returns while retaining candidates."""
+    """Deterministically shrink old tool returns while retaining candidates.
+
+    `frozen=True` only means this dataclass's own two fields never change;
+    `compact()` is not otherwise a pure transform — when `ctx.deps` carries a
+    live session (production `RuntimeDeps`), it mutates the shared
+    `session.compaction_retained_entities` ledger as a side effect (Task 5,
+    OQ-8(c)). That mutation can happen more than once per turn (once per
+    compacted `ToolReturnPart` in a multi-tool-call loop) and again on every
+    later turn, because `session_facade.build_message_history` replays every
+    past interaction's raw messages unchanged each turn rather than storing
+    a compacted version — `RetainedEntityLedger`'s dedup/oldest-wins policy
+    is what keeps that repeated replay from being observable as growth.
+    """
 
     summarize: ToolSummary
     keep_recent: int = KEEP_RECENT_MESSAGES
@@ -170,15 +190,19 @@ class CompactToolReturns(Generic[AgentDepsT]):
         session: SessionState | None,
     ) -> None:
         """Task 5 (OQ-8(c)): rescue a literal call argument verbatim into
-        session state before this tool return is shrunk to a summary."""
+        session state before this tool return is shrunk to a summary.
+
+        Skips a value that already equals `session.current_anime.title` —
+        that title is already carried, unabridged, by `current_anime` (and,
+        while still ambiguous, by `_candidate_summary`), so retaining it a
+        second time here would just double-pay the same prompt budget.
+        """
         if session is None:
             return
-        args = call_args.get(part.tool_call_id)
-        if args is None:
+        value = _entity_from_call_args(part.tool_name, call_args.get(part.tool_call_id))
+        if value is None or value == _current_anime_title(session):
             return
-        value = _entity_from_call_args(part.tool_name, args)
-        if value is not None:
-            session.compaction_retained_entities.record(part.tool_name, value)
+        session.compaction_retained_entities.record(part.tool_name, value)
 
     def _summary(self, tool_name: str, content: object) -> str:
         candidates = (

--- a/apps/agent/agent/agents/session_state.py
+++ b/apps/agent/agent/agents/session_state.py
@@ -221,6 +221,7 @@ class SessionState(_SessionModel):
         self.route_lru = _restore_lru(
             self.routes, self.route_lru, "route_lru" in fields
         )
+        self.compaction_retained_entities.enforce_bounds()
         return self
 
     def store_search_result(self, ref: ResultRef, payload: SearchPayloadState) -> None:

--- a/apps/agent/agent/agents/session_state.py
+++ b/apps/agent/agent/agents/session_state.py
@@ -6,6 +6,7 @@ from typing import Literal, NewType, Self, TypeAlias, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from agent.domain.compaction_retention import RetainedEntityLedger
 from agent.domain.fact_ledger import FactLedger
 
 MAX_REFS = 8
@@ -205,6 +206,9 @@ class SessionState(_SessionModel):
     last_result_ref: ResultRef | None = None
     clarification_revision: int = 0
     fact_ledger: FactLedger = Field(default_factory=FactLedger)
+    compaction_retained_entities: RetainedEntityLedger = Field(
+        default_factory=RetainedEntityLedger
+    )
 
     @model_validator(mode="after")
     def _bound_restored_registries(self) -> Self:

--- a/apps/agent/agent/domain/compaction_retention.py
+++ b/apps/agent/agent/domain/compaction_retention.py
@@ -12,17 +12,24 @@ previously verified that request.
 
 This ledger is deliberately standalone from `agent.domain.fact_ledger`
 (OQ-8 ruling) — different lifecycle, different consumer, no shared model.
+
+Eviction is **oldest-wins**, not FIFO: the whole point of this ledger is to
+rescue entities that are about to fall out of the raw sliding window (the
+*deepest*, oldest history), so once the ledger is full, a newer distinct
+entity is dropped rather than evicting an older one — a near-tail entity
+that gets dropped here is still covered verbatim by the sliding window
+itself for a while yet, but a turn-0 entity evicted here is lost for good.
 """
 
 from __future__ import annotations
 
-import re
-
 from pydantic import BaseModel, ConfigDict, Field
 
+from agent.domain.text_sanitize import truncate_text
+
 MAX_RETAINED_ENTITIES = 8
+MAX_RETAINED_BYTES = 8 * 1024
 _MAX_VALUE_BYTES = 96
-_CONTROL_OR_NEWLINE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 class _RetentionModel(BaseModel):
@@ -38,24 +45,18 @@ class RetainedEntity(_RetentionModel):
     value: str
 
 
-def sanitize_entity(value: str) -> str:
-    """Strip control characters/newlines so untrusted tool-call text replayed
-    into the trusted prompt context cannot forge extra structured lines."""
-    collapsed = _CONTROL_OR_NEWLINE.sub(" ", value)
-    return " ".join(collapsed.split())
-
-
-def truncate_entity(value: str, *, max_bytes: int = _MAX_VALUE_BYTES) -> str:
-    """Sanitize, then truncate by encoded byte length (CJK-safe)."""
-    sanitized = sanitize_entity(value)
-    encoded = sanitized.encode("utf-8")
-    if len(encoded) <= max_bytes:
-        return sanitized
-    return encoded[: max_bytes - 1].decode("utf-8", errors="ignore") + "…"
-
-
 class RetainedEntityLedger(_RetentionModel):
-    """Bounded, append-only list of compaction-retained entities."""
+    """Bounded, deduplicating, oldest-wins list of compaction-retained entities.
+
+    Deduplication matters because compaction is not a one-shot event: the
+    real persistence path (`session_facade.build_message_history`) replays
+    every past interaction's raw messages on every turn — old interactions
+    are never rewritten to a compacted form in storage — so the *same* old
+    tool call gets recompacted, and would otherwise get re-recorded, on
+    every subsequent turn (and can fire multiple times within one turn's
+    tool loop, once per compacted tool return). Without dedup, one
+    repeatedly-replayed entity would crowd out every other distinct entity.
+    """
 
     entities: list[RetainedEntity] = Field(default_factory=list)
 
@@ -64,14 +65,52 @@ class RetainedEntityLedger(_RetentionModel):
         return not self.entities
 
     def record(self, tool_name: str, value: str) -> None:
-        """Append a retained entity, evicting the oldest past the cap.
+        """Record a retained entity.
 
-        A blank value after sanitization degrades to a no-op — this is the
-        "no extractable key entity" path, not an error.
+        A repeat of the same (tool_name, value) moves to the tail instead of
+        duplicating. A genuinely new entity is dropped, not appended, once
+        the ledger is already at the count or byte cap (oldest-wins). A
+        blank value after sanitization is a no-op — the "no extractable key
+        entity" path, not an error.
         """
-        cleaned = truncate_entity(value)
-        if not cleaned:
+        clean_tool = truncate_text(tool_name, max_bytes=_MAX_VALUE_BYTES)
+        clean_value = truncate_text(value, max_bytes=_MAX_VALUE_BYTES)
+        if not clean_value:
             return
-        self.entities.append(RetainedEntity(tool_name=tool_name, value=cleaned))
+        self._replace(clean_tool, clean_value)
+
+    def _replace(self, tool_name: str, value: str) -> None:
+        before = len(self.entities)
+        self.entities = [
+            entity
+            for entity in self.entities
+            if (entity.tool_name, entity.value) != (tool_name, value)
+        ]
+        is_new_entity = len(self.entities) == before
+        if is_new_entity and self._at_capacity():
+            return
+        self.entities.append(RetainedEntity(tool_name=tool_name, value=value))
+
+    def _at_capacity(self) -> bool:
+        return (
+            len(self.entities) >= MAX_RETAINED_ENTITIES
+            or self.encoded_size_bytes() >= MAX_RETAINED_BYTES
+        )
+
+    def enforce_bounds(self) -> None:
+        """Re-apply the count/byte caps, keeping the oldest entries.
+
+        Called on every restore (`SessionState`'s restored-registry
+        validator), not only from `record()`'s own write path — a persisted
+        envelope produced by a future/rolled-back deploy, or corrupted at
+        rest, must not bypass the cap just because it hydrated directly via
+        `model_validate` instead of going through `record()`.
+        """
         if len(self.entities) > MAX_RETAINED_ENTITIES:
-            self.entities[:] = self.entities[-MAX_RETAINED_ENTITIES:]
+            self.entities[:] = self.entities[:MAX_RETAINED_ENTITIES]
+        while self.entities and self.encoded_size_bytes() > MAX_RETAINED_BYTES:
+            self.entities.pop()
+
+    def encoded_size_bytes(self) -> int:
+        """Return the encoded JSON byte length enforced by `enforce_bounds`."""
+        return len(self.model_dump_json().encode("utf-8"))

--- a/apps/agent/agent/domain/compaction_retention.py
+++ b/apps/agent/agent/domain/compaction_retention.py
@@ -1,0 +1,77 @@
+"""Deterministic compaction-time verbatim entity retention (Task 5, OQ-8(c)).
+
+`history_compaction.py`'s `CompactToolReturns` already has a precedent for
+deterministically rescuing structured data before an old tool return gets
+shrunk to a short summary — `_candidate_summary` pulls `resolve_anime`
+candidate ids verbatim out of the raw JSON. This module extends that same
+idea to a second, decoupled concern: when a compacted tool call carried a
+literal user-supplied entity string (an anime title, a place name), that
+exact string is retained here, in session state, so it survives even though
+`SUMMARY_PROMPT` only *asks* the model to preserve it verbatim and nothing
+previously verified that request.
+
+This ledger is deliberately standalone from `agent.domain.fact_ledger`
+(OQ-8 ruling) — different lifecycle, different consumer, no shared model.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field
+
+MAX_RETAINED_ENTITIES = 8
+_MAX_VALUE_BYTES = 96
+_CONTROL_OR_NEWLINE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+class _RetentionModel(BaseModel):
+    """Strict base: unknown fields are rejected, not silently stored."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class RetainedEntity(_RetentionModel):
+    """One verbatim entity string rescued from a compacted tool interaction."""
+
+    tool_name: str
+    value: str
+
+
+def sanitize_entity(value: str) -> str:
+    """Strip control characters/newlines so untrusted tool-call text replayed
+    into the trusted prompt context cannot forge extra structured lines."""
+    collapsed = _CONTROL_OR_NEWLINE.sub(" ", value)
+    return " ".join(collapsed.split())
+
+
+def truncate_entity(value: str, *, max_bytes: int = _MAX_VALUE_BYTES) -> str:
+    """Sanitize, then truncate by encoded byte length (CJK-safe)."""
+    sanitized = sanitize_entity(value)
+    encoded = sanitized.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return sanitized
+    return encoded[: max_bytes - 1].decode("utf-8", errors="ignore") + "…"
+
+
+class RetainedEntityLedger(_RetentionModel):
+    """Bounded, append-only list of compaction-retained entities."""
+
+    entities: list[RetainedEntity] = Field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        """Return whether no entity has ever been retained."""
+        return not self.entities
+
+    def record(self, tool_name: str, value: str) -> None:
+        """Append a retained entity, evicting the oldest past the cap.
+
+        A blank value after sanitization degrades to a no-op — this is the
+        "no extractable key entity" path, not an error.
+        """
+        cleaned = truncate_entity(value)
+        if not cleaned:
+            return
+        self.entities.append(RetainedEntity(tool_name=tool_name, value=cleaned))
+        if len(self.entities) > MAX_RETAINED_ENTITIES:
+            self.entities[:] = self.entities[-MAX_RETAINED_ENTITIES:]

--- a/apps/agent/agent/domain/fact_ledger.py
+++ b/apps/agent/agent/domain/fact_ledger.py
@@ -23,13 +23,14 @@ long-lived session's ledger bounded regardless of session age.
 
 from __future__ import annotations
 
-import re
 import uuid
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Literal, NewType, Protocol, TypeVar, cast, get_args
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from agent.domain.text_sanitize import truncate_text
 
 MAX_RECORDS_PER_FIELD = 8
 MAX_LEDGER_BYTES = 8 * 1024
@@ -39,8 +40,6 @@ _MAX_ID_BYTES = 96
 FactId = NewType("FactId", str)
 Pacing = Literal["chill", "normal", "packed"]
 SceneReferenceKind = Literal["episode_scene"]
-
-_CONTROL_OR_NEWLINE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 class _LedgerModel(BaseModel):
@@ -79,20 +78,11 @@ def _new_id() -> FactId:
     return FactId(uuid.uuid4().hex)
 
 
-def _sanitize(value: str) -> str:
-    """Strip control characters/newlines so untrusted point text replayed into
-    the trusted prompt context cannot forge extra ledger-shaped lines."""
-    collapsed = _CONTROL_OR_NEWLINE.sub(" ", value)
-    return " ".join(collapsed.split())
-
-
 def _truncate(value: str, *, max_bytes: int = _MAX_VALUE_BYTES) -> str:
-    """Sanitize, then truncate by encoded byte length (CJK-safe, not char count)."""
-    sanitized = _sanitize(value)
-    encoded = sanitized.encode("utf-8")
-    if len(encoded) <= max_bytes:
-        return sanitized
-    return encoded[: max_bytes - 1].decode("utf-8", errors="ignore") + "…"
+    """Sanitize, then truncate by encoded byte length (CJK-safe, not char
+    count). Delegates to the shared `text_sanitize` helper (also used by
+    `compaction_retention.py`) rather than duplicating the routine."""
+    return truncate_text(value, max_bytes=max_bytes)
 
 
 class FactLedger(_LedgerModel):

--- a/apps/agent/agent/domain/text_sanitize.py
+++ b/apps/agent/agent/domain/text_sanitize.py
@@ -1,0 +1,42 @@
+"""Shared sanitize/truncate helpers for untrusted text entering trusted state.
+
+Both `fact_ledger.py` and `compaction_retention.py` replay externally-sourced
+strings (point names, place names, anime titles) into session state that is
+later injected into the trusted prompt context. The OQ-8 ruling decoupled
+those two ledgers' *models* from each other; it did not ask for two copies of
+the same string-hygiene routine, so this module is the one shared home for it.
+"""
+
+from __future__ import annotations
+
+import re
+
+_ELLIPSIS = "…"
+_ELLIPSIS_BYTES = len(_ELLIPSIS.encode("utf-8"))
+
+# Control/format characters and every line/paragraph separator a JSON string
+# can carry (\x00-\x1f, DEL, NEL U+0085, LINE/PARAGRAPH SEPARATOR U+2028/29) —
+# anything that could forge extra structured lines once replayed verbatim
+# into the trusted prompt context.
+_CONTROL_OR_NEWLINE = re.compile(r"[\x00-\x1f\x7f  ]")
+
+
+def sanitize_text(value: str) -> str:
+    """Strip control/newline-like characters and collapse whitespace."""
+    collapsed = _CONTROL_OR_NEWLINE.sub(" ", value)
+    return " ".join(collapsed.split())
+
+
+def truncate_text(value: str, *, max_bytes: int) -> str:
+    """Sanitize, then truncate to at most `max_bytes` encoded UTF-8 bytes.
+
+    The `…` suffix's own encoded length is reserved out of the budget up
+    front, so the result never exceeds `max_bytes` (CJK-safe: sliced by byte
+    length, not character count).
+    """
+    sanitized = sanitize_text(value)
+    encoded = sanitized.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return sanitized
+    kept = encoded[: max_bytes - _ELLIPSIS_BYTES].decode("utf-8", errors="ignore")
+    return kept + _ELLIPSIS

--- a/apps/agent/agent/interfaces/session_facade.py
+++ b/apps/agent/agent/interfaces/session_facade.py
@@ -134,7 +134,7 @@ def _parse_runtime_state(raw: object) -> SessionState | None:
         return _parse_forward_compatible(raw)
 
 
-_FORWARD_COMPATIBLE_KEYS = frozenset({"fact_ledger"})
+_FORWARD_COMPATIBLE_KEYS = frozenset({"fact_ledger", "compaction_retained_entities"})
 
 
 def _parse_forward_compatible(raw: dict[str, object]) -> SessionState | None:
@@ -187,10 +187,13 @@ def build_context_block(
 
 
 def _serialize_runtime_state(state: SessionState) -> dict[str, object]:
-    """Dump the typed state; an ever-empty fact ledger adds no envelope key."""
+    """Dump the typed state; an ever-empty fact ledger or compaction-retention
+    ledger adds no envelope key."""
     dumped = cast(dict[str, object], state.model_dump(mode="json"))
     if state.fact_ledger.is_empty():
         dumped.pop("fact_ledger", None)
+    if state.compaction_retained_entities.is_empty():
+        dumped.pop("compaction_retained_entities", None)
     return dumped
 
 

--- a/apps/agent/agent/tests/integration/test_compaction_entity_retention.py
+++ b/apps/agent/agent/tests/integration/test_compaction_entity_retention.py
@@ -1,7 +1,15 @@
-"""Task 5 (#273, OQ-8(c)): compaction-retained entities survive multiple
+"""Task 5 (#273, OQ-8(c)): compaction-retained entities survive many
 compaction rounds through a real `SessionStore` round-trip — the same
 persistence path Task 4's fact ledger uses (`test_fact_ledger_persistence.py`),
 proving this retention payload is not tied to that ledger (OQ-8 decoupling).
+
+Each round replays the **full accumulated message history**, not just the
+newest pair — mirroring `session_facade.build_message_history`, which
+replays every past interaction's raw messages unchanged on every turn (old
+interactions are never rewritten to a compacted form in storage). This is
+what makes dedup load-bearing: a naive re-record on every replay of the
+same old tool call would otherwise crowd out other distinct entities via
+the count cap (#476 review).
 """
 
 from __future__ import annotations
@@ -68,22 +76,9 @@ def _call_pair(
     ]
 
 
-async def _run_compaction_turn(
-    store: InMemorySessionStore,
-    *,
-    tool_name: str,
-    args: dict[str, object],
-    call_id: str,
-    text: str,
+async def _persist_turn(
+    store: InMemorySessionStore, session: SessionState, stored: object, text: str
 ) -> None:
-    """Mirror `public_api.py`'s restore -> run -> persist sequence, with a
-    compaction round standing in for "run"."""
-    stored = await store.get(_SESSION_ID)
-    session = _restore(stored)
-    compact = CompactToolReturns[RuntimeDeps](_summarize_tool_content, keep_recent=0)
-
-    await compact.compact(_call_pair(tool_name, args, call_id), _ctx(session))
-
     result = AgentResult(
         output=QAResponseModel(message="ok"),
         intent="qa_response",
@@ -104,27 +99,53 @@ async def _run_compaction_turn(
     await store.set(_SESSION_ID, updated)
 
 
-async def test_entity_retained_in_round_one_survives_round_two() -> None:
-    store = InMemorySessionStore()
+async def _run_full_history_turn(
+    store: InMemorySessionStore,
+    *,
+    accumulated: list[ModelMessage],
+    new_pair: list[ModelMessage],
+    text: str,
+) -> list[ModelMessage]:
+    """One turn: reprocess the entire accumulated history (old + new pair)
+    through the compaction tier, then persist — matching how
+    `build_message_history` replays raw messages every turn in production."""
+    stored = await store.get(_SESSION_ID)
+    session = _restore(stored)
+    accumulated = [*accumulated, *new_pair]
+    compact = CompactToolReturns[RuntimeDeps](_summarize_tool_content, keep_recent=0)
 
-    await _run_compaction_turn(
-        store,
-        tool_name="search_nearby",
-        args={"location": "資生堂前"},
-        call_id="call-1",
-        text="資生堂前に行きたい",
+    await compact.compact(accumulated, _ctx(session))
+    await _persist_turn(store, session, stored, text)
+    return accumulated
+
+
+async def test_entity_survives_many_full_history_replays_and_a_second_round() -> None:
+    store = InMemorySessionStore()
+    accumulated: list[ModelMessage] = []
+    round_one = _call_pair("search_nearby", {"location": "資生堂前"}, "call-1")
+
+    accumulated = await _run_full_history_turn(
+        store, accumulated=accumulated, new_pair=round_one, text="資生堂前に行きたい"
     )
     stored = await store.get(_SESSION_ID)
     assert stored is not None
-    first_round = _restore(stored).compaction_retained_entities.entities
-    assert [e.value for e in first_round] == ["資生堂前"]
+    assert [
+        e.value for e in _restore(stored).compaction_retained_entities.entities
+    ] == ["資生堂前"]
 
-    await _run_compaction_turn(
-        store,
-        tool_name="resolve_anime",
-        args={"title": "けいおん!"},
-        call_id="call-2",
-        text="けいおんが見たい",
+    for i in range(7):
+        accumulated = await _run_full_history_turn(
+            store, accumulated=accumulated, new_pair=[], text=f"filler {i}"
+        )
+
+    stored = await store.get(_SESSION_ID)
+    assert stored is not None
+    entities = _restore(stored).compaction_retained_entities.entities
+    assert [e.value for e in entities] == ["資生堂前"]  # not duplicated by 7 replays
+
+    round_two = _call_pair("resolve_anime", {"title": "けいおん!"}, "call-2")
+    await _run_full_history_turn(
+        store, accumulated=accumulated, new_pair=round_two, text="けいおんが見たい"
     )
 
     stored = await store.get(_SESSION_ID)

--- a/apps/agent/agent/tests/integration/test_compaction_entity_retention.py
+++ b/apps/agent/agent/tests/integration/test_compaction_entity_retention.py
@@ -1,0 +1,134 @@
+"""Task 5 (#273, OQ-8(c)): compaction-retained entities survive multiple
+compaction rounds through a real `SessionStore` round-trip — the same
+persistence path Task 4's fact ledger uses (`test_fact_ledger_persistence.py`),
+proving this retention payload is not tied to that ledger (OQ-8 decoupling).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pydantic_ai import RunContext
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+
+from agent.agents.agent_result import AgentResult
+from agent.agents.animichi_agent import _summarize_tool_content
+from agent.agents.history_compaction import CompactToolReturns
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.runtime_models import QAResponseModel
+from agent.agents.session_state import SessionState
+from agent.agents.tool_state import ToolState
+from agent.infrastructure.session.memory import InMemorySessionStore
+from agent.interfaces.schemas import PublicAPIRequest
+from agent.interfaces.session_facade import (
+    SessionUpdate,
+    build_context_block,
+    build_updated_session_state,
+    extract_context_delta,
+    normalize_session_state,
+)
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+_SESSION_ID = "session-compaction-1"
+_LONG_CONTENT = "x" * 500
+
+
+def _restore(stored: dict[str, object] | None) -> SessionState:
+    context = build_context_block(normalize_session_state(stored))
+    if context is None:
+        return SessionState()
+    return SessionState.model_validate(context["session_state_v2"])
+
+
+def _ctx(session: SessionState) -> RunContext[RuntimeDeps]:
+    deps = RuntimeDeps(
+        db=MagicMock(),
+        locale="ja",
+        query="q",
+        catalog=MockCatalogClient(),
+        tool_state=ToolState(session=session),
+    )
+    return RunContext(deps=deps, model=TestModel(), usage=RunUsage())
+
+
+def _call_pair(
+    tool_name: str, args: dict[str, object], call_id: str
+) -> list[ModelMessage]:
+    return [
+        ModelResponse(parts=[ToolCallPart(tool_name, args, call_id)]),
+        ModelRequest(parts=[ToolReturnPart(tool_name, _LONG_CONTENT, call_id)]),
+    ]
+
+
+async def _run_compaction_turn(
+    store: InMemorySessionStore,
+    *,
+    tool_name: str,
+    args: dict[str, object],
+    call_id: str,
+    text: str,
+) -> None:
+    """Mirror `public_api.py`'s restore -> run -> persist sequence, with a
+    compaction round standing in for "run"."""
+    stored = await store.get(_SESSION_ID)
+    session = _restore(stored)
+    compact = CompactToolReturns[RuntimeDeps](_summarize_tool_content, keep_recent=0)
+
+    await compact.compact(_call_pair(tool_name, args, call_id), _ctx(session))
+
+    result = AgentResult(
+        output=QAResponseModel(message="ok"),
+        intent="qa_response",
+        session_state=session,
+        steps=[],
+    )
+    delta = extract_context_delta(result)
+    updated = build_updated_session_state(
+        normalize_session_state(stored),
+        SessionUpdate(
+            request=PublicAPIRequest(text=text),
+            response_intent=result.intent,
+            response_status="ok",
+            response_success=result.success,
+            context_delta=delta,
+        ),
+    )
+    await store.set(_SESSION_ID, updated)
+
+
+async def test_entity_retained_in_round_one_survives_round_two() -> None:
+    store = InMemorySessionStore()
+
+    await _run_compaction_turn(
+        store,
+        tool_name="search_nearby",
+        args={"location": "資生堂前"},
+        call_id="call-1",
+        text="資生堂前に行きたい",
+    )
+    stored = await store.get(_SESSION_ID)
+    assert stored is not None
+    first_round = _restore(stored).compaction_retained_entities.entities
+    assert [e.value for e in first_round] == ["資生堂前"]
+
+    await _run_compaction_turn(
+        store,
+        tool_name="resolve_anime",
+        args={"title": "けいおん!"},
+        call_id="call-2",
+        text="けいおんが見たい",
+    )
+
+    stored = await store.get(_SESSION_ID)
+    assert stored is not None
+    entities = _restore(stored).compaction_retained_entities.entities
+    assert [e.value for e in entities] == ["資生堂前", "けいおん!"]
+    assert [e.tool_name for e in entities] == ["search_nearby", "resolve_anime"]

--- a/apps/agent/agent/tests/unit/test_compaction_retention_ledger.py
+++ b/apps/agent/agent/tests/unit/test_compaction_retention_ledger.py
@@ -1,0 +1,128 @@
+"""Unit tests for `RetainedEntityLedger`'s bounded, deduplicating,
+oldest-wins record path and its restore-time bound enforcement.
+
+`CompactToolReturns`-level integration (the call-site that populates this
+ledger during compaction) lives in `test_history_compaction_verbatim.py`.
+"""
+
+from __future__ import annotations
+
+from agent.domain.compaction_retention import (
+    MAX_RETAINED_BYTES,
+    MAX_RETAINED_ENTITIES,
+    RetainedEntity,
+    RetainedEntityLedger,
+)
+
+
+def test_fresh_ledger_is_empty() -> None:
+    assert RetainedEntityLedger().is_empty()
+
+
+def test_blank_value_after_sanitization_is_a_no_op() -> None:
+    ledger = RetainedEntityLedger()
+
+    ledger.record("search_nearby", "   \x00\x1f  ")
+
+    assert ledger.is_empty()
+
+
+def test_recording_the_same_entity_twice_does_not_duplicate() -> None:
+    ledger = RetainedEntityLedger()
+
+    ledger.record("search_nearby", "資生堂前")
+    ledger.record("search_nearby", "資生堂前")
+
+    assert len(ledger.entities) == 1
+
+
+def test_recording_an_existing_entity_moves_it_to_the_tail() -> None:
+    ledger = RetainedEntityLedger()
+    for i in range(3):
+        ledger.record("search_nearby", f"place-{i}")
+
+    ledger.record("search_nearby", "place-0")
+
+    assert [e.value for e in ledger.entities] == ["place-1", "place-2", "place-0"]
+
+
+def test_repeated_record_of_the_same_entity_eight_times_is_idempotent() -> None:
+    """Pins the production replay scenario: the same tool call recompacted
+    on every subsequent turn (`session_facade.build_message_history` replays
+    every past interaction's raw messages unchanged) must not grow the
+    ledger."""
+    ledger = RetainedEntityLedger()
+
+    for _ in range(8):
+        ledger.record("search_nearby", "資生堂前")
+
+    assert len(ledger.entities) == 1
+
+
+def test_distinct_entities_past_the_cap_are_oldest_wins_not_fifo() -> None:
+    """The earliest, deep-history entities are the scarce resource this
+    ledger exists to protect: a near-tail entity dropped here is still
+    covered verbatim by the raw sliding window for a while yet, but a
+    turn-0 entity evicted here is lost for good. A 9th distinct entity is
+    therefore dropped, not swapped in over the 1st."""
+    ledger = RetainedEntityLedger()
+
+    for i in range(MAX_RETAINED_ENTITIES + 1):
+        ledger.record("search_nearby", f"place-{i}")
+
+    assert len(ledger.entities) == MAX_RETAINED_ENTITIES
+    assert ledger.entities[0].value == "place-0"
+    assert all(e.value != f"place-{MAX_RETAINED_ENTITIES}" for e in ledger.entities)
+
+
+def test_truncation_regression_never_exceeds_the_byte_cap() -> None:
+    """Regression pin for the mutation that survived with truncation
+    removed: an over-long tool_name and value are both truncated, and the
+    encoded record never exceeds the per-field byte cap."""
+    ledger = RetainedEntityLedger()
+    long_value = "資" * 60  # 180 bytes, over the 96-byte per-field cap
+    long_tool_name = "a-very-long-tool-name-" * 5
+
+    ledger.record(long_tool_name, long_value)
+
+    (entity,) = ledger.entities
+    assert len(entity.value.encode("utf-8")) <= 96
+    assert len(entity.tool_name.encode("utf-8")) <= 96
+    assert entity.value.endswith("…")
+
+
+def test_enforce_bounds_trims_a_directly_hydrated_oversized_ledger() -> None:
+    """Restore-time backstop: a payload hydrated straight through
+    `model_validate` — bypassing `record()` entirely, as a corrupted or
+    future-deploy envelope would — still gets trimmed to the count cap,
+    keeping the oldest entries."""
+    oversized = RetainedEntityLedger(
+        entities=[
+            RetainedEntity(tool_name="search_nearby", value=f"place-{i}")
+            for i in range(MAX_RETAINED_ENTITIES + 50)
+        ]
+    )
+
+    oversized.enforce_bounds()
+
+    assert len(oversized.entities) == MAX_RETAINED_ENTITIES
+    assert oversized.entities[0].value == "place-0"
+
+
+def test_enforce_bounds_trims_an_oversized_byte_payload() -> None:
+    """A directly-hydrated ledger can carry values `record()` would have
+    truncated (no per-field pydantic length constraint on `RetainedEntity`
+    itself) — the byte backstop caps the whole ledger at `MAX_RETAINED_BYTES`
+    even when the count cap alone would not have caught it."""
+    oversized = RetainedEntityLedger(
+        entities=[
+            RetainedEntity(tool_name="search_nearby", value="資" * 2000)
+            for _ in range(MAX_RETAINED_ENTITIES)
+        ]
+    )
+
+    oversized.enforce_bounds()
+
+    assert oversized.encoded_size_bytes() <= MAX_RETAINED_BYTES
+    assert oversized.entities
+    assert oversized.entities[0].tool_name == "search_nearby"

--- a/apps/agent/agent/tests/unit/test_fact_ledger_envelope.py
+++ b/apps/agent/agent/tests/unit/test_fact_ledger_envelope.py
@@ -83,6 +83,24 @@ def test_a_recorded_fact_is_present_in_the_serialized_envelope() -> None:
     assert "fact_ledger" in dumped
 
 
+def test_fresh_empty_compaction_ledger_adds_no_key_to_the_serialized_envelope() -> None:
+    """#476 P1-2: the new field must not regress the null/empty AC at the
+    persistence layer just because it inherited `fact_ledger`'s field, not
+    its `_serialize_runtime_state` pop discipline."""
+    dumped = _serialize_runtime_state(SessionState())
+
+    assert "compaction_retained_entities" not in dumped
+
+
+def test_a_recorded_compaction_entity_is_present_in_the_serialized_envelope() -> None:
+    state = SessionState()
+    state.compaction_retained_entities.record("search_nearby", "資生堂前")
+
+    dumped = _serialize_runtime_state(state)
+
+    assert "compaction_retained_entities" in dumped
+
+
 def test_an_unparseable_fact_ledger_is_dropped_not_left_to_sink_the_session() -> None:
     """A newer/rolled-back deploy's `fact_ledger` shape must not sink the
     rest of an otherwise-valid typed session (#473 review's rollback ask)."""
@@ -100,7 +118,13 @@ def test_an_unparseable_fact_ledger_is_dropped_not_left_to_sink_the_session() ->
 
 def test_dropping_fact_ledger_logs_a_logfire_visible_warning() -> None:
     """The rollback-compat path must be observable (#473 round 3), not a
-    silent degrade — `logger.warning("fact_ledger_dropped", ...)`."""
+    silent degrade — `logger.warning("fact_ledger_dropped", ...)`.
+
+    Both allowlisted keys are dropped together (the retry is a batch of the
+    intersection, not a per-key isolation) even though only `fact_ledger` is
+    actually malformed here — `compaction_retained_entities` is present
+    (empty, valid) and gets swept along, per #476's Task 5 review.
+    """
     dumped = SessionState().model_dump(mode="json")
     dumped["fact_ledger"] = "not even a dict"
 
@@ -109,7 +133,8 @@ def test_dropping_fact_ledger_logs_a_logfire_visible_warning() -> None:
 
     assert restored == SessionState()
     mock_logger.warning.assert_called_once_with(
-        "fact_ledger_dropped", dropped_keys=["fact_ledger"]
+        "fact_ledger_dropped",
+        dropped_keys=["compaction_retained_entities", "fact_ledger"],
     )
 
 

--- a/apps/agent/agent/tests/unit/test_history_compaction_verbatim.py
+++ b/apps/agent/agent/tests/unit/test_history_compaction_verbatim.py
@@ -1,8 +1,10 @@
 """Task 5 (#273, OQ-8(c)): compaction-time verbatim entity retention.
 
 Extends the existing `CompactToolReturns._candidate_summary` precedent —
-this covers the new, decoupled entity-retention path only. Ordinal
-candidate preservation stays covered by `test_native_history_candidates.py`.
+this covers the new, decoupled entity-retention path at the
+`CompactToolReturns.compact()` level only. `RetainedEntityLedger`'s own
+dedup/oldest-wins/byte-budget behavior lives in
+`test_compaction_retention_ledger.py` (kept separate per the ≤200-line rule).
 """
 
 from __future__ import annotations
@@ -21,12 +23,11 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
-from agent.agents.animichi_agent import _summarize_tool_content
+from agent.agents.animichi_agent import _summarize_tool_content, trusted_session_context
 from agent.agents.history_compaction import CompactToolReturns
 from agent.agents.runtime_deps import RuntimeDeps
-from agent.agents.session_state import SessionState
+from agent.agents.session_state import CurrentAnime, SessionState
 from agent.agents.tool_state import ToolState
-from agent.domain.compaction_retention import RetainedEntityLedger
 from agent.tests.eval.mock_catalog_client import MockCatalogClient
 
 _LONG_CONTENT = "x" * 500
@@ -120,27 +121,30 @@ async def test_missing_call_args_degrades_without_raising() -> None:
     assert session.compaction_retained_entities.is_empty()
 
 
-def test_fresh_ledger_is_empty() -> None:
-    assert RetainedEntityLedger().is_empty()
+async def test_entity_matching_current_anime_title_is_not_double_recorded() -> None:
+    """`current_anime.title` already carries a resolved anime's title
+    verbatim; retaining the identical `resolve_anime` call argument here too
+    would just double-pay the same prompt budget (#476 P2 review)."""
+    session = SessionState()
+    session.current_anime = CurrentAnime(bangumi_id="1", title="けいおん!")
+    messages = _call_pair(
+        "resolve_anime", {"title": "けいおん!"}, _LONG_CONTENT, "call-5"
+    )
+    compact = CompactToolReturns[RuntimeDeps](_summarize_tool_content, keep_recent=0)
 
+    await compact.compact(messages, _ctx(session))
 
-def test_blank_value_after_sanitization_is_a_no_op() -> None:
-    ledger = RetainedEntityLedger()
-
-    ledger.record("search_nearby", "   \x00\x1f  ")
-
-    assert ledger.is_empty()
+    assert session.compaction_retained_entities.is_empty()
 
 
 def test_consumption_gate_retained_entity_reaches_trusted_prompt_context() -> None:
     """Named consumption point: a retained entity's live value must appear in
     the actual rendered prompt, or this ledger would be dead scaffolding."""
-    from agent.agents.animichi_agent import trusted_session_context
-
     session = SessionState()
     session.compaction_retained_entities.record("search_nearby", "資生堂前")
 
     context = trusted_session_context(_ctx(session).deps)
 
-    assert "資生堂前" in context
+    assert "「資生堂前」" in context
     assert "Verbatim entity retained from an earlier search_nearby call" in context
+    assert "still treat it as valid context for anaphora" in context

--- a/apps/agent/agent/tests/unit/test_history_compaction_verbatim.py
+++ b/apps/agent/agent/tests/unit/test_history_compaction_verbatim.py
@@ -1,0 +1,146 @@
+"""Task 5 (#273, OQ-8(c)): compaction-time verbatim entity retention.
+
+Extends the existing `CompactToolReturns._candidate_summary` precedent —
+this covers the new, decoupled entity-retention path only. Ordinal
+candidate preservation stays covered by `test_native_history_candidates.py`.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock
+
+from pydantic_ai import RunContext
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+
+from agent.agents.animichi_agent import _summarize_tool_content
+from agent.agents.history_compaction import CompactToolReturns
+from agent.agents.runtime_deps import RuntimeDeps
+from agent.agents.session_state import SessionState
+from agent.agents.tool_state import ToolState
+from agent.domain.compaction_retention import RetainedEntityLedger
+from agent.tests.eval.mock_catalog_client import MockCatalogClient
+
+_LONG_CONTENT = "x" * 500
+
+
+def _call_pair(
+    tool_name: str, args: dict[str, object], content: object, call_id: str
+) -> list[ModelMessage]:
+    return [
+        ModelResponse(parts=[ToolCallPart(tool_name, args, call_id)]),
+        ModelRequest(parts=[ToolReturnPart(tool_name, content, call_id)]),
+    ]
+
+
+def _ctx(session: SessionState) -> RunContext[RuntimeDeps]:
+    deps = RuntimeDeps(
+        db=MagicMock(),
+        locale="ja",
+        query="q",
+        catalog=MockCatalogClient(),
+        tool_state=ToolState(session=session),
+    )
+    return RunContext(deps=deps, model=TestModel(), usage=RunUsage())
+
+
+async def test_place_name_survives_compaction_in_session_state() -> None:
+    session = SessionState()
+    messages = _call_pair(
+        "search_nearby", {"location": "資生堂前"}, _LONG_CONTENT, "call-1"
+    )
+    compact = CompactToolReturns[RuntimeDeps](_summarize_tool_content, keep_recent=0)
+
+    await compact.compact(messages, _ctx(session))
+
+    entities = session.compaction_retained_entities.entities
+    assert len(entities) == 1
+    assert entities[0].tool_name == "search_nearby"
+    assert entities[0].value == "資生堂前"
+
+
+async def test_no_extractable_entity_writes_no_retention_payload() -> None:
+    session = SessionState()
+    messages = _call_pair(
+        "plan_route", {"search_result_ref": "ref-1"}, _LONG_CONTENT, "call-2"
+    )
+    compact = CompactToolReturns[RuntimeDeps](_summarize_tool_content, keep_recent=0)
+
+    await compact.compact(messages, _ctx(session))
+
+    assert session.compaction_retained_entities.is_empty()
+
+
+async def test_short_return_needs_no_compaction_and_retains_nothing() -> None:
+    session = SessionState()
+    messages = _call_pair("search_nearby", {"location": "資生堂前"}, "ok", "call-3")
+    compact = CompactToolReturns[RuntimeDeps](_summarize_tool_content, keep_recent=0)
+
+    await compact.compact(messages, _ctx(session))
+
+    assert session.compaction_retained_entities.is_empty()
+
+
+async def test_extraction_failure_degrades_without_raising() -> None:
+    """A `ctx` shape that isn't a real `RunContext[RuntimeDeps]` (here, the
+    `None` sentinel other compaction tests already pass) must never raise —
+    it just degrades to today's plain truncation behaviour."""
+    messages = _call_pair(
+        "search_nearby", {"location": "資生堂前"}, _LONG_CONTENT, "call-4"
+    )
+    compact = CompactToolReturns[None](_summarize_tool_content, keep_recent=0)
+
+    compacted = await compact.compact(messages, cast(RunContext[None], None))
+
+    returned = cast(ToolReturnPart, cast(ModelRequest, compacted[1]).parts[0])
+    assert returned.content != _LONG_CONTENT
+
+
+async def test_missing_call_args_degrades_without_raising() -> None:
+    """A tool return with no matching `ToolCallPart` (the pair was itself
+    compacted away by an earlier turn) must not raise."""
+    session = SessionState()
+    request = ModelRequest(
+        parts=[ToolReturnPart("search_nearby", _LONG_CONTENT, "orphan-call")]
+    )
+    compact = CompactToolReturns[RuntimeDeps](_summarize_tool_content, keep_recent=0)
+
+    compacted = await compact.compact([request], _ctx(session))
+
+    returned = cast(ToolReturnPart, cast(ModelRequest, compacted[0]).parts[0])
+    assert returned.content != _LONG_CONTENT
+    assert session.compaction_retained_entities.is_empty()
+
+
+def test_fresh_ledger_is_empty() -> None:
+    assert RetainedEntityLedger().is_empty()
+
+
+def test_blank_value_after_sanitization_is_a_no_op() -> None:
+    ledger = RetainedEntityLedger()
+
+    ledger.record("search_nearby", "   \x00\x1f  ")
+
+    assert ledger.is_empty()
+
+
+def test_consumption_gate_retained_entity_reaches_trusted_prompt_context() -> None:
+    """Named consumption point: a retained entity's live value must appear in
+    the actual rendered prompt, or this ledger would be dead scaffolding."""
+    from agent.agents.animichi_agent import trusted_session_context
+
+    session = SessionState()
+    session.compaction_retained_entities.record("search_nearby", "資生堂前")
+
+    context = trusted_session_context(_ctx(session).deps)
+
+    assert "資生堂前" in context
+    assert "Verbatim entity retained from an earlier search_nearby call" in context

--- a/apps/agent/agent/tests/unit/test_session_facade.py
+++ b/apps/agent/agent/tests/unit/test_session_facade.py
@@ -99,6 +99,7 @@ def test_extract_delta_always_serializes_empty_state_clear() -> None:
     )
     dumped = SessionState().model_dump(mode="json")
     dumped.pop("fact_ledger")  # never-recorded ledger adds no envelope key
+    dumped.pop("compaction_retained_entities")  # ditto (#476)
     assert extract_context_delta(result) == {"session_state_v2": dumped}
 
 

--- a/apps/agent/agent/tests/unit/test_session_state_boundaries.py
+++ b/apps/agent/agent/tests/unit/test_session_state_boundaries.py
@@ -15,6 +15,7 @@ from agent.agents.session_state import (
     SearchPayloadState,
     SessionState,
 )
+from agent.domain.compaction_retention import MAX_RETAINED_ENTITIES
 
 
 def _search_payload() -> SearchPayloadState:
@@ -56,6 +57,24 @@ def test_route_lru_survives_jsonb_registry_key_reordering() -> None:
 
     assert refs[0] not in restored.routes
     assert refs[1] in restored.routes
+
+
+def test_session_state_restore_bounds_an_oversized_compaction_ledger() -> None:
+    """A persisted envelope with far more compaction-retained entities than
+    the cap (a corrupted or future-deploy payload, or an attacker-supplied
+    blob) must not bypass the bound just because it arrived through
+    `model_validate` instead of `RetainedEntityLedger.record()` (#476)."""
+    dumped = SessionState().model_dump(mode="json")
+    dumped["compaction_retained_entities"] = {
+        "entities": [
+            {"tool_name": "search_nearby", "value": f"place-{i}"} for i in range(500)
+        ]
+    }
+
+    restored = SessionState.model_validate(dumped)
+
+    assert len(restored.compaction_retained_entities.entities) == MAX_RETAINED_ENTITIES
+    assert restored.compaction_retained_entities.entities[0].value == "place-0"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Implements #273 S1.7 Task 5 (4 ACs, unit 3 / integration 1) per the OQ-8(c) ruling: extend `CompactToolReturns._candidate_summary` precedent in `history_compaction.py` to deterministically retain a verbatim key entity (anime title / place name) when an old tool return is compacted, storing it in a new standalone `SessionState` field — **not** coupled to Task 4's fact ledger (#473).

## What changed

- `agent/domain/compaction_retention.py` (new) — `RetainedEntityLedger` / `RetainedEntity`, bounded (8 entries) and byte-truncated/sanitized, mirroring the `_sanitize`/truncate discipline `fact_ledger.py` established.
- `agent/agents/history_compaction.py` — `CompactToolReturns` now builds a `tool_call_id -> args` lookup across the message window and, when a tool return is old enough to be shrunk, rescues its matching `ToolCallPart`'s literal entity argument (`resolve_anime.title`, `search_nearby.location`) into `ctx.deps.tool_state.session.compaction_retained_entities` before summarizing. A defensive `_session_of` lookup degrades to a no-op for any `ctx` shape without a real session (including the `None` sentinel other compaction unit tests already pass), so nothing raises out of the compaction tier.
- `agent/agents/session_state.py` — new `compaction_retained_entities: RetainedEntityLedger` field on `SessionState`, round-tripping through the existing `sessions.state` JSONB envelope automatically.
- `agent/agents/animichi_agent.py` — named consumption point `_compaction_retention_context`, wired into `trusted_session_context`, so a retained entity's live value actually reaches the rendered prompt (not dead scaffolding).

## Consumption point

`trusted_session_context()` renders `Verbatim entity retained from an earlier {tool_name} call: {value}.` for every live retained entity — asserted directly in `test_consumption_gate_retained_entity_reaches_trusted_prompt_context`.

## AC coverage

| AC | Test |
|---|---|
| Happy path — verbatim place-name string survives compaction in session state | `test_place_name_survives_compaction_in_session_state` |
| Null/empty — no extractable entity writes nothing | `test_no_extractable_entity_writes_no_retention_payload`, `test_short_return_needs_no_compaction_and_retains_nothing` |
| Error path — extraction/lookup failure degrades without raising | `test_extraction_failure_degrades_without_raising`, `test_missing_call_args_degrades_without_raising` |
| Multi-turn (integration) — entity retained in round 1 survives round 2 | `test_entity_retained_in_round_one_survives_round_two` (real `SessionStore` round-trip, mirrors `test_fact_ledger_persistence.py`'s pattern) |

Plus supporting ledger unit tests (`RetainedEntityLedger` empty/sanitize no-op) and the consumption-gate test above — 9 tests total in the two new files.

## Mutation verification

Removing the `self._retain_entity(...)` call inside `_compact_return` (deleting the retention wiring) fails `test_place_name_survives_compaction_in_session_state` immediately (`assert 0 == 1`), confirming the test is not a no-op-passing false-green. Reverted after verification.

## Gates

- `make lint` — ruff check + format: clean.
- `make typecheck` — mypy strict over `agent/agents`, `agent/domain`, etc.: no issues.
- `make test` (unit, 1574 tests) — all pass, coverage 89.30% (floor 87%).
- New integration tests (`test_compaction_entity_retention.py`, plus unaffected `test_fact_ledger_persistence.py`) pass against `InMemorySessionStore` (no live DB required). The DB-backed integration arm in this sandbox hits a pre-existing, unrelated environment gap (`installed Atlas is 1.2.4; expected 0.30.0`) — not caused by this change.

## Non-goals kept

- Did not rewrite `history_compaction.py` — only extended the existing tiers/precedent.
- Did not couple this to `fact_ledger.py` (Task 4, #473) — separate model, separate field, separate consumption point.

Not merging — awaiting review alongside the other #273 S1.7 task PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)