### PR TITLE
fix(catalog): stop publishing the Worker on workers.dev

### DIFF
--- a/workers/catalog/AGENTS.md
+++ b/workers/catalog/AGENTS.md
@@ -55,9 +55,12 @@ Root guide: `../../AGENTS.md`.
 - `*.worker.test.ts` runs inside workerd via `vitest.config.ts`; its filesystem is sandboxed.
 - `*.spike.test.ts` runs in the Node pool via `vitest.spike.config.ts` for filesystem, TCP, Docker,
   or child-process work. Filesystem parity checks belong here, not in Worker tests — **unless the
-  check must never be skippable**. The spike pool's `globalSetup` skips the entire suite without
-  `NEON_API_KEY`/`NEON_PROJECT_ID`, so a guard placed there silently disappears in a CI job that
-  has no Neon credentials. Config-as-data guards that must always run belong in the worker pool,
-  reading their file via Vite's `?raw` suffix (inlined at transform time, so the sandboxed
-  filesystem never comes into it). See `test/wrangler-private.worker.test.ts`.
+  check must never be skippable**. Two mechanisms make the spike pool skippable: `globalSetup`
+  provides `{ enabled: false }` without `NEON_API_KEY`/`NEON_PROJECT_ID` and `databaseDescribe`
+  turns that into `describe.skip`; and, decisively, the `catalog-spikes` CI job's `if:`
+  (`ci.yml`) restricts it to `workflow_dispatch` and same-repo `pull_request` — **on a push to
+  `main`, or on any fork PR, it does not run at all**. Config-as-data guards that must always run
+  therefore belong in the worker pool, reading their file via Vite's `?raw` suffix (inlined at
+  transform time, so the sandboxed filesystem never comes into it).
+  See `test/wrangler-private.worker.test.ts`.
 - TDD via `vitest-pool-workers`; keep `test/contract-parity.worker.test.ts` green.

--- a/workers/catalog/AGENTS.md
+++ b/workers/catalog/AGENTS.md
@@ -54,5 +54,10 @@ Root guide: `../../AGENTS.md`.
 
 - `*.worker.test.ts` runs inside workerd via `vitest.config.ts`; its filesystem is sandboxed.
 - `*.spike.test.ts` runs in the Node pool via `vitest.spike.config.ts` for filesystem, TCP, Docker,
-  or child-process work. Filesystem parity checks belong here, not in Worker tests.
+  or child-process work. Filesystem parity checks belong here, not in Worker tests — **unless the
+  check must never be skippable**. The spike pool's `globalSetup` skips the entire suite without
+  `NEON_API_KEY`/`NEON_PROJECT_ID`, so a guard placed there silently disappears in a CI job that
+  has no Neon credentials. Config-as-data guards that must always run belong in the worker pool,
+  reading their file via Vite's `?raw` suffix (inlined at transform time, so the sandboxed
+  filesystem never comes into it). See `test/wrangler-private.worker.test.ts`.
 - TDD via `vitest-pool-workers`; keep `test/contract-parity.worker.test.ts` green.

--- a/workers/catalog/test/raw-modules.d.ts
+++ b/workers/catalog/test/raw-modules.d.ts
@@ -1,0 +1,9 @@
+// Vite's `?raw` import suffix inlines a file's contents as a string at
+// transform time. `vite/client` declares this, but adding it to tsconfig's
+// `types` pulls in the whole DOM-flavoured client surface alongside
+// `@cloudflare/workers-types`, which is the wrong ambient environment for a
+// Worker package. Declaring just the one form keeps the type surface honest.
+declare module "*?raw" {
+  const content: string;
+  export default content;
+}

--- a/workers/catalog/test/wrangler-private.worker.test.ts
+++ b/workers/catalog/test/wrangler-private.worker.test.ts
@@ -21,10 +21,13 @@ import toml from "../wrangler.toml?raw";
 //                  public URL per deployed version, with real bindings.
 //
 // Not hypothetical. `catalog-staging.<account>.workers.dev` was answering
