### PR TITLE
docs: fix the stale dormant-Turnstile claim and pull two live credentials out of the tree

### DIFF
--- a/docs/design/palette-exploration.md
+++ b/docs/design/palette-exploration.md
@@ -21,7 +21,7 @@
 
 ## 分享预览
 - https://sharehtml.zhenjia.dev/s/7h4m2AU9eH （5 版迷你 hero,匿名存至 2027-06-19）
-- claimToken: `xGL5wMI50dGVXPLRmiWdXVXJld2pAKmb`（登录后认领/管理用）
+- claimToken: 本地保管，不入库（登录后认领/管理用）
 - 本地存档:`agent-review/palette-preview.{html,png}`、`palette-compare.png`
 
 ## 参考资源

--- a/docs/iterations/iter5/handoff-2026-07-26-s1x.md
+++ b/docs/iterations/iter5/handoff-2026-07-26-s1x.md
@@ -37,7 +37,7 @@ An active `/goal` governs this work. Its conditions, and where they stand:
 | PR | Card | Note |
 |---|---|---|
 | #435 | #261 S1.4 search cards + static map | Two P1s fixed (sentinel handling, SonarCloud S7727) |
-| #436 | #281 S1.9 Turnstile | Gate is **dormant** — built and tested, never called |
+| #436 | #281 S1.9 Turnstile | Gate was dormant when this was written; **#447 wired it** — `handleAnonymousV1` now calls `guardTurnstile`, which fails closed (403 `turnstile_required`) when `TURNSTILE_SECRET` is absent |
 | #439 | #271 S1.5 route card | AC3 (×1.3 coefficient) was already shipped; untouched |
 | #438 | #274 S1.8 anonymous + rate limit + budget breaker | Two P1s fixed (SSE buffering, metering exception tuple) |
 | #440 | #293 S1.13 eval gate + delivers #434's fix (issue itself still open, see note above) | P1 gate hole fixed (ModelHTTPError misclassification) |

--- a/docs/iterations/iter5/progress.md
+++ b/docs/iterations/iter5/progress.md
@@ -31,7 +31,7 @@ working method, the confirmed traps, and four decisions still waiting on the own
 
 ### Merged
 - `#435` S1.4 search content shapes + static map (C3a/C3b)
-- `#436` S1.9 Cloudflare Turnstile edge gate — **dormant**, not wired to any live path
+- `#436` S1.9 Cloudflare Turnstile edge gate — dormant as of this entry; **wired by #447** (see below)
 - `#439` S1.5 route card (TimedItinerary, map promotion, Walk CTA seam)
 - `#438` S1.8 anonymous access + edge rate limiting + daily budget breaker
 - `#440` S1.13 L0 smoke gate — classified actionable failures; delivers `#434`'s fix (issue stays open: non-default-branch merges don't fire `Closes`)

--- a/docs/superpowers/plans/2026-04-27-observability-error-chain.md
+++ b/docs/superpowers/plans/2026-04-27-observability-error-chain.md
@@ -399,7 +399,7 @@ First, get the read token from Logfire web UI (or use the write token for read a
 
 ```bash
 claude mcp add logfire \
-  -e LOGFIRE_READ_TOKEN="pylf_v1_us_NhmFgLwTWs60wGY4LwFbTVYw6DPY8DXnPQybln14M69b" \
+  -e LOGFIRE_READ_TOKEN="$LOGFIRE_READ_TOKEN" \
   -- uvx logfire-mcp@latest
 ```
 

--- a/docs/superpowers/plans/2026-04-27-observability-error-chain.md
+++ b/docs/superpowers/plans/2026-04-27-observability-error-chain.md
@@ -395,13 +395,16 @@ git commit -m "feat: improved error event handling in SSE parser"
 
 - [ ] **Step 1: Register Logfire MCP server with Claude Code**
 
-First, get the read token from Logfire web UI (or use the write token for read access):
+Use the hosted HTTP transport — it authenticates interactively, so no read token
+is pasted anywhere:
 
 ```bash
-claude mcp add logfire \
-  -e LOGFIRE_READ_TOKEN="$LOGFIRE_READ_TOKEN" \
-  -- uvx logfire-mcp@latest
+claude mcp add --transport http logfire https://logfire-us.pydantic.dev/mcp
 ```
+
+The older `uvx logfire-mcp@latest` form took a read token via `-e`, which is how
+a live `pylf_v1_…` token ended up committed to this file (removed 2026-07-29;
+the value itself is rotated in the Logfire console, not by deleting the line).
 
 - [ ] **Step 2: Verify MCP server is registered**
 


### PR DESCRIPTION
Two unrelated documentation defects, both found while preparing the repository to be made public.

## 1. The stale "dormant Turnstile" claim

- `docs/iterations/iter5/handoff-2026-07-26-s1x.md:40` — "Gate is **dormant** — built and tested, never called"
- `docs/iterations/iter5/progress.md:34` — "**dormant**, not wired to any live path"

Both predate #447, which wired it. On `main` today `handleAnonymousV1` calls `guardTurnstile`, and `worker/turnstile.ts:231-235` returns 403 `turnstile_required` when `TURNSTILE_SECRET` is unusable — it fails **closed**.

Two independent reviewers read these lines on two different PRs today and each raised a P1 built on them: that #493's staging Turnstile assertion could never pass and would permanently block production, and that staging exposed an unauthenticated LLM endpoint. Both were wrong; both were caught only by grepping the call site.

Review seats stay independent of each other, but they share the repository's account of itself. A stale doc is a single point of failure that produces *correlated* review errors — worse than isolated ones, because agreement reads as confirmation.

Both files are dated records, so the original wording is preserved and marked superseded rather than silently rewritten.

## 2. Two live credentials in tracked files

A full-history `gitleaks` + `trufflehog` scan found these on `main`:

- `docs/superpowers/plans/2026-04-27-observability-error-chain.md:402` — a real Logfire read token (`pylf_v1_…`) in an MCP setup snippet
- `docs/design/palette-exploration.md:24` — the claim token for the palette share preview

**Removing them here mitigates nothing on its own.** Both values remain reachable in git history, and GitHub keeps unreachable objects addressable by SHA. Rotation is the mitigation; this commit only stops them being visible to anyone reading the current tree.
