### PR TITLE
feat(#284 T3): BYOK model resolution and per-request injection

### DIFF
--- a/apps/agent/agent/agents/byok_models.py
+++ b/apps/agent/agent/agents/byok_models.py
@@ -15,7 +15,7 @@ itself, since the client must stay open for the whole agent run.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Final, Literal, cast
 
 import httpx
@@ -41,6 +41,7 @@ ByokProvider = Literal["openai-compatible", "anthropic", "gemini"]
 BYOK_PROVIDERS: Final[frozenset[str]] = frozenset(
     {"openai-compatible", "anthropic", "gemini"}
 )
+ByokErrorCode = Literal["invalid_request", "byok_credential_rejected"]
 
 
 class ByokError(Exception):
@@ -50,7 +51,7 @@ class ByokError(Exception):
     surface to the caller (never embeds the submitted key or `base_url`).
     """
 
-    def __init__(self, code: str, message: str) -> None:
+    def __init__(self, code: ByokErrorCode, message: str) -> None:
         self.code = code
         self.message = message
         super().__init__(message)
@@ -58,12 +59,20 @@ class ByokError(Exception):
 
 @dataclass(frozen=True, slots=True)
 class ByokCredential:
-    """In-memory-only BYOK credential. Never persisted, never cached."""
+    """In-memory-only BYOK credential. Never persisted, never cached.
+
+    `key`/`base_url` are excluded from `repr()` (P1-1 defense-in-depth): this
+    object is never placed in a FastAPI dependency-injected parameter (which
+    `logfire.instrument_fastapi()` would otherwise capture verbatim into
+    `fastapi.arguments.values`), but a masked repr means any other accidental
+    `repr()`/log call on this object — a debugger, a future `logger.info`,
+    an exception's local-variable dump — still can't leak the plaintext.
+    """
 
     provider: ByokProvider
-    key: str
+    key: str = field(repr=False)
     model: str
-    base_url: str | None = None
+    base_url: str | None = field(default=None, repr=False)
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,15 +103,23 @@ def _require_key(raw: bytes | None) -> str:
 
 
 def _require_base_url(raw: bytes | None, provider: ByokProvider) -> str | None:
-    if raw is None:
-        return None
-    text = _decode(raw)
-    if not text:
-        return None
+    text = _decode(raw) if raw is not None else ""
     if provider != "openai-compatible":
+        if text:
+            raise ByokError(
+                "invalid_request",
+                "X-BYOK-Base-Url is only valid for the openai-compatible family.",
+            )
+        return None
+    if not text:
+        # Dedicated parse-layer message (P1-3, Fable P2-1): without this, a
+        # missing base_url reached `validate_base_url(None)` at model-build
+        # time and failed with the generic egress-validation message —
+        # technically correct but confusing, since the real problem is
+        # "missing", not "SSRF-blocked".
         raise ByokError(
             "invalid_request",
-            "X-BYOK-Base-Url is only valid for the openai-compatible family.",
+            "X-BYOK-Base-Url is required for the openai-compatible family.",
         )
     if not text.lower().startswith("https://"):
         raise ByokError("invalid_request", "X-BYOK-Base-Url must be https.")
@@ -127,6 +144,18 @@ def _require_model(value: str | None, provider: ByokProvider) -> str:
     return model or _default_model_for(provider)
 
 
+def has_byok_signal(*, provider_header: str | None, key_header: bytes | None) -> bool:
+    """True if the request carries any BYOK signal at all.
+
+    Shared by `parse_byok_credential` (the `None` early-out) and the route
+    layer's login-gate check (P3), which must answer this question *before*
+    running full header-shape validation — otherwise a malformed BYOK header
+    from an anonymous caller would surface as `invalid_request` (400) instead
+    of `byok_requires_login` (403), the wrong rejection for the situation.
+    """
+    return provider_header is not None or key_header is not None
+
+
 def parse_byok_credential(
     *,
     provider_header: str | None,
@@ -138,8 +167,16 @@ def parse_byok_credential(
 
     `None` (no BYOK headers at all) is a distinct outcome from every rejection
     below: a plain request must resolve to `get_default_model()` unchanged.
+    An orphaned `X-BYOK-Model`/`X-BYOK-Base-Url` with neither provider nor key
+    (P3) is rejected rather than silently ignored — it is far more likely a
+    caller forgot the other two headers than that it means nothing.
     """
-    if provider_header is None and key_header is None:
+    if not has_byok_signal(provider_header=provider_header, key_header=key_header):
+        if model_header is not None or base_url_header is not None:
+            raise ByokError(
+                "invalid_request",
+                "X-BYOK-Model/X-BYOK-Base-Url require X-BYOK-Provider and X-BYOK-Key.",
+            )
         return None
     provider = _require_known_provider(provider_header)
     key = _require_key(key_header)
@@ -182,10 +219,27 @@ def _build_anthropic(credential: ByokCredential) -> ByokModel:
 
 
 def _build_gemini(credential: ByokCredential) -> ByokModel:
+    # `GoogleProvider.__init__` falls back to `os.getenv("GOOGLE_API_KEY")`
+    # only when the `api_key` it receives is falsy (P1-2) — `_require_nonblank_key`
+    # below is the structural guarantee that never happens here, so this call
+    # always uses `credential.key`, never a server-side env credential.
+    # Retry behaviour is left at the `google-genai` SDK default (unlike the
+    # openai-compatible family's explicit `max_retries=0`, T3-AC2 names only
+    # `AsyncOpenAI`) — pinned here as a deliberate choice, not an oversight.
     client = build_guarded_async_client()
     provider = GoogleProvider(api_key=credential.key, http_client=client)
     model: Model = GoogleModel(credential.model, provider=provider)
     return ByokModel(model=model, client=client)
+
+
+def _require_nonblank_key(credential: ByokCredential) -> None:
+    """Belt-and-suspenders (P1-2): `parse_byok_credential` already guarantees
+    a non-blank key, but `ByokCredential` can in principle be constructed
+    directly. A blank key reaching `GoogleProvider`/`AnthropicProvider` would
+    silently fall back to a server-side environment credential instead of
+    failing loudly — exactly the silent fallback this spec forbids."""
+    if not credential.key:
+        raise ByokError("invalid_request", "BYOK credential key must not be blank.")
 
 
 async def build_byok_model(credential: ByokCredential) -> ByokModel:
@@ -195,6 +249,7 @@ async def build_byok_model(credential: ByokCredential) -> ByokModel:
     guard, Task 2's httpx-instrumentation exclusion) — there is no second,
     unguarded way to build a BYOK-bound `httpx.AsyncClient` in this module.
     """
+    _require_nonblank_key(credential)
     if credential.provider == "openai-compatible":
         return await _build_openai_compatible(credential)
     if credential.provider == "anthropic":

--- a/apps/agent/agent/agents/byok_models.py
+++ b/apps/agent/agent/agents/byok_models.py
@@ -1,0 +1,202 @@
+"""BYOK per-request model construction (#284 Task 3).
+
+Parses the `X-BYOK-*` headers into a `ByokCredential`, then builds a
+per-request model for exactly one of three families — openai-compatible,
+anthropic, gemini — each wired to `egress_transport.build_guarded_async_client`
+(the SSRF guard, Task 1) so the request layer never has an unguarded path to
+an arbitrary caller-supplied endpoint.
+
+Construction is in-memory only: nothing here is cached, stored on `app.state`,
+persisted to a session, or written to the database (T3-AC9). The caller owns
+the returned `httpx.AsyncClient` and MUST `await client.aclose()` once the
+turn is over, success or failure (T3-AC8) — this module never closes it
+itself, since the client must stay open for the whole agent run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal, cast
+
+import httpx
+from anthropic import AsyncAnthropic
+from openai import AsyncOpenAI
+from pydantic_ai.models import Model
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.google import GoogleModel
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.anthropic import AnthropicProvider
+from pydantic_ai.providers.google import GoogleProvider
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from agent.config.byok_defaults import (
+    BYOK_ANTHROPIC_DEFAULT_MODEL,
+    BYOK_GEMINI_DEFAULT_MODEL,
+)
+from agent.infrastructure.egress_errors import EgressBlocked
+from agent.infrastructure.egress_guard import validate_base_url
+from agent.infrastructure.egress_transport import build_guarded_async_client
+
+ByokProvider = Literal["openai-compatible", "anthropic", "gemini"]
+BYOK_PROVIDERS: Final[frozenset[str]] = frozenset(
+    {"openai-compatible", "anthropic", "gemini"}
+)
+
+
+class ByokError(Exception):
+    """Typed, no-fallback BYOK rejection.
+
+    `.code` is the machine-readable taxonomy member; `.message` is safe to
+    surface to the caller (never embeds the submitted key or `base_url`).
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+@dataclass(frozen=True, slots=True)
+class ByokCredential:
+    """In-memory-only BYOK credential. Never persisted, never cached."""
+
+    provider: ByokProvider
+    key: str
+    model: str
+    base_url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ByokModel:
+    """A constructed per-request model plus the client the caller must close."""
+
+    model: Model
+    client: httpx.AsyncClient
+
+
+def _decode(raw: bytes) -> str:
+    return raw.decode("utf-8", errors="strict").strip()
+
+
+def _require_known_provider(value: str | None) -> ByokProvider:
+    if value not in BYOK_PROVIDERS:
+        raise ByokError("invalid_request", "Unknown or missing X-BYOK-Provider.")
+    return cast(ByokProvider, value)
+
+
+def _require_key(raw: bytes | None) -> str:
+    if raw is None:
+        raise ByokError("invalid_request", "X-BYOK-Key is required.")
+    key = _decode(raw)
+    if not key:
+        raise ByokError("invalid_request", "X-BYOK-Key must not be blank.")
+    return key
+
+
+def _require_base_url(raw: bytes | None, provider: ByokProvider) -> str | None:
+    if raw is None:
+        return None
+    text = _decode(raw)
+    if not text:
+        return None
+    if provider != "openai-compatible":
+        raise ByokError(
+            "invalid_request",
+            "X-BYOK-Base-Url is only valid for the openai-compatible family.",
+        )
+    if not text.lower().startswith("https://"):
+        raise ByokError("invalid_request", "X-BYOK-Base-Url must be https.")
+    return text
+
+
+def _default_model_for(provider: ByokProvider) -> str:
+    if provider == "anthropic":
+        return BYOK_ANTHROPIC_DEFAULT_MODEL
+    return BYOK_GEMINI_DEFAULT_MODEL
+
+
+def _require_model(value: str | None, provider: ByokProvider) -> str:
+    model = (value or "").strip()
+    if provider == "openai-compatible":
+        if not model:
+            raise ByokError(
+                "invalid_request",
+                "X-BYOK-Model is required for the openai-compatible family.",
+            )
+        return model
+    return model or _default_model_for(provider)
+
+
+def parse_byok_credential(
+    *,
+    provider_header: str | None,
+    key_header: bytes | None,
+    model_header: str | None,
+    base_url_header: bytes | None,
+) -> ByokCredential | None:
+    """Parse raw BYOK headers into a credential, or `None` if none were sent.
+
+    `None` (no BYOK headers at all) is a distinct outcome from every rejection
+    below: a plain request must resolve to `get_default_model()` unchanged.
+    """
+    if provider_header is None and key_header is None:
+        return None
+    provider = _require_known_provider(provider_header)
+    key = _require_key(key_header)
+    base_url = _require_base_url(base_url_header, provider)
+    model = _require_model(model_header, provider)
+    return ByokCredential(provider=provider, key=key, model=model, base_url=base_url)
+
+
+async def _validate_openai_base_url(base_url: str | None) -> None:
+    try:
+        await validate_base_url(base_url)
+    except EgressBlocked as exc:
+        raise ByokError(
+            "invalid_request", "base_url failed egress validation."
+        ) from exc
+
+
+async def _build_openai_compatible(credential: ByokCredential) -> ByokModel:
+    await _validate_openai_base_url(credential.base_url)
+    client = build_guarded_async_client()
+    sdk_client = AsyncOpenAI(
+        base_url=credential.base_url,
+        api_key=credential.key,
+        http_client=client,
+        max_retries=0,
+    )
+    provider = OpenAIProvider(openai_client=sdk_client)
+    model: Model = OpenAIChatModel(credential.model, provider=provider)
+    return ByokModel(model=model, client=client)
+
+
+def _build_anthropic(credential: ByokCredential) -> ByokModel:
+    client = build_guarded_async_client()
+    sdk_client = AsyncAnthropic(
+        api_key=credential.key, http_client=client, max_retries=0
+    )
+    provider = AnthropicProvider(anthropic_client=sdk_client)
+    model: Model = AnthropicModel(credential.model, provider=provider)
+    return ByokModel(model=model, client=client)
+
+
+def _build_gemini(credential: ByokCredential) -> ByokModel:
+    client = build_guarded_async_client()
+    provider = GoogleProvider(api_key=credential.key, http_client=client)
+    model: Model = GoogleModel(credential.model, provider=provider)
+    return ByokModel(model=model, client=client)
+
+
+async def build_byok_model(credential: ByokCredential) -> ByokModel:
+    """Build the per-request guarded model. Caller MUST `await client.aclose()`.
+
+    Every family routes through `build_guarded_async_client` (Task 1's SSRF
+    guard, Task 2's httpx-instrumentation exclusion) — there is no second,
+    unguarded way to build a BYOK-bound `httpx.AsyncClient` in this module.
+    """
+    if credential.provider == "openai-compatible":
+        return await _build_openai_compatible(credential)
+    if credential.provider == "anthropic":
+        return _build_anthropic(credential)
+    return _build_gemini(credential)

--- a/apps/agent/agent/config/byok_defaults.py
+++ b/apps/agent/agent/config/byok_defaults.py
@@ -1,0 +1,15 @@
+"""Named default models for BYOK families that don't require a caller model (OQ-1).
+
+The openai-compatible family always requires an explicit `X-BYOK-Model` (there
+is no safe default across arbitrary OpenAI-compatible endpoints). Anthropic
+and Gemini ship a well-known official API, so a visible+editable default lets
+the settings panel pre-fill a working model without the caller having to know
+one.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+BYOK_ANTHROPIC_DEFAULT_MODEL: Final[str] = "claude-sonnet-4-5"
+BYOK_GEMINI_DEFAULT_MODEL: Final[str] = "gemini-2.5-flash"

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -34,7 +34,13 @@ from agent.agents.base import (
     resolve_model_alias,
 )
 from agent.agents.error_messages import build_input_error_message
-from agent.agents.runtime_deps import OnStep, StepEvent, StepStatus, new_step_call_id
+from agent.agents.runtime_deps import (
+    OnStep,
+    StepEvent,
+    StepStatus,
+    TitleTranslator,
+    new_step_call_id,
+)
 from agent.agents.selected_route import execute_selected_route
 from agent.agents.selection import (
     SelectionError,
@@ -43,7 +49,7 @@ from agent.agents.selection import (
     validate_candidate_selection,
 )
 from agent.agents.session_state import SessionState
-from agent.agents.translation import translate_text
+from agent.agents.translation import TranslationResult, translate_text, translate_title
 from agent.application.errors import ApplicationError, ErrorCode
 from agent.clients.catalog_client import CatalogClient, CatalogClientProtocol
 from agent.config.settings import Settings, get_settings
@@ -102,6 +108,37 @@ logger = structlog.get_logger(__name__)
 class _TranslationContext:
     model: Model
     usage: RunUsage
+
+
+_BYOK_CREDENTIAL_REJECTED_MESSAGE = (
+    "Your BYOK provider rejected the credential. Please check your key and try again."
+)
+
+
+def _is_byok_credential_rejection(exc: BaseException) -> bool:
+    """A provider-reported auth failure for a BYOK-supplied credential.
+
+    Only `ModelHTTPError` carries a structured `status_code`; a 401/403 here
+    means the caller's own key/base_url was rejected, never the server's.
+    """
+    return isinstance(exc, ModelHTTPError) and exc.status_code in (401, 403)
+
+
+def _byok_credential_rejected_response() -> PublicAPIResponse:
+    """Fixed, safe copy only (T7): never echoes `str(exc)`, which could carry
+    provider response body content."""
+    return PublicAPIResponse(
+        success=False,
+        status="error",
+        intent="error",
+        message=_BYOK_CREDENTIAL_REJECTED_MESSAGE,
+        errors=[
+            PublicAPIError(
+                code="byok_credential_rejected",
+                message=_BYOK_CREDENTIAL_REJECTED_MESSAGE,
+            )
+        ],
+    )
 
 
 def _is_provider_error(exc: BaseException) -> bool:
@@ -196,6 +233,7 @@ class RuntimeAPI:
         request: PublicAPIRequest,
         *,
         model: Model | str | None = None,
+        is_byok: bool = False,
         user_id: str | None = None,
         user_type: str | None = None,
         on_step: OnStep | None = None,
@@ -225,6 +263,7 @@ class RuntimeAPI:
                     on_step,
                     span,
                     user_id,
+                    is_byok,
                 )
 
                 if session_id is None:
@@ -278,7 +317,7 @@ class RuntimeAPI:
                     transport="public_api",
                 )
 
-                await self._record_usage(result, user_id, user_type)
+                await self._record_usage(result, user_id, user_type, is_byok)
                 await self._log_request(
                     session_id=session_id,
                     request=request,
@@ -297,21 +336,26 @@ class RuntimeAPI:
         )
 
     async def _record_usage(
-        self, result: AgentResult | None, user_id: str | None, user_type: str | None
+        self,
+        result: AgentResult | None,
+        user_id: str | None,
+        user_type: str | None,
+        is_byok: bool = False,
     ) -> None:
         """SD-18 metering hook: bank this turn's RunUsage into ``daily_usage``.
 
         This is the sole data source the anonymous daily-budget breaker (X4)
         reads, so it runs in ``handle``'s finally block — a failed turn still
-        consumed tokens and must still be charged.
+        consumed tokens and must still be charged. A BYOK turn's token counts
+        are still recorded for observability, but its cost is always zero —
+        we did not pay the provider for it.
         """
         if result is None:
             return
+        scope = scope_for_identity(user_id, user_type, is_byok=is_byok)
+        prices = self._usage_prices() if scope != "byok" else UsagePrices(0.0, 0.0)
         await record_turn_usage(
-            self._db,
-            usage=result.usage,
-            scope=scope_for_identity(user_id, user_type),
-            prices=self._usage_prices(),
+            self._db, usage=result.usage, scope=scope, prices=prices
         )
 
     async def _prepare_session(
@@ -355,6 +399,7 @@ class RuntimeAPI:
         on_step: OnStep | None,
         span: object,
         user_id: str | None,
+        is_byok: bool = False,
     ) -> tuple[AgentResult | None, PublicAPIResponse, dict[str, object]]:
         """Run the pipeline (or synthetic plan) and map result to response."""
         context_delta: dict[str, object] = {}
@@ -366,6 +411,7 @@ class RuntimeAPI:
                 effective_model,
                 on_step,
                 user_id,
+                is_byok,
             )
         except TimeoutError:
             _span_record_exception(span, TimeoutError("agent timed out"))
@@ -415,6 +461,9 @@ class RuntimeAPI:
             return None, application_error_response(exc), context_delta
         except Exception as exc:
             _span_record_exception(span, exc)
+            if is_byok and _is_byok_credential_rejection(exc):
+                logger.warning("byok_credential_rejected")
+                return None, _byok_credential_rejected_response(), context_delta
             error_msg = str(exc)
             if _is_provider_error(exc):
                 logger.warning("provider_error", error=error_msg[:200])
@@ -456,7 +505,14 @@ class RuntimeAPI:
                 result,
                 resolve_reply_language(request.text, request.locale),
                 on_step,
-                model=resolved_model,
+                # D18: the post-turn translation pass reuses the run's own
+                # model when it can (cheaper, same connection) — but on a
+                # BYOK turn that model is the caller's own credential, and
+                # this helper call must never be billed to it. `model=None`
+                # forces `_translation_context`'s fallback to the server
+                # default (`resolve_model(animichi_agent.model)`), which is
+                # never influenced by a per-request override.
+                model=None if is_byok else resolved_model,
             )
         response = agent_result_to_response(
             result,
@@ -479,6 +535,7 @@ class RuntimeAPI:
         effective_model: Model | str | None,
         on_step: OnStep | None,
         user_id: str | None = None,
+        is_byok: bool = False,
     ) -> tuple[AgentResult, Model | None, bool]:
         """Dispatch exactly one of point, candidate, or model request modes."""
         model = _resolve_request_model(
@@ -492,7 +549,7 @@ class RuntimeAPI:
             result = await self._candidate_selection(request, context, on_step)
             return result, None, False
         result = await self._model_request(
-            request, context, history, model, on_step, user_id
+            request, context, history, model, on_step, user_id, is_byok
         )
         return result, model, True
 
@@ -547,6 +604,7 @@ class RuntimeAPI:
         model: Model | None,
         on_step: OnStep | None,
         user_id: str | None,
+        is_byok: bool = False,
     ) -> AgentResult:
         return await asyncio.wait_for(
             run_animichi_agent(
@@ -558,11 +616,33 @@ class RuntimeAPI:
                 message_history=history,
                 on_step=on_step,
                 catalog=self._catalog,
+                title_translator=self._server_title_translator() if is_byok else None,
                 memory_store=self._memory_store,
                 user_id=user_id,
             ),
             timeout=self._settings.agent_deadline,
         )
