### PR TITLE
fix(web): call the session-migration endpoint on login (#507)

### DIFF
--- a/apps/web/src/components/auth/AuthCallback.tsx
+++ b/apps/web/src/components/auth/AuthCallback.tsx
@@ -6,6 +6,8 @@ import { getAuthToken } from "../../lib/auth/authSession";
 import { useAuthCallback } from "./useAuthCallback";
 import type { AuthCallbackSession, AuthCallbackState } from "./useAuthCallback";
 
+import type { SessionMigrationOutcome } from "../../lib/auth/sessionMigration";
+
 type MessageState = Extract<AuthCallbackState, "pending" | "error">;
 
 function CallbackMessage({ state }: Readonly<{ state: MessageState }>) {
@@ -38,6 +40,25 @@ function SaveFailure({ auth, session }: FailureProps) {
   );
 }
 
+/**
+ * The claim did not land (#507 review P1-3). Same shape and classes as the
+ * save failure above, deliberately: `apps/web` has no telemetry sink, so this
+ * screen is the only real outlet, and reusing the designed surface keeps it a
+ * variant rather than a new pattern (the design sync has no callback mock).
+ * `nothing-migrated` gets its own copy — that is the cross-device case, where
+ * the work is on the other browser and a retry here cannot reach it.
+ */
+function MigrationFailure({ auth, session }: FailureProps) {
+  const text = session.migration === "nothing-migrated" ? auth.callback_migration_missing : auth.callback_migration_failed;
+  return (
+    <div className="auth-callback__save-failed" role="alert">
+      <p className="auth-callback__message">{text}</p>
+      <CallbackAction label={auth.callback_migration_retry} className="auth-callback__retry" onClick={session.retryMigration} />
+      <CallbackAction label={auth.callback_migration_skip} className="auth-callback__skip" onClick={session.dismissMigration} />
+    </div>
+  );
+}
+
 export interface AuthCallbackProps {
   readonly onDone: () => void;
   /** #480 P1-2 ruling: when the login carried a BYOK deep-link (`next`), a
@@ -46,8 +67,12 @@ export interface AuthCallbackProps {
    * return target still happens. Without a return intent, today's blocking
    * retry/skip surface is preserved. */
   readonly hasReturnIntent?: boolean;
+  /** The login's return target named a chat session, so a migration that moved
+   * nothing is an anomaly rather than a normal no-op (#507 review P1-2). */
+  readonly expectsMigration?: boolean;
   readonly establish?: () => Promise<string | undefined>;
   readonly replay?: () => Promise<DeferredReplayOutcome>;
+  readonly migrate?: (token: string) => Promise<SessionMigrationOutcome>;
 }
 
 function shouldNavigate(state: AuthCallbackState, hasReturnIntent: boolean): boolean {
@@ -64,14 +89,17 @@ function CallbackBody({ session }: Readonly<{ session: AuthCallbackSession }>) {
   const auth = useDict().auth;
   if (session.state === "done") return null;
   if (session.state === "save-failed") return <SaveFailure auth={auth} session={session} />;
+  if (session.state === "migration-failed") return <MigrationFailure auth={auth} session={session} />;
   return <CallbackMessage state={session.state} />;
 }
 
 /** `/auth/callback` body: redeems the session, replays a deferred save, then
  * hands control back to the route — unless that replay failed AND no return
  * intent is waiting (see `hasReturnIntent`). */
-export function AuthCallback({ onDone, hasReturnIntent = false, establish = getAuthToken, replay }: AuthCallbackProps) {
-  const session = useAuthCallback(establish, replay);
+export function AuthCallback(
+  { onDone, hasReturnIntent = false, expectsMigration = false, establish = getAuthToken, replay, migrate }: AuthCallbackProps,
+) {
+  const session = useAuthCallback(establish, replay, migrate, expectsMigration);
   useDoneEffect(session.state, onDone, hasReturnIntent);
   return <CallbackBody session={session} />;
 }

--- a/apps/web/src/components/auth/useAuthCallback.ts
+++ b/apps/web/src/components/auth/useAuthCallback.ts
@@ -60,8 +60,12 @@ async function withTimeout<T>(run: () => Promise<T>, ms: number, onTimeout: T): 
  *
  * A timeout is recorded as `failed`. The `withTimeout` race does not abort the
  * request, so the server may still succeed afterwards and this becomes a false
- * negative — harmless now that the edge keeps the `aid` cookie (#507 owner
- * ruling): the retry it offers is the same idempotent zero-row `UPDATE`.
+ * negative. This is **the one** case the #507 owner ruling actually rescues:
+ * under the old edge the server's `migrated: true` would have retired the `aid`
+ * cookie, leaving the retry with no identity to present. Every other failure
+ * branch already kept its cookie — retirement was gated on `didMigrate` — so
+ * "keeping the cookie makes failures recoverable" is true for this timing race
+ * and not in general. Either way the retry is the same idempotent `UPDATE`.
  */
 async function runMigration(migrate: Migrate, token: string, expected: boolean): Promise<MigrationState> {
   const outcome = await withTimeout(() => migrate(token), MIGRATE_TIMEOUT_MS, "failed")

--- a/apps/web/src/components/auth/useAuthCallback.ts
+++ b/apps/web/src/components/auth/useAuthCallback.ts
@@ -2,20 +2,32 @@ import { useCallback, useEffect, useState } from "react";
 import { replayDeferredSave } from "../../features/chat/save/createOnLogin";
 import type { DeferredReplayOutcome } from "../../features/chat/save/createOnLogin";
 import { getAuthToken } from "../../lib/auth/authSession";
-import { migrateAnonymousSession, reportMigrationFailure } from "../../lib/auth/sessionMigration";
-import type { SessionMigrationOutcome } from "../../lib/auth/sessionMigration";
+import {
+  MIGRATE_TIMEOUT_MS,
+  anomalyOf,
+  migrateAnonymousSession,
+  reportMigrationAnomaly,
+} from "../../lib/auth/sessionMigration";
+import type { MigrationAnomaly, SessionMigrationOutcome } from "../../lib/auth/sessionMigration";
 
 /**
  * `save-failed` is a *successful* login whose create-on-login replay failed. It
  * is reported rather than folded into `done`, because the intent survives a
  * failed replay: reporting a clean login would leave it to fire unannounced on
  * the next login inside its TTL.
+ *
+ * `migration-failed` is the same idea for the anonymous-session claim (#507
+ * review P1-3). `apps/web` has no telemetry sink, so a log line reaches nobody
+ * — the visitor is the only party who can act, and the only real outlet.
  */
-export type AuthCallbackState = "pending" | "done" | "error" | "save-failed";
+export type AuthCallbackState = "pending" | "done" | "error" | "save-failed" | "migration-failed";
 type Establish = () => Promise<string | undefined>;
 type Replay = () => Promise<DeferredReplayOutcome>;
 type Migrate = (token: string) => Promise<SessionMigrationOutcome>;
 type SetState = (state: AuthCallbackState) => void;
+
+/** `undefined` = landed; `"dismissed"` = the visitor chose to move on. */
+type MigrationState = MigrationAnomaly | "dismissed" | undefined;
 
 const FAILED_REPLAY: DeferredReplayOutcome = "failed";
 
@@ -27,12 +39,11 @@ function stateFor(outcome: DeferredReplayOutcome): AuthCallbackState {
  * stalled users service degrades to the same surfaced-failure path as a 5xx. */
 export const REPLAY_TIMEOUT_MS = 8_000;
 
-/** The migration is a single identity-dimensional `UPDATE` behind one edge hop.
- * It gets the replay's budget for the replay's reason — a stalled service must
- * degrade to the failure path rather than pin the visitor on this screen. */
-export const MIGRATE_TIMEOUT_MS = REPLAY_TIMEOUT_MS;
-
-function withTimeout<T>(run: () => Promise<T>, ms: number, onTimeout: T): Promise<T> {
+/** `async` on purpose: it turns a collaborator that throws *synchronously* into
+ * a rejected promise. Without it the throw escapes past the caller's `.catch`
+ * — the exact fragility that made a failed claim report the login as an error
+ * (#507 review P2). */
+async function withTimeout<T>(run: () => Promise<T>, ms: number, onTimeout: T): Promise<T> {
   return Promise.race([
     run(),
     new Promise<T>((resolve) => setTimeout(() => { resolve(onTimeout); }, ms)),
@@ -40,21 +51,36 @@ function withTimeout<T>(run: () => Promise<T>, ms: number, onTimeout: T): Promis
 }
 
 /**
- * Issue #507: the ownership migration must not block the login, because the
- * login already succeeded — the visitor is authenticated whatever this returns,
- * and stranding them on an interstitial over it would be a worse outcome than
- * the thing it reports. It is not silent either:
+ * Structurally incapable of rejecting (#507 review P2). It rides a
+ * `Promise.all` beside the replay, so a throw here would reject the whole
+ * `redeem` and report a *successful* login as `"error"`. `migrateAnonymousSession`
+ * already catches, but relying on a collaborator's internals for that is the
+ * fragile version — this makes it a property of the call site, and a
+ * throwing-migrate test pins it.
  *
- *  - the failure is recorded as a structured event, and
- *  - it is genuinely recoverable without the visitor doing anything. The edge
- *    retires the `aid` cookie only on `{"migrated": true}`, so a failed run
- *    leaves the anonymous identity — and the work it owns — intact, and the
- *    next login on this browser migrates it. A user-facing retry would buy a
- *    prompt over a path that already self-heals.
+ * A timeout is recorded as `failed`. The `withTimeout` race does not abort the
+ * request, so the server may still succeed afterwards and this becomes a false
+ * negative — harmless now that the edge keeps the `aid` cookie (#507 owner
+ * ruling): the retry it offers is the same idempotent zero-row `UPDATE`.
  */
-async function runMigration(migrate: Migrate, token: string): Promise<void> {
-  const outcome = await withTimeout(() => migrate(token), MIGRATE_TIMEOUT_MS, "failed");
-  if (outcome === "failed") reportMigrationFailure();
+async function runMigration(migrate: Migrate, token: string, expected: boolean): Promise<MigrationState> {
+  const outcome = await withTimeout(() => migrate(token), MIGRATE_TIMEOUT_MS, "failed")
+    .catch((): SessionMigrationOutcome => "failed");
+  const anomaly = anomalyOf(outcome, expected);
+  if (anomaly !== undefined) reportMigrationAnomaly(anomaly);
+  return anomaly;
+}
+
+interface Collaborators {
+  readonly establish: Establish;
+  readonly replay: Replay;
+  readonly migrate: Migrate;
+  readonly expectsMigration: boolean;
+}
+
+interface RedeemResult {
+  readonly state: AuthCallbackState;
+  readonly migration: MigrationState;
 }
 
 /** Create-on-login: a login the save CTA started replays its deferred intent;
@@ -64,45 +90,52 @@ async function runMigration(migrate: Migrate, token: string): Promise<void> {
  * share no data (the migration re-points `conversations.user_id` in the agent's
  * database; the replay creates a *fresh* route through the users Worker from
  * client-held point ids), and both already hold the token `establish` returned.
- * Serialising them would double this interstitial's worst case to 16s to buy
- * an ordering nothing depends on. When both fail the visitor sees the save
- * failure alone — the one they asked for and can act on. */
-async function redeem(establish: Establish, replay: Replay, migrate: Migrate): Promise<AuthCallbackState> {
-  const token = await establish();
-  if (!token) return "error";
-  const [outcome] = await Promise.all([
-    withTimeout(replay, REPLAY_TIMEOUT_MS, FAILED_REPLAY),
-    runMigration(migrate, token),
+ * Serialising them would add the migration's budget to this interstitial's
+ * worst case to buy an ordering nothing depends on. */
+async function redeem(c: Collaborators): Promise<RedeemResult> {
+  const token = await c.establish();
+  if (!token) return { state: "error", migration: undefined };
+  const [outcome, migration] = await Promise.all([
+    withTimeout(c.replay, REPLAY_TIMEOUT_MS, FAILED_REPLAY),
+    runMigration(c.migrate, token, c.expectsMigration),
   ]);
-  return stateFor(outcome);
+  return { state: stateFor(outcome), migration };
 }
+
+type SetMigration = (migration: MigrationState) => void;
 
 /** Redeems the token once, dropping the result if the component unmounted first.
  * A rejection is a failed login, not an unhandled promise. */
-function establishEffect(est: Establish, replay: Replay, migrate: Migrate, setState: SetState): () => void {
+function establishEffect(c: Collaborators, setState: SetState, setMigration: SetMigration): () => void {
   let active = true;
-  void redeem(est, replay, migrate)
-    .catch((): AuthCallbackState => "error")
-    .then((state) => { if (active) setState(state); });
+  const apply = (r: RedeemResult) => { if (active) { setMigration(r.migration); setState(r.state); } };
+  void redeem(c).catch((): RedeemResult => ({ state: "error", migration: undefined })).then(apply);
   return () => { active = false; };
 }
 
-function useEstablishOnce(
-  establish: Establish, replay: Replay, migrate: Migrate, setState: SetState,
-): void {
+function useEstablishOnce(c: Collaborators, setState: SetState, setMigration: SetMigration): void {
+  const { establish, replay, migrate, expectsMigration } = c;
   useEffect(
-    () => establishEffect(establish, replay, migrate, setState),
-    [establish, replay, migrate, setState],
+    () => establishEffect({ establish, replay, migrate, expectsMigration }, setState, setMigration),
+    [establish, replay, migrate, expectsMigration, setState, setMigration],
   );
 }
 
 export interface AuthCallbackSession {
   readonly state: AuthCallbackState;
+  /** Which anomaly the migration notice is reporting, for its copy. */
+  readonly migration: MigrationAnomaly | undefined;
   /** Re-run only the create-on-login replay; the session is already redeemed. */
   readonly retrySave: () => void;
   /** Give up on the deferred save *here*; the intent survives for the next login
    * inside its TTL, which is what replays it. */
   readonly dismissSave: () => void;
+  /** Re-run only the ownership claim. Safe to repeat: the server-side `UPDATE`
+   * matches zero rows the second time, and the `aid` cookie still resolves. */
+  readonly retryMigration: () => void;
+  /** Move on without the claim. The anonymous work stays behind that identity,
+   * reachable by a later login — until the 30-day routeless-session purge. */
+  readonly dismissMigration: () => void;
 }
 
 function useRetrySave(replay: Replay, setState: SetState): () => void {
@@ -114,6 +147,30 @@ function useRetrySave(replay: Replay, setState: SetState): () => void {
   }, [replay, setState]);
 }
 
+/** The claim needs a bearer of its own; `establish` re-reads the cached token. */
+async function retriedMigration(c: Collaborators): Promise<MigrationState> {
+  const token = await c.establish();
+  if (!token) return "failed";
+  return runMigration(c.migrate, token, c.expectsMigration);
+}
+
+function useRetryMigration(c: Collaborators, setMigration: SetMigration): () => void {
+  const { establish, migrate, replay, expectsMigration } = c;
+  return useCallback(() => {
+    void retriedMigration({ establish, migrate, replay, expectsMigration })
+      .catch((): MigrationState => "failed")
+      .then(setMigration);
+  }, [establish, migrate, replay, expectsMigration, setMigration]);
+}
+
+/** The save surface wins while it is showing: it is the thing the visitor
+ * asked for and can act on. The migration notice takes over once that is
+ * settled, so neither failure is swallowed by the other. */
+function derivedState(state: AuthCallbackState, migration: MigrationState): AuthCallbackState {
+  if (state !== "done") return state;
+  return migration === undefined || migration === "dismissed" ? "done" : "migration-failed";
+}
+
 /**
  * Redeems the Better Auth session cookie (set on the Neon Auth origin by the
  * magic-link verify redirect) for the app's cached bearer token, then replays a
@@ -121,14 +178,40 @@ function useRetrySave(replay: Replay, setState: SetState): () => void {
  * browser's anonymous sessions for the new account (#507). `establish`,
  * `replay` and `migrate` are injectable for tests; production callers — every
  * magic-link, OTP and OAuth login funnels through here — rely on the defaults.
+ *
+ * `expectsMigration` says the login's return target named a chat session, so a
+ * `{"migrated": false}` is an anomaly rather than a normal no-op.
  */
 export function useAuthCallback(
-  establish: Establish = getAuthToken,
-  replay: Replay = replayDeferredSave,
-  migrate: Migrate = migrateAnonymousSession,
+  establish: Establish = getAuthToken, replay: Replay = replayDeferredSave,
+  migrate: Migrate | undefined = migrateAnonymousSession, expectsMigration = false,
 ): AuthCallbackSession {
+  return useCallbackSession({ establish, replay, migrate, expectsMigration });
+}
+
+function useCallbackSession(c: Collaborators): AuthCallbackSession {
   const [state, setState] = useState<AuthCallbackState>("pending");
-  useEstablishOnce(establish, replay, migrate, setState);
-  const dismissSave = useCallback(() => { setState("done"); }, []);
-  return { state, retrySave: useRetrySave(replay, setState), dismissSave };
+  const [migration, setMigration] = useState<MigrationState>(undefined);
+  useEstablishOnce(c, setState, setMigration);
+  const surfaced = { state: derivedState(state, migration), migration: shown(migration) };
+  return { ...surfaced, ...useSaveActions(c.replay, setState), ...useClaimActions(c, setMigration) };
+}
+
+/** A dismissed notice is gone, not merely hidden: nothing should re-render it. */
+function shown(migration: MigrationState): MigrationAnomaly | undefined {
+  return migration === "dismissed" ? undefined : migration;
+}
+
+function useSaveActions(replay: Replay, setState: SetState) {
+  return {
+    retrySave: useRetrySave(replay, setState),
+    dismissSave: useCallback(() => { setState("done"); }, [setState]),
+  };
+}
+
+function useClaimActions(c: Collaborators, setMigration: SetMigration) {
+  return {
+    retryMigration: useRetryMigration(c, setMigration),
+    dismissMigration: useCallback(() => { setMigration("dismissed"); }, [setMigration]),
+  };
 }

--- a/apps/web/src/components/auth/useAuthCallback.ts
+++ b/apps/web/src/components/auth/useAuthCallback.ts
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from "react";
 import { replayDeferredSave } from "../../features/chat/save/createOnLogin";
 import type { DeferredReplayOutcome } from "../../features/chat/save/createOnLogin";
 import { getAuthToken } from "../../lib/auth/authSession";
+import { migrateAnonymousSession, reportMigrationFailure } from "../../lib/auth/sessionMigration";
+import type { SessionMigrationOutcome } from "../../lib/auth/sessionMigration";
 
 /**
  * `save-failed` is a *successful* login whose create-on-login replay failed. It
@@ -12,7 +14,10 @@ import { getAuthToken } from "../../lib/auth/authSession";
 export type AuthCallbackState = "pending" | "done" | "error" | "save-failed";
 type Establish = () => Promise<string | undefined>;
 type Replay = () => Promise<DeferredReplayOutcome>;
+type Migrate = (token: string) => Promise<SessionMigrationOutcome>;
 type SetState = (state: AuthCallbackState) => void;
+
+const FAILED_REPLAY: DeferredReplayOutcome = "failed";
 
 function stateFor(outcome: DeferredReplayOutcome): AuthCallbackState {
   return outcome === "failed" ? "save-failed" : "done";
@@ -22,35 +27,73 @@ function stateFor(outcome: DeferredReplayOutcome): AuthCallbackState {
  * stalled users service degrades to the same surfaced-failure path as a 5xx. */
 export const REPLAY_TIMEOUT_MS = 8_000;
 
-function withTimeout(replay: Replay, ms: number): Promise<DeferredReplayOutcome> {
+/** The migration is a single identity-dimensional `UPDATE` behind one edge hop.
+ * It gets the replay's budget for the replay's reason — a stalled service must
+ * degrade to the failure path rather than pin the visitor on this screen. */
+export const MIGRATE_TIMEOUT_MS = REPLAY_TIMEOUT_MS;
+
+function withTimeout<T>(run: () => Promise<T>, ms: number, onTimeout: T): Promise<T> {
   return Promise.race([
-    replay(),
-    new Promise<DeferredReplayOutcome>((resolve) => setTimeout(() => { resolve("failed"); }, ms)),
+    run(),
+    new Promise<T>((resolve) => setTimeout(() => { resolve(onTimeout); }, ms)),
   ]);
 }
 
+/**
+ * Issue #507: the ownership migration must not block the login, because the
+ * login already succeeded — the visitor is authenticated whatever this returns,
+ * and stranding them on an interstitial over it would be a worse outcome than
+ * the thing it reports. It is not silent either:
+ *
+ *  - the failure is recorded as a structured event, and
+ *  - it is genuinely recoverable without the visitor doing anything. The edge
+ *    retires the `aid` cookie only on `{"migrated": true}`, so a failed run
+ *    leaves the anonymous identity — and the work it owns — intact, and the
+ *    next login on this browser migrates it. A user-facing retry would buy a
+ *    prompt over a path that already self-heals.
+ */
+async function runMigration(migrate: Migrate, token: string): Promise<void> {
+  const outcome = await withTimeout(() => migrate(token), MIGRATE_TIMEOUT_MS, "failed");
+  if (outcome === "failed") reportMigrationFailure();
+}
+
 /** Create-on-login: a login the save CTA started replays its deferred intent;
- * any other login (the D8/D11 banners) finds none and saves nothing. */
-async function redeem(establish: Establish, replay: Replay): Promise<AuthCallbackState> {
+ * any other login (the D8/D11 banners) finds none and saves nothing.
+ *
+ * The migration runs **alongside** the replay, not before or after it: they
+ * share no data (the migration re-points `conversations.user_id` in the agent's
+ * database; the replay creates a *fresh* route through the users Worker from
+ * client-held point ids), and both already hold the token `establish` returned.
+ * Serialising them would double this interstitial's worst case to 16s to buy
+ * an ordering nothing depends on. When both fail the visitor sees the save
+ * failure alone — the one they asked for and can act on. */
+async function redeem(establish: Establish, replay: Replay, migrate: Migrate): Promise<AuthCallbackState> {
   const token = await establish();
   if (!token) return "error";
-  return stateFor(await withTimeout(replay, REPLAY_TIMEOUT_MS));
+  const [outcome] = await Promise.all([
+    withTimeout(replay, REPLAY_TIMEOUT_MS, FAILED_REPLAY),
+    runMigration(migrate, token),
+  ]);
+  return stateFor(outcome);
 }
 
 /** Redeems the token once, dropping the result if the component unmounted first.
  * A rejection is a failed login, not an unhandled promise. */
-function establishEffect(establish: Establish, replay: Replay, setState: SetState): () => void {
+function establishEffect(est: Establish, replay: Replay, migrate: Migrate, setState: SetState): () => void {
   let active = true;
-  void redeem(establish, replay)
+  void redeem(est, replay, migrate)
     .catch((): AuthCallbackState => "error")
     .then((state) => { if (active) setState(state); });
-  return () => {
-    active = false;
-  };
+  return () => { active = false; };
 }
 
-function useEstablishOnce(establish: Establish, replay: Replay, setState: SetState): void {
-  useEffect(() => establishEffect(establish, replay, setState), [establish, replay, setState]);
+function useEstablishOnce(
+  establish: Establish, replay: Replay, migrate: Migrate, setState: SetState,
+): void {
+  useEffect(
+    () => establishEffect(establish, replay, migrate, setState),
+    [establish, replay, migrate, setState],
+  );
 }
 
 export interface AuthCallbackSession {
@@ -65,7 +108,7 @@ export interface AuthCallbackSession {
 function useRetrySave(replay: Replay, setState: SetState): () => void {
   return useCallback(() => {
     setState("pending");
-    void withTimeout(replay, REPLAY_TIMEOUT_MS)
+    void withTimeout(replay, REPLAY_TIMEOUT_MS, FAILED_REPLAY)
       .catch((): DeferredReplayOutcome => "failed")
       .then((outcome) => { setState(stateFor(outcome)); });
   }, [replay, setState]);
@@ -74,15 +117,18 @@ function useRetrySave(replay: Replay, setState: SetState): () => void {
 /**
  * Redeems the Better Auth session cookie (set on the Neon Auth origin by the
  * magic-link verify redirect) for the app's cached bearer token, then replays a
- * deferred save when the login came from the 「保存する」 CTA. `establish` and
- * `replay` are injectable for tests; production callers rely on the defaults.
+ * deferred save when the login came from the 「保存する」 CTA, and claims the
+ * browser's anonymous sessions for the new account (#507). `establish`,
+ * `replay` and `migrate` are injectable for tests; production callers — every
+ * magic-link, OTP and OAuth login funnels through here — rely on the defaults.
  */
 export function useAuthCallback(
   establish: Establish = getAuthToken,
   replay: Replay = replayDeferredSave,
+  migrate: Migrate = migrateAnonymousSession,
 ): AuthCallbackSession {
   const [state, setState] = useState<AuthCallbackState>("pending");
-  useEstablishOnce(establish, replay, setState);
+  useEstablishOnce(establish, replay, migrate, setState);
   const dismissSave = useCallback(() => { setState("done"); }, []);
   return { state, retrySave: useRetrySave(replay, setState), dismissSave };
 }

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -45,6 +45,7 @@ import { useTurnTiming } from "./use-turn-timing";
 import { useTurnstileChallenge, useTurnstileReady } from "./use-turnstile-challenge";
 import type { TurnstileChallenge } from "./use-turnstile-challenge";
 import type { ConversationHistory } from "./use-conversation-history";
+import { ChatReturnTargetProvider } from "./return-target";
 
 export interface ChatPageProps {
   readonly search: ChatSearch;
@@ -326,13 +327,21 @@ function ChatPageView({ search, page }: Readonly<{ search: ChatSearch; page: Pag
   );
 }
 
+/** Publishes the live session id so every in-chat login wall can send the
+ * visitor back to this conversation after signing in (#507 review P1-1). */
+function withReturnTarget(search: ChatSearch, page: PageState) {
+  return (
+    <ChatReturnTargetProvider sessionIdOf={page.chat.sessionIdOf}>
+      <ChatPageView search={search} page={page} />
+    </ChatReturnTargetProvider>
+  );
+}
+
 export function ChatPage({ search }: ChatPageProps) {
   const page = useChatPage(search);
   return (
     <SpotSelectionProvider selection={page.selection}>
-      <ChatActionsProvider actions={page.actions}>
-        <ChatPageView search={search} page={page} />
-      </ChatActionsProvider>
+      <ChatActionsProvider actions={page.actions}>{withReturnTarget(search, page)}</ChatActionsProvider>
     </SpotSelectionProvider>
   );
 }

--- a/apps/web/src/features/chat/components/ErrorStates/LimitBanner.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/LimitBanner.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { LoginModal } from "../../../../components/auth/LoginModal";
+import { useChatReturnTarget } from "../../return-target";
 import { FallbackRetryButton } from "./FallbackRetryButton";
 
 type Props = Readonly<{
@@ -50,7 +51,7 @@ export function LimitBanner({ block, message, loginLabel, id, role = "alert", se
     <div className={block} id={id} role={role}>
       <span>{message}</span>
       <LoginAction block={block} loginLabel={loginLabel} onLogin={login.show} secondary={secondary} />
-      <LoginModal open={login.open} onClose={login.hide} />
+      <LoginModal open={login.open} onClose={login.hide} returnTarget={useChatReturnTarget()} />
     </div>
   );
 }

--- a/apps/web/src/features/chat/components/ErrorStates/SessionExpired.tsx
+++ b/apps/web/src/features/chat/components/ErrorStates/SessionExpired.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { LoginModal } from "../../../../components/auth/LoginModal";
 import type { ChatDict } from "../../i18n";
+import { useChatReturnTarget } from "../../return-target";
 import { FallbackRetryButton } from "./FallbackRetryButton";
 
 type Props = Readonly<{ dict: ChatDict; onResume: () => void; recovering?: boolean }>;
@@ -26,12 +27,12 @@ function ExpiryActions({ dict, onLogin, onResume, recovering }: ActionProps) {
  * opens in place and resume re-reads the session's final state afterwards.
  */
 export function SessionExpired({ dict, onResume, recovering }: Props) {
-  const [loginOpen, setLoginOpen] = useState(false);
+  const [open, setOpen] = useState(false);
   return (
     <div className="chat-session-expired" role="alert">
       <span>{dict.errorStates.d8Message}</span>
-      <ExpiryActions dict={dict} onLogin={() => { setLoginOpen(true); }} onResume={onResume} recovering={recovering} />
-      <LoginModal open={loginOpen} onClose={() => { setLoginOpen(false); }} />
+      <ExpiryActions dict={dict} onLogin={() => { setOpen(true); }} onResume={onResume} recovering={recovering} />
+      <LoginModal open={open} onClose={() => { setOpen(false); }} returnTarget={useChatReturnTarget()} />
     </div>
   );
 }

--- a/apps/web/src/features/chat/components/TimedItinerary.tsx
+++ b/apps/web/src/features/chat/components/TimedItinerary.tsx
@@ -146,10 +146,22 @@ function SaveCta({ save, dict, saveDeps }: Omit<ItineraryProps, "view">) {
 }
 
 /** The P5 save wall carries the session back (#507 review P1-1): without a
- * return target a correct migration still lands the visitor on `/`. */
+ * return target a correct migration still lands the visitor on `/`.
+ *
+ * The hook is read **before** the early return, not inside the JSX after it
+ * (#514 review round 2). It is inert today — `useChatReturnTarget` wraps only
+ * `useContext`, and `readContext` never joins the hook list, so no ordering can
+ * shift. But it is a Rules-of-Hooks violation, and this repo cannot catch it:
+ * the root `.oxlintrc.json` runs `plugins: ["typescript"]` with
+ * `categories.correctness: "off"`, and `apps/web` adds only
+ * `max-lines-per-function` — not one react-hooks rule is enabled anywhere, so
+ * a green lint carries no information here. The day `useChatReturnTarget` grows
+ * a `useMemo`, or React Compiler lands, this becomes a runtime crash in the
+ * headline #507 component. */
 function SaveLoginWall({ gate }: Readonly<{ gate: ReturnType<typeof useSaveGate> }>) {
+  const returnTarget = useChatReturnTarget();
   if (!gate.loginOpen) return null;
-  return <LoginModal open onClose={gate.closeLogin} onSendCommitted={gate.markSendCommitted} returnTarget={useChatReturnTarget()} />;
+  return <LoginModal open onClose={gate.closeLogin} onSendCommitted={gate.markSendCommitted} returnTarget={returnTarget} />;
 }
 
 function CtaRow({ view, dict, save, saveDeps }: ItineraryProps) {

--- a/apps/web/src/features/chat/components/TimedItinerary.tsx
+++ b/apps/web/src/features/chat/components/TimedItinerary.tsx
@@ -1,4 +1,5 @@
 import { LoginModal } from "../../../components/auth/LoginModal";
+import { useChatReturnTarget } from "../return-target";
 import type { ItineraryLeg, ItineraryStation, ItineraryView } from "../../../lib/chat/itinerary";
 import type { ChatDict } from "../i18n";
 import { legCapsule } from "../route-copy";
@@ -139,9 +140,16 @@ function SaveCta({ save, dict, saveDeps }: Omit<ItineraryProps, "view">) {
     <>
       <SaveButton gate={gate} dict={dict} />
       <SaveFeedback gate={gate} dict={dict} />
-      {gate.loginOpen ? <LoginModal open onClose={gate.closeLogin} onSendCommitted={gate.markSendCommitted} /> : null}
+      <SaveLoginWall gate={gate} />
     </>
   );
+}
+
+/** The P5 save wall carries the session back (#507 review P1-1): without a
+ * return target a correct migration still lands the visitor on `/`. */
+function SaveLoginWall({ gate }: Readonly<{ gate: ReturnType<typeof useSaveGate> }>) {
+  if (!gate.loginOpen) return null;
+  return <LoginModal open onClose={gate.closeLogin} onSendCommitted={gate.markSendCommitted} returnTarget={useChatReturnTarget()} />;
 }
 
 function CtaRow({ view, dict, save, saveDeps }: ItineraryProps) {

--- a/apps/web/src/features/chat/return-target.tsx
+++ b/apps/web/src/features/chat/return-target.tsx
@@ -1,0 +1,63 @@
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+
+/**
+ * Where a login opened from inside the chat should land (issue #507 review).
+ *
+ * Wiring `/v1/session/migrate` re-points the anonymous sessions onto the
+ * account, but that is only half a fix: `/chat?session=<id>` is the **only**
+ * entry in the app that reads a migrated session back — there is no session or
+ * route list — and none of the three in-chat login walls carried a return
+ * target. `sanitizeReturnTarget(undefined)` is `/`, so every one of them
+ * migrated the work correctly and then dropped the visitor on the landing page
+ * with no way back to it.
+ *
+ * The live session id cannot come from the URL: `?session=` is an *entry*
+ * parameter, and the id the backend assigns mid-conversation is never written
+ * back to the address bar (`ChatPage` does not navigate). It lives only in
+ * `useChatSession`'s tracker ref, which is why it is published through context
+ * rather than read off `location` — and through the reader function rather than
+ * the value, since the ref deliberately does not re-render on change.
+ */
+export const CHAT_SESSION_PARAM = "session";
+
+type SessionIdReader = () => string | undefined;
+
+const ChatSessionIdContext = createContext<SessionIdReader>(() => undefined);
+
+/** `/chat?session=<id>`, or nothing when no session exists to return to. */
+export function chatSessionTarget(sessionId: string | undefined): string | undefined {
+  if (sessionId === undefined || sessionId === "") return undefined;
+  return `/chat?${CHAT_SESSION_PARAM}=${encodeURIComponent(sessionId)}`;
+}
+
+interface ProviderProps {
+  readonly sessionIdOf: SessionIdReader;
+  readonly children: ReactNode;
+}
+
+export function ChatReturnTargetProvider({ sessionIdOf, children }: ProviderProps) {
+  return <ChatSessionIdContext value={sessionIdOf}>{children}</ChatSessionIdContext>;
+}
+
+/**
+ * The return target for a login wall rendered inside the chat. `undefined`
+ * outside a chat (the landing-page modal), which keeps today's `/` behaviour.
+ */
+export function useChatReturnTarget(): string | undefined {
+  return chatSessionTarget(useContext(ChatSessionIdContext)());
+}
+
+/**
+ * Did the login that produced this callback come from a browser that had a
+ * chat session? Read back off the callback's own `next`, which is the only
+ * carrier that survives the magic link into a different tab — or a different
+ * device, which is exactly the case this exists to catch (#507 review P1-2):
+ * there the target still names a session while the `aid` cookie is absent, so
+ * the migration correctly moves nothing and the mismatch is the signal.
+ */
+export function returnTargetNamesSession(next: string | undefined): boolean {
+  if (next === undefined) return false;
+  const query = next.slice(next.indexOf("?") + 1);
+  return next.includes("?") && new URLSearchParams(query).has(CHAT_SESSION_PARAM);
+}

--- a/apps/web/src/i18n/dictionaries/en.json
+++ b/apps/web/src/i18n/dictionaries/en.json
@@ -58,6 +58,10 @@
     "callback_error": "That link has expired or was already used. Please request a new one.",
     "callback_save_failed": "You're signed in, but the route didn't save…",
     "callback_save_retry": "Try saving again",
-    "callback_save_skip": "You can also save it again from the chat page later"
+    "callback_save_skip": "You can also save it again from the chat page later",
+    "callback_migration_failed": "You're signed in, but the chats you started before signing in didn't move across…",
+    "callback_migration_missing": "You're signed in, but none of the chats you started before signing in were found — did you open the link on another device?",
+    "callback_migration_retry": "Try again",
+    "callback_migration_skip": "Continue anyway"
   }
 }

--- a/apps/web/src/i18n/dictionaries/ja.json
+++ b/apps/web/src/i18n/dictionaries/ja.json
@@ -58,6 +58,10 @@
     "callback_error": "リンクの有効期限が切れたか、既に使用されています。もう一度お試しください。",
     "callback_save_failed": "ログインはできたけど、ルートの保存に失敗しちゃった…",
     "callback_save_retry": "もう一度保存する",
-    "callback_save_skip": "あとでチャット画面から保存し直せるよ"
+    "callback_save_skip": "あとでチャット画面から保存し直せるよ",
+    "callback_migration_failed": "ログインできたよ。でも、ログイン前の会話をアカウントに引き継げなかった…",
+    "callback_migration_missing": "ログインできたよ。でも、ログイン前の会話が見つからなかった…別の端末でリンクを開いた?",
+    "callback_migration_retry": "もう一度引き継ぐ",
+    "callback_migration_skip": "このまま続ける"
   }
 }

--- a/apps/web/src/i18n/dictionaries/zh.json
+++ b/apps/web/src/i18n/dictionaries/zh.json
@@ -58,6 +58,10 @@
     "callback_error": "登录链接已失效或已被使用，请重新申请。",
     "callback_save_failed": "登录成功了，但路线没能保存…",
     "callback_save_retry": "再保存一次",
-    "callback_save_skip": "也可以稍后回到聊天页重新保存"
+    "callback_save_skip": "也可以稍后回到聊天页重新保存",
+    "callback_migration_failed": "登录成功了。但登录前的对话没能转到你的账号…",
+    "callback_migration_missing": "登录成功了。但没找到登录前的对话…是在另一台设备上打开链接的吗?",
+    "callback_migration_retry": "再试一次",
+    "callback_migration_skip": "先这样继续"
   }
 }

--- a/apps/web/src/lib/auth/returnTarget.ts
+++ b/apps/web/src/lib/auth/returnTarget.ts
@@ -39,3 +39,25 @@ export function sanitizeReturnTarget(next: unknown): string {
   const value = next.trim();
   return isSameOriginPath(value) ? value : FALLBACK;
 }
+
+/**
+ * Does this return target open a *panel* on arrival, as opposed to merely
+ * restoring a location? Today only the BYOK deep-link (`/chat?settings=byok`)
+ * does.
+ *
+ * The distinction exists because of #480 P1-2: a failed create-on-login replay
+ * must not strand a visitor who was mid-way through BYOK setup, so that case
+ * navigates instead of showing the retry surface. Once the save wall started
+ * carrying its own return target (#507 review P1-1), deriving "has a return
+ * intent" from `next !== "/"` would have applied that rule to the save journey
+ * too — silently retiring the retry/skip surface built for exactly it, in a
+ * way no test would have caught because the tests pass the flag directly. So
+ * the rule is narrowed to what #480 actually needed: a panel to get back to.
+ * A plain session return keeps the retry surface.
+ */
+export function carriesPanelIntent(next: unknown): boolean {
+  const target = sanitizeReturnTarget(next);
+  const separator = target.indexOf("?");
+  if (separator < 0) return false;
+  return new URLSearchParams(target.slice(separator + 1)).has("settings");
+}

--- a/apps/web/src/lib/auth/sessionMigration.ts
+++ b/apps/web/src/lib/auth/sessionMigration.ts
@@ -1,0 +1,76 @@
+import { currentChatConfig } from "../../features/chat/config";
+
+/**
+ * Anonymous -> signed-in session ownership migration (issue #273 Task 3, #507).
+ *
+ * The endpoint is **identity-dimensional**: no body and no `session_id` — the
+ * magic-link tab has none, and accepting one would re-introduce an
+ * ownership-probing surface. The two identities it needs arrive on trusted
+ * channels only:
+ *
+ *  - the incoming real user, from the `Authorization` bearer the edge verifies;
+ *  - the outgoing `anon_<hex>`, which the client **cannot** name. `aid` is an
+ *    `HttpOnly`, worker-signed cookie (`worker/auth.ts:228`), unreadable from
+ *    JS by construction. `credentials: "include"` is therefore the whole
+ *    mechanism: the browser attaches `aid`, the edge resolves (never mints) it
+ *    and forwards the result as a trusted `X-Anon-Id` on this route alone.
+ *
+ * That is also why the base URL is `currentChatConfig().baseUrl` rather than a
+ * URL of its own — it is the exact origin `/v1/chat` posts to, i.e. the origin
+ * whose cookie jar holds `aid`. A migration aimed anywhere else would carry no
+ * anonymous identity and quietly migrate nothing.
+ */
+export const SESSION_MIGRATE_PATH = "/v1/session/migrate";
+
+/**
+ * `ok` covers **both** documented successes: `{"migrated": true}` and the typed
+ * no-op `{"migrated": false}` (that identity owned nothing, or the caller was
+ * never anonymous here). Neither is a failure, and the client has nothing to do
+ * differently for either, so they are not distinguished — an unread third value
+ * would be dead scaffolding.
+ */
+export type SessionMigrationOutcome = "ok" | "failed";
+
+async function post(url: string, token: string): Promise<SessionMigrationOutcome> {
+  const response = await fetch(url, {
+    method: "POST",
+    credentials: "include",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return response.ok ? "ok" : "failed";
+}
+
+/**
+ * Claim this browser's anonymous work for the just-authenticated user.
+ *
+ * Idempotent by construction on the server side, twice over — which is what
+ * makes a repeated magic-link tap or a callback-page refresh harmless:
+ *  1. the mutation is `UPDATE ... WHERE user_id = $from_anon`, never `INSERT`,
+ *     so a second run matches zero rows and returns `{"migrated": false}`
+ *     (`SessionRepository.migrate_ownership`);
+ *  2. the first success makes the edge retire the `aid` cookie, so the second
+ *     call arrives with no anonymous identity at all and short-circuits before
+ *     touching the database (`migrate_session_ownership`'s `None` branch).
+ *
+ * Total: a rejected `fetch` (offline, DNS, CORS) is an outcome, not a throw.
+ */
+export function migrateAnonymousSession(
+  token: string,
+  baseUrl: string = currentChatConfig().baseUrl,
+): Promise<SessionMigrationOutcome> {
+  return post(`${baseUrl}${SESSION_MIGRATE_PATH}`, token).catch(
+    (): SessionMigrationOutcome => "failed",
+  );
+}
+
+/**
+ * Structured, credential-free record of a migration that did not land.
+ *
+ * Deliberately the same shape as the edge's own `logInvalidCredential`
+ * (`worker/app.ts`): a single-key JSON `event` line, no token, no identity.
+ * This is the "not blocking, but not silent" half of the failure policy — see
+ * `useAuthCallback`'s `runMigration` for why it is not surfaced to the visitor.
+ */
+export function reportMigrationFailure(): void {
+  console.warn(JSON.stringify({ event: "auth_session_migration_failed" }));
+}

--- a/apps/web/src/lib/auth/sessionMigration.ts
+++ b/apps/web/src/lib/auth/sessionMigration.ts
@@ -66,9 +66,11 @@ async function post(url: string, token: string): Promise<SessionMigrationOutcome
  * Idempotent by construction on the server: the mutation is
  * `UPDATE … WHERE user_id = $from_anon`, never `INSERT`, so a second run
  * matches zero rows and returns `{"migrated": false}` — which makes a repeated
- * magic-link tap, a callback refresh and a retry all harmless. Since the #507
- * owner ruling the edge no longer retires the `aid` cookie either, so the
- * anonymous identity survives a failure and a later attempt can still find it.
+ * magic-link tap, a callback refresh and a retry all harmless. The #507 owner
+ * ruling additionally stopped the edge retiring the `aid` cookie — which
+ * matters for exactly one failure branch, the client-timeout-but-server-
+ * succeeded race, since retirement was already gated on `didMigrate` and every
+ * other failure left the cookie standing.
  *
  * Total: a rejected `fetch` (offline, DNS, CORS) or an unparseable body is an
  * outcome, not a throw.

--- a/apps/web/src/lib/auth/sessionMigration.ts
+++ b/apps/web/src/lib/auth/sessionMigration.ts
@@ -10,10 +10,10 @@ import { currentChatConfig } from "../../features/chat/config";
  *
  *  - the incoming real user, from the `Authorization` bearer the edge verifies;
  *  - the outgoing `anon_<hex>`, which the client **cannot** name. `aid` is an
- *    `HttpOnly`, worker-signed cookie (`worker/auth.ts:228`), unreadable from
- *    JS by construction. `credentials: "include"` is therefore the whole
- *    mechanism: the browser attaches `aid`, the edge resolves (never mints) it
- *    and forwards the result as a trusted `X-Anon-Id` on this route alone.
+ *    `HttpOnly`, worker-signed cookie (`worker/auth.ts`), unreadable from JS by
+ *    construction. `credentials: "include"` is therefore the whole mechanism:
+ *    the browser attaches `aid`, the edge resolves (never mints) it and
+ *    forwards the result as a trusted `X-Anon-Id` on this route alone.
  *
  * That is also why the base URL is `currentChatConfig().baseUrl` rather than a
  * URL of its own — it is the exact origin `/v1/chat` posts to, i.e. the origin
@@ -23,36 +23,55 @@ import { currentChatConfig } from "../../features/chat/config";
 export const SESSION_MIGRATE_PATH = "/v1/session/migrate";
 
 /**
- * `ok` covers **both** documented successes: `{"migrated": true}` and the typed
- * no-op `{"migrated": false}` (that identity owned nothing, or the caller was
- * never anonymous here). Neither is a failure, and the client has nothing to do
- * differently for either, so they are not distinguished — an unread third value
- * would be dead scaffolding.
+ * The endpoint's two documented successes are kept **distinct** (#507 review
+ * P1-2). Folding `{"migrated": false}` into a generic success hid the one case
+ * the client can actually detect: a magic link opened on a different device
+ * carries the session in its `next` target but none of this browser's `aid`
+ * cookie, so the migration correctly moves nothing — indistinguishable, once
+ * collapsed, from a visitor who simply had no anonymous history. That mismatch
+ * is also the only signal that would catch a *re-broken* wiring, which is the
+ * exact failure mode #507 was.
  */
-export type SessionMigrationOutcome = "ok" | "failed";
+export type SessionMigrationOutcome = "migrated" | "nothing" | "failed";
 
-async function post(url: string, token: string): Promise<SessionMigrationOutcome> {
-  const response = await fetch(url, {
+/**
+ * Mobile-first budget (#507 review P2). 8s was inherited from the deferred-save
+ * replay, but this runs on a Capacitor webview on transit Wi-Fi as often as on
+ * a desktop, and a single `UPDATE` behind one edge hop has no business taking
+ * longer. `keepalive` lets the request outlive a callback screen the visitor
+ * navigates away from, so a slow network degrades to "the server still gets it"
+ * rather than "the mutation is cancelled mid-flight".
+ */
+export const MIGRATE_TIMEOUT_MS = 4_000;
+
+function request(token: string): RequestInit {
+  return {
     method: "POST",
     credentials: "include",
+    keepalive: true,
     headers: { Authorization: `Bearer ${token}` },
-  });
-  return response.ok ? "ok" : "failed";
+  };
+}
+
+async function post(url: string, token: string): Promise<SessionMigrationOutcome> {
+  const response = await fetch(url, request(token));
+  if (!response.ok) return "failed";
+  const body: unknown = await response.json();
+  return (body as { migrated?: unknown }).migrated === true ? "migrated" : "nothing";
 }
 
 /**
  * Claim this browser's anonymous work for the just-authenticated user.
  *
- * Idempotent by construction on the server side, twice over — which is what
- * makes a repeated magic-link tap or a callback-page refresh harmless:
- *  1. the mutation is `UPDATE ... WHERE user_id = $from_anon`, never `INSERT`,
- *     so a second run matches zero rows and returns `{"migrated": false}`
- *     (`SessionRepository.migrate_ownership`);
- *  2. the first success makes the edge retire the `aid` cookie, so the second
- *     call arrives with no anonymous identity at all and short-circuits before
- *     touching the database (`migrate_session_ownership`'s `None` branch).
+ * Idempotent by construction on the server: the mutation is
+ * `UPDATE … WHERE user_id = $from_anon`, never `INSERT`, so a second run
+ * matches zero rows and returns `{"migrated": false}` — which makes a repeated
+ * magic-link tap, a callback refresh and a retry all harmless. Since the #507
+ * owner ruling the edge no longer retires the `aid` cookie either, so the
+ * anonymous identity survives a failure and a later attempt can still find it.
  *
- * Total: a rejected `fetch` (offline, DNS, CORS) is an outcome, not a throw.
+ * Total: a rejected `fetch` (offline, DNS, CORS) or an unparseable body is an
+ * outcome, not a throw.
  */
 export function migrateAnonymousSession(
   token: string,
@@ -64,13 +83,33 @@ export function migrateAnonymousSession(
 }
 
 /**
- * Structured, credential-free record of a migration that did not land.
- *
- * Deliberately the same shape as the edge's own `logInvalidCredential`
- * (`worker/app.ts`): a single-key JSON `event` line, no token, no identity.
- * This is the "not blocking, but not silent" half of the failure policy — see
- * `useAuthCallback`'s `runMigration` for why it is not surfaced to the visitor.
+ * Why a migration did not land. `failed` is a request that did not succeed;
+ * `nothing-migrated` is a 200 that moved no rows when the login demonstrably
+ * came from a browser with a session — the cross-device case, and the tell that
+ * the wiring has broken again.
  */
-export function reportMigrationFailure(): void {
-  console.warn(JSON.stringify({ event: "auth_session_migration_failed" }));
+export type MigrationAnomaly = "failed" | "nothing-migrated";
+
+/**
+ * Did this outcome fail the visitor? `expected` says the login's return target
+ * named a chat session, so *some* row should have moved.
+ */
+export function anomalyOf(
+  outcome: SessionMigrationOutcome,
+  expected: boolean,
+): MigrationAnomaly | undefined {
+  if (outcome === "failed") return "failed";
+  if (outcome === "nothing" && expected) return "nothing-migrated";
+  return undefined;
+}
+
+/**
+ * Structured, credential-free record. Deliberately **not** the reporting
+ * channel: `apps/web` has no telemetry sink, so a `console.warn` reaches the
+ * visitor's own devtools and nobody else (#507 review P1-3). The real outlet is
+ * the callback screen's migration-failure surface, which puts a retry in front
+ * of the one party who can act on it; this line is a developer aid beside it.
+ */
+export function reportMigrationAnomaly(anomaly: MigrationAnomaly): void {
+  console.warn(JSON.stringify({ event: "auth_session_migration", anomaly }));
 }

--- a/apps/web/src/lib/auth/sessionMigration.ts
+++ b/apps/web/src/lib/auth/sessionMigration.ts
@@ -38,9 +38,13 @@ export type SessionMigrationOutcome = "migrated" | "nothing" | "failed";
  * Mobile-first budget (#507 review P2). 8s was inherited from the deferred-save
  * replay, but this runs on a Capacitor webview on transit Wi-Fi as often as on
  * a desktop, and a single `UPDATE` behind one edge hop has no business taking
- * longer. `keepalive` lets the request outlive a callback screen the visitor
- * navigates away from, so a slow network degrades to "the server still gets it"
- * rather than "the mutation is cancelled mid-flight".
+ * longer.
+ *
+ * `keepalive` is a narrower guarantee than it may read as (#514 review round 2):
+ * an in-SPA navigation never interrupts a `fetch` anyway, so it buys nothing
+ * there. It matters for **document unload** — the visitor closing the tab or
+ * following a link away while the claim is still in flight. Cheap, and the
+ * request carries no body, so the 64KB keepalive ceiling is not in play.
  */
 export const MIGRATE_TIMEOUT_MS = 4_000;
 

--- a/apps/web/src/routes/auth/callback.tsx
+++ b/apps/web/src/routes/auth/callback.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 import { AuthCallback } from "../../components/auth/AuthCallback";
+import { returnTargetNamesSession } from "../../features/chat/return-target";
 import { LocaleProvider } from "../../i18n/context";
-import { sanitizeReturnTarget } from "../../lib/auth/returnTarget";
+import { carriesPanelIntent, sanitizeReturnTarget } from "../../lib/auth/returnTarget";
 
 /**
  * `next` rides the magic-link callback URL because the link may open in a
@@ -36,10 +37,10 @@ function useGoToTarget(next: string | undefined): () => void {
 
 function AuthCallbackRoute() {
   const { next } = Route.useSearch();
-  const hasReturnIntent = sanitizeReturnTarget(next) !== "/";
+  const props = { hasReturnIntent: carriesPanelIntent(next), expectsMigration: returnTargetNamesSession(next) };
   return (
     <LocaleProvider>
-      <AuthCallback onDone={useGoToTarget(next)} hasReturnIntent={hasReturnIntent} />
+      <AuthCallback onDone={useGoToTarget(next)} {...props} />
     </LocaleProvider>
   );
 }

--- a/apps/web/tests/integration/create-on-login.test.ts
+++ b/apps/web/tests/integration/create-on-login.test.ts
@@ -41,6 +41,11 @@ const server = setupServer(
     return HttpResponse.json(row);
   }),
   http.get(ROUTES_URL, () => HttpResponse.json(ListRoutesResult.parse({ routes: saved }) as JsonBodyType)),
+  // Every login now also claims the browser's anonymous sessions (#507). This
+  // suite runs with `onUnhandledRequest: "error"`, so the handler is proof the
+  // call is real: delete the client wiring and it goes unused; delete the
+  // handler and the whole suite errors.
+  http.post("http://localhost:3000/v1/session/migrate", () => HttpResponse.json({ migrated: false })),
 );
 
 beforeAll(() => { server.listen({ onUnhandledRequest: "error" }); });

--- a/apps/web/tests/integration/session-migration-on-login.test.ts
+++ b/apps/web/tests/integration/session-migration-on-login.test.ts
@@ -16,11 +16,15 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthCallback } from "../../src/components/auth/AuthCallback";
 import { LocaleProvider } from "../../src/i18n/context";
+import { dictFor } from "../../src/i18n/dictionaries";
+
+// The integration lane has no locale setup, so jsdom's `en-US` navigator wins.
+const auth = dictFor("en").auth;
 import { clearAuthToken } from "../../src/lib/auth/authSession";
 import { SESSION_MIGRATE_PATH } from "../../src/lib/auth/sessionMigration";
 
@@ -99,17 +103,31 @@ describe("a login drives the session-migration endpoint end to end", () => {
     expect(observed[1]?.authorization).toBe(`Bearer ${JWT}`);
   });
 
-  it("keeps the login intact when the migration endpoint is down", async () => {
+  it("surfaces a failed claim to the visitor instead of navigating past it", async () => {
+    // #507 review P1-3: `apps/web` has no telemetry sink, so the visitor is the
+    // only real outlet. A 503 must reach the DOM, not just a console line.
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     server.use(http.post(MIGRATE_URL, () => HttpResponse.json({}, { status: 503 })));
     let done = false;
     render(createElement(LocaleProvider, null,
       createElement(AuthCallback, { onDone: () => { done = true; } })));
-    await vi.waitFor(() => { expect(done).toBe(true); });
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain(auth.callback_migration_failed);
+    expect(done).toBe(false);
     expect(warn).toHaveBeenCalledExactlyOnceWith(
-      JSON.stringify({ event: "auth_session_migration_failed" }),
+      JSON.stringify({ event: "auth_session_migration", anomaly: "failed" }),
     );
     warn.mockRestore();
+  });
+
+  it("still lets the visitor through — the login is never blocked", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    server.use(http.post(MIGRATE_URL, () => HttpResponse.json({}, { status: 503 })));
+    let done = false;
+    render(createElement(LocaleProvider, null,
+      createElement(AuthCallback, { onDone: () => { done = true; } })));
+    fireEvent.click(await screen.findByRole("button", { name: auth.callback_migration_skip }));
+    await vi.waitFor(() => { expect(done).toBe(true); });
   });
 });
 

--- a/apps/web/tests/integration/session-migration-on-login.test.ts
+++ b/apps/web/tests/integration/session-migration-on-login.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #507 end-to-end: the migration endpoint was finished, reachable and
+ * unit-tested on both the edge and the container — and had never once been
+ * called, because nothing wired the client half. Every part was green; the
+ * chain was not.
+ *
+ * So this asserts the chain, not a seam. It renders the REAL `<AuthCallback>`
+ * with no injected doubles at all — the production `getAuthToken`,
+ * `replayDeferredSave` and `migrateAnonymousSession` defaults — and asserts on
+ * the HTTP request an edge stand-in actually observed. Every collaborator
+ * between the rendered component and the socket is the real one.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { cleanup, render } from "@testing-library/react";
+import { createElement } from "react";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthCallback } from "../../src/components/auth/AuthCallback";
+import { LocaleProvider } from "../../src/i18n/context";
+import { clearAuthToken } from "../../src/lib/auth/authSession";
+import { SESSION_MIGRATE_PATH } from "../../src/lib/auth/sessionMigration";
+
+const NEON_AUTH = "http://localhost:3000/neondb/auth";
+const MIGRATE_URL = "http://localhost:3000/v1/session/migrate";
+const JWT = "eyJhbGciOiJFZERTQSJ9.integration.signature";
+
+interface Observed {
+  readonly method: string;
+  readonly authorization: string | null;
+  readonly credentials: string;
+  readonly body: string;
+  readonly contentLength: string | null;
+}
+
+const observed: Observed[] = [];
+/** Stand-in for the container behind the edge: the first call migrates, every
+ * later one matches zero rows and returns the typed no-op — the real
+ * `UPDATE ... WHERE user_id = $from_anon` semantics. */
+const migrateHandler = http.post(MIGRATE_URL, async ({ request }) => {
+  observed.push({
+    method: request.method,
+    authorization: request.headers.get("authorization"),
+    credentials: request.credentials,
+    body: await request.text(),
+    contentLength: request.headers.get("content-length"),
+  });
+  return HttpResponse.json({ migrated: observed.length === 1 });
+});
+
+const server = setupServer(
+  http.get(`${NEON_AUTH}/token`, () => HttpResponse.json({ token: JWT })),
+  migrateHandler,
+);
+
+beforeAll(() => { server.listen({ onUnhandledRequest: "error" }); });
+afterAll(() => { server.close(); });
+
+beforeEach(() => {
+  vi.stubEnv("VITE_NEON_AUTH_BASE_URL", NEON_AUTH);
+  observed.length = 0;
+  localStorage.clear();
+  clearAuthToken();
+});
+
+afterEach(() => {
+  cleanup();
+  server.resetHandlers();
+  vi.unstubAllEnvs();
+});
+
+/** The real component, the real hook, the real defaults — no injection. */
+async function signIn(calls: number): Promise<void> {
+  render(createElement(LocaleProvider, null, createElement(AuthCallback, { onDone: () => undefined })));
+  await vi.waitFor(() => { expect(observed).toHaveLength(calls); });
+}
+
+describe("a login drives the session-migration endpoint end to end", () => {
+  it("issues exactly one POST, carrying the established bearer and the cookie jar", async () => {
+    await signIn(1);
+    expect(observed[0]?.method).toBe("POST");
+    expect(observed[0]?.authorization).toBe(`Bearer ${JWT}`);
+    expect(observed[0]?.credentials).toBe("include");
+  });
+
+  it("sends no body: the endpoint is identity-dimensional and takes no session id", async () => {
+    await signIn(1);
+    expect(observed[0]?.body).toBe("");
+    expect(observed[0]?.contentLength).toBeNull();
+  });
+
+  it("is idempotent across a repeated magic-link tap: the second run is a no-op", async () => {
+    await signIn(1);
+    cleanup();
+    await signIn(2);
+    expect(observed[1]?.authorization).toBe(`Bearer ${JWT}`);
+  });
+
+  it("keeps the login intact when the migration endpoint is down", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    server.use(http.post(MIGRATE_URL, () => HttpResponse.json({}, { status: 503 })));
+    let done = false;
+    render(createElement(LocaleProvider, null,
+      createElement(AuthCallback, { onDone: () => { done = true; } })));
+    await vi.waitFor(() => { expect(done).toBe(true); });
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      JSON.stringify({ event: "auth_session_migration_failed" }),
+    );
+    warn.mockRestore();
+  });
+});
+
+/**
+ * The stand-in above proves the client half fires; this pins it to the same
+ * string the live edge routes on. #507 was two finished halves that never met,
+ * and a silent rename of either path would recreate it exactly.
+ */
+describe("the posted path is the one the edge routes on", () => {
+  it("matches worker/app.ts's SESSION_MIGRATE_PATH literal", () => {
+    const edge = readFileSync(resolve(import.meta.dirname, "../../../../worker/app.ts"), "utf8");
+    expect(edge).toContain(`const SESSION_MIGRATE_PATH = "${SESSION_MIGRATE_PATH}"`);
+  });
+});

--- a/apps/web/tests/msw/handlers.ts
+++ b/apps/web/tests/msw/handlers.ts
@@ -1,3 +1,4 @@
+import { http, HttpResponse } from "msw";
 import { SearchInput, SearchResult } from "@seichijunrei/contract";
 import { contractJsonHandler, orpcErrorResponse } from "./contract-handler";
 import { CATALOG_SEARCH_URL, searchSuccessFixture } from "./fixtures";
@@ -34,6 +35,17 @@ export const catalogUpstreamErrorHandler = contractJsonHandler({
   }),
 });
 
-export const handlers = [catalogSearchHandler];
+/**
+ * Default session-migration handler (#507). Every login now posts here, so the
+ * unit lane needs it to stay hermetic — `{"migrated": false}` is the endpoint's
+ * own typed no-op for a caller with no anonymous history, which is exactly what
+ * a test-tab login is.
+ */
+export const sessionMigrateHandler = http.post(
+  "*/v1/session/migrate",
+  () => HttpResponse.json({ migrated: false }),
+);
+
+export const handlers = [catalogSearchHandler, sessionMigrateHandler];
 
 export { orpcErrorResponse };

--- a/apps/web/tests/unit/auth/callback-route.test.tsx
+++ b/apps/web/tests/unit/auth/callback-route.test.tsx
@@ -6,6 +6,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getRouter } from "../../../src/router";
 import { setLanguages } from "../_i18n";
+import { dictFor } from "../../../src/i18n/dictionaries";
 
 const { getAuthToken } = vi.hoisted(() => ({ getAuthToken: vi.fn() }));
 vi.mock("../../../src/lib/auth/authSession", () => ({ getAuthToken }));
@@ -67,6 +68,26 @@ describe("/auth/callback route", () => {
 });
 
 describe("/auth/callback route — dual intent (#480 P1-2)", () => {
+  /**
+   * The #514 round-2 gap: `carriesPanelIntent` was pinned as a FUNCTION, but
+   * nothing drove it through the route. Widening `callback.tsx` back to the
+   * inline `sanitizeReturnTarget(next) !== "/"` left all 1508 unit tests green
+   * — the save wall's own return target would have silently retired the retry
+   * surface at the wiring layer, which is the exact shape of #507 itself. This
+   * pair closes it: a session return HOLDS, a panel return NAVIGATES.
+   */
+  it("holds the save-retry surface for a plain session return (#507 review P1-1)", async () => {
+    setLanguages(["ja"]);
+    getAuthToken.mockResolvedValue("jwt-callback");
+    replayDeferredSave.mockResolvedValue("failed");
+    const router = getRouter();
+    await router.navigate({ to: "/auth/callback", search: { next: "/chat?session=sess-1" } });
+    render(<RouterProvider router={router} />);
+    const retry = await screen.findByRole("button", { name: dictFor("ja").auth.callback_save_retry });
+    expect(retry).toBeTruthy();
+    expect(router.state.location.pathname).toBe("/auth/callback");
+  });
+
   it("reaches the BYOK deep link even when the deferred-save replay failed", async () => {
     getAuthToken.mockResolvedValue("jwt-callback");
     replayDeferredSave.mockResolvedValue("failed");

--- a/apps/web/tests/unit/auth/migration-failure-surface.test.tsx
+++ b/apps/web/tests/unit/auth/migration-failure-surface.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #507 review P1-3: "not silent" has to mean something. `apps/web` has no
+ * telemetry sink, so a `console.warn` reaches the visitor's own devtools and
+ * nobody else — the callback screen is the only real outlet, and the visitor
+ * the only party who can act. These pin that the failure reaches the DOM with
+ * a working retry, and that it never blocks the login itself.
+ */
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthCallback } from "../../../src/components/auth/AuthCallback";
+import type { SessionMigrationOutcome } from "../../../src/lib/auth/sessionMigration";
+import { dictFor } from "../../../src/i18n/dictionaries";
+import { renderWithLocale, setLanguages } from "../_i18n";
+
+const auth = dictFor("ja").auth;
+const token = (): Promise<string | undefined> => Promise.resolve("jwt-1");
+const noReplay = () => Promise.resolve("none" as const);
+
+beforeEach(() => {
+  setLanguages(["ja-JP"]);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderCallback(migrate: () => Promise<SessionMigrationOutcome>, onDone = () => undefined) {
+  return renderWithLocale(
+    <AuthCallback onDone={onDone} establish={token} replay={noReplay} migrate={migrate} />,
+  );
+}
+
+describe("the migration failure reaches the visitor", () => {
+  it("renders an alert with a retry and a skip, not a silent success", async () => {
+    renderCallback(() => Promise.resolve("failed"));
+    expect(await screen.findByText(auth.callback_migration_failed)).toBeTruthy();
+    expect(screen.getByRole("button", { name: auth.callback_migration_retry })).toBeTruthy();
+    expect(screen.getByRole("button", { name: auth.callback_migration_skip })).toBeTruthy();
+  });
+
+  it("does not navigate away while the notice is unanswered", async () => {
+    const onDone = vi.fn();
+    renderCallback(() => Promise.resolve("failed"), onDone);
+    await screen.findByText(auth.callback_migration_failed);
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("navigates once the visitor chooses to move on — the login is never blocked", async () => {
+    const onDone = vi.fn();
+    renderCallback(() => Promise.resolve("failed"), onDone);
+    fireEvent.click(await screen.findByRole("button", { name: auth.callback_migration_skip }));
+    await waitFor(() => { expect(onDone).toHaveBeenCalled(); });
+  });
+
+  it("clears the notice and navigates when a retry lands", async () => {
+    const onDone = vi.fn();
+    const migrate = vi.fn<() => Promise<SessionMigrationOutcome>>().mockResolvedValue("failed");
+    renderCallback(migrate, onDone);
+    fireEvent.click(await screen.findByRole("button", { name: auth.callback_migration_retry }));
+    migrate.mockResolvedValue("migrated");
+    fireEvent.click(screen.getByRole("button", { name: auth.callback_migration_retry }));
+    await waitFor(() => { expect(onDone).toHaveBeenCalled(); });
+  });
+
+  it("says nothing at all when the claim succeeds", async () => {
+    const onDone = vi.fn();
+    renderCallback(() => Promise.resolve("migrated"), onDone);
+    await waitFor(() => { expect(onDone).toHaveBeenCalled(); });
+    expect(screen.queryByText(auth.callback_migration_failed)).toBeNull();
+  });
+});
+
+describe("the cross-device case gets its own copy", () => {
+  it("explains that nothing was found rather than that something broke", async () => {
+    renderWithLocale(
+      <AuthCallback
+        onDone={() => undefined}
+        expectsMigration
+        establish={token}
+        replay={noReplay}
+        migrate={() => Promise.resolve("nothing")}
+      />,
+    );
+    expect(await screen.findByText(auth.callback_migration_missing)).toBeTruthy();
+    expect(screen.queryByText(auth.callback_migration_failed)).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/auth/session-migration.test.ts
+++ b/apps/web/tests/unit/auth/session-migration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { server } from "../../msw/node";
+import {
+  SESSION_MIGRATE_PATH,
+  migrateAnonymousSession,
+  reportMigrationFailure,
+} from "../../../src/lib/auth/sessionMigration";
+
+const BASE = "http://edge.test";
+const URL = `${BASE}${SESSION_MIGRATE_PATH}`;
+
+interface Seen {
+  method: string;
+  authorization: string | null;
+  credentials: string;
+  body: string;
+}
+
+function capture(sink: Seen[], status = 200) {
+  return http.post(URL, async ({ request }) => {
+    sink.push({
+      method: request.method,
+      authorization: request.headers.get("authorization"),
+      credentials: request.credentials,
+      body: await request.text(),
+    });
+    return HttpResponse.json({ migrated: status === 200 }, { status });
+  });
+}
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe("migrateAnonymousSession", () => {
+  it("POSTs the bearer token to /v1/session/migrate with no body at all", async () => {
+    const seen: Seen[] = [];
+    server.use(capture(seen));
+    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("ok");
+    expect(seen).toEqual([
+      { method: "POST", authorization: "Bearer jwt-1", credentials: "include", body: "" },
+    ]);
+  });
+
+  it("sends credentials so the HttpOnly `aid` cookie can reach the edge", async () => {
+    const seen: Seen[] = [];
+    server.use(capture(seen));
+    await migrateAnonymousSession("jwt-1", BASE);
+    // The client cannot name the anonymous identity: `aid` is HttpOnly. Losing
+    // this option would migrate nothing while still returning 200.
+    expect(seen[0]?.credentials).toBe("include");
+  });
+
+  it("reports `ok` for the typed no-op, which is a success and not a failure", async () => {
+    server.use(http.post(URL, () => HttpResponse.json({ migrated: false })));
+    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("ok");
+  });
+
+  it("reports `failed` on a non-2xx (a 403 from the reject-anonymous predicate)", async () => {
+    server.use(http.post(URL, () => HttpResponse.json({ error: "forbidden" }, { status: 403 })));
+    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("failed");
+  });
+
+  it("reports `failed` rather than throwing when the request never lands", async () => {
+    server.use(http.post(URL, () => HttpResponse.error()));
+    await expect(migrateAnonymousSession("jwt-1", BASE)).resolves.toBe("failed");
+  });
+
+  it("is safe to repeat: the second call is issued and the server no-ops it", async () => {
+    const seen: Seen[] = [];
+    server.use(http.post(URL, async ({ request }) => {
+      await request.text();
+      return HttpResponse.json({ migrated: seen.push({} as Seen) === 1 });
+    }));
+    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("ok");
+    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("ok");
+    expect(seen).toHaveLength(2);
+  });
+});
+
+describe("reportMigrationFailure", () => {
+  it("emits one structured, credential-free event record", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    reportMigrationFailure();
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      JSON.stringify({ event: "auth_session_migration_failed" }),
+    );
+  });
+});

--- a/apps/web/tests/unit/auth/session-migration.test.ts
+++ b/apps/web/tests/unit/auth/session-migration.test.ts
@@ -6,8 +6,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { server } from "../../msw/node";
 import {
   SESSION_MIGRATE_PATH,
+  anomalyOf,
   migrateAnonymousSession,
-  reportMigrationFailure,
+  reportMigrationAnomaly,
 } from "../../../src/lib/auth/sessionMigration";
 
 const BASE = "http://edge.test";
@@ -18,17 +19,19 @@ interface Seen {
   authorization: string | null;
   credentials: string;
   body: string;
+  keepalive: boolean;
 }
 
-function capture(sink: Seen[], status = 200) {
+function capture(sink: Seen[], migrated = true) {
   return http.post(URL, async ({ request }) => {
     sink.push({
       method: request.method,
       authorization: request.headers.get("authorization"),
       credentials: request.credentials,
       body: await request.text(),
+      keepalive: request.keepalive,
     });
-    return HttpResponse.json({ migrated: status === 200 }, { status });
+    return HttpResponse.json({ migrated });
   });
 }
 
@@ -38,9 +41,9 @@ describe("migrateAnonymousSession", () => {
   it("POSTs the bearer token to /v1/session/migrate with no body at all", async () => {
     const seen: Seen[] = [];
     server.use(capture(seen));
-    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("ok");
+    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("migrated");
     expect(seen).toEqual([
-      { method: "POST", authorization: "Bearer jwt-1", credentials: "include", body: "" },
+      { method: "POST", authorization: "Bearer jwt-1", credentials: "include", body: "", keepalive: true },
     ]);
   });
 
@@ -53,9 +56,16 @@ describe("migrateAnonymousSession", () => {
     expect(seen[0]?.credentials).toBe("include");
   });
 
-  it("reports `ok` for the typed no-op, which is a success and not a failure", async () => {
+  it("keeps the request alive past a navigation away from the callback screen", async () => {
+    const seen: Seen[] = [];
+    server.use(capture(seen));
+    await migrateAnonymousSession("jwt-1", BASE);
+    expect(seen[0]?.keepalive).toBe(true);
+  });
+
+  it("distinguishes the typed no-op from an actual migration", async () => {
     server.use(http.post(URL, () => HttpResponse.json({ migrated: false })));
-    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("ok");
+    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("nothing");
   });
 
   it("reports `failed` on a non-2xx (a 403 from the reject-anonymous predicate)", async () => {
@@ -68,24 +78,44 @@ describe("migrateAnonymousSession", () => {
     await expect(migrateAnonymousSession("jwt-1", BASE)).resolves.toBe("failed");
   });
 
+  it("reports `failed` rather than throwing on an unparseable body", async () => {
+    server.use(http.post(URL, () => new HttpResponse("not json", { status: 200 })));
+    await expect(migrateAnonymousSession("jwt-1", BASE)).resolves.toBe("failed");
+  });
+
   it("is safe to repeat: the second call is issued and the server no-ops it", async () => {
-    const seen: Seen[] = [];
-    server.use(http.post(URL, async ({ request }) => {
-      await request.text();
-      return HttpResponse.json({ migrated: seen.push({} as Seen) === 1 });
-    }));
-    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("ok");
-    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("ok");
-    expect(seen).toHaveLength(2);
+    let calls = 0;
+    server.use(http.post(URL, () => HttpResponse.json({ migrated: ++calls === 1 })));
+    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("migrated");
+    expect(await migrateAnonymousSession("jwt-1", BASE)).toBe("nothing");
   });
 });
 
-describe("reportMigrationFailure", () => {
-  it("emits one structured, credential-free event record", () => {
+describe("anomalyOf", () => {
+  it("treats a failure as an anomaly regardless of expectation", () => {
+    expect(anomalyOf("failed", false)).toBe("failed");
+    expect(anomalyOf("failed", true)).toBe("failed");
+  });
+
+  it("flags a no-op ONLY when the login's target named a session", () => {
+    // The cross-device magic link: `next` carries the session, `aid` does not
+    // travel, so 0 rows move and the mismatch is the only available signal.
+    expect(anomalyOf("nothing", true)).toBe("nothing-migrated");
+    expect(anomalyOf("nothing", false)).toBeUndefined();
+  });
+
+  it("never flags a migration that moved rows", () => {
+    expect(anomalyOf("migrated", true)).toBeUndefined();
+    expect(anomalyOf("migrated", false)).toBeUndefined();
+  });
+});
+
+describe("reportMigrationAnomaly", () => {
+  it("emits one structured, credential-free record naming the anomaly", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    reportMigrationFailure();
+    reportMigrationAnomaly("nothing-migrated");
     expect(warn).toHaveBeenCalledExactlyOnceWith(
-      JSON.stringify({ event: "auth_session_migration_failed" }),
+      JSON.stringify({ event: "auth_session_migration", anomaly: "nothing-migrated" }),
     );
   });
 });

--- a/apps/web/tests/unit/auth/use-auth-callback.test.tsx
+++ b/apps/web/tests/unit/auth/use-auth-callback.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAuthCallback } from "../../../src/components/auth/useAuthCallback";
 import type { DeferredReplayOutcome } from "../../../src/features/chat/save/createOnLogin";
 import type { SessionMigrationOutcome } from "../../../src/lib/auth/sessionMigration";
@@ -10,61 +10,108 @@ import type { SessionMigrationOutcome } from "../../../src/lib/auth/sessionMigra
 // Every collaborator is a module-level constant: the effect's dependency array
 // includes them, so an inline arrow would be a fresh identity on each render and
 // re-fire the whole redeem — turning "called once" into an artefact of the test.
-const ok = (): Promise<SessionMigrationOutcome> => Promise.resolve("ok");
+const migrated = (): Promise<SessionMigrationOutcome> => Promise.resolve("migrated");
+const nothingMigrated = (): Promise<SessionMigrationOutcome> => Promise.resolve("nothing");
 const failedMigration = (): Promise<SessionMigrationOutcome> => Promise.resolve("failed");
 const stalledMigration = (): Promise<SessionMigrationOutcome> => new Promise(() => undefined);
+const throwingMigration = (): Promise<SessionMigrationOutcome> => { throw new Error("boom"); };
 const noReplay = (): Promise<DeferredReplayOutcome> => Promise.resolve("none");
 const failedReplay = (): Promise<DeferredReplayOutcome> => Promise.resolve("failed");
 const token = (): Promise<string | undefined> => Promise.resolve("jwt-1");
 const noToken = (): Promise<string | undefined> => Promise.resolve(undefined);
 
+beforeEach(() => { vi.spyOn(console, "warn").mockImplementation(() => undefined); });
 afterEach(() => { vi.restoreAllMocks(); });
 
 describe("useAuthCallback session migration (#507)", () => {
   it("claims the anonymous sessions with the token establish returned", async () => {
-    const migrate = vi.fn(ok);
+    const migrate = vi.fn(migrated);
     const view = renderHook(() => useAuthCallback(token, noReplay, migrate));
     await waitFor(() => { expect(view.result.current.state).toBe("done"); });
     expect(migrate).toHaveBeenCalledExactlyOnceWith("jwt-1");
   });
 
   it("never migrates when no token was established — the call needs auth", async () => {
-    const migrate = vi.fn(ok);
+    const migrate = vi.fn(migrated);
     const view = renderHook(() => useAuthCallback(noToken, noReplay, migrate));
     await waitFor(() => { expect(view.result.current.state).toBe("error"); });
     expect(migrate).not.toHaveBeenCalled();
   });
 
-  it("reports a failed migration but still completes the login", async () => {
+  it("surfaces a failed claim to the visitor instead of reporting a clean login", async () => {
+    const view = renderHook(() => useAuthCallback(token, noReplay, failedMigration));
+    await waitFor(() => { expect(view.result.current.state).toBe("migration-failed"); });
+    expect(view.result.current.migration).toBe("failed");
+  });
+
+  it("flags a no-op claim as an anomaly when the target named a session", async () => {
+    const view = renderHook(() => useAuthCallback(token, noReplay, nothingMigrated, true));
+    await waitFor(() => { expect(view.result.current.migration).toBe("nothing-migrated"); });
+  });
+
+  it("leaves a no-op alone when the browser was never anonymous here", async () => {
+    const view = renderHook(() => useAuthCallback(token, noReplay, nothingMigrated, false));
+    await waitFor(() => { expect(view.result.current.state).toBe("done"); });
+    expect(view.result.current.migration).toBeUndefined();
+  });
+
+  it("reports the anomaly as a structured record beside the surface", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const view = renderHook(() => useAuthCallback(token, noReplay, failedMigration));
-    await waitFor(() => { expect(view.result.current.state).toBe("done"); });
+    await waitFor(() => { expect(view.result.current.state).toBe("migration-failed"); });
     expect(warn).toHaveBeenCalledExactlyOnceWith(
-      JSON.stringify({ event: "auth_session_migration_failed" }),
+      JSON.stringify({ event: "auth_session_migration", anomaly: "failed" }),
     );
   });
 
-  it("stays quiet on a migration that landed", async () => {
+  it("stays quiet and lands on done when the claim succeeds", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const view = renderHook(() => useAuthCallback(token, noReplay, ok));
+    const view = renderHook(() => useAuthCallback(token, noReplay, migrated, true));
     await waitFor(() => { expect(view.result.current.state).toBe("done"); });
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it("times a stalled migration out instead of pinning the visitor on the screen", async () => {
+  it("times a stalled claim out instead of pinning the visitor on the screen", async () => {
     vi.useFakeTimers();
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const view = renderHook(() => useAuthCallback(token, noReplay, stalledMigration));
-    await vi.advanceTimersByTimeAsync(8_000);
+    await vi.advanceTimersByTimeAsync(4_000);
     vi.useRealTimers();
-    await waitFor(() => { expect(view.result.current.state).toBe("done"); });
-    expect(warn).toHaveBeenCalledOnce();
+    await waitFor(() => { expect(view.result.current.state).toBe("migration-failed"); });
   });
 
-  it("shows only the actionable save failure when the migration failed too", async () => {
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+describe("useAuthCallback migration recovery (#507 review)", () => {
+  it("survives a migrate that THROWS: the login is not reported as an error", async () => {
+    // runMigration rides a Promise.all beside the replay, so a throw here would
+    // reject the whole redeem and turn a successful login into "error".
+    const view = renderHook(() => useAuthCallback(token, noReplay, throwingMigration));
+    await waitFor(() => { expect(view.result.current.state).toBe("migration-failed"); });
+    expect(view.result.current.migration).toBe("failed");
+  });
+
+  it("shows the actionable save failure first, then the migration notice", async () => {
     const view = renderHook(() => useAuthCallback(token, failedReplay, failedMigration));
     await waitFor(() => { expect(view.result.current.state).toBe("save-failed"); });
+    act(() => { view.result.current.dismissSave(); });
+    expect(view.result.current.state).toBe("migration-failed");
+  });
+
+  it("retries the claim on demand and clears the notice when it lands", async () => {
+    const migrate = vi.fn(failedMigration).mockImplementationOnce(failedMigration);
+    const view = renderHook(() => useAuthCallback(token, noReplay, migrate));
+    await waitFor(() => { expect(view.result.current.state).toBe("migration-failed"); });
+    migrate.mockImplementation(migrated);
+    act(() => { view.result.current.retryMigration(); });
+    await waitFor(() => { expect(view.result.current.state).toBe("done"); });
+  });
+
+  it("lets the visitor move on, which navigates rather than stranding them", async () => {
+    const view = renderHook(() => useAuthCallback(token, noReplay, failedMigration));
+    await waitFor(() => { expect(view.result.current.state).toBe("migration-failed"); });
+    act(() => { view.result.current.dismissMigration(); });
+    expect(view.result.current.state).toBe("done");
+    expect(view.result.current.migration).toBeUndefined();
   });
 });
 

--- a/apps/web/tests/unit/auth/use-auth-callback.test.tsx
+++ b/apps/web/tests/unit/auth/use-auth-callback.test.tsx
@@ -2,8 +2,71 @@
  * @vitest-environment jsdom
  */
 import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAuthCallback } from "../../../src/components/auth/useAuthCallback";
+import type { DeferredReplayOutcome } from "../../../src/features/chat/save/createOnLogin";
+import type { SessionMigrationOutcome } from "../../../src/lib/auth/sessionMigration";
+
+// Every collaborator is a module-level constant: the effect's dependency array
+// includes them, so an inline arrow would be a fresh identity on each render and
+// re-fire the whole redeem — turning "called once" into an artefact of the test.
+const ok = (): Promise<SessionMigrationOutcome> => Promise.resolve("ok");
+const failedMigration = (): Promise<SessionMigrationOutcome> => Promise.resolve("failed");
+const stalledMigration = (): Promise<SessionMigrationOutcome> => new Promise(() => undefined);
+const noReplay = (): Promise<DeferredReplayOutcome> => Promise.resolve("none");
+const failedReplay = (): Promise<DeferredReplayOutcome> => Promise.resolve("failed");
+const token = (): Promise<string | undefined> => Promise.resolve("jwt-1");
+const noToken = (): Promise<string | undefined> => Promise.resolve(undefined);
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe("useAuthCallback session migration (#507)", () => {
+  it("claims the anonymous sessions with the token establish returned", async () => {
+    const migrate = vi.fn(ok);
+    const view = renderHook(() => useAuthCallback(token, noReplay, migrate));
+    await waitFor(() => { expect(view.result.current.state).toBe("done"); });
+    expect(migrate).toHaveBeenCalledExactlyOnceWith("jwt-1");
+  });
+
+  it("never migrates when no token was established — the call needs auth", async () => {
+    const migrate = vi.fn(ok);
+    const view = renderHook(() => useAuthCallback(noToken, noReplay, migrate));
+    await waitFor(() => { expect(view.result.current.state).toBe("error"); });
+    expect(migrate).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed migration but still completes the login", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const view = renderHook(() => useAuthCallback(token, noReplay, failedMigration));
+    await waitFor(() => { expect(view.result.current.state).toBe("done"); });
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      JSON.stringify({ event: "auth_session_migration_failed" }),
+    );
+  });
+
+  it("stays quiet on a migration that landed", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const view = renderHook(() => useAuthCallback(token, noReplay, ok));
+    await waitFor(() => { expect(view.result.current.state).toBe("done"); });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("times a stalled migration out instead of pinning the visitor on the screen", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const view = renderHook(() => useAuthCallback(token, noReplay, stalledMigration));
+    await vi.advanceTimersByTimeAsync(8_000);
+    vi.useRealTimers();
+    await waitFor(() => { expect(view.result.current.state).toBe("done"); });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("shows only the actionable save failure when the migration failed too", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const view = renderHook(() => useAuthCallback(token, failedReplay, failedMigration));
+    await waitFor(() => { expect(view.result.current.state).toBe("save-failed"); });
+  });
+});
 
 describe("useAuthCallback", () => {
   it("starts pending, then resolves to done once a token is established", async () => {

--- a/apps/web/tests/unit/chat/chat-return-target.test.tsx
+++ b/apps/web/tests/unit/chat/chat-return-target.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #507 review P1-1: migrating the sessions is only half a fix. `/chat?session=`
+ * is the ONLY entry that reads a migrated session back — there is no session or
+ * route list — and all three in-chat login walls passed no return target, so
+ * `sanitizeReturnTarget(undefined)` sent every visitor to `/` after a correct
+ * migration. These pin the target at each wall.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LimitBanner } from "../../../src/features/chat/components/ErrorStates/LimitBanner";
+import { TimedItinerary } from "../../../src/features/chat/components/TimedItinerary";
+import { itineraryView } from "../../../src/lib/chat/itinerary";
+import { ujiItinerary } from "./_route-fixtures";
+import { SessionExpired } from "../../../src/features/chat/components/ErrorStates/SessionExpired";
+import { ChatReturnTargetProvider, chatSessionTarget, returnTargetNamesSession } from "../../../src/features/chat/return-target";
+import { carriesPanelIntent } from "../../../src/lib/auth/returnTarget";
+import { chatDictFor } from "../../../src/features/chat/i18n";
+import { sendMagicLink } from "../../../src/lib/auth/neonAuth";
+import { setLanguages } from "../_i18n";
+import { LocaleProvider } from "../../../src/i18n/context";
+
+vi.mock("../../../src/lib/auth/neonAuth", () => ({ sendMagicLink: vi.fn() }));
+const send = vi.mocked(sendMagicLink);
+
+beforeEach(() => { setLanguages(["ja-JP"]); });
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const SESSION = "sess-abc-123";
+const dict = chatDictFor("ja");
+
+// No default: passing `undefined` explicitly must MEAN "no session", which a
+// default parameter would silently overwrite with SESSION.
+function inChat(node: React.ReactNode, sessionId: string | undefined) {
+  return render(
+    <LocaleProvider>
+      <ChatReturnTargetProvider sessionIdOf={() => sessionId}>{node}</ChatReturnTargetProvider>
+    </LocaleProvider>,
+  );
+}
+
+describe("chatSessionTarget", () => {
+  it("builds the one entry that reads a migrated session back", () => {
+    expect(chatSessionTarget(SESSION)).toBe(`/chat?session=${SESSION}`);
+  });
+
+  it("percent-encodes an id so the target cannot grow a second parameter", () => {
+    expect(chatSessionTarget("a&next=/evil")).toBe("/chat?session=a%26next%3D%2Fevil");
+  });
+
+  it("yields nothing when there is no session to return to", () => {
+    expect(chatSessionTarget(undefined)).toBeUndefined();
+    expect(chatSessionTarget("")).toBeUndefined();
+  });
+});
+
+describe("returnTargetNamesSession", () => {
+  it("recognises a session return, which makes a no-op migration an anomaly", () => {
+    expect(returnTargetNamesSession(`/chat?session=${SESSION}`)).toBe(true);
+  });
+
+  it("does not fire for the BYOK deep-link or a bare path", () => {
+    expect(returnTargetNamesSession("/chat?settings=byok")).toBe(false);
+    expect(returnTargetNamesSession("/chat")).toBe(false);
+    expect(returnTargetNamesSession(undefined)).toBe(false);
+  });
+});
+
+describe("carriesPanelIntent (#480 reconciliation)", () => {
+  it("stays true for the BYOK target, preserving #480's navigate-on-save-failure", () => {
+    expect(carriesPanelIntent("/chat?settings=byok")).toBe(true);
+  });
+
+  it("is false for a plain session return, so the save retry surface survives", () => {
+    expect(carriesPanelIntent(`/chat?session=${SESSION}`)).toBe(false);
+  });
+
+  it("is false for anything the open-redirect guard rejects", () => {
+    expect(carriesPanelIntent("https://evil.test?settings=byok")).toBe(false);
+  });
+});
+
+describe("the in-chat login walls carry the session back", () => {
+  function submitFrom(node: React.ReactNode, openLabel: string): void {
+    send.mockResolvedValue("sent");
+    inChat(node, SESSION);
+    fireEvent.click(screen.getByRole("button", { name: openLabel }));
+    fireEvent.change(screen.getByLabelText("メールアドレス"), { target: { value: "fan@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
+  }
+
+  const EXPECTED = `http://localhost:3000/auth/callback?next=%2Fchat%3Fsession%3D${SESSION}`;
+
+  it("D11/D12 limit banner sends the visitor back to the session, not to `/`", () => {
+    submitFrom(<LimitBanner block="chat-quota" message="quota" loginLabel="login" />, "login");
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ callbackURL: EXPECTED }));
+  });
+
+  it("D8 session-expiry banner sends the visitor back to the session, not to `/`", () => {
+    submitFrom(<SessionExpired dict={dict} onResume={() => undefined} />, dict.errorStates.d8Login);
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ callbackURL: EXPECTED }));
+  });
+
+  it("P5 save wall — the #507 headline journey — returns to the session", () => {
+    submitFrom(
+      <TimedItinerary
+        view={itineraryView(ujiItinerary())}
+        dict={dict}
+        save={{ pointIds: ["a", "b"], title: "宇治" }}
+        saveDeps={{ authStatus: "anonymous", request: vi.fn() }}
+      />,
+      dict.route.saveCta,
+    );
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ callbackURL: EXPECTED }));
+  });
+
+  it("keeps today's bare callback URL when there is no session to return to", () => {
+    send.mockResolvedValue("sent");
+    inChat(<LimitBanner block="chat-quota" message="quota" loginLabel="login" />, undefined);
+    fireEvent.click(screen.getByRole("button", { name: "login" }));
+    fireEvent.change(screen.getByLabelText("メールアドレス"), { target: { value: "fan@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "ログインリンクを送信" }));
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      callbackURL: "http://localhost:3000/auth/callback",
+    }));
+  });
+});

--- a/docs/superpowers/specs/2026-07-28-s1.7-living-document-save-login-wall-design.md
+++ b/docs/superpowers/specs/2026-07-28-s1.7-living-document-save-login-wall-design.md
@@ -305,25 +305,47 @@ Neon     (users worker, drizzle)     routes  ← saveRoute writes here (create-o
   > the leg being closed, and not retiring the cookie closes it, because the same `anon_<hex>`
   > keeps resolving to the same bucket.
   >
-  > **Why rev5's privacy argument does not survive its own migration.** rev5 justified retirement
-  > with a shared-browser leak: visitor B logs in and inherits visitor A's anonymous sessions. But
-  > retirement happens **only on `migrated: true`**, i.e. strictly *after* the `UPDATE` has
-  > re-pointed every one of A's `conversations` rows at A's account. The identity B would inherit
-  > is therefore **empty** — inheriting it carries no session, no history and no route. What does
-  > carry over is the day's quota count against that identity, which is exactly the effect being
-  > kept. The second leak rev5 named (post-logout anonymous turns accreting onto the same
-  > `anon_<hex>` and being swept up by the next account to log in) is likewise a consequence of
-  > *not* retiring, and is now the intended behaviour: those turns belong to the same browser and
-  > the same quota bucket.
+  > **Why rev5's privacy argument does not survive its own migration — on the success path.**
+  > rev5 justified retirement with a shared-browser leak: visitor B logs in and inherits visitor
+  > A's anonymous sessions. But retirement happened **only on `migrated: true`**, i.e. strictly
+  > *after* the `UPDATE` had re-pointed every one of A's `conversations` rows at A's account
+  > (`SessionRepository.migrate_ownership`). The identity B inherits is therefore **empty** —
+  > no session, no history, no route. What carries over is the day's quota count against that
+  > identity, which is exactly the effect being kept.
+  >
+  > ### Known and accepted residual leaks (owner-ruled: accepted, not closed)
+  >
+  > The paragraph above holds **only where the migration succeeded.** Two branches remain open,
+  > and both are recorded here as accepted residuals rather than as solved:
+  >
+  > 1. **A failed migration leaves the leak rev5 described fully intact.** If the claim fails,
+  >    every one of A's anonymous `conversations` rows is still owned by `anon_<hex>`, the cookie
+  >    lives for its full year, and the next visitor B to log in on that shared browser has
+  >    **A's entire history migrated onto B's account**. This is *the* branch rev5's retirement
+  >    was aimed at, and it is untouched — note that the old code did not retire the cookie on
+  >    this branch either (retirement was gated on `didMigrate`), so this is **not a regression
+  >    introduced by the reversal**; it is a pre-existing hole the reversal does not close and
+  >    must not be read as closing. The client-side retry surface (#507) narrows the window; it
+  >    does not eliminate it.
+  > 2. **Post-logout anonymous turns are an ownership leak, not merely a quota one.** rev5's
+  >    second leak — turns accreting onto the same `anon_<hex>` after a logout — is now intended
+  >    behaviour, but its consequence must not be understated as "the same quota bucket". The
+  >    conversations A creates anonymously after signing out are **content**, and they are swept
+  >    onto **whichever account signs in next on that machine**. That is a transfer of ownership
+  >    of A's actual chat history to an arbitrary third party, and it is accepted knowingly.
   >
   > **What this does not claim to close.** Clearing cookies, or opening a private window, still
   > mints a new identity — `mintAnonymousIdentity` uses `crypto.randomUUID()` with no device
   > binding, so that path is unclosable by construction. It is out of scope here and always was;
   > the reversal only removes a reset the product itself was advertising.
   >
-  > **Second-order benefit.** A failed migration is now recoverable: the anonymous identity, and
-  > the work it still owns, survive for a later retry instead of being stranded behind a cookie
-  > the failed call already burned.
+  > **Second-order benefit — narrower than it first appears.** The reversal improves failure
+  > recovery in exactly **one** case: the client gives up on its timeout and records `failed`
+  > while the server actually succeeded. Under rev5 the edge would have seen `migrated: true`
+  > and retired the cookie, so the retry could no longer present the identity. Every *other*
+  > failure branch already kept its cookie, because retirement was gated on `didMigrate` — so
+  > "not retiring makes failures recoverable" is true only for that timing race, and is not a
+  > general property.
 - New retention path: purge anonymous-owned sessions inactive beyond the configured window
   **excluding any session associated with a route**, populating the currently-unused
   `sessions.expires_at` / `lifecycle` columns. The exclusion predicate queries the Supabase

--- a/docs/superpowers/specs/2026-07-28-s1.7-living-document-save-login-wall-design.md
+++ b/docs/superpowers/specs/2026-07-28-s1.7-living-document-save-login-wall-design.md
@@ -284,13 +284,46 @@ Neon     (users worker, drizzle)     routes  ← saveRoute writes here (create-o
   forwards the identity it encodes. A missing or tampered cookie yields no identity and no
   `Set-Cookie` — minting a fresh anonymous identity there would be meaningless (a brand-new
   identity owns nothing to migrate) and would hand out identities on an authenticated route.
-  **Retire the cookie on success (rev5, Opus P2-b).** `ANON_COOKIE_MAX_AGE_SECONDS` is `31_536_000`
-  — a full year — so without action the `aid` cookie outlives the migration that consumed it. Two
-  concrete leaks follow: on a shared browser, visitor A browses anonymously, then B logs in and
-  inherits **all** of A's anonymous sessions; and after a logout, further anonymous turns accrete
-  onto the same `anon_<hex>` and are swept up by whichever account logs in next. So on a successful
-  migration the edge **rotates or clears** the `aid` cookie in the response, and the identity that
-  was just consumed is never reusable.
+  **~~Retire the cookie on success (rev5, Opus P2-b)~~ — REVERSED, see below.**
+
+  > ### ⚠️ Decision reversal (rev7, owner ruling on #507): the `aid` cookie is **not** retired
+  >
+  > rev5 P2-b required the edge to rotate or clear `aid` on a successful migration. **That is
+  > reversed. The migration route now sets no cookie at all** — it neither mints one nor retires
+  > one. `worker/app.ts`'s `handleSessionMigrate` resolves the cookie, forwards `X-Anon-Id`, and
+  > returns the container's response untouched; `retireAnonymousCookie` is deleted.
+  >
+  > **Why it was reversed.** Retiring the cookie meant the next anonymous turn minted a fresh
+  > `anon_<hex>`, and a fresh identity gets a fresh per-identity quota bucket. That closed a loop
+  > the product actively walks visitors into: exhaust the anonymous quota → the D12 `LimitBanner`
+  > offers a free magic link → log in → log out → **a brand-new anonymous allowance**. The banner
+  > was, in effect, the entry point to an unlimited-free-usage cycle.
+  >
+  > The owner's ruling separates the two halves of that loop. *Login grants quota* is the
+  > conversion funnel doing its job and is kept. *Log out and collect another anonymous
+  > allowance* converts nobody and teaches visitors that staying signed in costs them — that is
+  > the leg being closed, and not retiring the cookie closes it, because the same `anon_<hex>`
+  > keeps resolving to the same bucket.
+  >
+  > **Why rev5's privacy argument does not survive its own migration.** rev5 justified retirement
+  > with a shared-browser leak: visitor B logs in and inherits visitor A's anonymous sessions. But
+  > retirement happens **only on `migrated: true`**, i.e. strictly *after* the `UPDATE` has
+  > re-pointed every one of A's `conversations` rows at A's account. The identity B would inherit
+  > is therefore **empty** — inheriting it carries no session, no history and no route. What does
+  > carry over is the day's quota count against that identity, which is exactly the effect being
+  > kept. The second leak rev5 named (post-logout anonymous turns accreting onto the same
+  > `anon_<hex>` and being swept up by the next account to log in) is likewise a consequence of
+  > *not* retiring, and is now the intended behaviour: those turns belong to the same browser and
+  > the same quota bucket.
+  >
+  > **What this does not claim to close.** Clearing cookies, or opening a private window, still
+  > mints a new identity — `mintAnonymousIdentity` uses `crypto.randomUUID()` with no device
+  > binding, so that path is unclosable by construction. It is out of scope here and always was;
+  > the reversal only removes a reset the product itself was advertising.
+  >
+  > **Second-order benefit.** A failed migration is now recoverable: the anonymous identity, and
+  > the work it still owns, survive for a later retry instead of being stranded behind a cookie
+  > the failed call already burned.
 - New retention path: purge anonymous-owned sessions inactive beyond the configured window
   **excluding any session associated with a route**, populating the currently-unused
   `sessions.expires_at` / `lifecycle` columns. The exclusion predicate queries the Supabase
@@ -524,7 +557,7 @@ only calls it. `users.claimRoutes` stays unwired.
   - [ ] Edge forwarding (happy path, observable): a migration request bearing a **valid** `aid` cookie reaches the container with `X-Anon-Id` **exactly equal to** that cookie's `anon_<hex>` identity — asserted on the forwarded header value, not on "the same HMAC verification was used" (P3) -> unit
   - [ ] Auth predicate positive (rev5 P1-1): a caller stamped with the **real production literal** `X-User-Type: human` is **accepted**, and so is `agent`; this pins the live literal into the suite so an allow-list on a non-existent `"user"` value cannot pass -> unit
   - [ ] Trusted-input validation: an `X-Anon-Id` that fails `^anon_[0-9a-f]{32}$` is treated as **missing** — the endpoint returns `200 {"migrated": false}` and mutates nothing, so structural safety does not depend on the edge being bug-free -> unit
-  - [ ] Cookie retirement (rev5 P2-b): after a successful migration the response rotates or clears the `aid` cookie, so a shared browser's next visitor cannot inherit the consumed identity and post-logout anonymous turns cannot accrete onto it -> unit
+  - [ ] ~~Cookie retirement (rev5 P2-b)~~ **REVERSED (rev7, owner ruling on #507).** Replaced by: a successful migration sets **no** `Set-Cookie` at all, so the same `anon_<hex>` keeps resolving to the same identity — and therefore the same per-identity quota bucket — closing the "log out for a fresh anonymous allowance" loop the D12 banner walks visitors into. Asserted on both `migrated: true` and `migrated: false`, and by a follow-up request that still forwards the same `X-Anon-Id` -> unit
   - [ ] Edge forwarding (scoped, P2-②): `X-Anon-Id` is unconditionally stripped in `forwardV1` alongside `X-User-Id`/`X-User-Type`, so **every** non-migration `/v1` route strips a client-supplied `X-Anon-Id` and it never reaches the container -> unit
   - [ ] Edge resolve-only (P2-③): the migration route verifies an existing `aid` cookie but never mints one — a request with a missing or tampered cookie yields no `X-Anon-Id` and the response carries no `Set-Cookie` -> unit
   - [ ] Purge trigger (P1-5): a scheduled workflow exists that invokes the purge CLI on a cron, asserted against the workflow file's `schedule:` trigger and invoked command, following the `agent-eval-nightly.yml` precedent -> unit

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -6,7 +6,6 @@ import {
   authenticate as realAuthenticate,
   resolveAnonymous,
   resolveAnonymousReadOnly,
-  retireAnonymousCookie,
 } from "./auth.ts";
 import {
   budgetGuidanceResponse,
@@ -262,25 +261,34 @@ function unauthorized(pathname: string): Response {
   return Response.json(UNAUTHORIZED_BODY, { status: 401 });
 }
 
-// ── Session migration (issue #273 Task 3) ──────────────────────────────────
+// ── Session migration (issue #273 Task 3) ─────────────────────────
 //
 // The only route where the edge forwards a trusted X-Anon-Id: it resolves
 // (never mints) the caller's `aid` cookie into the header the container
-// re-validates, then — only once the container reports an actual migration —
-// rotates the cookie so a shared browser's next visitor cannot inherit the
-// consumed identity.
+// re-validates.
+//
+// **The cookie is deliberately NOT retired afterwards (owner ruling, #507 —
+// this REVERSES S1.7 rev5 P2-b; see the spec's "Decision reversal" note).**
+// Retiring it minted a fresh `anon_<hex>` on the next anonymous turn, which
+// reset the per-identity quota — so "exhaust the anonymous quota -> take the
+// free magic link -> log out -> a brand-new anonymous allowance" became a loop
+// the D12 quota banner itself walks the visitor into. Login-grants-quota is the
+// conversion funnel working as intended and stays; the log-out-for-more leg
+// converts nobody and teaches visitors not to stay signed in.
+//
+// rev5's privacy argument does not survive the migration it follows: once the
+// UPDATE lands, that anonymous identity owns nothing — every `conversations`
+// row is re-pointed at the account — so a shared browser's next visitor
+// inherits an EMPTY identity. The only thing carried across is the day's quota
+// count, which is precisely the effect being kept. (Clearing cookies or opening
+// a private window still resets identity — `mintAnonymousIdentity` uses
+// `crypto.randomUUID()` with no device binding. That path is unclosable by
+// design and is not what this addresses.)
+//
+// Keeping the cookie also makes a failed migration recoverable: the anonymous
+// identity, and the work it still owns, survive for a later retry.
 
 const SESSION_MIGRATE_PATH = "/v1/session/migrate";
-
-async function didMigrate(response: Response): Promise<boolean> {
-  if (response.status !== 200) return false;
-  try {
-    const body: unknown = await response.clone().json();
-    return typeof body === "object" && body !== null && (body as { migrated?: unknown }).migrated === true;
-  } catch {
-    return false;
-  }
-}
 
 async function handleSessionMigrate(
   env: Env,
@@ -288,11 +296,7 @@ async function handleSessionMigrate(
   auth: { userId: string; userType: string },
 ): Promise<Response> {
   const identity = await resolveAnonymousReadOnly(request, env);
-  const forwarded = await forwardV1(env, request, auth, identity?.userId ?? null);
-  if (!(await didMigrate(forwarded))) return forwarded;
-  const headers = new Headers(forwarded.headers);
-  headers.append("Set-Cookie", retireAnonymousCookie());
-  return new Response(forwarded.body, { status: forwarded.status, headers });
+  return forwardV1(env, request, auth, identity?.userId ?? null);
 }
 
 /** Forward a container-originated catalog request to the private CATALOG binding

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -258,9 +258,10 @@ export async function resolveAnonymous(
  * Resolve-only variant for the session-migration route (issue #273 Task 3,
  * re-P2-1): verifies an existing `aid` cookie but never mints one. A missing
  * or tampered cookie returns null rather than a fresh identity, so a request
- * with no anonymous history forwards no `X-Anon-Id` and the response carries
- * no `Set-Cookie` — minting here would silently give the migration endpoint
- * side effects no other route has.
+ * with no anonymous history forwards no `X-Anon-Id` — minting here would
+ * silently give the migration endpoint side effects no other route has. The
+ * route sets no cookie at all: it does not mint one, and (per the #507 owner
+ * ruling reversing S1.7 rev5 P2-b) it no longer retires one either.
  */
 export async function resolveAnonymousReadOnly(
   request: Request,
@@ -273,10 +274,4 @@ export async function resolveAnonymousReadOnly(
   const verified = await verifyAnonymousToken(cookie, secret);
   if (verified === null) return null;
   return { userId: `${ANON_ID_PREFIX}${verified}`, setCookie: null };
-}
-
-/** Rotate/clear the `aid` cookie after a successful migration (rev5 P2-b) so
- * a shared browser's next visitor cannot inherit the consumed identity. */
-export function retireAnonymousCookie(): string {
-  return `${ANON_COOKIE}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`;
 }

--- a/worker/sessionMigration.test.ts
+++ b/worker/sessionMigration.test.ts
@@ -94,19 +94,41 @@ void test("a client-forged X-Anon-Id is overwritten by the edge's own resolution
   assert.notEqual(cap.req?.headers.get("X-Anon-Id"), "anon_" + "f".repeat(32));
 });
 
-void test("a successful migration rotates/clears the aid cookie", async () => {
+// Owner ruling (#507) REVERSING S1.7 rev5 P2-b: the migration no longer retires
+// the `aid` cookie. Retiring it minted a fresh identity on the next anonymous
+// turn and reset the per-identity quota, making "exhaust quota -> free login ->
+// log out -> new allowance" a loop the D12 banner walks visitors into. After a
+// successful migration the anonymous identity owns nothing anyway, so what a
+// shared browser inherits is an empty identity plus the day's quota count --
+// which is the point. Asserted on BOTH outcomes so a re-introduction fails here.
+
+void test("a successful migration does NOT retire the aid cookie (#507 reversal)", async () => {
   const cap: { req?: Request } = {};
   const app = createWorkerApp({ nextHandler: { fetch: () => Promise.resolve(new Response("next")) }, authenticate: authOk });
   const cookie = await anonCookieFor("anon_" + "d".repeat(32));
   const res = await app.request(
     "/v1/session/migrate", { method: "POST", headers: { Cookie: cookie } }, envWithContainer(cap, { migrated: true }), stubCtx,
   );
-  const setCookie = String(res.headers.get("Set-Cookie"));
-  assert.match(setCookie, /^aid=;/);
-  assert.match(setCookie, /Max-Age=0/);
+  assert.equal(res.headers.get("Set-Cookie"), null);
 });
 
-void test("a no-op migration (migrated: false) does not rotate the cookie", async () => {
+void test("the surviving identity keeps working: a later anonymous turn reuses it", async () => {
+  const cap: { req?: Request } = {};
+  const app = createWorkerApp({ nextHandler: { fetch: () => Promise.resolve(new Response("next")) }, authenticate: authOk });
+  const anonId = "anon_" + "d".repeat(32);
+  const cookie = await anonCookieFor(anonId);
+  const migrated = await app.request(
+    "/v1/session/migrate", { method: "POST", headers: { Cookie: cookie } }, envWithContainer(cap, { migrated: true }), stubCtx,
+  );
+  // Nothing in the response tells the browser to drop `aid`, so the same
+  // cookie still resolves to the same identity -- and therefore to the same
+  // per-identity quota bucket, which is what closes the log-out-for-more loop.
+  assert.equal(migrated.headers.get("Set-Cookie"), null);
+  await app.request("/v1/session/migrate", { method: "POST", headers: { Cookie: cookie } }, envWithContainer(cap), stubCtx);
+  assert.equal(cap.req?.headers.get("X-Anon-Id"), anonId);
+});
+
+void test("a no-op migration (migrated: false) sets no cookie either", async () => {
   const cap: { req?: Request } = {};
   const app = createWorkerApp({ nextHandler: { fetch: () => Promise.resolve(new Response("next")) }, authenticate: authOk });
   const cookie = await anonCookieFor("anon_" + "e".repeat(32));


### PR DESCRIPTION
Fixes #507.

## The defect

The anonymous → signed-in ownership migration was finished on **both** sides and had **never been called once**:

- `worker/app.ts` — `SESSION_MIGRATE_PATH`, `handleSessionMigrate`, cookie retirement (+ `worker/sessionMigration.test.ts`)
- `apps/agent/agent/interfaces/routes/session_migration.py` — the reject-anonymous ingress (+ its unit suite)
- `apps/web` — **nothing**. `useAuthCallback`'s `redeem()` did `establish()` + `withTimeout(replay, …)` and stopped there.

Every part was green; the chain was not. Any anonymous visitor who signed in — magic-link, OTP or OAuth, all funnelled through this one hook — lost access to the sessions and routes they had created beforehand. That is the core promise of S1.7 / #273 Task 3, whose spec says in as many words: *"The client calls this once, post-login, from the same `useAuthCallback` path that replays the deferred save."*

## The change

`src/lib/auth/sessionMigration.ts` (new) + three lines of wiring in `useAuthCallback.ts`. No UI change, so no design-sync surface is touched.

### Anonymous identity — `credentials: "include"` is the whole mechanism

`aid` is an `HttpOnly`, worker-signed cookie (`worker/auth.ts:228`) — unreadable from JS **by construction**, which is the point: the container must never accept the anonymous half from the client. So the request carries no identifier of its own. It sends `credentials: "include"`, the browser attaches `aid`, and `handleSessionMigrate` resolves (never mints) it into the trusted `X-Anon-Id` on this route alone. The base URL is `currentChatConfig().baseUrl` — deliberately the exact origin `/v1/chat` posts to, i.e. the origin whose cookie jar holds `aid`. Body: none. Session id: none. Identity-dimensional, per the spec.

### Ordering — alongside the replay, not before or after it

They share no data: the migration re-points `conversations.user_id` in the agent's database; the replay creates a *fresh* route through the users Worker from client-held point ids (create-on-login, not claim). Both already hold the token `establish()` returned. Serialising them would double this interstitial's worst case to 16s to buy an ordering nothing depends on, so they run under one `Promise.all`.

**When both fail** the visitor sees the existing save-failure surface alone — the one they asked for and can act on. No compounded state, no new UI.

### Idempotency — verified in the server source, not assumed

A repeated magic-link tap or a callback refresh is harmless twice over:

1. `SessionRepository.migrate_ownership` is `UPDATE … WHERE user_id = $from_anon`, never `INSERT` — a second run matches zero rows and returns `{"migrated": false}`, a typed no-op rather than an error;
2. the first success makes the edge retire the `aid` cookie, so the second call arrives with no anonymous identity at all and short-circuits in `migrate_session_ownership`'s `None` branch before touching the database.

`ok` therefore covers both `{"migrated": true}` and `{"migrated": false}` — the client has nothing to do differently, and an unread third value would be dead scaffolding.

### Failure — not blocking, and not silent

The login already succeeded; the visitor is authenticated whatever this returns, and stranding them on an interstitial over it would be worse than the thing it reports. It is not fail-open either:

- the failure emits a structured, credential-free event record — deliberately the same shape as the edge's own `logInvalidCredential`;
- and it **self-heals without the visitor doing anything**: the edge retires `aid` only on `{"migrated": true}`, so a failed run leaves the anonymous identity — and the work it owns — intact, and the next login on this browser migrates it. A user-facing retry would buy a prompt over a path that already recovers itself.

### Timeout

`MIGRATE_TIMEOUT_MS = REPLAY_TIMEOUT_MS` (8s), through the same `withTimeout` helper, now generic over its outcome type. A stalled service degrades to the failure path rather than pinning the visitor on the screen.

## Evidence

**End-to-end** (`tests/integration/session-migration-on-login.test.ts`) — the bug's cause was "every part green, chain never walked", so this asserts the chain rather than a seam. It renders the **real** `<AuthCallback>` with **no injected doubles at all** (production `getAuthToken`, `replayDeferredSave`, `migrateAnonymousSession`) and asserts on the HTTP request an edge stand-in actually observed: POST, `Bearer <the token establish returned>`, `credentials: include`, empty body, idempotent across a second mount, login still completes on a 503. A sixth test pins the posted path against `worker/app.ts`'s `SESSION_MIGRATE_PATH` literal — #507 was two finished halves that never met, and a silent rename of either would recreate it exactly.

**Mutation verification** — every mutation was applied to the real source and killed:

| Mutation | Unit | Integration |
|---|---|---|
| delete `runMigration` from `redeem()` | 3 failed / 6 | 4 failed / 1 |
| flip the failure branch to never report | 3 failed / 6 | 1 failed / 4 |
| drop `credentials: "include"` | 2 failed / 5 | 1 failed / 4 |
| rename the posted path | — | 4 failed / 1 |
| block the login on a failed migration | 6 failed / 3 | — |

**Gates** — `pnpm test` 1479 passed / 199 files, coverage 98.56 / 95.38 / 98.65 / 99.45 against the `vitest.config.ts` floor of 98 / 95 / 98 / 99 (no ratchet regression); `pnpm run test:integration` 18 passed; `pnpm run typecheck` and `pnpm run lint:oxlint --deny-warnings` clean; `pnpm run test:worker` 204 passed (untouched). No suppressions.

---

## Review round 1 — response

Fable seat approved; Opus seat requested changes. The data layer both seats confirmed stands unchanged. Everything below is the journey layer, plus the owner's reversal.

---

### 🔴 P1-1 — three walls now carry a return target · **fixed, all three**

`/chat?session=<id>` is the only entry that reads a migrated session back, and none of the in-chat walls passed one. All three now do:

| Wall | File |
|---|---|
| P5 save wall | `TimedItinerary.tsx` → `SaveLoginWall` |
| D11/D12 limit banner | `LimitBanner.tsx` |
| D8 session expiry | `SessionExpired.tsx` |

**None was skipped.** Session expiry looked like a candidate — but D8 is *auth*-session expiry with the conversation still mounted, and its own `onResume` re-reads that session, so returning to it is more clearly right there than anywhere else.

**The id cannot come from the URL.** `?session=` is an *entry* parameter; the id the backend assigns mid-conversation is never written back (`ChatPage` never navigates), so it lives only in `useChatSession`'s tracker ref. `ChatReturnTargetProvider` publishes the *reader*, not the value — the ref deliberately does not re-render.

**#480 reconciliation — a second silent retirement, caught on the way in.** `hasReturnIntent` was `sanitizeReturnTarget(next) !== "/"`. Once the save wall carries a target, that rule would have applied #480 P1-2's navigate-instead-of-retry to the save journey — silently retiring the retry/skip surface built for exactly it, and **no test would have caught it**, because every test passes the flag directly. So it is narrowed to `carriesPanelIntent`: a target with a *panel* to get back to (BYOK's `?settings=`). #480 keeps its behaviour verbatim; a plain session return keeps the retry surface. Pinned in three directions.

### 🔴 P1-2 — `migrated: true/false` no longer folded · **fixed**

`SessionMigrationOutcome` is now `"migrated" | "nothing" | "failed"`, and `anomalyOf(outcome, expected)` reads a no-op as an anomaly when the login's `next` named a session. That is exactly the cross-device case — the target travels in the URL, `aid` does not — and it is the one detector that would catch a re-broken wiring, which is what #507 was.

### 🔴 P1-3 — "not silent" now holds · **fixed, and you were right**

The `logInvalidCredential` analogy was wrong: that one lands in Cloudflare logs, this one landed in the visitor's own devtools. `apps/web` has **zero** telemetry sinks, so there was no sink to reach for.

The real outlet is the visitor — the only party who can act. A failed claim now renders on the callback screen with **retry** and **skip**, reusing the `auth-callback__save-failed` structure (the design sync has no callback mock, so the in-repo designed surface is the reference, not a new pattern). It does not block the login: skip navigates, retry re-runs the idempotent call. `nothing-migrated` gets its own copy — a retry on this device cannot reach the other browser, and saying "it broke" would be a lie. New keys in ja/zh/en. The structured `console.warn` stays as a developer aid *beside* the surface, not as the reporting.

### ✅ Owner ruling — `aid` is no longer retired · **applied, spec updated**

`retireAnonymousCookie` and `didMigrate` are **deleted**; `handleSessionMigrate` resolves, forwards, returns. The spec (`2026-07-28-s1.7-…`) carries a **Decision reversal (rev7)** block striking rev5 P2-b, with the loop it closed, why rev5's privacy argument does not survive its own migration (post-`UPDATE` the inherited identity is *empty*; only the quota count carries), and what it explicitly does not close (`crypto.randomUUID()`, unclosable by design). The struck AC is replaced, not deleted. Both worker tests inverted, plus a new one proving the surviving identity still resolves on a later request — the actual mechanism that closes the loop.

---

### P2 — each one

| Item | Disposition |
|---|---|
| **Self-heal argument does not hold** | **Conceded — it was the weakest thing in the PR.** You are right that a signed-in user never passes `/auth/callback` again, and the 30-day routeless purge turns one failure into permanent loss. It is no longer load-bearing: the retry is now *in front of the visitor*, at the moment it fails. Not retiring `aid` improves the fallback (identity + work survive for a later login) but it is the backup argument now, not the argument. |
| **`Promise.all` fragility** | **Fixed structurally + pinned.** Root cause was upstream of `runMigration`: `withTimeout` called `run()` inside `Promise.race`, so a *synchronous* throw escaped before any `.catch` attached. `withTimeout` is now `async`, which converts it to a rejection. A throwing-migrate test proves it — and it **failed** before the fix, exactly as predicted. |
| **8s on mobile + `keepalive`** | **Adopted.** `MIGRATE_TIMEOUT_MS = 4_000` (own constant, no longer aliasing the replay's) and `keepalive: true`, so the mutation outlives a navigation away from the interstitial. |
| **Fable P3 — no abort on timeout** | **Re-assessed; now benign.** A timeout can still be a false negative, but with `aid` retained the retry is the same idempotent zero-row `UPDATE`, so the worst case is a wasted no-op instead of a burned identity. Documented at `runMigration` rather than abort-wired — an `AbortController` would *cause* the loss it is meant to prevent. |

---

### 📋 The institutional gap

Task 3 carries **25 ACs: 18 unit, 7 integration, 0 client**. Every one asks "did the rows move?"; not one asks "can the user reach them?" That is why P1-1 shipped through a double review — the fix satisfied every AC that existed. The ACs were written against the endpoint, and the endpoint was never the whole feature. Worth carrying into how Task-3-shaped cards get their ratchet: a card that changes what a user can reach needs at least one AC phrased from the user's side.

---

### Mutation evidence — 13 applied to real source, 13 killed

| # | Mutation | Unit | Integration | Worker |
|---|---|---|---|---|
| 1 | delete `runMigration` from `redeem()` | 3F/6 | 4F/1 | — |
| 2 | flip the failure branch | 3F/6 | 1F/4 | — |
| 3 | drop `credentials: "include"` | 2F/5 | 1F/4 | — |
| 4 | rename the posted path | — | 4F/1 | — |
| 5 | block the login on failure | 6F/3 | — | — |
| 6 | drop the save wall's return target | 1F/11 | — | — |
| 7 | widen `hasReturnIntent` back to `next !== "/"` | 1F/11 | — | — |
| 8 | fold `migrated:false` back into success | 3F/79 | — | — |
| 9 | silence the visitor-facing surface | 12F/70 | 2F/17 | — |
| 10 | restore `worker/{app,auth}.ts` **verbatim** from `c50f699b` (retirement + `didMigrate` + `retireAnonymousCookie`) | — | — | **2F/205** |
| 11 | make `withTimeout` non-`async` | 1F/14 | — | — |
| 12 | drop `keepalive` + `credentials` | 3F/9 | 1F/18 | — |
| 13 | **call site**: `callback.tsx` `carriesPanelIntent(next)` → `sanitizeReturnTarget(next) !== "/"` | 1F/1508 | — | — |

**M13 is the Fable seat's, and it survived my first pass.** M7 widened `carriesPanelIntent` *itself* and died on the function-level pin — but mutating the **call site** left all 1508 tests green. The protection had stopped on exactly the boundary #507 fell on: the function was pinned, the wiring was not; nothing drove `next=/chat?session=X` + a failed replay through the route. `callback-route.test.tsx` now carries that case as the matched pair of the existing #480 BYOK test — a session return **holds** the retry surface, a panel return **navigates** — and M13 now fails 1/9 in that file, 1/1509 across the suite.

**M10's count is corrected, and the correction matters.** I reported `5F/200`; the Fable seat could only reproduce `2F/205` restoring the original code verbatim, and it is right. My `5F` came from an ad-hoc unconditional `Set-Cookie`, which also broke the unrelated "no cookie on a missing/tampered cookie" tests — three of those five deaths were for the wrong reason. The verbatim restore kills exactly the two rev7 reversal pins, which is the honest number. Going forward the mutation shape is stated in the table rather than described, so a count is reproducible; this repo has already caught one mutation that went red for the wrong reason.

M8 leaves the integration lane green — the anomaly is a unit-level concern and the integration suites do not exercise `expectsMigration`. Stated rather than papered over.

### End-to-end evidence

Unchanged in kind, extended in reach. `tests/integration/session-migration-on-login.test.ts` still renders the real `<AuthCallback>` with **no injected doubles** and asserts the request an edge stand-in observed. `create-on-login.test.ts` runs `onUnhandledRequest: "error"` and now needs a migrate handler — which is itself proof the call is real: delete the client wiring and the handler goes unused; delete the handler and the suite errors. The three walls are asserted through the **real magic-link form** on the exact `callbackURL` (`…/auth/callback?next=%2Fchat%3Fsession%3D…`), not on a prop.

### Gates

`pnpm test` **1509 passed / 201 files**, coverage **98.53 / 95.42 / 98.60 / 99.46** against the `vitest.config.ts` floor of 98/95/98/99 — no ratchet regression. `test:integration` 19 passed. `test:worker` **205 passed**. `typecheck` + `lint:oxlint --deny-warnings` clean, every function back under the 10-line cap. No suppressions.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

