### PR TITLE
fix(agent): anonymous photo-search was billed at the member tier (#534)

### DIFF
--- a/apps/agent/agent/interfaces/routes/photo_search.py
+++ b/apps/agent/agent/interfaces/routes/photo_search.py
@@ -48,6 +48,7 @@ from agent.interfaces.routes._deps import (
     _get_settings_from_request,
     _get_trusted_auth_context,
 )
+from agent.interfaces.usage_metering import is_anonymous_identity
 
 router = APIRouter(prefix="/v1", tags=["photo-search"])
 
@@ -246,7 +247,9 @@ async def handle_photo_search(
     """Run the standalone vision pipeline and reply with a chat-shaped envelope."""
     runtime = _get_photo_runtime(request)
     byok = _byok_endpoint(request)
-    authenticated = auth.user_id is not None
+    authenticated = auth.user_id is not None and not is_anonymous_identity(
+        auth.user_id, auth.user_type
+    )
     try:
         image = _decode_image(body)
         tier = quota_tier_for(authenticated)

--- a/apps/agent/agent/interfaces/usage_metering.py
+++ b/apps/agent/agent/interfaces/usage_metering.py
@@ -68,6 +68,13 @@ def utc_today(now: datetime | None = None) -> date:
     return (now or datetime.now(UTC)).astimezone(UTC).date()
 
 
+def is_anonymous_identity(user_id: str | None, user_type: str | None) -> bool:
+    """Prefer the typed edge marker, with the ID convention as a fallback."""
+    if user_type == ANONYMOUS_USER_TYPE:
+        return True
+    return user_id is not None and user_id.startswith(ANON_USER_ID_PREFIX)
+
+
 def scope_for_identity(
     user_id: str | None, user_type: str | None, *, is_byok: bool = False
 ) -> UsageScope:
@@ -80,9 +87,7 @@ def scope_for_identity(
     """
     if is_byok:
         return "byok"
-    if user_type == ANONYMOUS_USER_TYPE:
-        return "anon"
-    if user_id is not None and user_id.startswith(ANON_USER_ID_PREFIX):
+    if is_anonymous_identity(user_id, user_type):
         return "anon"
     return "user"
 

--- a/apps/agent/agent/tests/unit/test_photo_search_anonymous_tier.py
+++ b/apps/agent/agent/tests/unit/test_photo_search_anonymous_tier.py
@@ -1,0 +1,27 @@
+"""Regression coverage for anonymous photo-search tier selection (#534)."""
+
+from agent.tests.unit.conftest_fastapi import async_client
+from agent.tests.unit.test_photo_search_route import _app, _body, _settings
+
+_ANON_USER_ID = "anon_0123456789abcdef0123456789abcdef"
+
+
+async def test_typed_anonymous_identity_consumes_the_anonymous_quota() -> None:
+    app = _app(settings=_settings(anon=0, member=1))
+    headers = {"X-User-Id": _ANON_USER_ID, "X-User-Type": "anonymous"}
+    async with async_client(app) as client:
+        response = await client.post("/v1/photo-search", json=_body(), headers=headers)
+    assert response.status_code == 429
+    assert response.json()["error"]["code"] == "photo_search_quota_exhausted"
+
+
+async def test_anonymous_id_prefix_consumes_the_anonymous_quota() -> None:
+    app = _app(settings=_settings(anon=0, member=1))
+    async with async_client(app) as client:
+        response = await client.post(
+            "/v1/photo-search",
+            json=_body(),
+            headers={"X-User-Id": _ANON_USER_ID},
+        )
+    assert response.status_code == 429
+    assert response.json()["error"]["code"] == "photo_search_quota_exhausted"


### PR DESCRIPTION
`photo_search.py` decided the caller's tier with

    authenticated = auth.user_id is not None

which is **always true for anonymous callers** — anonymous identities carry a
`user_id` too, of the form `anon_<hex>`, minted by the edge Worker. So every
anonymous photo-search consumed the member quota instead of the anonymous one.

The correct predicate already existed in this codebase, in
`usage_metering.scope_for_identity`. Rather than copy it — copying is how the
two diverged in the first place — it is extracted as
`is_anonymous_identity(user_id, user_type)` and `scope_for_identity` now calls
it too, so there is one definition rather than two.

It prefers the typed marker (`user_type == ANONYMOUS_USER_TYPE`) and falls back
to the ID prefix. The type is a contract; the prefix is a convention.

Deliberately NOT changed: `photo_search.py:197`, which is the other
`auth.user_id is not None` in the file. It builds the quota KEY, and there the
anonymous `anon_<hex>` is exactly the right key — stable per browser, which is
the entire purpose of the `aid` cookie. Treating anonymous as absent there
would fall back to `request.client.host`, i.e. IP-derived keying, which
`worker/auth.ts` explicitly set out to avoid ("survives IP changes and CGNAT").

Same expression, two call sites, opposite correct answers:
  :250 asks "is this a member?"           → true for anonymous = bug
  :197 asks "is there a stable key?"      → true for anonymous = correct

Tests assert the CONSEQUENCE, not the call. With `anon=0, member=1`, a
correctly-classified anonymous caller hits the exhausted anonymous bucket
(429); a misclassified one finds the member quota available (200). Both the
typed-marker path and the prefix-only fallback are covered.

Mutation: restoring `authenticated = auth.user_id is not None` fails with
`assert 200 == 429` — the exact shape of the bug.

Gates: 1681 passed · ruff clean · ruff format clean · mypy no issues.

Closes #534.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)