### PR TITLE
fix(ci): give the changes job full history so push-event path filtering works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,15 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # On `push`, paths-filter diffs the event's `before` SHA against HEAD using
+          # local git (the API listFiles path is pull_request-only). The default
+          # fetch-depth of 1 leaves `before` unreachable, and `persist-credentials:
+          # false` means the action's own fallback fetch has no auth — it exits 128
+          # and every downstream lane, INCLUDING all eight deploy jobs, reports
+          # `skipping`. That is how the #483 merge to main deployed nothing while
+          # only this job showed red (2026-07-29, run 30429636371). Full history
+          # keeps the credentials hardening and makes `before` locally reachable.
+          fetch-depth: 0
           persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: f


### PR DESCRIPTION
## What broke

The `#483` merge to `main` (S1 Iteration 1, 22 PRs) ran **zero test lanes and deployed nothing**. Run [30429636371](https://github.com/lifeodyssey/animichi/actions/runs/30429636371): `changes` failed, and all 12 test lanes plus all 8 deploy jobs reported `skipping`.

## Root cause

`dorny/paths-filter` has two modes. On `pull_request` it calls the GitHub API `listFiles` — that path works and is what `permissions: pull-requests: read` (added 2026-07-28) fixed. On **`push`** it instead diffs the event's `before` SHA against `HEAD` with local git:

```
Changes will be detected between 02cd7fa0… and main
fatal: Not a valid object name 02cd7fa0…^{commit}
git fetch --depth=1 --no-tags origin 02cd7fa0…
fatal: could not read Username for 'https://github.com': No such device or address
##[error]The process '/usr/bin/git' failed with exit code 128
```

Two settings combine: checkout's default `fetch-depth: 1` leaves `before` unreachable, and `persist-credentials: false` (zizmor hardening) denies the action's own fallback fetch. The defect was invisible on every PR because PRs never take the git path — it only fires on push to `main`/`develop`.

## Fix

`fetch-depth: 0` on that one checkout. Keeps `persist-credentials: false`, so the security hardening is not rolled back; full history makes `before` locally reachable, which is the mode paths-filter documents for push events.

`ci.yml` is the only workflow using paths-filter. `actionlint` clean.

## Verification

Cannot be reproduced on a PR by construction (PRs use the API path). The real proof is the next push to `main`: `changes` must succeed and the deploy jobs must run rather than skip. Reviewers should treat "green on this PR" as **no evidence at all** and judge the mechanism.

## Related

Directly enables #484 (the post-deploy gate cannot assert anything if deploys never run) and is a second instance of the failure class in #457 — no roll-up job, so "everything skipped" renders as a mergeable board.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build validation by ensuring complete change history is available during checks.
  * Prevented valid updates from being incorrectly skipped when determining which areas require verification.
  * No changes to product functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->