### PR TITLE
fix(ci): web smoke probe must accept text/html

### DIFF
--- a/.github/scripts/post-deploy-assert.sh
+++ b/.github/scripts/post-deploy-assert.sh
@@ -59,15 +59,15 @@ esac
 # this: that plaintext shape is undocumented, varies by the client's `Accept`
 # header, and is specific to today's error code — a different edge-error
 # family on a future first-deploy would silently bypass a hardcoded match.
-# Instead, every request in this script asks for `Accept: application/json`
-# (see the `fetch` args below). Cloudflare's documented error-response
+# Instead, every request in this script asks for `application/json` FIRST in
+# its `Accept` header (see `ACCEPT_HEADER` / the `fetch` args below).
+# Cloudflare's documented error-response
 # contract (https://developers.cloudflare.com/fundamentals/reference/error-responses/)
 # renders ANY edge/network error it generates itself — 1xxx client/DNS-side,
 # 5xx origin-side alike — as an RFC-9457-shaped JSON body carrying a
 # top-level `"cloudflare_error": true` field when JSON is requested; an
 # origin/application response (this app's real JSON error envelopes, or its
-# branded HTML 404 — apps/web does not content-negotiate on `Accept`, so it
-# renders the same HTML regardless) never emits that field. Checking
+# branded HTML 404) never emits that field. Checking
 # BODY_FILE from THIS SAME request — not firing a second, separate request —
 # matters: two requests to a workers.dev hostname mid-propagation can land on
 # two different edge PoPs (one still stale, one already updated), so a