+
+    def _server_title_translator(self) -> TitleTranslator:
+        """D18: force `translate_anime_title` onto the server key on a BYOK
+        turn. Without this override the tool inherits the active run's own
+        model via `RunContext.model` (cheap connection reuse on every other
+        turn) — which on a BYOK turn *is* the caller's credential. Passing an
+        explicit callable here bypasses that inheritance: `ctx=None` makes
+        `translate_title` fall back to `translation_agent`'s own baked-in
+        server default, never the per-request override.
+        """
+
+        async def _translate(title: str, target_language: str) -> TranslationResult:
+            return await translate_title(
+                title,
+                target_locale=target_language,
+                kind="anime_title",
+                catalog=self._catalog,
+                ctx=None,
+            )
+
+        return _translate
 
     async def _log_request(
         self,

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -263,7 +263,7 @@ class RuntimeAPI:
                     on_step,
                     span,
                     user_id,
-                    is_byok,
+                    is_byok=is_byok,
                 )
 
                 if session_id is None:
@@ -317,7 +317,7 @@ class RuntimeAPI:
                     transport="public_api",
                 )
 
-                await self._record_usage(result, user_id, user_type, is_byok)
+                await self._record_usage(result, user_id, user_type, is_byok=is_byok)
                 await self._log_request(
                     session_id=session_id,
                     request=request,
@@ -340,6 +340,7 @@ class RuntimeAPI:
         result: AgentResult | None,
         user_id: str | None,
         user_type: str | None,
+        *,
         is_byok: bool = False,
     ) -> None:
         """SD-18 metering hook: bank this turn's RunUsage into ``daily_usage``.
@@ -399,6 +400,7 @@ class RuntimeAPI:
         on_step: OnStep | None,
         span: object,
         user_id: str | None,
+        *,
         is_byok: bool = False,
     ) -> tuple[AgentResult | None, PublicAPIResponse, dict[str, object]]:
         """Run the pipeline (or synthetic plan) and map result to response."""
@@ -411,7 +413,7 @@ class RuntimeAPI:
                 effective_model,
                 on_step,
                 user_id,
-                is_byok,
+                is_byok=is_byok,
             )
         except TimeoutError:
             _span_record_exception(span, TimeoutError("agent timed out"))
@@ -535,6 +537,7 @@ class RuntimeAPI:
         effective_model: Model | str | None,
         on_step: OnStep | None,
         user_id: str | None = None,
+        *,
         is_byok: bool = False,
     ) -> tuple[AgentResult, Model | None, bool]:
         """Dispatch exactly one of point, candidate, or model request modes."""
@@ -549,7 +552,7 @@ class RuntimeAPI:
             result = await self._candidate_selection(request, context, on_step)
             return result, None, False
         result = await self._model_request(
-            request, context, history, model, on_step, user_id, is_byok
+            request, context, history, model, on_step, user_id, is_byok=is_byok
         )
         return result, model, True
 
@@ -604,6 +607,7 @@ class RuntimeAPI:
         model: Model | None,
         on_step: OnStep | None,
         user_id: str | None,
+        *,
         is_byok: bool = False,
     ) -> AgentResult:
         return await asyncio.wait_for(

--- a/apps/agent/agent/interfaces/routes/_deps.py
+++ b/apps/agent/agent/interfaces/routes/_deps.py
@@ -14,6 +14,12 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 
+from agent.agents.byok_models import (
+    ByokCredential,
+    ByokError,
+    has_byok_signal,
+    parse_byok_credential,
+)
 from agent.clients.catalog_client import CatalogClientProtocol
 from agent.config.settings import Settings
 from agent.infrastructure.session import SessionStore, create_session_store
@@ -175,6 +181,59 @@ def _get_trusted_anon_id(
     return value
 
 
+def _raw_byok_headers(
+    request: Request,
+) -> tuple[str | None, bytes | None, str | None, bytes | None]:
+    """Read the four raw `X-BYOK-*` header values directly from `request`.
+
+    Local import breaks the import cycle: `_middleware.py` (the credential
+    stripper whose stash this reads) imports helpers from this module.
+    """
+    from agent.interfaces.routes._middleware import get_raw_sensitive_header
+
+    return (
+        _normalize_optional_header(request.headers.get("x-byok-provider")),
+        get_raw_sensitive_header(request, "x-byok-key"),
+        _normalize_optional_header(request.headers.get("x-byok-model")),
+        get_raw_sensitive_header(request, "x-byok-base-url"),
+    )
+
+
+def _has_byok_headers(request: Request) -> bool:
+    """Presence-only check, no shape validation (P1-3/P3 ordering).
+
+    Deliberately **not** a FastAPI dependency (P1-1): resolving it via
+    `Depends()` would place the result in the endpoint's `values` dict, which
+    `logfire.instrument_fastapi()` captures verbatim into
+    `fastapi.arguments.values`. This function — and `_get_byok_credential`
+    below — must be called directly from inside a route handler body instead.
+    """
+    provider_header, key_header, _model_header, _base_url_header = _raw_byok_headers(
+        request
+    )
+    return has_byok_signal(provider_header=provider_header, key_header=key_header)
+
+
+def _get_byok_credential(request: Request) -> ByokCredential | None:
+    """Parse `X-BYOK-*` headers; the key/base_url raw values never touch a log.
+
+    See `_has_byok_headers` for why this is a plain function, called from a
+    route body, never a `Depends()`-resolved endpoint parameter.
+    """
+    provider_header, key_header, model_header, base_url_header = _raw_byok_headers(
+        request
+    )
+    try:
+        return parse_byok_credential(
+            provider_header=provider_header,
+            key_header=key_header,
+            model_header=model_header,
+            base_url_header=base_url_header,
+        )
+    except ByokError as exc:
+        raise HTTPException(status_code=400, detail=exc.message) from exc
+
+
 def _get_runtime_api(request: Request) -> RuntimeAPI:
     return cast(RuntimeAPI, request.app.state.runtime_api)
 
@@ -270,6 +329,8 @@ def _http_status_for_response(response: PublicAPIResponse) -> int:
         return 400
     if codes & {"authentication_error", "invalid_credentials"}:
         return 401
+    if codes & {"byok_credential_rejected", "byok_requires_login"}:
+        return 403
     if codes & {"not_found"}:
         return 404
     if codes & {"already_exists"}:

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from typing import Annotated, Literal, Never, cast
 
@@ -10,6 +11,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from starlette.responses import Response, StreamingResponse
 
+from agent.agents.byok_models import (
+    ByokCredential,
+    ByokError,
+    ByokModel,
+    build_byok_model,
+)
 from agent.agents.error_messages import InputError, build_input_error_message
 from agent.agents.runtime_deps import OnStep
 from agent.interfaces.anon_quota import (
@@ -17,8 +24,11 @@ from agent.interfaces.anon_quota import (
     QUOTA_RESETS_AT_FIELD,
     anonymous_quota_verdict,
 )
+from agent.interfaces.public_api import RuntimeAPI
 from agent.interfaces.routes._deps import (
     TrustedAuthContext,
+    _error_response,
+    _get_byok_credential,
     _get_db_from_request,
     _get_runtime_api,
     _get_settings_from_request,
@@ -223,12 +233,75 @@ async def _quota_rejection(
     return _quota_exhausted_response(verdict.resets_at) if verdict.exhausted else None
 
 
+BYOK_REQUIRES_LOGIN_MESSAGE = "BYOKを使うにはログインが必要です。"
+
+
+def _byok_login_rejection(
+    auth: TrustedAuthContext, byok: ByokCredential | None
+) -> JSONResponse | None:
+    """Reject a BYOK credential from an anonymous caller (#284 T3/T4).
+
+    BYOK is login-gated by design (never honoured, never used to skip the
+    anonymous budget) — an anonymous request presenting `X-BYOK-*` headers is
+    refused outright rather than silently served either way.
+    """
+    if byok is None or auth.user_type != ANONYMOUS_USER_TYPE:
+        return None
+    return _error_response(
+        "byok_requires_login", BYOK_REQUIRES_LOGIN_MESSAGE, status_code=403
+    )
+
+
+async def _resolve_byok_model(byok: ByokCredential | None) -> ByokModel | None:
+    """Build the per-request guarded model before any streaming begins.
+
+    Any structural/SSRF rejection here (`ByokError`) is a pre-stream 400 —
+    the response has not been constructed yet, so `HTTPException` behaves
+    normally through FastAPI's own exception handling.
+    """
+    if byok is None:
+        return None
+    try:
+        return await build_byok_model(byok)
+    except ByokError as exc:
+        raise HTTPException(status_code=400, detail=exc.message) from exc
+
+
+def _chat_handler(
+    runtime_api: RuntimeAPI,
+    api_request: PublicAPIRequest,
+    auth: TrustedAuthContext,
+    byok_model: ByokModel | None,
+) -> Callable[[OnStep], Awaitable[PublicAPIResponse]]:
+    async def handler(on_step: OnStep) -> PublicAPIResponse:
+        try:
+            return await runtime_api.handle(
+                api_request,
+                model=byok_model.model if byok_model is not None else None,
+                is_byok=byok_model is not None,
+                user_id=auth.user_id,
+                user_type=auth.user_type,
+                on_step=on_step,
+            )
+        finally:
+            # T3-AC8: closed even when the turn raises, whether the credential
+            # was rejected or the turn failed for an unrelated reason.
+            if byok_model is not None:
+                await byok_model.client.aclose()
+
+    return handler
+
+
 @router.post("/chat", responses={422: {"description": "Invalid chat request"}})
 async def handle_chat(
     request: Request,
     auth: Annotated[TrustedAuthContext, Depends(_require_trusted_user)],
+    byok: Annotated[ByokCredential | None, Depends(_get_byok_credential)] = None,
 ) -> Response:
     """Stream chat as an AI SDK UI message stream with tool + data parts."""
+    login_rejection = _byok_login_rejection(auth, byok)
+    if login_rejection is not None:
+        return login_rejection
     rejection = await _budget_rejection(request, auth)
     if rejection is None:
         rejection = await _quota_rejection(request, auth)
@@ -239,14 +312,8 @@ async def handle_chat(
     api_request = _runtime_request(request, body, settings.message_max_chars)
     runtime_api = _get_runtime_api(request)
     await runtime_api.validate_session_owner(api_request.session_id, auth.user_id)
-
-    async def handler(on_step: OnStep) -> PublicAPIResponse:
-        return await runtime_api.handle(
-            api_request,
-            user_id=auth.user_id,
-            user_type=auth.user_type,
-            on_step=on_step,
-        )
+    byok_model = await _resolve_byok_model(byok)
+    handler = _chat_handler(runtime_api, api_request, auth, byok_model)
 
     return StreamingResponse(
         stream_chat(handler),

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -9,10 +9,10 @@ from typing import Annotated, Literal, Never, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
+from starlette.background import BackgroundTask
 from starlette.responses import Response, StreamingResponse
 
 from agent.agents.byok_models import (
-    ByokCredential,
     ByokError,
     ByokModel,
     build_byok_model,
@@ -32,6 +32,7 @@ from agent.interfaces.routes._deps import (
     _get_db_from_request,
     _get_runtime_api,
     _get_settings_from_request,
+    _has_byok_headers,
     _require_trusted_user,
 )
 from agent.interfaces.routes.chat_stream import stream_chat
@@ -237,34 +238,55 @@ BYOK_REQUIRES_LOGIN_MESSAGE = "BYOKを使うにはログインが必要です。
 
 
 def _byok_login_rejection(
-    auth: TrustedAuthContext, byok: ByokCredential | None
+    request: Request, auth: TrustedAuthContext
 ) -> JSONResponse | None:
     """Reject a BYOK credential from an anonymous caller (#284 T3/T4).
 
     BYOK is login-gated by design (never honoured, never used to skip the
     anonymous budget) — an anonymous request presenting `X-BYOK-*` headers is
     refused outright rather than silently served either way.
+
+    Ordering (P3): this is a **presence-only** check
+    (`_has_byok_headers`) evaluated *before* `_get_byok_credential`'s full
+    header-shape validation. An anonymous caller with malformed BYOK headers
+    must see `byok_requires_login` (403) — the actually-actionable rejection
+    for their situation — not `invalid_request` (400), which would leak the
+    fact that BYOK exists and *almost* worked.
     """
-    if byok is None or auth.user_type != ANONYMOUS_USER_TYPE:
+    if auth.user_type != ANONYMOUS_USER_TYPE or not _has_byok_headers(request):
         return None
     return _error_response(
         "byok_requires_login", BYOK_REQUIRES_LOGIN_MESSAGE, status_code=403
     )
 
 
-async def _resolve_byok_model(byok: ByokCredential | None) -> ByokModel | None:
-    """Build the per-request guarded model before any streaming begins.
+async def _resolve_byok_model(request: Request) -> ByokModel | None:
+    """Parse and build the per-request guarded model before streaming begins.
 
-    Any structural/SSRF rejection here (`ByokError`) is a pre-stream 400 —
-    the response has not been constructed yet, so `HTTPException` behaves
-    normally through FastAPI's own exception handling.
+    Called directly from the route body (P1-1) — never via `Depends()` — so
+    the credential is never resolved into a FastAPI endpoint parameter that
+    `logfire.instrument_fastapi()` would otherwise capture into
+    `fastapi.arguments.values`.
+
+    Any rejection here is a pre-stream 4xx: the response has not been
+    constructed yet, so a raised `HTTPException` behaves normally through
+    FastAPI's own exception handling. `ByokError` (a client-input problem)
+    maps to its own code; anything else raised during provider/client
+    construction (P2) is still the caller's malformed input from this
+    boundary's point of view, so it maps to the same `invalid_request` shape
+    rather than an unhandled 500.
     """
+    byok = _get_byok_credential(request)
     if byok is None:
         return None
     try:
         return await build_byok_model(byok)
     except ByokError as exc:
         raise HTTPException(status_code=400, detail=exc.message) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400, detail="Unable to construct the BYOK model."
+        ) from exc
 
 
 def _chat_handler(
@@ -274,20 +296,14 @@ def _chat_handler(
     byok_model: ByokModel | None,
 ) -> Callable[[OnStep], Awaitable[PublicAPIResponse]]:
     async def handler(on_step: OnStep) -> PublicAPIResponse:
-        try:
-            return await runtime_api.handle(
-                api_request,
-                model=byok_model.model if byok_model is not None else None,
-                is_byok=byok_model is not None,
-                user_id=auth.user_id,
-                user_type=auth.user_type,
-                on_step=on_step,
-            )
-        finally:
-            # T3-AC8: closed even when the turn raises, whether the credential
-            # was rejected or the turn failed for an unrelated reason.
-            if byok_model is not None:
-                await byok_model.client.aclose()
+        return await runtime_api.handle(
+            api_request,
+            model=byok_model.model if byok_model is not None else None,
+            is_byok=byok_model is not None,
+            user_id=auth.user_id,
+            user_type=auth.user_type,
+            on_step=on_step,
+        )
 
     return handler
 
@@ -296,10 +312,9 @@ def _chat_handler(
 async def handle_chat(
     request: Request,
     auth: Annotated[TrustedAuthContext, Depends(_require_trusted_user)],
-    byok: Annotated[ByokCredential | None, Depends(_get_byok_credential)] = None,
 ) -> Response:
     """Stream chat as an AI SDK UI message stream with tool + data parts."""
-    login_rejection = _byok_login_rejection(auth, byok)
+    login_rejection = _byok_login_rejection(request, auth)
     if login_rejection is not None:
         return login_rejection
     rejection = await _budget_rejection(request, auth)
@@ -312,11 +327,19 @@ async def handle_chat(
     api_request = _runtime_request(request, body, settings.message_max_chars)
     runtime_api = _get_runtime_api(request)
     await runtime_api.validate_session_owner(api_request.session_id, auth.user_id)
-    byok_model = await _resolve_byok_model(byok)
+    byok_model = await _resolve_byok_model(request)
     handler = _chat_handler(runtime_api, api_request, auth, byok_model)
 
-    return StreamingResponse(
+    response = StreamingResponse(
         stream_chat(handler),
         media_type="text/event-stream",
         headers={"x-vercel-ai-ui-message-stream": "v1"},
     )
+    if byok_model is not None:
+        # T3-AC8 (P2): cleanup via `BackgroundTask` rather than a
+        # try/finally inside the streaming handler — Starlette guarantees
+        # this runs after the response completes, including on a client
+        # disconnect mid-stream, decoupled from whether the body iterator
+        # itself ever got to run to completion.
+        response.background = BackgroundTask(byok_model.client.aclose)
+    return response

--- a/apps/agent/agent/interfaces/usage_metering.py
+++ b/apps/agent/agent/interfaces/usage_metering.py
@@ -68,8 +68,18 @@ def utc_today(now: datetime | None = None) -> date:
     return (now or datetime.now(UTC)).astimezone(UTC).date()
 
 
-def scope_for_identity(user_id: str | None, user_type: str | None) -> UsageScope:
-    """Classify a turn's spend by who paid for it."""
+def scope_for_identity(
+    user_id: str | None, user_type: str | None, *, is_byok: bool = False
+) -> UsageScope:
+    """Classify a turn's spend by who paid for it.
+
+    A BYOK turn is checked first: the caller supplied and paid for the model
+    call directly, so it is never folded into the anonymous or user scopes
+    even when it also happens to carry an anonymous-shaped identity (BYOK is
+    login-gated, so in practice it never does — see `byok_requires_login`).
+    """
+    if is_byok:
+        return "byok"
     if user_type == ANONYMOUS_USER_TYPE:
         return "anon"
     if user_id is not None and user_id.startswith(ANON_USER_ID_PREFIX):

--- a/apps/agent/agent/tests/integration/_byok_redaction_shared.py
+++ b/apps/agent/agent/tests/integration/_byok_redaction_shared.py
@@ -29,6 +29,7 @@ BYOK_HEADER_FAMILIES: dict[str, dict[str, str]] = {
     "openai-compatible": {
         "X-BYOK-Provider": "openai-compatible",
         "X-BYOK-Key": FAKE_KEY,
+        "X-BYOK-Model": "byok-test-model",
         "X-BYOK-Base-Url": f"https://byok.example.internal{SENSITIVE_PATH}",
     },
     "anthropic": {

--- a/apps/agent/agent/tests/integration/test_byok_chat_routing.py
+++ b/apps/agent/agent/tests/integration/test_byok_chat_routing.py
@@ -1,0 +1,183 @@
+"""BYOK wiring on POST /v1/chat (#284 T3).
+
+Covers the route-level ACs: null/empty golden behaviour, the anonymous
+login gate, the pre-stream invalid_request truth table, and the
+close-on-raise / no-persisted-credential guarantees. Model-family
+construction itself is covered by `test_byok_model_construction.py`;
+`test_byok_internal_calls_use_server_key.py` covers the D18 boundary.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from pydantic_ai.models import Model
+
+from agent.agents.byok_models import ByokModel
+from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.schemas import PublicAPIResponse
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+pytestmark = pytest.mark.integration
+
+HUMAN_HEADERS = {"X-User-Id": "user-1", "X-User-Type": "human"}
+ANON_HEADERS = {
+    "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
+    "X-User-Type": "anonymous",
+}
+BYOK_HEADERS = {
+    "X-BYOK-Provider": "openai-compatible",
+    "X-BYOK-Key": "sk-fake-secret-value",
+    "X-BYOK-Model": "byok-test-model",
+    "X-BYOK-Base-Url": "https://byok.example.test/v1",
+}
+
+
+def _body() -> dict[str, object]:
+    return {
+        "messages": [
+            {"id": "u1", "role": "user", "parts": [{"type": "text", "text": "京吹"}]}
+        ]
+    }
+
+
+def _db() -> MagicMock:
+    db = build_stub_db()
+    db.usage = MagicMock()
+    db.usage.accumulate_usage = AsyncMock(return_value=None)
+    db.usage.total_cost_usd = AsyncMock(return_value=0.0)
+    return db
+
+
+def _runtime(db: MagicMock, *, side_effect: BaseException | None = None) -> MagicMock:
+    runtime = MagicMock(spec=RuntimeAPI)
+    response = PublicAPIResponse(
+        success=True, status="ok", intent="plan_route", message="ルートだよ。"
+    )
+    runtime.handle = AsyncMock(return_value=response, side_effect=side_effect)
+    runtime.validate_session_owner = AsyncMock(return_value=None)
+    runtime._db = db
+    return runtime
+
+
+def _app(runtime: MagicMock, db: MagicMock) -> FastAPI:
+    app, _ = build_app(runtime_api=runtime, db=db)
+    return app
+
+
+async def _post(app: FastAPI, headers: dict[str, str]) -> httpx.Response:
+    async with async_client(app) as client:
+        return await client.post("/v1/chat", json=_body(), headers=headers)
+
+
+def _fake_byok_model() -> tuple[ByokModel, AsyncMock]:
+    fake_client = AsyncMock(spec=httpx.AsyncClient)
+    fake_model = cast(Model, MagicMock(spec=Model))
+    return ByokModel(model=fake_model, client=fake_client), fake_client
+
+
+def _patched_build(byok_model: ByokModel) -> object:
+    return patch(
+        "agent.interfaces.routes.chat.build_byok_model",
+        AsyncMock(return_value=byok_model),
+    )
+
+
+async def test_no_byok_headers_resolves_to_default_model() -> None:
+    """T3-AC4: absent BYOK headers must leave existing behaviour unchanged."""
+    db = _db()
+    runtime = _runtime(db)
+    app = _app(runtime, db)
+    response = await _post(app, HUMAN_HEADERS)
+    assert response.status_code == 200
+    assert runtime.handle.await_args.kwargs["model"] is None
+    assert runtime.handle.await_args.kwargs["is_byok"] is False
+
+
+async def test_byok_headers_build_a_concrete_model_and_mark_the_turn() -> None:
+    """T3-AC1/AC2: a BYOK turn passes the constructed model, flagged as BYOK."""
+    db = _db()
+    runtime = _runtime(db)
+    app = _app(runtime, db)
+    byok_model, fake_client = _fake_byok_model()
+    with _patched_build(byok_model):
+        response = await _post(app, HUMAN_HEADERS | BYOK_HEADERS)
+    assert response.status_code == 200
+    assert runtime.handle.await_args.kwargs["model"] is byok_model.model
+    assert runtime.handle.await_args.kwargs["is_byok"] is True
+    fake_client.aclose.assert_awaited_once()
+
+
+async def test_client_is_closed_even_when_the_turn_raises() -> None:
+    """T3-AC8: the guarded client is closed even when the turn raises."""
+    db = _db()
+    runtime = _runtime(db, side_effect=RuntimeError("boom"))
+    app = _app(runtime, db)
+    byok_model, fake_client = _fake_byok_model()
+    with _patched_build(byok_model):
+        response = await _post(app, HUMAN_HEADERS | BYOK_HEADERS)
+    assert response.status_code == 200  # SSE stream still opens; error is in-band
+    fake_client.aclose.assert_awaited_once()
+
+
+async def test_anonymous_caller_with_byok_headers_is_rejected() -> None:
+    """T3/T4: BYOK is login-gated — anonymous + BYOK headers is refused."""
+    db = _db()
+    runtime = _runtime(db)
+    app = _app(runtime, db)
+    response = await _post(app, ANON_HEADERS | BYOK_HEADERS)
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "byok_requires_login"
+    assert runtime.handle.await_count == 0
+
+
+async def test_anonymous_caller_without_byok_headers_is_unaffected() -> None:
+    db = _db()
+    runtime = _runtime(db)
+    app = _app(runtime, db)
+    response = await _post(app, ANON_HEADERS)
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "bad_headers",
+    [
+        {"X-BYOK-Provider": "openai-compatible", "X-BYOK-Key": "   "},
+        {"X-BYOK-Provider": "not-a-real-provider", "X-BYOK-Key": "sk-x"},
+        {
+            "X-BYOK-Provider": "anthropic",
+            "X-BYOK-Key": "sk-x",
+            "X-BYOK-Base-Url": "https://example.test",
+        },
+        {"X-BYOK-Provider": "openai-compatible", "X-BYOK-Key": "sk-x"},
+    ],
+)
+async def test_malformed_byok_headers_are_rejected_pre_stream(
+    bad_headers: dict[str, str],
+) -> None:
+    """T3-AC5: the truth table rejects as 400 `invalid_request`, never a 500,
+    never a silent fallthrough to the default model."""
+    db = _db()
+    runtime = _runtime(db)
+    app = _app(runtime, db)
+    response = await _post(app, HUMAN_HEADERS | bad_headers)
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_request"
+    assert runtime.handle.await_count == 0
+
+
+async def test_byok_credential_never_reaches_app_state() -> None:
+    """T3-AC9: no reference on `app.state` after the turn."""
+    db = _db()
+    runtime = _runtime(db)
+    app = _app(runtime, db)
+    byok_model, _fake_client = _fake_byok_model()
+    with _patched_build(byok_model):
+        await _post(app, HUMAN_HEADERS | BYOK_HEADERS)
+    state_repr = repr(vars(app.state))
+    assert "sk-fake-secret-value" not in state_repr
+    assert not hasattr(app.state, "byok_credential")

--- a/apps/agent/agent/tests/integration/test_byok_d18_transport_isolation.py
+++ b/apps/agent/agent/tests/integration/test_byok_d18_transport_isolation.py
@@ -1,0 +1,121 @@
+"""D18 end-to-end transport isolation (#284 T3, P1-3①).
+
+Split out of `test_byok_internal_calls_use_server_key.py` to keep that file
+under the 200-line test-file cap. That file's kwarg-presence checks prove
+`RuntimeAPI` *passes* a server-locked `title_translator`; this file proves,
+with real wire traffic on two separate recording transports, that the
+callable actually reaches the server credential end-to-end and the main
+loop's BYOK credential never crosses into it (or vice versa) — a class of
+regression a kwarg-presence check cannot catch (e.g. a bug *inside* the
+injected translator that let `ctx` leak back in).
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import cast
+from unittest.mock import patch
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from agent.agents.byok_models import ByokCredential, build_byok_model
+from agent.clients.catalog_client import CatalogClientProtocol
+from agent.interfaces.public_api import RuntimeAPI
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _stub_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hermetic DNS (P2①) — see `test_byok_model_construction.py` for why
+    this patches `socket.getaddrinfo` directly rather than the resolver
+    default."""
+
+    def _fake_getaddrinfo(
+        host: str, port: int, *_args: object, **_kwargs: object
+    ) -> list[tuple[object, ...]]:
+        del host
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+
+_CHAT_COMPLETION = b"""{
+  "id": "chatcmpl-server",
+  "choices": [{
+    "finish_reason": "stop",
+    "index": 0,
+    "message": {"content": "Title", "role": "assistant"}
+  }],
+  "created": 0,
+  "model": "server-model",
+  "object": "chat.completion"
+}"""
+
+
+class _RecordingTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(
+            200,
+            content=_CHAT_COMPLETION,
+            headers={"Content-Type": "application/json"},
+            request=request,
+        )
+
+
+async def test_end_to_end_transport_isolation_between_main_loop_and_helper() -> None:
+    """A single test, real wire traffic on two separate transports — proves
+    the main loop hits the BYOK credential and `translate_anime_title` hits
+    the server's, with neither key ever crossing into the other's captured
+    request."""
+    byok_credential = ByokCredential(
+        provider="openai-compatible",
+        key="sk-byok-fake",
+        model="byok-model",
+        base_url="https://example.com/v1",
+    )
+    byok_model = await build_byok_model(byok_credential)
+    byok_recorder = _RecordingTransport()
+    byok_model.client._transport = byok_recorder
+
+    server_recorder = _RecordingTransport()
+    server_client = httpx.AsyncClient(transport=server_recorder)
+    server_sdk = AsyncOpenAI(
+        base_url="https://server.example.com/v1",
+        api_key="sk-server-fake",
+        http_client=server_client,
+    )
+    server_model = OpenAIChatModel(
+        "server-model", provider=OpenAIProvider(openai_client=server_sdk)
+    )
+
+    api = RuntimeAPI(
+        object(),
+        catalog=cast(CatalogClientProtocol, object()),
+        model_http_client=cast(httpx.AsyncClient, object()),
+    )
+    try:
+        with patch("agent.agents.translation.resolve_model", return_value=server_model):
+            translator = api._server_title_translator()
+            await translator("タイトル", "en")
+
+        await Agent(byok_model.model).run("hi")
+    finally:
+        await byok_model.client.aclose()
+        await server_client.aclose()
+
+    byok_auth = byok_recorder.requests[0].headers["authorization"]
+    server_auth = server_recorder.requests[0].headers["authorization"]
+    assert byok_auth == "Bearer sk-byok-fake"
+    assert server_auth == "Bearer sk-server-fake"
+    assert "sk-server-fake" not in byok_auth
+    assert "sk-byok-fake" not in server_auth

--- a/apps/agent/agent/tests/integration/test_byok_dependency_injection_leak.py
+++ b/apps/agent/agent/tests/integration/test_byok_dependency_injection_leak.py
@@ -1,0 +1,71 @@
+"""P1-1 regression: the BYOK credential never enters `fastapi.arguments.values`.
+
+`logfire.instrument_fastapi()` captures every `Depends()`-resolved endpoint
+parameter verbatim into the `fastapi.arguments.values` span attribute. An
+earlier revision put `byok: ByokCredential | None` in `handle_chat`'s own
+signature — the plaintext key was kept out of spans only because the
+dependency happened to be named `byok`, which the Task 2 scrub pattern
+(`r"byok"`) matches by coincidence, not by any structural guarantee. Renaming
+the parameter (or refactoring the credential to a differently-named field)
+would have silently reopened the leak.
+
+The fix (`_get_byok_credential`/`_resolve_byok_model` called directly from
+inside `handle_chat`'s body, never as a route parameter) makes this
+impossible by construction: `byok` is never a key in `solve_dependencies`'
+`values` dict at all, so there is nothing for any scrub pattern to have to
+save. This test proves that structurally, with real `logfire.instrument_fastapi()`
+active — not the homegrown scrubber, which is Task 2's own concern.
+"""
+
+from __future__ import annotations
+
+import pytest
+from logfire.testing import TestExporter
+
+from agent.tests.integration import _byok_redaction_shared as shared
+from agent.tests.unit.conftest_fastapi import async_client, build_app
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def logfire_sinks(monkeypatch: pytest.MonkeyPatch) -> TestExporter:
+    return shared.build_logfire_sinks(monkeypatch, scrubbing_enabled=False)
+
+
+def _fastapi_arguments_values(exporter: TestExporter) -> str:
+    """Extract only the `fastapi.arguments.values` span attribute, so the
+    assertion is tied to the actual vulnerability rather than to a
+    file-wide text search that could pass or fail for unrelated reasons."""
+    chunks: list[str] = []
+    for span in exporter.exported_spans:
+        if not span.attributes:
+            continue
+        value = span.attributes.get("fastapi.arguments.values")
+        if value is not None:
+            chunks.append(str(value))
+    return "\n".join(chunks)
+
+
+async def test_byok_credential_never_enters_fastapi_arguments_values(
+    logfire_sinks: TestExporter,
+) -> None:
+    """With Logfire's own scrubbing disabled (isolating this from Task 2's
+    scrub-pattern safety net entirely): the credential must still not be
+    capturable, because it is never a `Depends()`-resolved value in the
+    first place."""
+    app, _ = build_app(runtime_api=shared.success_runtime())
+
+    async with async_client(app) as client:
+        await client.post(
+            "/v1/chat",
+            json=shared.chat_body(),
+            headers={
+                "X-User-Id": "user-1",
+                **shared.BYOK_HEADER_FAMILIES["openai-compatible"],
+            },
+        )
+
+    arguments_text = _fastapi_arguments_values(logfire_sinks)
+    assert shared.FAKE_KEY not in arguments_text
+    assert "byok" not in arguments_text.lower()

--- a/apps/agent/agent/tests/integration/test_byok_error_taxonomy.py
+++ b/apps/agent/agent/tests/integration/test_byok_error_taxonomy.py
@@ -47,7 +47,7 @@ async def test_byok_credential_rejection_maps_to_the_typed_code() -> None:
         new=AsyncMock(side_effect=ModelHTTPError(401, "byok-model")),
     ):
         _result, response, _delta = await api._execute_pipeline(
-            request, None, [], object(), None, object(), None, True
+            request, None, [], object(), None, object(), None, is_byok=True
         )
     try:
         assert response.errors[0].code == "byok_credential_rejected"
@@ -69,7 +69,7 @@ async def test_byok_credential_rejection_never_leaks_the_key_or_base_url() -> No
         new=AsyncMock(side_effect=ModelHTTPError(403, "byok-model", body=leaking_body)),
     ):
         _result, response, _delta = await api._execute_pipeline(
-            request, None, [], object(), None, object(), None, True
+            request, None, [], object(), None, object(), None, is_byok=True
         )
     try:
         body_repr = repr(response.model_dump(mode="json"))
@@ -98,7 +98,7 @@ async def test_byok_turn_never_falls_back_to_the_server_default_model() -> None:
         ),
     ):
         await api._execute_pipeline(
-            request, None, [], byok_model, None, object(), None, True
+            request, None, [], byok_model, None, object(), None, is_byok=True
         )
     await client.aclose()
 
@@ -115,7 +115,7 @@ async def test_non_byok_model_rejection_still_uses_the_generic_taxonomy() -> Non
         new=AsyncMock(side_effect=ModelHTTPError(401, "server-model")),
     ):
         _result, response, _delta = await api._execute_pipeline(
-            request, None, [], object(), None, object(), None, False
+            request, None, [], object(), None, object(), None, is_byok=False
         )
     try:
         assert response.errors[0].code != "byok_credential_rejected"

--- a/apps/agent/agent/tests/integration/test_byok_error_taxonomy.py
+++ b/apps/agent/agent/tests/integration/test_byok_error_taxonomy.py
@@ -1,0 +1,123 @@
+"""BYOK error taxonomy at the `RuntimeAPI` layer (#284 T3-AC6, T3-AC7).
+
+Exercises `_execute_pipeline` directly, mirroring the pattern
+`test_model_failover.py` already uses for the server-default model
+(`api._dispatch_request(...)`, `patch(..., side_effect=AssertionError(...))`
+as a canary for "must never be called") — the lightest faithful way to
+reach the new BYOK branch without spinning up the full agent pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.models import Model
+
+from agent.clients.catalog_client import CatalogClientProtocol
+from agent.interfaces.public_api import PublicAPIRequest, RuntimeAPI
+from agent.interfaces.routes._deps import _http_status_for_response
+
+pytestmark = pytest.mark.integration
+
+_FAKE_KEY = "sk-fake-secret-value"
+_FAKE_BASE_URL = "https://byok.example.test/v1"
+
+
+def _api(client: httpx.AsyncClient) -> RuntimeAPI:
+    return RuntimeAPI(
+        object(),
+        catalog=cast(CatalogClientProtocol, object()),
+        model_http_client=client,
+    )
+
+
+async def test_byok_credential_rejection_maps_to_the_typed_code() -> None:
+    """T3-AC6: a 401 from the caller's own provider is `byok_credential_rejected`,
+    never the generic `provider_error`/`internal_error` branch."""
+    client = httpx.AsyncClient()
+    api = _api(client)
+    request = PublicAPIRequest(text="hello")
+    with patch.object(
+        api,
+        "_model_request",
+        new=AsyncMock(side_effect=ModelHTTPError(401, "byok-model")),
+    ):
+        _result, response, _delta = await api._execute_pipeline(
+            request, None, [], object(), None, object(), None, True
+        )
+    try:
+        assert response.errors[0].code == "byok_credential_rejected"
+        assert _http_status_for_response(response) == 403
+    finally:
+        await client.aclose()
+
+
+async def test_byok_credential_rejection_never_leaks_the_key_or_base_url() -> None:
+    """T3-AC7: the response body carries no substring of the submitted
+    key or base_url — the exception's own `str()` is never surfaced."""
+    client = httpx.AsyncClient()
+    api = _api(client)
+    request = PublicAPIRequest(text="hello")
+    leaking_body = f"unauthorized key={_FAKE_KEY} base_url={_FAKE_BASE_URL}"
+    with patch.object(
+        api,
+        "_model_request",
+        new=AsyncMock(side_effect=ModelHTTPError(403, "byok-model", body=leaking_body)),
+    ):
+        _result, response, _delta = await api._execute_pipeline(
+            request, None, [], object(), None, object(), None, True
+        )
+    try:
+        body_repr = repr(response.model_dump(mode="json"))
+        assert _FAKE_KEY not in body_repr
+        assert _FAKE_BASE_URL not in body_repr
+    finally:
+        await client.aclose()
+
+
+async def test_byok_turn_never_falls_back_to_the_server_default_model() -> None:
+    """T3-AC6: zero calls to `get_default_model` on a BYOK turn, success or
+    failure — a concrete `Model` instance always bypasses the default path."""
+    client = httpx.AsyncClient()
+    api = _api(client)
+    request = PublicAPIRequest(text="hello")
+    byok_model = cast(Model, object())
+    with (
+        patch.object(
+            api,
+            "_model_request",
+            new=AsyncMock(side_effect=ModelHTTPError(401, "byok-model")),
+        ),
+        patch(
+            "agent.interfaces.public_api.get_default_model",
+            side_effect=AssertionError("must not fall back to the server default"),
+        ),
+    ):
+        await api._execute_pipeline(
+            request, None, [], byok_model, None, object(), None, True
+        )
+    await client.aclose()
+
+
+async def test_non_byok_model_rejection_still_uses_the_generic_taxonomy() -> None:
+    """Regression: the same exception on a non-BYOK turn is unaffected —
+    `is_byok=False` must not accidentally widen the new branch."""
+    client = httpx.AsyncClient()
+    api = _api(client)
+    request = PublicAPIRequest(text="hello")
+    with patch.object(
+        api,
+        "_model_request",
+        new=AsyncMock(side_effect=ModelHTTPError(401, "server-model")),
+    ):
+        _result, response, _delta = await api._execute_pipeline(
+            request, None, [], object(), None, object(), None, False
+        )
+    try:
+        assert response.errors[0].code != "byok_credential_rejected"
+    finally:
+        await client.aclose()

--- a/apps/agent/agent/tests/integration/test_byok_instrumentation_ordering.py
+++ b/apps/agent/agent/tests/integration/test_byok_instrumentation_ordering.py
@@ -1,0 +1,111 @@
+"""Pins the construction-order requirement left as a P3 backlog item on #474.
+
+`GuardedAsyncTransport.__init__` excludes itself from Logfire/OTel's global
+httpx instrumentation by unwrapping whatever is currently patched onto
+`httpx.AsyncHTTPTransport.handle_async_request`. `logfire.instrument_httpx()`
+applies that patch at the *class* level — so a transport built **before**
+`instrument_httpx()` runs has nothing to unwrap yet, and the later global
+patch still lands on it. Production always calls `setup_logfire()` at app
+startup, long before any per-request BYOK client is built, so this ordering
+holds by construction — but nothing asserted it. This test proves the wrong
+order actually leaks (transport IS instrumented), and the right order (every
+other BYOK test in this suite) stays clean.
+"""
+
+from __future__ import annotations
+
+import ssl
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+
+import logfire
+import pytest
+from logfire.testing import TestExporter
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+from agent.infrastructure import egress_guard
+from agent.infrastructure.egress_transport import build_guarded_async_client
+from agent.tests.integration import _byok_redaction_shared as shared
+from agent.tests.integration._egress_tls_stub import (
+    TEST_HOSTNAME,
+    TlsProbeServer,
+    write_self_signed_cert,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _fresh_httpx_instrumentor_state() -> Iterator[None]:
+    instrumentor = HTTPXClientInstrumentor()
+    if instrumentor.is_instrumented_by_opentelemetry:
+        instrumentor.uninstrument()
+    yield
+    if instrumentor.is_instrumented_by_opentelemetry:
+        instrumentor.uninstrument()
+
+
+@pytest.fixture
+def logfire_sinks(monkeypatch: pytest.MonkeyPatch) -> TestExporter:
+    return shared.build_logfire_sinks(monkeypatch)
+
+
+@pytest.fixture(scope="session")
+def tls_cert_files(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, str]:
+    directory = tmp_path_factory.mktemp("byok-ordering-tls")
+    return write_self_signed_cert(directory)
+
+
+@pytest.fixture
+async def tls_stub_server(
+    tls_cert_files: tuple[str, str],
+) -> AsyncIterator[TlsProbeServer]:
+    cert_path, key_path = tls_cert_files
+    server = TlsProbeServer(cert_path, key_path)
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.aclose()
+
+
+def _resolver(addresses: list[str]) -> Callable[[str, int], Awaitable[list[str]]]:
+    async def _resolve(_host: str, _port: int) -> list[str]:
+        return addresses
+
+    return _resolve
+
+
+def _allow_loopback(monkeypatch: pytest.MonkeyPatch, port: int) -> None:
+    monkeypatch.setattr(egress_guard, "ALLOWED_PORTS", frozenset({port}))
+    monkeypatch.setattr(egress_guard, "_is_address_accepted", lambda _ip: True)
+
+
+async def test_client_built_before_instrumentation_is_not_protected(
+    logfire_sinks: TestExporter,
+    tls_stub_server: TlsProbeServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wrong order: build the guarded client, *then* instrument httpx.
+
+    Production never does this (instrumentation happens once at startup,
+    long before any per-request client), but this proves the ordering is
+    load-bearing rather than incidental — a future refactor that reversed it
+    would leak silently without a test like this one.
+    """
+    _allow_loopback(monkeypatch, tls_stub_server.port)
+    trust_ctx = ssl.create_default_context(cafile=tls_stub_server.cert_path)
+    client = build_guarded_async_client(
+        resolver=_resolver(["127.0.0.1"]), verify=trust_ctx
+    )
+
+    logfire.configure()
+    logfire.instrument_httpx()
+    logfire_sinks.clear()
+
+    await client.get(
+        f"https://{TEST_HOSTNAME}:{tls_stub_server.port}{shared.SENSITIVE_PATH}"
+    )
+    await client.aclose()
+
+    span_text = shared.all_span_text(logfire_sinks)
+    assert shared.SENSITIVE_PATH in span_text

--- a/apps/agent/agent/tests/integration/test_byok_internal_calls_use_server_key.py
+++ b/apps/agent/agent/tests/integration/test_byok_internal_calls_use_server_key.py
@@ -1,0 +1,110 @@
+"""D18 boundary regression: helper calls use the server key, never BYOK (#284 T3).
+
+`translate_anime_title` (via `RuntimeDeps.title_translator`) and the post-turn
+translation gate both have an optional per-call model override that, absent
+this override, would otherwise inherit the *active run's* model — the user's
+own BYOK credential when one is active. `RuntimeAPI` must inject a
+server-locked `title_translator` and pass `model=None` to the translation
+gate on every BYOK turn, so neither helper is ever billed to the caller's key
+— and, symmetrically, a non-BYOK turn must NOT gain this override (it would
+silently change today's cost/connection-reuse behaviour for every ordinary
+turn).
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic_ai.models import Model
+
+from agent.agents.translation import TranslationResult
+from agent.clients.catalog_client import CatalogClientProtocol
+from agent.interfaces.public_api import RuntimeAPI
+
+pytestmark = pytest.mark.integration
+
+
+def _api() -> RuntimeAPI:
+    return RuntimeAPI(
+        object(),
+        catalog=cast(CatalogClientProtocol, object()),
+        model_http_client=cast(object, object()),  # unused by the methods under test
+    )
+
+
+async def test_byok_turn_injects_a_server_locked_title_translator() -> None:
+    """`_model_request` must pass a `title_translator` on a BYOK turn."""
+    api = _api()
+    with patch(
+        "agent.interfaces.public_api.run_animichi_agent", new=AsyncMock()
+    ) as run_mock:
+        await api._model_request(
+            _request(), None, [], cast(Model, object()), None, None, True
+        )
+    assert run_mock.await_args.kwargs["title_translator"] is not None
+
+
+async def test_non_byok_turn_leaves_title_translator_untouched() -> None:
+    """A plain turn keeps today's behaviour: no override injected."""
+    api = _api()
+    with patch(
+        "agent.interfaces.public_api.run_animichi_agent", new=AsyncMock()
+    ) as run_mock:
+        await api._model_request(
+            _request(), None, [], cast(Model, object()), None, None, False
+        )
+    assert run_mock.await_args.kwargs["title_translator"] is None
+
+
+async def test_injected_title_translator_calls_translate_title_with_no_ctx() -> None:
+    """The injected callable must bypass `ctx` entirely — the only way
+    `translate_title` falls back to `translation_agent`'s server default."""
+    api = _api()
+    translator = api._server_title_translator()
+    fake_result = TranslationResult(
+        original="タイトル", translated="Title", source="llm"
+    )
+    with patch(
+        "agent.interfaces.public_api.translate_title",
+        new=AsyncMock(return_value=fake_result),
+    ) as translate_mock:
+        result = await translator("タイトル", "en")
+    assert result is fake_result
+    assert translate_mock.await_args.kwargs["ctx"] is None
+
+
+async def test_byok_turn_forces_the_translation_gate_off_the_run_model() -> None:
+    """`_apply_translation_gate` must receive `model=None` on a BYOK turn so
+    `_translation_context` falls back to the server default, never the
+    resolved (BYOK) model."""
+    from agent.interfaces.public_api import _apply_translation_gate
+
+    with patch(
+        "agent.interfaces.public_api._apply_translation_gate", new=AsyncMock()
+    ) as gate_mock:
+        gate_mock.side_effect = _apply_translation_gate
+        api = _api()
+        with (
+            patch.object(
+                api, "_dispatch_request", new=AsyncMock(side_effect=_dispatch_stub)
+            ),
+        ):
+            await api._execute_pipeline(
+                _request(), None, [], cast(Model, object()), None, object(), None, True
+            )
+    assert gate_mock.await_args.kwargs["model"] is None
+
+
+def _request() -> object:
+    from agent.interfaces.schemas import PublicAPIRequest
+
+    return PublicAPIRequest(text="hello")
+
+
+async def _dispatch_stub(*_args: object, **_kwargs: object) -> object:
+    from agent.tests.unit.conftest_public_api import make_result
+
+    result = make_result(intent="qa", message="hello there")
+    return result, cast(Model, object()), True

--- a/apps/agent/agent/tests/integration/test_byok_internal_calls_use_server_key.py
+++ b/apps/agent/agent/tests/integration/test_byok_internal_calls_use_server_key.py
@@ -41,7 +41,7 @@ async def test_byok_turn_injects_a_server_locked_title_translator() -> None:
         "agent.interfaces.public_api.run_animichi_agent", new=AsyncMock()
     ) as run_mock:
         await api._model_request(
-            _request(), None, [], cast(Model, object()), None, None, True
+            _request(), None, [], cast(Model, object()), None, None, is_byok=True
         )
     assert run_mock.await_args.kwargs["title_translator"] is not None
 
@@ -53,7 +53,7 @@ async def test_non_byok_turn_leaves_title_translator_untouched() -> None:
         "agent.interfaces.public_api.run_animichi_agent", new=AsyncMock()
     ) as run_mock:
         await api._model_request(
-            _request(), None, [], cast(Model, object()), None, None, False
+            _request(), None, [], cast(Model, object()), None, None, is_byok=False
         )
     assert run_mock.await_args.kwargs["title_translator"] is None
 
@@ -92,7 +92,14 @@ async def test_byok_turn_forces_the_translation_gate_off_the_run_model() -> None
             ),
         ):
             await api._execute_pipeline(
-                _request(), None, [], cast(Model, object()), None, object(), None, True
+                _request(),
+                None,
+                [],
+                cast(Model, object()),
+                None,
+                object(),
+                None,
+                is_byok=True,
             )
     assert gate_mock.await_args.kwargs["model"] is None
 

--- a/apps/agent/agent/tests/integration/test_byok_login_gate_ordering.py
+++ b/apps/agent/agent/tests/integration/test_byok_login_gate_ordering.py
@@ -1,0 +1,60 @@
+"""P3 ordering: `byok_requires_login` (403) precedes header-shape validation
+(400) (#284 T3).
+
+An anonymous caller with **malformed** BYOK headers must still see 403
+`byok_requires_login` — the actionable rejection for their situation — not
+400 `invalid_request`, which would both leak that BYOK exists and mask the
+real reason (they're not logged in) behind a decoy validation error.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+
+from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.schemas import PublicAPIResponse
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+pytestmark = pytest.mark.integration
+
+ANON_HEADERS = {
+    "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
+    "X-User-Type": "anonymous",
+}
+
+
+def _body() -> dict[str, object]:
+    return {
+        "messages": [
+            {"id": "u1", "role": "user", "parts": [{"type": "text", "text": "京吹"}]}
+        ]
+    }
+
+
+def _app() -> tuple[FastAPI, MagicMock]:
+    db = build_stub_db()
+    runtime = MagicMock(spec=RuntimeAPI)
+    runtime.handle = AsyncMock(
+        return_value=PublicAPIResponse(success=True, status="ok", intent="qa")
+    )
+    runtime.validate_session_owner = AsyncMock(return_value=None)
+    app, _ = build_app(runtime_api=runtime, db=db)
+    return app, runtime
+
+
+async def test_malformed_byok_headers_from_anonymous_caller_still_get_403() -> None:
+    """`X-BYOK-Key` blank (would 400 for a logged-in caller) — for an
+    anonymous caller this must resolve to the login gate first."""
+    app, runtime = _app()
+    headers = ANON_HEADERS | {
+        "X-BYOK-Provider": "openai-compatible",
+        "X-BYOK-Key": "   ",
+    }
+    async with async_client(app) as client:
+        response = await client.post("/v1/chat", json=_body(), headers=headers)
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "byok_requires_login"
+    assert runtime.handle.await_count == 0

--- a/apps/agent/agent/tests/integration/test_byok_model_construction.py
+++ b/apps/agent/agent/tests/integration/test_byok_model_construction.py
@@ -12,6 +12,8 @@ place", without depending on either provider's exact wire format.
 
 from __future__ import annotations
 
+import socket
+
 import httpx
 import pytest
 from pydantic_ai import Agent
@@ -23,6 +25,28 @@ from agent.agents.byok_models import ByokCredential, ByokProvider, build_byok_mo
 from agent.infrastructure.egress_transport import GuardedAsyncTransport
 
 pytestmark = pytest.mark.integration
+
+_STUB_PUBLIC_IP = "8.8.8.8"
+
+
+@pytest.fixture(autouse=True)
+def _stub_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hermetic DNS (P2①): the `openai-compatible` family's pre-flight
+    `validate_base_url` call does a real resolution. Mirrors Task 1's own
+    pattern (`test_egress_dns_resolution.py`) of patching `socket.getaddrinfo`
+    directly — `default_resolve`'s `resolver` parameter is bound at
+    function-definition time, so reassigning the `egress_guard` module
+    attribute would have no effect on an already-bound default.
+    """
+
+    def _fake_getaddrinfo(
+        host: str, port: int, *_args: object, **_kwargs: object
+    ) -> list[tuple[object, ...]]:
+        del host
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (_STUB_PUBLIC_IP, port))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
 
 _CHAT_COMPLETION = b"""{
   "id": "chatcmpl-byok",
@@ -104,6 +128,13 @@ async def test_anthropic_routes_to_the_anthropic_adapter() -> None:
         await byok_model.client.aclose()
 
 
+def _google_api_key(model: GoogleModel) -> str:
+    """The genai SDK's actual credential — not just proof a string was
+    passed somewhere, but the exact value the wire request will carry
+    (`_api_client.api_key` backs the `x-goog-api-key` request header)."""
+    return str(model.provider.client._api_client.api_key)
+
+
 async def test_gemini_routes_to_the_google_adapter() -> None:
     """T3-AC2: the gemini family builds a `GoogleModel` carrying the user's
     key, never the server's."""
@@ -113,6 +144,25 @@ async def test_gemini_routes_to_the_google_adapter() -> None:
     byok_model = await build_byok_model(credential)
     try:
         assert isinstance(byok_model.model, GoogleModel)
+        assert _google_api_key(byok_model.model) == "gemini-user-fake"
+    finally:
+        await byok_model.client.aclose()
+
+
+async def test_gemini_never_falls_back_to_a_server_side_env_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """P1-2: `GoogleProvider` falls back to `os.getenv("GOOGLE_API_KEY")`
+    only when the `api_key` it receives is falsy. With a real server-side
+    env credential present, the BYOK turn must still carry the caller's own
+    key — never silently substitute the environment's."""
+    monkeypatch.setenv("GOOGLE_API_KEY", "server-side-env-key-should-never-be-used")
+    credential = ByokCredential(
+        provider="gemini", key="gemini-user-fake", model="gemini-test"
+    )
+    byok_model = await build_byok_model(credential)
+    try:
+        assert _google_api_key(byok_model.model) == "gemini-user-fake"
     finally:
         await byok_model.client.aclose()
 

--- a/apps/agent/agent/tests/integration/test_byok_model_construction.py
+++ b/apps/agent/agent/tests/integration/test_byok_model_construction.py
@@ -1,0 +1,144 @@
+"""Integration tests for the three BYOK model families (#284 T3-AC1, T3-AC2).
+
+Every family is verified separately. `openai-compatible` gets a full live
+request round-trip (transport swapped post-construction for a recording
+double, proving the header actually reaches an outbound call); `anthropic`
+and `gemini` are verified by inspecting the constructed SDK client the same
+way `test_model_failover.py` already does for the server-default model
+(`model.client.api_key`, `model.client.max_retries`) — a lighter but
+equally load-bearing assertion of "the user's credential reached the right
+place", without depending on either provider's exact wire format.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.google import GoogleModel
+from pydantic_ai.models.openai import OpenAIChatModel
+
+from agent.agents.byok_models import ByokCredential, ByokProvider, build_byok_model
+from agent.infrastructure.egress_transport import GuardedAsyncTransport
+
+pytestmark = pytest.mark.integration
+
+_CHAT_COMPLETION = b"""{
+  "id": "chatcmpl-byok",
+  "choices": [{
+    "finish_reason": "stop",
+    "index": 0,
+    "message": {"content": "ok", "role": "assistant"}
+  }],
+  "created": 0,
+  "model": "byok-model",
+  "object": "chat.completion"
+}"""
+
+
+class _RecordingTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(
+            200,
+            content=_CHAT_COMPLETION,
+            headers={"Content-Type": "application/json"},
+            request=request,
+        )
+
+
+async def test_openai_compatible_reaches_the_wire_with_the_users_credential() -> None:
+    """T3-AC1: the outbound call carries the caller's Authorization, not the
+    server default's — asserted at the transport layer."""
+    credential = ByokCredential(
+        provider="openai-compatible",
+        key="sk-user-fake",
+        model="byok-model",
+        base_url="https://example.com/v1",
+    )
+    byok_model = await build_byok_model(credential)
+    recorder = _RecordingTransport()
+    byok_model.client._transport = recorder
+    try:
+        result = await Agent(byok_model.model).run("hi")
+    finally:
+        await byok_model.client.aclose()
+    assert result.output == "ok"
+    assert recorder.requests[0].headers["authorization"] == "Bearer sk-user-fake"
+    assert recorder.requests[0].url.host == "example.com"
+
+
+async def test_openai_compatible_disables_sdk_retries() -> None:
+    """T3-AC2: `AsyncOpenAI` is constructed with `max_retries == 0`."""
+    credential = ByokCredential(
+        provider="openai-compatible",
+        key="sk-user-fake",
+        model="byok-model",
+        base_url="https://example.com/v1",
+    )
+    byok_model = await build_byok_model(credential)
+    try:
+        assert isinstance(byok_model.model, OpenAIChatModel)
+        assert byok_model.model.client.max_retries == 0
+        assert byok_model.model.client.api_key == "sk-user-fake"
+    finally:
+        await byok_model.client.aclose()
+
+
+async def test_anthropic_routes_to_the_anthropic_adapter() -> None:
+    """T3-AC2: the anthropic family builds an `AnthropicModel` carrying the
+    user's key, never the server's."""
+    credential = ByokCredential(
+        provider="anthropic", key="sk-ant-user-fake", model="claude-test"
+    )
+    byok_model = await build_byok_model(credential)
+    try:
+        assert isinstance(byok_model.model, AnthropicModel)
+        assert byok_model.model.client.api_key == "sk-ant-user-fake"
+        assert byok_model.model.client.max_retries == 0
+    finally:
+        await byok_model.client.aclose()
+
+
+async def test_gemini_routes_to_the_google_adapter() -> None:
+    """T3-AC2: the gemini family builds a `GoogleModel` carrying the user's
+    key, never the server's."""
+    credential = ByokCredential(
+        provider="gemini", key="gemini-user-fake", model="gemini-test"
+    )
+    byok_model = await build_byok_model(credential)
+    try:
+        assert isinstance(byok_model.model, GoogleModel)
+    finally:
+        await byok_model.client.aclose()
+
+
+@pytest.mark.parametrize(
+    ("provider", "key", "model"),
+    [
+        ("openai-compatible", "sk-a", "m"),
+        ("anthropic", "sk-ant-a", "claude-test"),
+        ("gemini", "gemini-a", "gemini-test"),
+    ],
+)
+async def test_every_family_is_wired_through_the_guarded_transport(
+    provider: ByokProvider, key: str, model: str
+) -> None:
+    """Every family's client uses `GuardedAsyncTransport` (Task 1's SSRF
+    guard) — there is no unguarded path to a BYOK-supplied endpoint."""
+    base_url = "https://example.com/v1" if provider == "openai-compatible" else None
+    credential = ByokCredential(
+        provider=provider,
+        key=key,
+        model=model,
+        base_url=base_url,
+    )
+    byok_model = await build_byok_model(credential)
+    try:
+        assert isinstance(byok_model.client._transport, GuardedAsyncTransport)
+    finally:
+        await byok_model.client.aclose()

--- a/apps/agent/agent/tests/integration/test_byok_redaction_inbound.py
+++ b/apps/agent/agent/tests/integration/test_byok_redaction_inbound.py
@@ -162,7 +162,13 @@ class TestAC5ResponseHeadersAndSseFramesNeverLeak:
                 json=shared.chat_body(),
                 headers={
                     "X-User-Id": "user-1",
+                    # #284 T3: the shared fixture's base_url is a
+                    # deliberately non-resolving domain for the leak-proofing
+                    # assertions elsewhere in this file; here it must
+                    # actually resolve so the request reaches the mocked
+                    # `runtime.handle` instead of failing SSRF pre-flight.
                     **shared.BYOK_HEADER_FAMILIES["openai-compatible"],
+                    "X-BYOK-Base-Url": "https://example.com/v1",
                 },
             )
 

--- a/apps/agent/agent/tests/integration/test_byok_redaction_inbound.py
+++ b/apps/agent/agent/tests/integration/test_byok_redaction_inbound.py
@@ -17,7 +17,6 @@ every test in this file red, not just the exception-path ones.
 from __future__ import annotations
 
 from collections.abc import Iterator
-from unittest.mock import AsyncMock
 
 import pytest
 from logfire.testing import TestExporter
@@ -150,31 +149,6 @@ class TestAC5ResponseHeadersAndSseFramesNeverLeak:
 
         assert shared.FAKE_KEY not in str(response.headers)
         assert response.json()["seen_key"] == "[redacted]"
-
-    async def test_runtime_error_stream_frame_has_no_credential(self) -> None:
-        runtime = shared.success_runtime()
-        runtime.handle = AsyncMock(side_effect=RuntimeError(f"boom {shared.FAKE_KEY}"))
-        app, _ = build_app(runtime_api=runtime)
-
-        async with async_client(app) as client:
-            response = await client.post(
-                "/v1/chat",
-                json=shared.chat_body(),
-                headers={
-                    "X-User-Id": "user-1",
-                    # #284 T3: the shared fixture's base_url is a
-                    # deliberately non-resolving domain for the leak-proofing
-                    # assertions elsewhere in this file; here it must
-                    # actually resolve so the request reaches the mocked
-                    # `runtime.handle` instead of failing SSRF pre-flight.
-                    **shared.BYOK_HEADER_FAMILIES["openai-compatible"],
-                    "X-BYOK-Base-Url": "https://example.com/v1",
-                },
-            )
-
-        assert response.status_code == 200
-        assert shared.FAKE_KEY not in response.text
-        assert '"errorText"' in response.text
 
 
 class TestLogfireTokenGatesRealInstrumentation:

--- a/apps/agent/agent/tests/integration/test_byok_redaction_runtime_error.py
+++ b/apps/agent/agent/tests/integration/test_byok_redaction_runtime_error.py
@@ -1,0 +1,66 @@
+"""BYOK redaction — a runtime exception's SSE frame carries no credential.
+
+Split out of `test_byok_redaction_inbound.py` (Task 2, T2-AC5) so this one
+`/v1/chat` round-trip — the only test in that suite needing a real,
+resolvable `base_url` (every other test there routes through `/__test/echo`
+or `/__test/crash`, never exercising the real SSRF pre-flight) — can carry
+its own hermetic-DNS fixture without pushing that file over the 200-line cap.
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.tests.integration import _byok_redaction_shared as shared
+from agent.tests.unit.conftest_fastapi import async_client, build_app
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _stub_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hermetic DNS (P3-a): the real `build_byok_model` this test exercises
+    does a real pre-flight resolution of `X-BYOK-Base-Url`. Mirrors Task 1's
+    own `test_egress_dns_resolution.py` pattern of patching
+    `socket.getaddrinfo` directly — `default_resolve`'s `resolver` parameter
+    is bound at function-definition time, so reassigning the `egress_guard`
+    module attribute would have no effect on an already-bound default.
+    """
+
+    def _fake_getaddrinfo(
+        host: str, port: int, *_args: object, **_kwargs: object
+    ) -> list[tuple[object, ...]]:
+        del host
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+
+async def test_runtime_error_stream_frame_has_no_credential() -> None:
+    runtime = shared.success_runtime()
+    runtime.handle = AsyncMock(side_effect=RuntimeError(f"boom {shared.FAKE_KEY}"))
+    app, _ = build_app(runtime_api=runtime)
+
+    async with async_client(app) as client:
+        response = await client.post(
+            "/v1/chat",
+            json=shared.chat_body(),
+            headers={
+                "X-User-Id": "user-1",
+                # #284 T3: the shared fixture's base_url is a deliberately
+                # non-resolving domain for the leak-proofing assertions in
+                # `test_byok_redaction_inbound.py`; here it must actually
+                # resolve (via the stubbed DNS above) so the request reaches
+                # the mocked `runtime.handle` instead of failing SSRF
+                # pre-flight.
+                **shared.BYOK_HEADER_FAMILIES["openai-compatible"],
+                "X-BYOK-Base-Url": "https://example.com/v1",
+            },
+        )
+
+    assert response.status_code == 200
+    assert shared.FAKE_KEY not in response.text
+    assert '"errorText"' in response.text

--- a/apps/agent/agent/tests/integration/test_byok_session_store_isolation.py
+++ b/apps/agent/agent/tests/integration/test_byok_session_store_isolation.py
@@ -1,0 +1,60 @@
+"""AC9's session-store half, made falsifiable with a real store (Fable P2-3).
+
+`test_byok_chat_routing.py::test_byok_credential_never_reaches_app_state`
+uses a `MagicMock(spec=RuntimeAPI)` for the route-level assertion — but a
+mocked runtime never touches persistence at all, so "no credential in the
+session store" was true there by construction, not by anything this suite
+actually exercised. This file runs a real `RuntimeAPI` with a real,
+fully-built `ByokModel` (not a message-embedded stand-in) against a real
+`InMemorySessionStore`, and inspects its internal state after the turn.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agent.agents.byok_models import ByokCredential, build_byok_model
+from agent.clients.catalog_client import CatalogClientProtocol
+from agent.infrastructure.session.memory import InMemorySessionStore
+from agent.interfaces.public_api import PublicAPIRequest, RuntimeAPI
+from agent.tests.unit.conftest_public_api import make_result
+
+_FAKE_KEY = "sk-fake-secret-value-must-never-persist"
+
+
+async def test_byok_key_never_lands_in_the_session_store() -> None:
+    """A real session store, a real constructed `ByokModel`, one real
+    `RuntimeAPI.handle` turn — the fake key must not appear anywhere in the
+    store's internal state afterward."""
+    credential = ByokCredential(
+        provider="anthropic", key=_FAKE_KEY, model="claude-test"
+    )
+    byok_model = await build_byok_model(credential)
+    session_store = InMemorySessionStore()
+    db = MagicMock()
+    db.session = AsyncMock()
+    api = RuntimeAPI(
+        db,
+        catalog=cast(CatalogClientProtocol, object()),
+        session_store=session_store,
+        model_http_client=AsyncMock(),
+    )
+    result = make_result(intent="qa", message="hello there")
+    try:
+        with patch(
+            "agent.interfaces.public_api.run_animichi_agent",
+            new=AsyncMock(return_value=result),
+        ):
+            await api.handle(
+                PublicAPIRequest(text="hello"),
+                model=byok_model.model,
+                is_byok=True,
+                user_id="user-1",
+                user_type="human",
+            )
+    finally:
+        await byok_model.client.aclose()
+
+    store_repr = repr(session_store._sessions) + repr(session_store._metadata)
+    assert _FAKE_KEY not in store_repr

--- a/apps/agent/agent/tests/integration/test_byok_sse_error_taxonomy.py
+++ b/apps/agent/agent/tests/integration/test_byok_sse_error_taxonomy.py
@@ -1,0 +1,89 @@
+"""SSE-level `byok_credential_rejected` end-to-end (#284 T3-AC6, P1-3②).
+
+`test_byok_error_taxonomy.py` exercises `_execute_pipeline` directly — the
+lightest reach to the new branch. This file goes the other way: a real
+`RuntimeAPI` wired into the actual FastAPI app via `/v1/chat`, so the
+assertion is on the literal SSE bytes a browser client would receive, not on
+an internal method's return value. Only `run_animichi_agent` (the deepest
+call in the real pipeline) is mocked, to simulate the caller's own provider
+rejecting the credential.
+
+OQ-4 (optional `error_code` on the contract's error chunk): no
+`packages/contract/` change was made. `PublicAPIErrorWire.code` (in
+`agent/interfaces/chat_wire.py`) is already an untyped `str`, so
+`byok_credential_rejected` flows through the existing `data-response` SSE
+chunk's `errors[].code` field without a schema change — this is the
+documented deviation from doing a zod-enum update on the frontend contract.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.models import Model
+
+from agent.agents.byok_models import ByokModel
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+pytestmark = pytest.mark.integration
+
+_FAKE_KEY = "sk-fake-secret-value-should-never-leak"
+HUMAN_HEADERS = {"X-User-Id": "user-1", "X-User-Type": "human"}
+BYOK_HEADERS = {
+    "X-BYOK-Provider": "openai-compatible",
+    "X-BYOK-Key": _FAKE_KEY,
+    "X-BYOK-Model": "byok-test-model",
+    "X-BYOK-Base-Url": "https://byok.example.test/v1",
+}
+
+
+def _body() -> dict[str, object]:
+    return {
+        "messages": [
+            {"id": "u1", "role": "user", "parts": [{"type": "text", "text": "京吹"}]}
+        ]
+    }
+
+
+def _db_with_session_repo() -> MagicMock:
+    """`build_stub_db()` plus a fully-async session repo: `get_session_repo`
+    duck-types on `upsert_session` being a coroutine function, and the real
+    `RuntimeAPI.handle` pipeline this test exercises also calls
+    `create_owned_session`/`upsert_conversation` along the way."""
+    db = build_stub_db()
+    db.session = AsyncMock()
+    return db
+
+
+async def test_sse_stream_carries_byok_credential_rejected_with_no_key_leak() -> None:
+    """A real `RuntimeAPI` turn, provider-rejected 401 deep in the pipeline —
+    the SSE frame must carry the typed code and never the submitted key."""
+    db = _db_with_session_repo()
+    app, _ = build_app(db=db)
+    fake_client = AsyncMock(spec=httpx.AsyncClient)
+    byok_model = ByokModel(model=cast(Model, object()), client=fake_client)
+
+    with (
+        patch(
+            "agent.interfaces.routes.chat.build_byok_model",
+            AsyncMock(return_value=byok_model),
+        ),
+        patch(
+            "agent.interfaces.public_api.run_animichi_agent",
+            new=AsyncMock(side_effect=ModelHTTPError(401, "byok-model")),
+        ),
+    ):
+        async with async_client(app) as client:
+            response = await client.post(
+                "/v1/chat", json=_body(), headers=HUMAN_HEADERS | BYOK_HEADERS
+            )
+
+    assert response.status_code == 200
+    body = response.text
+    assert '"byok_credential_rejected"' in body
+    assert _FAKE_KEY not in body
+    fake_client.aclose.assert_awaited_once()

--- a/apps/agent/agent/tests/integration/test_byok_ssrf_route.py
+++ b/apps/agent/agent/tests/integration/test_byok_ssrf_route.py
@@ -1,0 +1,61 @@
+"""SSRF-blocked `base_url` -> 400 at the route layer (Fable P2-1, #284 T3).
+
+Split out of `test_byok_chat_routing.py` to stay under the 200-line cap.
+This is the one BYOK route test that deliberately does **not** mock
+`build_byok_model` — it exercises the real function, so the assertion covers
+the SSRF guard (Task 1) reaching all the way through to a route-level 400,
+not just the header-shape checks in `parse_byok_credential`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+
+from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.schemas import PublicAPIResponse
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+pytestmark = pytest.mark.integration
+
+HUMAN_HEADERS = {"X-User-Id": "user-1", "X-User-Type": "human"}
+
+
+def _body() -> dict[str, object]:
+    return {
+        "messages": [
+            {"id": "u1", "role": "user", "parts": [{"type": "text", "text": "京吹"}]}
+        ]
+    }
+
+
+def _app() -> tuple[FastAPI, MagicMock]:
+    db = build_stub_db()
+    runtime = MagicMock(spec=RuntimeAPI)
+    runtime.handle = AsyncMock(
+        return_value=PublicAPIResponse(
+            success=True, status="ok", intent="plan_route", message="ルートだよ。"
+        )
+    )
+    runtime.validate_session_owner = AsyncMock(return_value=None)
+    app, _ = build_app(runtime_api=runtime, db=db)
+    return app, runtime
+
+
+async def test_ssrf_blocked_base_url_is_rejected_pre_stream() -> None:
+    """A private-IP `base_url` is rejected via the *real* `build_byok_model`
+    (not mocked) — a 400 at the route layer, never a silent fallthrough."""
+    app, runtime = _app()
+    headers = HUMAN_HEADERS | {
+        "X-BYOK-Provider": "openai-compatible",
+        "X-BYOK-Key": "sk-x",
+        "X-BYOK-Model": "byok-test-model",
+        "X-BYOK-Base-Url": "https://127.0.0.1/v1",
+    }
+    async with async_client(app) as client:
+        response = await client.post("/v1/chat", json=_body(), headers=headers)
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_request"
+    assert runtime.handle.await_count == 0

--- a/apps/agent/agent/tests/unit/conftest_public_api.py
+++ b/apps/agent/agent/tests/unit/conftest_public_api.py
@@ -187,6 +187,7 @@ def make_fake_agent(
         message_history: object | None = None,
         on_step: object | None = None,
         catalog: object | None = None,
+        title_translator: object | None = None,
         memory_store: object | None = None,
         user_id: str | None = None,
     ) -> AgentResult:
@@ -198,6 +199,7 @@ def make_fake_agent(
             message_history,
             on_step,
             catalog,
+            title_translator,
             memory_store,
             user_id,
         )
@@ -240,6 +242,7 @@ def make_run_agent_stub(
         message_history: object | None = None,
         on_step: object | None = None,
         catalog: object | None = None,
+        title_translator: object | None = None,
         memory_store: object | None = None,
         user_id: str | None = None,
     ) -> AgentResult:
@@ -252,6 +255,7 @@ def make_run_agent_stub(
             "message_history": message_history,
             "on_step": on_step,
             "catalog": catalog,
+            "title_translator": title_translator,
             "memory_store": memory_store,
             "user_id": user_id,
         }

--- a/apps/agent/agent/tests/unit/test_byok_credential_parsing.py
+++ b/apps/agent/agent/tests/unit/test_byok_credential_parsing.py
@@ -1,0 +1,154 @@
+"""Unit tests for BYOK header parsing (#284 T3-AC4, T3-AC5).
+
+Each truth-table row is asserted individually with its own expected verdict,
+mirroring the discipline used for the egress guard's own boundary table
+(T1-AC2) — a single "all reject" assertion would pass even if the parser
+picked the wrong reason for each case.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.agents.byok_models import ByokCredential, ByokError, parse_byok_credential
+
+pytestmark = pytest.mark.unit
+
+
+def test_no_byok_headers_returns_none() -> None:
+    """T3-AC4: absent headers must resolve to `None`, not a rejection."""
+    result = parse_byok_credential(
+        provider_header=None,
+        key_header=None,
+        model_header=None,
+        base_url_header=None,
+    )
+    assert result is None
+
+
+def test_openai_compatible_happy_path() -> None:
+    credential = parse_byok_credential(
+        provider_header="openai-compatible",
+        key_header=b"sk-fake-key",
+        model_header="gpt-test",
+        base_url_header=b"https://example.test/v1",
+    )
+    assert credential == ByokCredential(
+        provider="openai-compatible",
+        key="sk-fake-key",
+        model="gpt-test",
+        base_url="https://example.test/v1",
+    )
+
+
+def test_anthropic_happy_path_no_model_uses_default() -> None:
+    credential = parse_byok_credential(
+        provider_header="anthropic",
+        key_header=b"sk-ant-fake",
+        model_header=None,
+        base_url_header=None,
+    )
+    assert credential is not None
+    assert credential.provider == "anthropic"
+    assert credential.model
+    assert credential.base_url is None
+
+
+def test_gemini_happy_path_no_model_uses_default() -> None:
+    credential = parse_byok_credential(
+        provider_header="gemini",
+        key_header=b"gemini-fake",
+        model_header=None,
+        base_url_header=None,
+    )
+    assert credential is not None
+    assert credential.provider == "gemini"
+    assert credential.model
+
+
+def test_provider_present_key_empty_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="openai-compatible",
+            key_header=b"   ",
+            model_header="gpt-test",
+            base_url_header=None,
+        )
+    assert excinfo.value.code == "invalid_request"
+
+
+def test_provider_present_key_missing_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="anthropic",
+            key_header=None,
+            model_header=None,
+            base_url_header=None,
+        )
+    assert excinfo.value.code == "invalid_request"
+
+
+def test_unknown_provider_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="unknown-provider",
+            key_header=b"sk-fake",
+            model_header=None,
+            base_url_header=None,
+        )
+    assert excinfo.value.code == "invalid_request"
+
+
+def test_base_url_on_anthropic_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="anthropic",
+            key_header=b"sk-ant-fake",
+            model_header=None,
+            base_url_header=b"https://example.test",
+        )
+    assert excinfo.value.code == "invalid_request"
+
+
+def test_base_url_on_gemini_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="gemini",
+            key_header=b"gemini-fake",
+            model_header=None,
+            base_url_header=b"https://example.test",
+        )
+    assert excinfo.value.code == "invalid_request"
+
+
+def test_base_url_not_https_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="openai-compatible",
+            key_header=b"sk-fake",
+            model_header="gpt-test",
+            base_url_header=b"http://example.test",
+        )
+    assert excinfo.value.code == "invalid_request"
+
+
+def test_openai_compatible_missing_model_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="openai-compatible",
+            key_header=b"sk-fake",
+            model_header=None,
+            base_url_header=b"https://example.test",
+        )
+    assert excinfo.value.code == "invalid_request"
+
+
+def test_openai_compatible_blank_model_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="openai-compatible",
+            key_header=b"sk-fake",
+            model_header="   ",
+            base_url_header=None,
+        )
+    assert excinfo.value.code == "invalid_request"

--- a/apps/agent/agent/tests/unit/test_byok_credential_parsing.py
+++ b/apps/agent/agent/tests/unit/test_byok_credential_parsing.py
@@ -152,3 +152,43 @@ def test_openai_compatible_blank_model_rejected() -> None:
             base_url_header=None,
         )
     assert excinfo.value.code == "invalid_request"
+
+
+def test_openai_compatible_missing_base_url_rejected() -> None:
+    """P1-3/Fable P2-1: a dedicated parse-layer message — without this, a
+    missing base_url reached `validate_base_url(None)` at model-build time
+    and failed with the generic egress-validation message instead."""
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="openai-compatible",
+            key_header=b"sk-fake",
+            model_header="gpt-test",
+            base_url_header=None,
+        )
+    assert excinfo.value.code == "invalid_request"
+    assert "base-url" in excinfo.value.message.lower()
+
+
+def test_orphan_model_header_without_provider_or_key_is_rejected() -> None:
+    """P3 (both review seats): an `X-BYOK-Model` with neither provider nor
+    key is far more likely a caller mistake than a no-op — reject it rather
+    than silently falling back to the default model."""
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header=None,
+            key_header=None,
+            model_header="gpt-test",
+            base_url_header=None,
+        )
+    assert excinfo.value.code == "invalid_request"
+
+
+def test_orphan_base_url_header_without_provider_or_key_is_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header=None,
+            key_header=None,
+            model_header=None,
+            base_url_header=b"https://example.test",
+        )
+    assert excinfo.value.code == "invalid_request"

--- a/apps/agent/agent/tests/unit/test_chat_endpoint.py
+++ b/apps/agent/agent/tests/unit/test_chat_endpoint.py
@@ -167,10 +167,13 @@ def _replay_runtime(response: PublicAPIResponse, steps: list[StepEvent]) -> Magi
     async def _handle(
         request: object,
         *,
+        model: object | None = None,
+        is_byok: bool = False,
         user_id: str | None = None,
         user_type: str | None = None,
         on_step: OnStep | None = None,
     ) -> PublicAPIResponse:
+        del model, is_byok
         for step in steps:
             if on_step is not None:
                 await on_step(step)

--- a/apps/agent/agent/tests/unit/test_chat_tool_event_routes.py
+++ b/apps/agent/agent/tests/unit/test_chat_tool_event_routes.py
@@ -79,20 +79,26 @@ def _event_pair(
 async def _static_handler(
     _request: object,
     *,
+    model: object | None = None,
+    is_byok: bool = False,
     user_id: str | None = None,
     user_type: str | None = None,
     on_step: OnStep | None = None,
 ) -> PublicAPIResponse:
+    del model, is_byok
     return _response()
 
 
 async def _official_handler(
     _request: object,
     *,
+    model: object | None = None,
+    is_byok: bool = False,
     user_id: str | None = None,
     user_type: str | None = None,
     on_step: OnStep | None = None,
 ) -> PublicAPIResponse:
+    del model, is_byok
     deps = RuntimeDeps(MagicMock(), "en", "query", MockCatalogClient(), on_step=on_step)
     await tool_event_bridge(MagicMock(deps=deps), _events(_official_events()))
     return _response()
@@ -101,10 +107,13 @@ async def _official_handler(
 async def _timeout_handler(
     _request: object,
     *,
+    model: object | None = None,
+    is_byok: bool = False,
     user_id: str | None = None,
     user_type: str | None = None,
     on_step: OnStep | None = None,
 ) -> PublicAPIResponse:
+    del model, is_byok
     deps = RuntimeDeps(MagicMock(), "en", "query", MockCatalogClient(), on_step=on_step)
     call = ToolCallPart("web_search", {"query": "slow"}, tool_call_id="active-9")
     await tool_event_bridge(

--- a/apps/agent/agent/tests/unit/test_public_api_metering_hook.py
+++ b/apps/agent/agent/tests/unit/test_public_api_metering_hook.py
@@ -82,6 +82,25 @@ async def test_a_logged_in_turn_is_banked_against_the_user_pool() -> None:
     assert db.usage.accumulate_usage.await_args.kwargs["scope"] == "user"
 
 
+async def test_a_byok_turn_is_banked_at_zero_cost_but_full_token_counts() -> None:
+    """#284 T3: we did not pay the provider for a BYOK turn — `cost_usd` is
+    always zero, but token counts are still recorded for observability."""
+    db = _db()
+    stub = make_run_agent_stub(_metered_result())
+    with patch("agent.interfaces.public_api.run_animichi_agent", side_effect=stub):
+        await _api(db).handle(
+            PublicAPIRequest(text="京吹の聖地"),
+            is_byok=True,
+            user_id="user-1",
+            user_type="human",
+        )
+    kwargs = db.usage.accumulate_usage.await_args.kwargs
+    assert kwargs["scope"] == "byok"
+    assert kwargs["cost_usd"] == 0.0
+    assert kwargs["input_tokens"] == 1_000_000
+    assert kwargs["output_tokens"] == 500_000
+
+
 async def test_a_turn_that_raises_after_the_agent_ran_is_still_metered() -> None:
     """Persistence blew up, but the model was already paid for."""
     db = _db()

--- a/apps/agent/agent/tests/unit/test_usage_metering.py
+++ b/apps/agent/agent/tests/unit/test_usage_metering.py
@@ -68,6 +68,17 @@ def test_logged_in_traffic_is_metered_as_user_scope() -> None:
     assert scope_for_identity("user-1", "human") == "user"
 
 
+def test_byok_turn_is_metered_as_byok_scope() -> None:
+    """#284 T3: a logged-in BYOK turn is its own scope, not folded into "user"."""
+    assert scope_for_identity("user-1", "human", is_byok=True) == "byok"
+
+
+def test_byok_flag_wins_even_over_an_anonymous_shaped_identity() -> None:
+    """BYOK is login-gated so this pairing never occurs in production, but the
+    classifier must not silently mis-scope it if it ever did."""
+    assert scope_for_identity("anon_abc", "anonymous", is_byok=True) == "byok"
+
+
 def test_cost_prices_input_and_output_tokens_separately() -> None:
     usage = RunUsage(input_tokens=1_000_000, output_tokens=500_000)
     assert usage_cost_usd(usage, PRICES) == 6.0


### PR DESCRIPTION
## Summary

Implements Task 3 of #284 (BYOK spec) — BYOK model resolution and request-level injection. Base: `origin/feat/frontend-rebuild` (freshness confirmed against #458 T1, #474 T2, #467 T6, #451 T9, all merged).

- `agent/agents/byok_models.py` (new): header truth-table parsing (`ByokCredential`, `ByokError`) + per-family model construction. All three families (openai-compatible/anthropic/gemini) route through `build_guarded_async_client` (Task 1's SSRF guard + Task 2's httpx-instrumentation exclusion) — never a hand-rolled client. `AsyncOpenAI` built with `max_retries=0`.
- `agent/config/byok_defaults.py` (new): named default models for anthropic/gemini (OQ-1).
- `chat.py` / `_deps.py`: new `_get_byok_credential` dependency (reads `X-BYOK-Provider`/`X-BYOK-Model` normally, `X-BYOK-Key`/`X-BYOK-Base-Url` via `_middleware.py`'s `get_raw_sensitive_header` stash), anonymous+BYOK → `byok_requires_login` (403), malformed headers → pre-stream `invalid_request` (400), guaranteed `client.aclose()` in a `finally` around the turn.
- `public_api.py`: `is_byok` threaded through `handle` → `_dispatch_request` → `_model_request`/`_execute_pipeline`; new `byok_credential_rejected` taxonomy branch for a 401/403 from the caller's own provider (fixed, safe copy — never echoes `str(exc)`); `_http_status_for_response` maps it to 403.
  - **D18 fix**: `_apply_translation_gate` and `translate_anime_title` both previously inherited the *active run's* model by default (a cost/connection-reuse optimization) — which on a BYOK turn would silently spend the caller's own key on translation helper calls. Fixed by injecting a server-locked `title_translator` and passing `model=None` to the translation gate whenever `is_byok`.
- `usage_metering.py`: `scope_for_identity` gains a `byok` arm; BYOK turns record token counts but `cost_usd=0.0`.

## AC coverage (9/9)

| AC | Test |
|---|---|
| AC1 main-loop uses BYOK creds (transport-level) | `test_byok_model_construction.py::test_openai_compatible_reaches_the_wire_with_the_users_credential` |
| AC2 three families, correct adapter, `max_retries=0` | `test_byok_model_construction.py` (7 tests) |
| AC3 D18 boundary (helper=server, main=BYOK) | `test_byok_internal_calls_use_server_key.py` (4 tests) |
| AC4 null/empty golden | `test_byok_chat_routing.py::test_no_byok_headers_resolves_to_default_model`, `test_byok_credential_parsing.py` |
| AC5 truth table → 400 `invalid_request` | `test_byok_credential_parsing.py` (12 cases) + `test_byok_chat_routing.py` (4 parametrized) |
| AC6 `byok_credential_rejected`, zero fallback | `test_byok_error_taxonomy.py` |
| AC7 no key/base_url leak in body | `test_byok_error_taxonomy.py::test_byok_credential_rejection_never_leaks_the_key_or_base_url` |
| AC8 client closed even on raise | `test_byok_chat_routing.py::test_client_is_closed_even_when_the_turn_raises` |
| AC9 no persisted credential | `test_byok_chat_routing.py::test_byok_credential_never_reaches_app_state` |

Also: an ordering-pin regression for the P3 backlog item from #474 (`test_byok_instrumentation_ordering.py` — proves `GuardedAsyncTransport` must be built *after* `logfire.instrument_httpx()`), and a real regression fix in the Task 2 redaction suite (its fixture was missing `X-BYOK-Model`, which the new truth table now requires).

## Verification

- `make lint` / `make typecheck` (mypy strict scope) — clean.
- `make test` (unit): **1588 passed**, 89.56% coverage (floor 87%).
- Integration (offline arm blocked locally by an unrelated Atlas version mismatch — 1.2.4 installed vs pinned 0.30.0, a pre-existing environment gap, not from this change): all DB-independent integration tests pass, including all BYOK suites (41 tests) and the full non-DB subset of the existing integration suite.
- 5 targeted mutations spot-checked by hand (disable `byok_credential_rejected` branch, disable `byok_requires_login` gate, disable zero-cost override, disable D18 `title_translator` injection, revert `max_retries=0`) — each one kills its corresponding test.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `make test` (unit, 1588 passed)
- [x] Non-DB integration tests (BYOK suites + broader non-DB subset)
- [x] Manual mutation spot-checks (5/5 caught)
- [ ] Full `make test-integration` (blocked locally by Atlas 1.2.4 vs 0.30.0 pin mismatch — should run clean in CI)

Not merging — for review only, per process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)