-// unauthenticated requests with real data. The Worker's entire security model
-// is the comment at worker/app.ts:330 ("catalog is private, reached via
-// service binding") — nothing in the request tells catalog whether a caller
-// came through the binding or off the open internet.
+// unauthenticated requests with real data, and preview.yml published the
+// per-version URLs as comments on public PRs.
+//
+// Do NOT cite worker/app.ts's "no /catalog/* route — catalog is private"
+// comment as the authority here: seventeen lines below it the same file
+// registers `/catalog/public/anime-overview/:bangumiId`. The reachability
+// story is what this file asserts, not what any comment claims.
 //
 // Parsing here is deliberately line-based rather than via a TOML library: the
 // point is to assert on the file a human edits, and adding a parser dependency
@@ -65,15 +68,15 @@ const environments = (toml: string): Section[] =>
 // policy: a reader deciding whether an environment is private should not have
 // to know wrangler's inheritance rules to answer it.
 //
-// `[env.preview]` is the one deliberate exception — per-PR previews (#305) are
-// reached through version preview URLs, so `preview_urls` is true there on
-// purpose. It is listed explicitly rather than excluded by a wildcard, so a
-// second environment cannot quietly join the exception.
+// There is no exception. `[env.preview]` briefly carried preview_urls = true
+// for per-PR previews (#305); the owner retired those on 2026-07-29 because
+// staging already serves that role, and because preview.yml published the
+// resulting public URLs on public PRs.
 const PRIVACY: Record<string, string[]> = {
   "top-level": ["workers_dev = false", "preview_urls = false"],
   "env.staging": ["workers_dev = false", "preview_urls = false"],
   "env.production": ["workers_dev = false", "preview_urls = false"],
-  "env.preview": ["workers_dev = false", "preview_urls = true"],
+  "env.preview": ["workers_dev = false", "preview_urls = false"],
 };
 
 describe("catalog has no public host", () => {

--- a/workers/catalog/test/wrangler-private.worker.test.ts
+++ b/workers/catalog/test/wrangler-private.worker.test.ts
@@ -5,21 +5,26 @@ import { describe, expect, it } from "vitest";
 // AGENTS.md routes "filesystem parity checks" to the *.spike.test.ts Node pool.
 // That rule exists because the worker pool's filesystem is sandboxed, which
 // does not apply to a transform-time inline; and following it here would be
-// actively harmful — the spike pool's globalSetup skips the whole suite without
-// NEON_API_KEY/NEON_PROJECT_ID, so this guard would silently vanish in CI. A
-// skipped guard is not a guard.
+// actively harmful — the `catalog-spikes` CI job's `if:` restricts it to
+// workflow_dispatch and same-repo pull_request, so on a push to main (and on
+// any fork PR) it does not run at all. A guard that does not run is not a guard.
 import toml from "../wrangler.toml?raw";
 
-// catalog has no `routes` in any environment, and wrangler resolves
-// `defaultWorkersDev = routes.length === 0` — so every environment that does
-// not say `workers_dev = false` is published on `*.workers.dev` BY DEFAULT.
+// catalog must have no public host. Two independent defaults would give it
+// one, and both were live:
 //
-// This is not hypothetical. `[env.preview]` declared it, `[env.staging]` and
-// `[env.production]` did not, and `catalog-staging.<account>.workers.dev` was
-// answering unauthenticated requests with real data. The Worker's entire
-// security model is the comment at worker/app.ts:330 ("catalog is private,
-// reached via service binding") — nothing in the request tells catalog whether
-// a caller came through the binding or off the open internet.
+//   workers_dev  — catalog declares no `routes`, and wrangler resolves
+//                  `defaultWorkersDev = routes.length === 0`, so leaving the
+//                  key out publishes the Worker.
+//   preview_urls — leaving the key out sends no `previews_enabled` at all, so
+//                  the server keeps Cloudflare's enabled-by-default state: a
+//                  public URL per deployed version, with real bindings.
+//
+// Not hypothetical. `catalog-staging.<account>.workers.dev` was answering
+// unauthenticated requests with real data. The Worker's entire security model
+// is the comment at worker/app.ts:330 ("catalog is private, reached via
+// service binding") — nothing in the request tells catalog whether a caller
+// came through the binding or off the open internet.
 //
 // Parsing here is deliberately line-based rather than via a TOML library: the
 // point is to assert on the file a human edits, and adding a parser dependency
@@ -31,22 +36,23 @@ interface Section {
   lines: string[];
 }
 
+// A sub-table ([env.staging.vars], [[env.staging.r2_buckets]]) ends the
+// environment's own key list; keys after it belong to the sub-table.
+const nameOf = (line: string, current: string): string | null => {
+  const header = /^\[(env\.[A-Za-z0-9_-]+)\]$/.exec(line);
+  if (header?.[1]) return header[1];
+  return line.startsWith("[") ? `${current}:subtable` : null;
+};
+
 const sections = (toml: string): Section[] => {
   let current: Section = { name: "top-level", lines: [] };
   const out: Section[] = [current];
-  const open = (name: string): void => {
-    current = { name, lines: [] };
-    out.push(current);
-  };
   for (const raw of toml.split("\n")) {
     const line = raw.trim();
     if (line.startsWith("#")) continue;
-    const header = /^\[(env\.[A-Za-z0-9_-]+)\]$/.exec(line);
-    // A sub-table ([env.staging.vars], [[env.staging.r2_buckets]]) ends the
-    // environment's own key list; keys after it belong to the sub-table.
-    if (header?.[1]) open(header[1]);
-    else if (line.startsWith("[")) open(`${current.name}:subtable`);
-    else current.lines.push(line);
+    const opened = nameOf(line, current.name);
+    if (opened === null) current.lines.push(line);
+    else out.push((current = { name: opened, lines: [] }));
   }
   return out;
 };
@@ -54,28 +60,35 @@ const sections = (toml: string): Section[] => {
 const environments = (toml: string): Section[] =>
   sections(toml).filter((s) => s.name === "top-level" || /^env\.[A-Za-z0-9_-]+$/.test(s.name));
 
-describe("catalog is not published on workers.dev", () => {
+// Both keys are `inheritable` in wrangler (4.112 cli.js:35080 / :35088), so the
+// top-level value alone would suffice. Asserting per environment anyway is the
+// policy: a reader deciding whether an environment is private should not have
+// to know wrangler's inheritance rules to answer it.
+//
+// `[env.preview]` is the one deliberate exception — per-PR previews (#305) are
+// reached through version preview URLs, so `preview_urls` is true there on
+// purpose. It is listed explicitly rather than excluded by a wildcard, so a
+// second environment cannot quietly join the exception.
+const PRIVACY: Record<string, string[]> = {
+  "top-level": ["workers_dev = false", "preview_urls = false"],
+  "env.staging": ["workers_dev = false", "preview_urls = false"],
+  "env.production": ["workers_dev = false", "preview_urls = false"],
+  "env.preview": ["workers_dev = false", "preview_urls = true"],
+};
+
+describe("catalog has no public host", () => {
   it("declares no routes, so workers_dev cannot be left to its default", () => {
     expect(toml).not.toMatch(/^\s*routes\s*=/m);
   });
 
-  it.each(environments(toml).map((s) => s.name))(
-    "%s sets workers_dev = false explicitly",
-    (name) => {
-      const section = environments(toml).find((s) => s.name === name);
-      expect(section?.lines).toContain("workers_dev = false");
-    },
-  );
+  it.each(Object.entries(PRIVACY))("%s declares %s", (name, expected) => {
+    const section = environments(toml).find((s) => s.name === name);
+    expect(section?.lines).toEqual(expect.arrayContaining(expected));
+  });
 
-  it("finds every environment the file actually declares", () => {
-    // Guards the parser itself: if a new [env.X] is added and this list is not
-    // updated, the count assertion fails and the per-environment case above
-    // cannot silently skip it.
-    expect(environments(toml).map((s) => s.name)).toEqual([
-      "top-level",
-      "env.staging",
-      "env.production",
-      "env.preview",
-    ]);
+  it("finds exactly the environments the file declares", () => {
+    // Guards the parser and the table together: a new [env.X] that nobody adds
+    // to PRIVACY fails here rather than being silently skipped by it.each.
+    expect(environments(toml).map((s) => s.name)).toEqual(Object.keys(PRIVACY));
   });
 });

--- a/workers/catalog/test/wrangler-private.worker.test.ts
+++ b/workers/catalog/test/wrangler-private.worker.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+// `?raw` inlines the file at transform time, so by the time this runs inside
+// workerd the config is just a string constant — no filesystem is touched.
+//
+// AGENTS.md routes "filesystem parity checks" to the *.spike.test.ts Node pool.
+// That rule exists because the worker pool's filesystem is sandboxed, which
+// does not apply to a transform-time inline; and following it here would be
+// actively harmful — the spike pool's globalSetup skips the whole suite without
+// NEON_API_KEY/NEON_PROJECT_ID, so this guard would silently vanish in CI. A
+// skipped guard is not a guard.
+import toml from "../wrangler.toml?raw";
+
+// catalog has no `routes` in any environment, and wrangler resolves
+// `defaultWorkersDev = routes.length === 0` — so every environment that does
+// not say `workers_dev = false` is published on `*.workers.dev` BY DEFAULT.
+//
+// This is not hypothetical. `[env.preview]` declared it, `[env.staging]` and
+// `[env.production]` did not, and `catalog-staging.<account>.workers.dev` was
+// answering unauthenticated requests with real data. The Worker's entire
+// security model is the comment at worker/app.ts:330 ("catalog is private,
+// reached via service binding") — nothing in the request tells catalog whether
+// a caller came through the binding or off the open internet.
+//
+// Parsing here is deliberately line-based rather than via a TOML library: the
+// point is to assert on the file a human edits, and adding a parser dependency
+// to guard three lines is a worse trade than a strict reader that fails loudly
+// on anything it does not understand.
+
+interface Section {
+  name: string;
+  lines: string[];
+}
+
+const sections = (toml: string): Section[] => {
+  let current: Section = { name: "top-level", lines: [] };
+  const out: Section[] = [current];
+  const open = (name: string): void => {
+    current = { name, lines: [] };
+    out.push(current);
+  };
+  for (const raw of toml.split("\n")) {
+    const line = raw.trim();
+    if (line.startsWith("#")) continue;
+    const header = /^\[(env\.[A-Za-z0-9_-]+)\]$/.exec(line);
+    // A sub-table ([env.staging.vars], [[env.staging.r2_buckets]]) ends the
+    // environment's own key list; keys after it belong to the sub-table.
+    if (header?.[1]) open(header[1]);
+    else if (line.startsWith("[")) open(`${current.name}:subtable`);
+    else current.lines.push(line);
+  }
+  return out;
+};
+
+const environments = (toml: string): Section[] =>
+  sections(toml).filter((s) => s.name === "top-level" || /^env\.[A-Za-z0-9_-]+$/.test(s.name));
+
+describe("catalog is not published on workers.dev", () => {
+  it("declares no routes, so workers_dev cannot be left to its default", () => {
+    expect(toml).not.toMatch(/^\s*routes\s*=/m);
+  });
+
+  it.each(environments(toml).map((s) => s.name))(
+    "%s sets workers_dev = false explicitly",
+    (name) => {
+      const section = environments(toml).find((s) => s.name === name);
+      expect(section?.lines).toContain("workers_dev = false");
+    },
+  );
+
+  it("finds every environment the file actually declares", () => {
+    // Guards the parser itself: if a new [env.X] is added and this list is not
+    // updated, the count assertion fails and the per-environment case above
+    // cannot silently skip it.
+    expect(environments(toml).map((s) => s.name)).toEqual([
+      "top-level",
+      "env.staging",
+      "env.production",
+      "env.preview",
+    ]);
+  });
+});

--- a/workers/catalog/wrangler.toml
+++ b/workers/catalog/wrangler.toml
@@ -20,7 +20,7 @@ compatibility_flags = ["nodejs_compat"]
 # below are a deliberate policy choice enforced by
 # test/wrangler-private.worker.test.ts — a reader should not have to know the
 # inheritance rules to see that an environment is private — NOT a wrangler
-# requirement. `[env.preview]` overrides preview_urls back to true on purpose.
+# requirement. Every environment is private; there is no exception.
 workers_dev = false
 preview_urls = false
 
@@ -91,14 +91,17 @@ ENVIRONMENT = "production"
 binding = "MEDIA_BUCKET"
 bucket_name = "catalog-media"
 
-# Per-PR preview environment (issue #305). Routeless: CI deploys only the
-# one-time bootstrap that creates the Worker; previews are undeployed versions
-# reached through preview URLs. DATABASE_URL is injected per version from the
-# Neon branch preview/pr-<N> by .github/workflows/preview.yml.
+# Per-PR preview environment (issue #305). Version preview URLs are
+# `<alias>-<name>.<subdomain>.workers.dev` and are PUBLIC when enabled — and
+# `.github/workflows/preview.yml` posts them as a comment on a public PR, so
+# enabling them published the address of an unauthenticated catalog carrying a
+# DDL-privileged DATABASE_URL. Owner retired per-PR previews on 2026-07-29:
+# staging already serves that role. This block stays private like every other
+# until the machinery itself is removed (tracked separately).
 [env.preview]
 name = "catalog-preview"
 workers_dev = false
-preview_urls = true
+preview_urls = false
 
 [env.preview.vars]
 ENVIRONMENT = "preview"

--- a/workers/catalog/wrangler.toml
+++ b/workers/catalog/wrangler.toml
@@ -2,6 +2,10 @@ name = "catalog"
 main = "src/index.ts"
 compatibility_date = "2025-09-23"
 compatibility_flags = ["nodejs_compat"]
+# No public workers.dev host — reached only via the root Worker CATALOG service
+# binding. wrangler defaults workers_dev to true when no route is declared, so
+# every environment must say this explicitly (see workers/users/wrangler.toml).
+workers_dev = false
 
 # Hyperdrive binds the Worker to a pooled Postgres connection in production.
 # src/index.ts reads env.HYPERDRIVE.connectionString first, falling back to
@@ -48,6 +52,7 @@ ENVIRONMENT = "development"
 
 [env.staging]
 name = "catalog-staging"
+workers_dev = false
 
 [env.staging.vars]
 ENVIRONMENT = "staging"
@@ -58,6 +63,7 @@ bucket_name = "catalog-media-staging"
 
 [env.production]
 name = "catalog"
+workers_dev = false
 
 [env.production.vars]
 ENVIRONMENT = "production"

--- a/workers/catalog/wrangler.toml
+++ b/workers/catalog/wrangler.toml
@@ -2,10 +2,27 @@ name = "catalog"
 main = "src/index.ts"
 compatibility_date = "2025-09-23"
 compatibility_flags = ["nodejs_compat"]
-# No public workers.dev host — reached only via the root Worker CATALOG service
-# binding. wrangler defaults workers_dev to true when no route is declared, so
-# every environment must say this explicitly (see workers/users/wrangler.toml).
+# No public host of any kind — catalog is reached only through the root
+# Worker's CATALOG service binding. Two separate doors have to be shut:
+#
+#   workers_dev  — the <name>.<subdomain>.workers.dev host. wrangler resolves
+#                  `defaultWorkersDev = routes.length === 0`, and catalog
+#                  declares no routes, so omitting this publishes the Worker.
+#   preview_urls — the per-version <prefix>-<name>.<subdomain>.workers.dev
+#                  host. When the key is absent wrangler sends no
+#                  `previews_enabled` at all, so the server keeps Cloudflare's
+#                  enabled-by-default state — a public URL per version, with
+#                  real bindings. wrangler's "unintentionally public" warning
+#                  does not save us: it early-returns under isNonInteractiveOrCI.
+#
+# Both are `inheritable` keys (wrangler 4.112 cli.js:35080 / :35088), so the
+# top-level value alone covers every environment. The per-environment repeats
+# below are a deliberate policy choice enforced by
+# test/wrangler-private.worker.test.ts — a reader should not have to know the
+# inheritance rules to see that an environment is private — NOT a wrangler
+# requirement. `[env.preview]` overrides preview_urls back to true on purpose.
 workers_dev = false
+preview_urls = false
 
 # Hyperdrive binds the Worker to a pooled Postgres connection in production.
 # src/index.ts reads env.HYPERDRIVE.connectionString first, falling back to
@@ -53,6 +70,7 @@ ENVIRONMENT = "development"
 [env.staging]
 name = "catalog-staging"
 workers_dev = false
+preview_urls = false
 
 [env.staging.vars]
 ENVIRONMENT = "staging"
@@ -64,6 +82,7 @@ bucket_name = "catalog-media-staging"
 [env.production]
 name = "catalog"
 workers_dev = false
+preview_urls = false
 
 [env.production.vars]
 ENVIRONMENT = "production"


### PR DESCRIPTION
## The exposure

`catalog-staging.<account>.workers.dev` was publicly reachable and answering unauthenticated requests with real data. Verified directly:

| request | response |
|---|---|
| `GET /healthz` | `{"status":"ok","service":"catalog","env":"staging"}` |
| `POST /catalog/resolve` | 200, real bangumi rows |
| `POST /catalog/geocode` | 200, real gazetteer rows |
| `POST /catalog/nearby` | 200, PostGIS query executed |

The 404 shapes distinguish it cleanly: `catalog-staging` returns the *application's* plain-text `404 Not Found` (Worker present, path unrouted), while `catalog` and `catalog-preview` return Cloudflare's `error code: 1042` (no Worker on that subdomain — production has never deployed).

## Root cause

catalog declares no `routes`, and wrangler resolves `defaultWorkersDev = routes.length === 0`. So **every environment that does not say `workers_dev = false` is published publicly by default.** Only `[env.preview]` said it.

`workers/users/wrangler.toml` declares it in all three blocks and is confirmed unreachable (edge `1042` on all three subdomains). Same repo, same pattern, one written out fully and one not.

## Severity — stated honestly

The read surface is **catalog-domain data that is public by design** (anime titles, covers, pilgrimage points, place-name coordinates). catalog's Drizzle schema only declares `bangumi` / `points` / `cluster_version` / `aliases` / `series_edges`; no handler touches user-domain tables. **This is not a data leak, and I am not going to call it one.**

What does matter is **`POST /catalog/ingest`** — an unauthenticated *write* path that triggers outbound Bangumi/Anitabi calls and writes Neon. Per-work singleflight bounds a single work; nothing bounds a scan across `bangumi_id`s. (Existence confirmed by reading the router; not invoked.)

## The deeper issue this PR does *not* fix

catalog's entire security model is the comment at `worker/app.ts:330`:

> `// NOTE: no /catalog/* route — catalog is private (reached via service binding by the container)`

A service binding forwards an ordinary `Request`. Nothing in it distinguishes a binding caller from the open internet — `worker/app.ts:66-68` adds no shared secret, and catalog's handlers make no authorization check. A default value flipped the whole model off while that comment kept confidently stating the old assumption.

Application-layer defence for `ingest` is tracked separately. The structural fix is a **named `WorkerEntrypoint`**, which removes `ingest`'s HTTP surface entirely rather than guarding it with a shared secret — no secret to provision in four places, no new route that can forget the check, and the binding is validated at deploy time.

## Test

`test/wrangler-private.worker.test.ts` asserts no `routes` are declared and that **every** environment sets `workers_dev = false` explicitly, plus a parser self-check so a newly added `[env.X]` cannot be silently skipped.

**Mutation-verified**: removing the line from `[env.staging]`, `[env.production]`, or the top-level block each turns it red. All three checked.

### On test placement

`AGENTS.md` routes filesystem checks to the `*.spike.test.ts` Node pool. This one deliberately stays in the worker pool, and the guide is updated to say why:

- the rule exists because the worker pool's filesystem is sandboxed — this test reads nothing at runtime, since Vite's `?raw` inlines the config at transform time
- following the rule here would be **actively harmful**: the spike pool's `globalSetup` skips the entire suite without `NEON_API_KEY`/`NEON_PROJECT_ID`, so this guard would silently vanish in CI. A skipped guard is not a guard.

## Gates

`typecheck` clean · `lint:oxlint --type-aware --deny-warnings` clean · `test:worker` 262/262 · coverage unchanged (92.69/78.37/95.63/94.69) · zero suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Disabled public Workers.dev and preview URLs for the catalog service across all environments.
  * Retired per-pull-request preview hosting; staging remains the only preview-like exposure.

* **Tests**
  * Added automated checks to verify deployment privacy settings remain disabled and consistently configured across environments.

* **Documentation**
  * Expanded guidance for test pools and configuration safeguards.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->