@@ -89,9 +89,18 @@ is_cloudflare_edge_error() {
 # by design — a 404 that is NOT confirmed as Cloudflare's own is one of those
 # real, final answers too (it is exactly what a genuinely broken route, or
 # this app's own branded 404 page, returns).
+#
+# `ACCEPT_HEADER` lets a caller widen what it will accept. It must keep
+# `application/json` FIRST so Cloudflare still renders its own edge errors as
+# JSON (the discrimination above depends on that); appending `text/html` is
+# for origins that refuse JSON-only requests. `apps/web` is one: it 500s with
+# `{"error":"Only HTML requests are supported here"}` unless `text/html`
+# appears in `Accept` (verified against animichi-web-staging on 2026-07-29 —
+# it substring-matches rather than doing q-value negotiation, so ordering is
+# free to serve Cloudflare's preference).
 fetch() {
   local method="$1" url="$2" auth_header="${3:-}" body="${4:-}"
-  local args=(-sS -o "${BODY_FILE}" -w '%{http_code}' --connect-timeout 10 --max-time 20 -X "${method}" "${url}" -H 'Accept: application/json')
+  local args=(-sS -o "${BODY_FILE}" -w '%{http_code}' --connect-timeout 10 --max-time 20 -X "${method}" "${url}" -H "Accept: ${ACCEPT_HEADER:-application/json}")
   [ -n "${auth_header}" ] && args+=(-H "Authorization: ${auth_header}")
   [ -n "${body}" ] && args+=(-H "Content-Type: application/json" -d "${body}")
   local attempt status rc retry_reason
@@ -206,7 +215,7 @@ cmd_anon_disabled_production() {
 # to render. The `landing` class only exists on LandingPage's own <main>.
 cmd_web_landing() {
   : "${WEB_URL:?WEB_URL is required}"
-  local status
+  local status ACCEPT_HEADER='application/json, text/html'
   status="$(fetch GET "${WEB_URL}/")"
   diag "${status}"
   [ "${status}" = "200" ] || fail "GET ${WEB_URL}/ expected 200, got ${status}"

--- a/.github/scripts/post-deploy-assert.test.sh
+++ b/.github/scripts/post-deploy-assert.test.sh
@@ -121,9 +121,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
 # ── Case 3: Cloudflare edge 404 twice, then the real 200 -> recovers on the
 #    3rd request. Its edge-error branch renders JSON only when JSON is
-#    requested (as Cloudflare does), so this case also guards that
-#    `application/json` stays in ACCEPT_HEADER: drop it and the probe can no
-#    longer tell an edge 404 from a real one. ────────────────────────────────
+#    requested AND listed first (Cloudflare does true q-value negotiation:
+#    at equal q, first-listed wins), so this case guards both that
+#    application/json stays in ACCEPT_HEADER and that it stays FIRST. ──────
 test_cf_edge_404_then_recovers() {
   local port=18803 counter_file pid rc=0 requests
   counter_file="$(mktemp)"
@@ -136,7 +136,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
         served['n'] += 1
         if served['n'] <= 2:
             self.send_response(404)
-            if 'application/json' in self.headers.get('Accept', ''):
+            if self.headers.get('Accept', '').startswith('application/json'):
                 self.send_header('Content-Type', 'application/json')
                 self.end_headers()
                 self.wfile.write(b'''${CF_JSON_BODY}''')

--- a/.github/scripts/post-deploy-assert.test.sh
+++ b/.github/scripts/post-deploy-assert.test.sh
@@ -120,7 +120,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
 }
 
 # ── Case 3: Cloudflare edge 404 twice, then the real 200 -> recovers on the
-#    3rd request ────────────────────────────────────────────────────────────
+#    3rd request. Its edge-error branch renders JSON only when JSON is
+#    requested (as Cloudflare does), so this case also guards that
+#    `application/json` stays in ACCEPT_HEADER: drop it and the probe can no
+#    longer tell an edge 404 from a real one. ────────────────────────────────
 test_cf_edge_404_then_recovers() {
   local port=18803 counter_file pid rc=0 requests
   counter_file="$(mktemp)"
@@ -133,9 +136,14 @@ class Handler(http.server.BaseHTTPRequestHandler):
         served['n'] += 1
         if served['n'] <= 2:
             self.send_response(404)
-            self.send_header('Content-Type', 'application/json')
-            self.end_headers()
-            self.wfile.write(b'''${CF_JSON_BODY}''')
+            if 'application/json' in self.headers.get('Accept', ''):
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(b'''${CF_JSON_BODY}''')
+            else:
+                self.send_header('Content-Type', 'text/html')
+                self.end_headers()
+                self.wfile.write(b'<html>edge error</html>')
         else:
             self.send_response(200)
             self.send_header('Content-Type', 'text/html')

--- a/.github/scripts/post-deploy-assert.test.sh
+++ b/.github/scripts/post-deploy-assert.test.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
-# Behavioral tests for post-deploy-assert.sh. There is no shell mocking
-# framework in this repo, so these drive the real script against throwaway
-# Python mock servers.
+# Behavioral tests for post-deploy-assert.sh, driven against throwaway Python
+# mock servers (this repo has no shell mocking framework).
 #
-# Per this repo's "mock the clock" rule (AGENTS.md#cross-stack-guardrails),
-# every assertion here is on OBSERVABLE BEHAVIOR — request COUNT and exit
-# code — never on elapsed time. An earlier version asserted a duration
-# window and flaked in CI while passing locally.
-# `POST_DEPLOY_ASSERT_RETRY_BACKOFF_BASE_SECONDS` is lowered only so the
-# retrying cases don't sleep for real minutes; no assertion depends on it.
+# Per the "mock the clock" rule (AGENTS.md), every assertion is on OBSERVABLE
+# BEHAVIOR — request COUNT and exit code — never elapsed time; an earlier
+# version asserted a duration window and flaked in CI while passing locally.
+# `POST_DEPLOY_ASSERT_RETRY_BACKOFF_BASE_SECONDS` only shortens the sleeps.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -23,11 +20,9 @@ fail_test() {
   exit 1
 }
 
-# Starts a background mock server on the given port using the given Python
-# handler body (must define class Handler(BaseHTTPRequestHandler) and serve
-# it). The handler is expected to append one line to COUNTER_FILE per request
-# it serves — request COUNT, not elapsed time, is what these tests assert on.
-# Prints nothing; caller tracks the PID via $!.
+# Starts a background mock server. `handler_body` must define
+# class Handler(BaseHTTPRequestHandler) and append one line to COUNTER_FILE
+# per request served. Prints nothing; caller tracks the PID via $!.
 start_mock() {
   local port="$1" counter_file="$2" handler_body="$3"
   python3 -c "
@@ -120,10 +115,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
 }
 
 # ── Case 3: Cloudflare edge 404 twice, then the real 200 -> recovers on the
-#    3rd request. Its edge-error branch renders JSON only when JSON is
-#    requested AND listed first (Cloudflare does true q-value negotiation:
-#    at equal q, first-listed wins), so this case guards both that
-#    application/json stays in ACCEPT_HEADER and that it stays FIRST. ──────
+#    3rd request. Its edge-error branch renders JSON only when JSON is asked
+#    for FIRST (Cloudflare negotiates on q; at equal q the first-listed type
+#    wins), so this case also guards ACCEPT_HEADER's ordering. ─────────────
 test_cf_edge_404_then_recovers() {
   local port=18803 counter_file pid rc=0 requests
   counter_file="$(mktemp)"
@@ -141,7 +135,6 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self.end_headers()
                 self.wfile.write(b'''${CF_JSON_BODY}''')
             else:
-                self.send_header('Content-Type', 'text/html')
                 self.end_headers()
                 self.wfile.write(b'<html>edge error</html>')
         else:
@@ -164,9 +157,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
 }
 
 # ── Case 4: an HTML-only origin (apps/web) -> the probe must ask for
-#    text/html. Mirrors the real staging failure: apps/web answers 500
-#    {"error":"Only HTML requests are supported here"} to a JSON-only Accept.
-#    Kill `ACCEPT_HEADER` in cmd_web_landing and this case goes red.
+#    text/html. Mirrors the real staging failure — a JSON-only Accept gets
+#    500 {"error":"Only HTML requests are supported here"}. ────────────────
 test_html_only_origin_is_accepted() {
   local port=18804 counter_file pid rc=0 requests
   counter_file="$(mktemp)"

--- a/.github/scripts/post-deploy-assert.test.sh
+++ b/.github/scripts/post-deploy-assert.test.sh
@@ -1,23 +1,14 @@
 #!/usr/bin/env bash
-# Behavioral tests for post-deploy-assert.sh's #522 fix: a real application
-# 404 must fail immediately, and a Cloudflare-edge 404 (cloudflare_error:true
-# body) must retry until it resolves. No mocking framework in this repo
-# (no bats, no JS test runner wired to shell scripts) — this drives the real
-# script against a throwaway Python mock server, the same way this fix was
-# verified by hand during review of #522/#523.
+# Behavioral tests for post-deploy-assert.sh. There is no shell mocking
+# framework in this repo, so these drive the real script against throwaway
+# Python mock servers.
 #
-# Per this repo's "mock the clock" test-quality rule
-# (AGENTS.md#cross-stack-guardrails), assertions here are on the OBSERVABLE
-# BEHAVIOR that the retry logic is actually responsible for — how many
-# requests were made, and the final exit code — never on how long it took. A
-# shared CI runner's wall clock is not reliable enough to assert a duration
-# window against without intermittent flakes (this is exactly what an
-# earlier version of this file did, and it flaked in CI while passing
-# locally). `POST_DEPLOY_ASSERT_RETRY_BACKOFF_BASE_SECONDS` is set to a tiny
-# value purely so the retrying test cases don't spend real wall-clock minutes
-# sleeping — the assertions below do not depend on that value at all, only
-# on request counts, so an even smaller or larger override would not change
-# what these tests check.
+# Per this repo's "mock the clock" rule (AGENTS.md#cross-stack-guardrails),
+# every assertion here is on OBSERVABLE BEHAVIOR — request COUNT and exit
+# code — never on elapsed time. An earlier version asserted a duration
+# window and flaked in CI while passing locally.
+# `POST_DEPLOY_ASSERT_RETRY_BACKOFF_BASE_SECONDS` is lowered only so the
+# retrying cases don't sleep for real minutes; no assertion depends on it.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -164,8 +155,44 @@ class Handler(http.server.BaseHTTPRequestHandler):
   echo "PASS: recovers after 2 Cloudflare edge 404s once the real 200 lands (${requests} requests, exit ${rc})"
 }
 
+# ── Case 4: an HTML-only origin (apps/web) -> the probe must ask for
+#    text/html. Mirrors the real staging failure: apps/web answers 500
+#    {"error":"Only HTML requests are supported here"} to a JSON-only Accept.
+#    Kill `ACCEPT_HEADER` in cmd_web_landing and this case goes red.
+test_html_only_origin_is_accepted() {
+  local port=18804 counter_file pid rc=0 requests
+  counter_file="$(mktemp)"
+  rm -f "${counter_file}"
+  start_mock "${port}" "${counter_file}" "
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        record_request()
+        if 'text/html' not in self.headers.get('Accept', ''):
+            self.send_response(500)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(b'{\"error\":\"Only HTML requests are supported here\"}')
+            return
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.end_headers()
+        self.wfile.write(b'''${LANDING_BODY}''')
+    def log_message(self, *a): pass
+"
+  pid=$!
+  wait_for_port "${port}"
+  WEB_URL="http://127.0.0.1:${port}" bash "${ASSERT_SH}" web-landing >/tmp/htmlonly.out 2>&1 || rc=$?
+  stop_mock "${pid}"
+  requests="$(request_count "${counter_file}")"
+  rm -f "${counter_file}"
+  [ "${rc}" -eq 0 ] || fail_test "HTML-only origin should pass, got exit ${rc}: $(cat /tmp/htmlonly.out)"
+  [ "${requests}" -eq 1 ] || fail_test "expected exactly 1 request (no retry needed), got ${requests}"
+  echo "PASS: HTML-only origin served (${requests} request, exit ${rc})"
+}
+
 test_branded_404_fails_fast
 test_cf_edge_404_retries_then_fails
 test_cf_edge_404_then_recovers
+test_html_only_origin_is_accepted
 
-echo "All post-deploy-assert.sh #522 behavioral tests passed."
+echo "All post-deploy-assert.sh behavioral tests passed."


### PR DESCRIPTION
## What broke

`Deploy web staging` failed on `main` — **against a healthy deployment.**

`apps/web` is deployed and serving. Verified directly:

| `Accept` | status |
|---|---|
| `text/html` | 200 |
| (none) | 200 |
| `application/json` | **500** `{"error":"Only HTML requests are supported here"}` |

The probe sent `Accept: application/json` on every request. That header was added deliberately in #484: Cloudflare renders its own edge errors as JSON carrying `"cloudflare_error": true`, which is the only reliable way to tell a CF edge 404 (retry) from a real application 404 (fail now). It is correct against the JSON-API components — and it breaks against an HTML-only SSR origin.

**The diagnostic technique and the thing being diagnosed were in conflict**, and both components share `_deploy-component.yml`.

## Fix

`cmd_web_landing` sets `ACCEPT_HEADER='application/json, text/html'`. Both properties hold at once:

- JSON stays **first**, so Cloudflare's error-response preference is unchanged
- `apps/web` substring-matches on `text/html` rather than negotiating q-values, so it serves the page

Verified empirically against `animichi-web-staging` — `text/html, application/json`, `application/json, text/html`, `text/html;q=0.9, application/json` and `*/*` all return 200.

`ACCEPT_HEADER` is a `local` in `cmd_web_landing`; bash's dynamic scoping makes it visible to `fetch` and it disappears on return, so no other assertion's header changes.

## Also corrected: a comment that was wrong

The script claimed:

> branded HTML 404 — apps/web does not content-negotiate on `Accept`, so it renders the same HTML regardless

`apps/web` *does* branch on `Accept`, and 500s. The reasoning was written, reviewed, and never executed against a deployed `apps/web` — the same defect class as the rest of this deploy chain.

## Test

New case 4 drives an HTML-only mock (500 unless `text/html` in `Accept`).

**Mutation-verified**: removing `ACCEPT_HEADER` from `cmd_web_landing` makes case 4 fail with the *exact* staging output —

```
FAIL: HTML-only origin should pass, got exit 1: status=500
body (first 500 chars):
{"error":"Only HTML requests are supported here"}
```

The killing assertion is `[ "${rc}" -eq 0 ]`. 4/4 pass with the fix; `shellcheck` clean; test file 198 lines (under the 200 limit).

## Not in scope

`Deploy root staging` also failed, for unrelated and deeper reasons — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-deployment checks for Cloudflare edge and network errors.
  * Updated web landing-page checks to support HTML responses while retaining reliable error detection.
  * Prevented unnecessary retries when validating HTML-only origins.

* **Tests**
  * Added coverage for HTML-only origin responses.
  * Clarified test expectations around request counts and exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->