### PR TITLE
fix(worker): deny-by-default allowlist on the container's catalog outbound (#540 layer 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:frontend": "pnpm --filter ./frontend run build",
     "deploy": "pnpm run build:frontend && npx wrangler deploy",
     "lint:oxlint": "pnpm --filter catalog --filter users --filter web run lint:oxlint",
-    "test:worker": "node --test worker/entry.test.ts worker/photoSearch.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/turnstileArm.test.ts worker/turnstileReplay.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/sessionMigration.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/byokBudgetExemption.test.ts worker/byokProbeAuth.test.ts worker/edgeGuard.test.ts worker/authRateLimitScope.test.ts worker/containerEnv.test.ts"
+    "test:worker": "node --test worker/entry.test.ts worker/catalogOutbound.test.ts worker/photoSearch.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/turnstileArm.test.ts worker/turnstileReplay.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/sessionMigration.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/byokBudgetExemption.test.ts worker/byokProbeAuth.test.ts worker/edgeGuard.test.ts worker/authRateLimitScope.test.ts worker/containerEnv.test.ts"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -302,11 +302,18 @@ async function handleSessionMigrate(
 
 /** Forward a container-originated catalog request to the private CATALOG binding
  * (in-datacenter hop, never the public internet). Wired as the container's
- * outboundByHost handler in entry.ts. */
+ * outboundByHost handler in entry.ts.
+ *
+ * This is one of two CATALOG call sites — `forwardPublicCatalog` above is the
+ * other, serving the browser's one allowlisted GET. This one is the container's,
+ * and it is deny-by-default: the container runs an LLM, so anything it can name
+ * it can be talked into naming. */
 export function catalogOutbound(request: Request, env: Env): Promise<Response> {
   if (!catalogRequestAllowed(request)) {
     const { pathname } = new URL(request.url);
-    console.warn(JSON.stringify({ event: "catalog_outbound_denied", method: request.method, pathname }));
+    // Logged as an object, not a JSON string: Workers Logs only indexes fields
+    // of structured entries, and filtering is the entire point of this line.
+    console.warn({ event: "catalog_outbound_denied", method: request.method, pathname });
     return Promise.resolve(Response.json({ error: "catalog_request_forbidden" }, { status: 403 }));
   }
   return env.CATALOG.fetch(request);

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -21,6 +21,7 @@ import {
   checkRateLimit,
   rateLimitConfigFrom,
 } from "./rateLimiter.ts";
+import { catalogRequestAllowed } from "./catalogPolicy.ts";
 import { type TurnstileGate, createTurnstileGate, guardTurnstile } from "./turnstile.ts";
 
 export interface Env {
@@ -303,6 +304,11 @@ async function handleSessionMigrate(
  * (in-datacenter hop, never the public internet). Wired as the container's
  * outboundByHost handler in entry.ts. */
 export function catalogOutbound(request: Request, env: Env): Promise<Response> {
+  if (!catalogRequestAllowed(request)) {
+    const { pathname } = new URL(request.url);
+    console.warn(JSON.stringify({ event: "catalog_outbound_denied", method: request.method, pathname }));
+    return Promise.resolve(Response.json({ error: "catalog_request_forbidden" }, { status: 403 }));
+  }
   return env.CATALOG.fetch(request);
 }
 

--- a/worker/catalogOutbound.test.ts
+++ b/worker/catalogOutbound.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { catalogOutbound } from "./app.ts";
+import { CATALOG_OUTBOUND_ALLOWLIST } from "./catalogPolicy.ts";
+
+const EXPECTED_CATALOG_CALLS = [
+  "POST /catalog/search",
+  "POST /catalog/resolve",
+  "POST /catalog/points-by-work-id",
+  "POST /catalog/spots",
+  "POST /catalog/nearby",
+  "POST /catalog/geocode",
+  "POST /catalog/route",
+  "POST /catalog/ingest",
+];
+
+function catalogEnv(received: Request[]): never {
+  return {
+    CATALOG: {
+      fetch: (request: Request) => {
+        received.push(request);
+        return Promise.resolve(new Response("catalog"));
+      },
+    },
+  } as never;
+}
+
+void test("catalog outbound policy exactly matches the agent client", () => {
+  assert.deepEqual([...CATALOG_OUTBOUND_ALLOWLIST], EXPECTED_CATALOG_CALLS);
+});
+
+void test("catalog outbound forwards every allowlisted method and path", async () => {
+  const received: Request[] = [];
+  for (const route of EXPECTED_CATALOG_CALLS) {
+    const [method, pathname] = route.split(" ");
+    const request = new Request(`http://catalog.internal${pathname}`, { method });
+    assert.equal((await catalogOutbound(request, catalogEnv(received))).status, 200);
+  }
+  assert.equal(received.length, EXPECTED_CATALOG_CALLS.length);
+});
+
+void test("catalog outbound rejects a write path outside the allowlist", async () => {
+  const received: Request[] = [];
+  const request = new Request("http://catalog.internal/catalog/publish", { method: "POST" });
+  const response = await catalogOutbound(request, catalogEnv(received));
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), { error: "catalog_request_forbidden" });
+  assert.equal(received.length, 0);
+});
+
+void test("catalog outbound matches method as well as path", async () => {
+  const received: Request[] = [];
+  const request = new Request("http://catalog.internal/catalog/search", { method: "GET" });
+  assert.equal((await catalogOutbound(request, catalogEnv(received))).status, 403);
+  assert.equal(received.length, 0);
+});

--- a/worker/catalogOutbound.test.ts
+++ b/worker/catalogOutbound.test.ts
@@ -11,7 +11,6 @@ const EXPECTED_CATALOG_CALLS = [
   "POST /catalog/nearby",
   "POST /catalog/geocode",
   "POST /catalog/route",
-  "POST /catalog/ingest",
 ];
 
 function catalogEnv(received: Request[]): never {

--- a/worker/catalogPolicy.ts
+++ b/worker/catalogPolicy.ts
@@ -6,7 +6,6 @@ export const CATALOG_OUTBOUND_ALLOWLIST = [
   "POST /catalog/nearby",
   "POST /catalog/geocode",
   "POST /catalog/route",
-  "POST /catalog/ingest",
 ] as const;
 
 const CATALOG_OUTBOUND_ROUTES = new Set<string>(CATALOG_OUTBOUND_ALLOWLIST);

--- a/worker/catalogPolicy.ts
+++ b/worker/catalogPolicy.ts
@@ -1,0 +1,17 @@
+export const CATALOG_OUTBOUND_ALLOWLIST = [
+  "POST /catalog/search",
+  "POST /catalog/resolve",
+  "POST /catalog/points-by-work-id",
+  "POST /catalog/spots",
+  "POST /catalog/nearby",
+  "POST /catalog/geocode",
+  "POST /catalog/route",
+  "POST /catalog/ingest",
+] as const;
+
+const CATALOG_OUTBOUND_ROUTES = new Set<string>(CATALOG_OUTBOUND_ALLOWLIST);
+
+export function catalogRequestAllowed(request: Request): boolean {
+  const pathname = new URL(request.url).pathname;
+  return CATALOG_OUTBOUND_ROUTES.has(`${request.method} ${pathname}`);
+}


### PR DESCRIPTION
catalogOutbound forwarded whatever path the container sent:

    export function catalogOutbound(request, env) {
      return env.CATALOG.fetch(request);   // any path, no check
    }

The container runs an LLM-driven agent, so a URL-construction bug or an
indirect injection arriving through web_search/translate could reach every
catalog route — including POST /catalog/ingest, an unauthenticated write
path that triggers outbound Bangumi/Anitabi calls and writes Neon.

Network isolation does not help here: catalog already has no hostname, no
DNS, no route and workers_dev=false in all three environments (#539). The
attacker is already inside as a legitimate component. The gateway is the one
chokepoint the container cannot bypass, so the check belongs here.

worker/catalogPolicy.ts holds the allowlist as a constant table — method AND
path, not path alone — derived from what apps/agent/agent/clients/
catalog_client.py actually calls. Anything else gets 403 and a structured
log line, and never reaches the CATALOG binding.

This finishes a convention the file already had: worker/app.ts:52-66's
PUBLIC_CATALOG_HEADERS / forwardPublicCatalog is the same pattern applied to
headers on the other env.CATALOG.fetch call site, 240 lines above the bare one.

Tests (220/220, +4): the allowlist is pinned against a hard-coded expectation,
so widening it requires editing an assertion — this repo is public and takes
drive-by PRs, and a policy change must be impossible to slip past review.
Rejection asserts received.length === 0, i.e. the binding was never touched,
not merely that a 403 came back. Method is asserted separately from path.

Known gaps, tracked rather than hidden:

- ctx.props (the caller-assertion layer) is NOT in this PR. Cloudflare's
  official primitive for this, verified in miniflare and present in wrangler
  4.112's schema; deny-by-default enforcement in catalog is the follow-up.
- The 403 body is {error: "..."} where this file's convention is
  {error: {code, message}} (see rateLimitedResponse:180, unauthorized:259).
  Rides with the props change.
- worker/ is outside the lint gate — filed separately. The 6 type-aware
  oxlint errors in the new test file are identical in kind to existing ones
  in worker/photoSearch.test.ts, so this PR is no worse than the baseline.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

## Not in this PR, deliberately

**`ctx.props` — the caller-assertion layer.** Cloudflare's official primitive for Worker-to-Worker access control; `services[].props` is in wrangler 4.112's schema and the docs say plainly *"There is no need to use secret keys or cryptographic signatures"*. Verified live in miniflare, including that it reaches a default-export `fetch(req, env, ctx)` — no `WorkerEntrypoint` needed. Follow-up.

**This supersedes #540's original plan.** That issue proposed a named `WorkerEntrypoint` RPC migration, chosen from a false binary — *shared secret vs RPC* — because I did not know `ctx.props` existed. See the pivot comment on #540 for the full survey of what Cloudflare actually offers, and why RPC was dropped: it cannot remove the container's HTTP hop, so a gateway translation layer would be needed regardless, and it blocks nothing this allowlist does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strengthened outbound catalog request access control with allowlisted method/path checks.
  * Unauthorized catalog operations are now blocked with a `403` response (`{ error: "catalog_request_forbidden" }`).

* **Bug Fixes**
  * Prevented disallowed catalog requests (including the removed `POST /catalog/ingest`) from being forwarded.

* **Tests**
  * Updated worker catalog outbound tests to match the new allowlist and verify both allowed forwarding and denied rejection.
  * Expanded the worker test run to include additional coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->