### PR TITLE
fix(agent): a BYOK turn that falls back to the platform model is now billed (#532)

### DIFF
--- a/apps/agent/agent/agents/agent_result.py
+++ b/apps/agent/agent/agents/agent_result.py
@@ -55,6 +55,15 @@ StepProvenance: TypeAlias = (
     ProducedSearch | RejectedSearch | ProducedRoute | RejectedRoute
 )
 StepData: TypeAlias = dict[str, object]
+UsagePayer: TypeAlias = Literal["platform", "byok"]
+
+
+@dataclass(frozen=True)
+class AttributedUsage:
+    """Usage from one model call, labeled by who paid its provider."""
+
+    usage: RunUsage
+    payer: UsagePayer
 
 
 @dataclass(frozen=True)
@@ -96,6 +105,7 @@ class AgentResult:
     status: str | None = None
     success_override: bool | None = None
     provenance: TurnProvenance = field(default_factory=TurnProvenance)
+    supplemental_usage: list[AttributedUsage] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if self.provenance == TurnProvenance():

--- a/apps/agent/agent/agents/translation.py
+++ b/apps/agent/agent/agents/translation.py
@@ -11,7 +11,7 @@ from pydantic_ai.exceptions import FallbackExceptionGroup
 from pydantic_ai.models import Model
 from pydantic_ai.usage import RunUsage
 
-from agent.agents.base import create_agent, resolve_model
+from agent.agents.base import create_agent
 from agent.agents.title_matching import looks_like_wrong_variant
 from agent.clients.catalog_client import (
     CatalogClientProtocol,
@@ -73,7 +73,7 @@ async def translate_title(
     target_locale: str,
     kind: TranslationKind,
     catalog: CatalogClientProtocol,
-    ctx: TranslationContext | None = None,
+    ctx: TranslationContext,
 ) -> TranslationResult:
     """Translate by semantic kind, using catalog only for Chinese anime titles."""
     catalog_title = await _catalog_zh_title(catalog, title, target_locale, kind)
@@ -115,7 +115,7 @@ async def _translate_title_with_llm(
     title: str,
     target_locale: str,
     kind: TranslationKind,
-    ctx: TranslationContext | None,
+    ctx: TranslationContext,
 ) -> str | None:
     translated = await _run_translation(_title_prompt(title, target_locale, kind), ctx)
     if translated is None:
@@ -138,7 +138,7 @@ async def translate_text(
     text: str,
     *,
     target_locale: str,
-    ctx: TranslationContext | None = None,
+    ctx: TranslationContext,
 ) -> str:
     """Translate a general UI or clarification string without tools."""
     if not text:
@@ -148,10 +148,9 @@ async def translate_text(
     return translated or text
 
 
-async def _run_translation(prompt: str, ctx: TranslationContext | None) -> str | None:
-    model, usage = _translation_run_scope(ctx)
+async def _run_translation(prompt: str, ctx: TranslationContext) -> str | None:
     try:
-        result = await translation_agent.run(prompt, usage=usage, model=model)
+        result = await translation_agent.run(prompt, usage=ctx.usage, model=ctx.model)
     except (FallbackExceptionGroup, OSError, RuntimeError, ValueError) as exc:
         logger.warning("translation_agent_failed", error=str(exc))
         return None
@@ -173,11 +172,3 @@ def _result(
         "translation_complete", original=original, source=source, confidence=confidence
     )
     return TranslationResult(original, translated, source, confidence)
-
-
-def _translation_run_scope(
-    ctx: TranslationContext | None,
-) -> tuple[Model, RunUsage]:
-    if ctx is not None:
-        return ctx.model, ctx.usage
-    return resolve_model(translation_agent.model), RunUsage()

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -23,7 +23,7 @@ from pydantic_ai.models import Model
 from pydantic_ai.usage import RunUsage
 from pydantic_ai_harness.memory import MemoryStore
 
-from agent.agents.agent_result import AgentResult
+from agent.agents.agent_result import AgentResult, AttributedUsage, UsagePayer
 from agent.agents.animichi_agent import animichi_agent
 from agent.agents.animichi_runner import run_animichi_agent
 from agent.agents.base import (
@@ -345,19 +345,15 @@ class RuntimeAPI:
     ) -> None:
         """SD-18 metering hook: bank this turn's RunUsage into ``daily_usage``.
 
-        This is the sole data source the anonymous daily-budget breaker (X4)
-        reads, so it runs in ``handle``'s finally block — a failed turn still
-        consumed tokens and must still be charged. A BYOK turn's token counts
-        are still recorded for observability, but its cost is always zero —
-        we did not pay the provider for it.
+        The request's primary BYOK call is zero-cost, while supplemental calls
+        are priced from their actual payer attribution.
         """
         if result is None:
             return
-        scope = scope_for_identity(user_id, user_type, is_byok=is_byok)
-        prices = self._usage_prices() if scope != "byok" else UsagePrices(0.0, 0.0)
-        await record_turn_usage(
-            self._db, usage=result.usage, scope=scope, prices=prices
-        )
+        for item in _attributed_usage(result, is_byok):
+            await _record_attributed_usage(
+                self._db, item, user_id, user_type, self._usage_prices()
+            )
 
     async def _prepare_session(
         self, request: PublicAPIRequest, user_id: str | None
@@ -515,6 +511,7 @@ class RuntimeAPI:
                 # default (`resolve_model(animichi_agent.model)`), which is
                 # never influenced by a per-request override.
                 model=None if is_byok else resolved_model,
+                isolate_platform_usage=is_byok,
             )
         response = agent_result_to_response(
             result,
@@ -765,6 +762,7 @@ async def _apply_translation_gate(
     on_step: OnStep | None,
     *,
     model: Model | None,
+    isolate_platform_usage: bool = False,
 ) -> None:
     """Translate the agent message when its language mismatches *locale*.
 
@@ -784,7 +782,7 @@ async def _apply_translation_gate(
         translated = await translate_text(
             message,
             target_locale=locale,
-            ctx=_translation_context(result, model),
+            ctx=_translation_context(result, model, isolate_platform_usage),
         )
         # Mutate the output model's message field
         object.__setattr__(result.output, "message", translated)
@@ -796,11 +794,37 @@ async def _apply_translation_gate(
 
 
 def _translation_context(
-    result: AgentResult, model: Model | None
+    result: AgentResult, model: Model | None, isolate_platform_usage: bool = False
 ) -> _TranslationContext:
     selected = model or resolve_model(animichi_agent.model)
-    usage = result.usage or RunUsage()
+    usage = _translation_usage(result, isolate_platform_usage)
     return _TranslationContext(model=selected, usage=usage)
+
+
+def _translation_usage(result: AgentResult, isolated: bool) -> RunUsage:
+    if not isolated:
+        return result.usage or RunUsage()
+    usage = RunUsage()
+    result.supplemental_usage.append(AttributedUsage(usage, "platform"))
+    return usage
+
+
+def _attributed_usage(result: AgentResult, is_byok: bool) -> list[AttributedUsage]:
+    payer: UsagePayer = "byok" if is_byok else "platform"
+    primary = [] if result.usage is None else [AttributedUsage(result.usage, payer)]
+    return [*primary, *result.supplemental_usage]
+
+
+async def _record_attributed_usage(
+    db: object,
+    item: AttributedUsage,
+    user_id: str | None,
+    user_type: str | None,
+    platform_prices: UsagePrices,
+) -> None:
+    scope = scope_for_identity(user_id, user_type, is_byok=item.payer == "byok")
+    prices = platform_prices if item.payer == "platform" else UsagePrices(0.0, 0.0)
+    await record_turn_usage(db, usage=item.usage, scope=scope, prices=prices)
 
 
 def _set_span_request_attrs(

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -49,7 +49,12 @@ from agent.agents.selection import (
     validate_candidate_selection,
 )
 from agent.agents.session_state import SessionState
-from agent.agents.translation import TranslationResult, translate_text, translate_title
+from agent.agents.translation import (
+    TranslationResult,
+    translate_text,
+    translate_title,
+    translation_agent,
+)
 from agent.application.errors import ApplicationError, ErrorCode
 from agent.clients.catalog_client import CatalogClient, CatalogClientProtocol
 from agent.config.settings import Settings, get_settings
@@ -607,7 +612,8 @@ class RuntimeAPI:
         *,
         is_byok: bool = False,
     ) -> AgentResult:
-        return await asyncio.wait_for(
+        supplemental_usage: list[AttributedUsage] = []
+        result = await asyncio.wait_for(
             run_animichi_agent(
                 text=request.text,
                 db=cast(DatabasePort, self._db),
@@ -617,14 +623,22 @@ class RuntimeAPI:
                 message_history=history,
                 on_step=on_step,
                 catalog=self._catalog,
-                title_translator=self._server_title_translator() if is_byok else None,
+                title_translator=(
+                    self._server_title_translator(supplemental_usage)
+                    if is_byok
+                    else None
+                ),
                 memory_store=self._memory_store,
                 user_id=user_id,
             ),
             timeout=self._settings.agent_deadline,
         )
+        result.supplemental_usage.extend(supplemental_usage)
+        return result
 
-    def _server_title_translator(self) -> TitleTranslator:
+    def _server_title_translator(
+        self, supplemental_usage: list[AttributedUsage]
+    ) -> TitleTranslator:
         """D18: force `translate_anime_title` onto the server key on a BYOK
         turn. Without this override the tool inherits the active run's own
         model via `RunContext.model` (cheap connection reuse on every other
@@ -635,13 +649,17 @@ class RuntimeAPI:
         """
 
         async def _translate(title: str, target_language: str) -> TranslationResult:
-            return await translate_title(
+            usage = RunUsage()
+            result = await translate_title(
                 title,
                 target_locale=target_language,
                 kind="anime_title",
                 catalog=self._catalog,
-                ctx=None,
+                ctx=_TranslationContext(resolve_model(translation_agent.model), usage),
             )
+            if usage.requests > 0:
+                supplemental_usage.append(AttributedUsage(usage, "platform"))
+            return result
 
         return _translate
 

--- a/apps/agent/agent/tests/eval/translation_eval_cases.py
+++ b/apps/agent/agent/tests/eval/translation_eval_cases.py
@@ -8,11 +8,19 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict, cast
 
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
 from pydantic_evals import Case, Dataset
 from pydantic_evals.evaluators import Evaluator, EvaluatorContext
 
 from agent.agents.translation import TranslationKind
 from agent.clients.catalog_client import CatalogClientProtocol
+
+
+@dataclass(frozen=True)
+class _TranslationContext:
+    model: TestModel
+    usage: RunUsage
 
 
 @dataclass
@@ -49,6 +57,7 @@ def make_translation_task(catalog: CatalogClientProtocol) -> TaskFn:
             target_locale=inp.target_locale,
             kind=inp.kind,
             catalog=catalog,
+            ctx=_TranslationContext(model=TestModel(), usage=RunUsage()),
         )
         return TranslationOutput(
             translated=result.translated,

--- a/apps/agent/agent/tests/integration/test_byok_d18_transport_isolation.py
+++ b/apps/agent/agent/tests/integration/test_byok_d18_transport_isolation.py
@@ -105,7 +105,7 @@ async def test_end_to_end_transport_isolation_between_main_loop_and_helper() -> 
     )
     try:
         with patch("agent.agents.translation.resolve_model", return_value=server_model):
-            translator = api._server_title_translator()
+            translator = api._server_title_translator([])
             await translator("タイトル", "en")
 
         await Agent(byok_model.model).run("hi")

--- a/apps/agent/agent/tests/integration/test_byok_d18_transport_isolation.py
+++ b/apps/agent/agent/tests/integration/test_byok_d18_transport_isolation.py
@@ -104,7 +104,17 @@ async def test_end_to_end_transport_isolation_between_main_loop_and_helper() -> 
         model_http_client=cast(httpx.AsyncClient, object()),
     )
     try:
-        with patch("agent.agents.translation.resolve_model", return_value=server_model):
+        # Patch where the lookup happens, not where the function is defined:
+        # `public_api` does `from agent.agents.base import resolve_model`, so a
+        # patch on `agent.agents.translation.resolve_model` misses entirely and
+        # the helper reaches the real endpoint — the transport records nothing
+        # and this test dies on an empty `requests` list rather than a wrong
+        # key. That is how it failed when the server-model choice moved out of
+        # `translation._translation_run_scope` and into
+        # `_server_title_translator`. Retarget this string if it moves again.
+        with patch(
+            "agent.interfaces.public_api.resolve_model", return_value=server_model
+        ):
             translator = api._server_title_translator([])
             await translator("タイトル", "en")
 

--- a/apps/agent/agent/tests/integration/test_byok_internal_calls_use_server_key.py
+++ b/apps/agent/agent/tests/integration/test_byok_internal_calls_use_server_key.py
@@ -19,7 +19,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pydantic_ai.models import Model
 
-from agent.agents.translation import TranslationResult
+from agent.agents.base import resolve_model
+from agent.agents.translation import TranslationResult, translation_agent
 from agent.clients.catalog_client import CatalogClientProtocol
 from agent.interfaces.public_api import RuntimeAPI
 
@@ -58,9 +59,18 @@ async def test_non_byok_turn_leaves_title_translator_untouched() -> None:
     assert run_mock.await_args.kwargs["title_translator"] is None
 
 
-async def test_injected_title_translator_calls_translate_title_with_no_ctx() -> None:
-    """The injected callable must bypass `ctx` entirely — the only way
-    `translate_title` falls back to `translation_agent`'s server default."""
+async def test_injected_title_translator_runs_on_the_server_model() -> None:
+    """The injected callable must not spend the user's BYOK key on our own
+    internal translation — it runs on `translation_agent`'s server default.
+
+    This used to be asserted as `ctx is None`, because passing no context was
+    how the server default got selected. That proxy was also why the platform
+    spend went unrecorded: `_translation_run_scope(None)` minted a `RunUsage`
+    nobody held. The context is now supplied *with* the server model and an
+    owned usage sink, so the assertion moved to the property that was always
+    the point — which model runs — rather than the mechanism that happened to
+    select it.
+    """
     api = _api()
     translator = api._server_title_translator([])
     fake_result = TranslationResult(
@@ -72,7 +82,9 @@ async def test_injected_title_translator_calls_translate_title_with_no_ctx() -> 
     ) as translate_mock:
         result = await translator("タイトル", "en")
     assert result is fake_result
-    assert translate_mock.await_args.kwargs["ctx"] is not None
+    ctx = translate_mock.await_args.kwargs["ctx"]
+    assert ctx is not None
+    assert ctx.model is resolve_model(translation_agent.model)
 
 
 async def test_byok_turn_forces_the_translation_gate_off_the_run_model() -> None:

--- a/apps/agent/agent/tests/integration/test_byok_internal_calls_use_server_key.py
+++ b/apps/agent/agent/tests/integration/test_byok_internal_calls_use_server_key.py
@@ -62,7 +62,7 @@ async def test_injected_title_translator_calls_translate_title_with_no_ctx() -> 
     """The injected callable must bypass `ctx` entirely — the only way
     `translate_title` falls back to `translation_agent`'s server default."""
     api = _api()
-    translator = api._server_title_translator()
+    translator = api._server_title_translator([])
     fake_result = TranslationResult(
         original="タイトル", translated="Title", source="llm"
     )
@@ -72,7 +72,7 @@ async def test_injected_title_translator_calls_translate_title_with_no_ctx() -> 
     ) as translate_mock:
         result = await translator("タイトル", "en")
     assert result is fake_result
-    assert translate_mock.await_args.kwargs["ctx"] is None
+    assert translate_mock.await_args.kwargs["ctx"] is not None
 
 
 async def test_byok_turn_forces_the_translation_gate_off_the_run_model() -> None:

--- a/apps/agent/agent/tests/unit/test_agent_quality_304.py
+++ b/apps/agent/agent/tests/unit/test_agent_quality_304.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
 
 from agent.agents.catalog_tools import run_resolve
 from agent.agents.runtime_deps import RuntimeDeps
@@ -34,6 +36,12 @@ _PENDING_EVAL_IDS = {
         "Q304_T_ALIAS_001",
     },
 }
+
+
+@dataclass(frozen=True)
+class _TranslationContext:
+    model: TestModel
+    usage: RunUsage
 
 
 def _deps(catalog: MockCatalogClient) -> RuntimeDeps:
@@ -92,6 +100,7 @@ async def test_place_name_translation_never_uses_anime_retrieval() -> None:
             target_locale="zh",
             kind="place_name",
             catalog=catalog,
+            ctx=_TranslationContext(model=translator.model, usage=RunUsage()),
         )
 
     catalog.resolve.assert_not_awaited()

--- a/apps/agent/agent/tests/unit/test_byok_translation_billing.py
+++ b/apps/agent/agent/tests/unit/test_byok_translation_billing.py
@@ -10,7 +10,8 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
 from agent.agents.agent_result import AgentResult
-from agent.agents.translation import TranslationContext
+from agent.agents.runtime_deps import TitleTranslator
+from agent.agents.translation import TranslationContext, TranslationResult
 from agent.clients.catalog_client import CatalogClientProtocol
 from agent.config.settings import Settings
 from agent.interfaces.public_api import PublicAPIRequest, RuntimeAPI
@@ -106,6 +107,31 @@ async def _translated_text(
     return "已翻译"
 
 
+async def _translated_title(
+    title: str,
+    *,
+    target_locale: str,
+    kind: str,
+    catalog: CatalogClientProtocol,
+    ctx: TranslationContext | None = None,
+) -> TranslationResult:
+    del target_locale, kind, catalog
+    assert ctx is not None
+    ctx.usage.requests += 1
+    ctx.usage.input_tokens += 1_000_000
+    ctx.usage.output_tokens += 1_000_000
+    return TranslationResult(title, "Title", "llm")
+
+
+async def _run_with_title_translation(
+    *, title_translator: TitleTranslator | None = None, **kwargs: object
+) -> AgentResult:
+    del kwargs
+    assert title_translator is not None
+    await title_translator("タイトル", "en")
+    return _result("already English")
+
+
 async def test_byok_without_translation_stays_zero_cost() -> None:
     repo = UsageRepo()
     result = _result("已经是中文")
@@ -128,6 +154,35 @@ async def test_byok_platform_translation_is_billed_to_user_scope() -> None:
         await _run_pipeline(_api(repo), result, TestModel(), is_byok=True)
 
     assert translate.await_args.kwargs["ctx"].model is server_model
+    assert [(call.scope, call.cost_usd) for call in repo.calls] == [
+        ("byok", 0.0),
+        ("user", 10.0),
+    ]
+
+
+async def test_byok_title_translation_platform_usage_is_billed_to_user_scope() -> None:
+    repo = UsageRepo()
+    api = _api(repo)
+    with (
+        patch(
+            "agent.interfaces.public_api.run_animichi_agent",
+            new=AsyncMock(side_effect=_run_with_title_translation),
+        ),
+        patch(
+            "agent.interfaces.public_api.translate_title",
+            new=AsyncMock(side_effect=_translated_title),
+        ),
+    ):
+        result = await api._model_request(
+            PublicAPIRequest(text="translate title"),
+            None,
+            [],
+            TestModel(),
+            None,
+            "user-1",
+            is_byok=True,
+        )
+    await api._record_usage(result, "user-1", "human", is_byok=True)
     assert [(call.scope, call.cost_usd) for call in repo.calls] == [
         ("byok", 0.0),
         ("user", 10.0),

--- a/apps/agent/agent/tests/unit/test_byok_translation_billing.py
+++ b/apps/agent/agent/tests/unit/test_byok_translation_billing.py
@@ -1,0 +1,144 @@
+"""Billing attribution for the BYOK post-turn translation fallback (#532)."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+
+from agent.agents.agent_result import AgentResult
+from agent.agents.translation import TranslationContext
+from agent.clients.catalog_client import CatalogClientProtocol
+from agent.config.settings import Settings
+from agent.interfaces.public_api import PublicAPIRequest, RuntimeAPI
+from agent.interfaces.usage_metering import UsageScope
+from agent.tests.unit.conftest_public_api import make_result
+
+PRICED = Settings(
+    model_input_cost_per_mtok_usd=2.0,
+    model_output_cost_per_mtok_usd=8.0,
+)
+
+
+class UsageCall:
+    def __init__(self, scope: UsageScope, usage: RunUsage, cost_usd: float) -> None:
+        self.scope = scope
+        self.usage = usage
+        self.cost_usd = cost_usd
+
+
+class UsageRepo:
+    def __init__(self) -> None:
+        self.calls: list[UsageCall] = []
+
+    async def accumulate_usage(
+        self,
+        *,
+        usage_date: date,
+        scope: UsageScope,
+        requests: int,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+    ) -> None:
+        del usage_date
+        usage = RunUsage(
+            requests=requests,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+        self.calls.append(UsageCall(scope, usage, cost_usd))
+
+
+class Database:
+    def __init__(self, usage: UsageRepo) -> None:
+        self.usage = usage
+
+
+def _api(repo: UsageRepo) -> RuntimeAPI:
+    return RuntimeAPI(
+        Database(repo),
+        catalog=cast(CatalogClientProtocol, object()),
+        model_http_client=cast(object, object()),
+        settings=PRICED,
+    )
+
+
+def _result(message: str) -> AgentResult:
+    result = make_result(intent="qa", message=message)
+    result.usage = RunUsage(requests=1, input_tokens=1_000_000)
+    return result
+
+
+async def _run_pipeline(
+    api: RuntimeAPI,
+    result: AgentResult,
+    model: TestModel,
+    *,
+    is_byok: bool,
+) -> None:
+    dispatch = AsyncMock(return_value=(result, model, True))
+    with patch.object(api, "_dispatch_request", new=dispatch):
+        await api._execute_pipeline(
+            PublicAPIRequest(text="请翻译", locale="zh"),
+            None,
+            [],
+            model,
+            None,
+            object(),
+            "user-1",
+            is_byok=is_byok,
+        )
+    await api._record_usage(result, "user-1", "human", is_byok=is_byok)
+
+
+async def _translated_text(
+    text: str, *, target_locale: str, ctx: TranslationContext | None = None
+) -> str:
+    del text, target_locale
+    assert ctx is not None
+    ctx.usage.requests += 1
+    ctx.usage.input_tokens += 1_000_000
+    ctx.usage.output_tokens += 1_000_000
+    return "已翻译"
+
+
+async def test_byok_without_translation_stays_zero_cost() -> None:
+    repo = UsageRepo()
+    result = _result("已经是中文")
+
+    await _run_pipeline(_api(repo), result, TestModel(), is_byok=True)
+
+    assert [(call.scope, call.cost_usd) for call in repo.calls] == [("byok", 0.0)]
+
+
+async def test_byok_platform_translation_is_billed_to_user_scope() -> None:
+    repo = UsageRepo()
+    result = _result("日本語の返答")
+    server_model = TestModel()
+    translate = AsyncMock(side_effect=_translated_text)
+
+    with (
+        patch("agent.interfaces.public_api.resolve_model", return_value=server_model),
+        patch("agent.interfaces.public_api.translate_text", new=translate),
+    ):
+        await _run_pipeline(_api(repo), result, TestModel(), is_byok=True)
+
+    assert translate.await_args.kwargs["ctx"].model is server_model
+    assert [(call.scope, call.cost_usd) for call in repo.calls] == [
+        ("byok", 0.0),
+        ("user", 10.0),
+    ]
+
+
+async def test_non_byok_translation_remains_platform_billed() -> None:
+    repo = UsageRepo()
+    result = _result("日本語の返答")
+
+    with patch("agent.interfaces.public_api.translate_text", new=_translated_text):
+        await _run_pipeline(_api(repo), result, TestModel(), is_byok=False)
+
+    assert [(call.scope, call.cost_usd) for call in repo.calls] == [("user", 12.0)]

--- a/apps/agent/agent/tests/unit/test_model_layer_phase3.py
+++ b/apps/agent/agent/tests/unit/test_model_layer_phase3.py
@@ -20,7 +20,6 @@ from agent.agents.base import (
     resolve_model_alias,
 )
 from agent.agents.route_area_splitter import split_into_areas
-from agent.agents.translation import _translation_run_scope, translation_agent
 from agent.config.model_aliases import (
     CredentialRef,
     ModelAlias,
@@ -166,10 +165,13 @@ async def test_override_helpers_forward_the_shared_client() -> None:
         create.return_value.run = AsyncMock(return_value=result)
         await _generate_title("session", "query", "response", http_client=client)
     default.assert_called_once_with(http_client=client)
-    with patch("agent.agents.translation.resolve_model", return_value=model) as resolve:
-        selected, _ = _translation_run_scope(None)
-    assert selected is model
-    resolve.assert_called_once_with(translation_agent.model)
+    # The translation arm of this test asserted `_translation_run_scope(None)`
+    # resolved the server default. That helper is gone: passing no context was
+    # exactly the path that minted a `RunUsage` nobody held, so platform spend
+    # went unrecorded (#532). The guarantee it was reaching for — internal
+    # translation runs on the server model — now lives in
+    # `test_injected_title_translator_runs_on_the_server_model`, asserted on the
+    # context that is actually supplied rather than on its absence.
     with patch(
         "agent.agents.route_area_splitter.route_planner_agent.run", new=AsyncMock()
     ) as run:

--- a/apps/agent/agent/tests/unit/test_public_api_translation.py
+++ b/apps/agent/agent/tests/unit/test_public_api_translation.py
@@ -141,3 +141,22 @@ async def test_translation_gate_shares_parent_scope_with_toolless_agent(
     ctx = translate.await_args.kwargs["ctx"]
     assert ctx.model is model
     assert ctx.usage is result.usage
+
+
+async def test_public_translation_accumulates_requests_in_caller_usage(
+    mock_db: MagicMock,
+) -> None:
+    result = _search_result(locale="zh", message="3件の聖地が見つかりました。")
+    result.usage = RunUsage()
+    model = TestModel(custom_output_text="找到了3处圣地。")
+
+    with patch(
+        "agent.interfaces.public_api.run_animichi_agent",
+        new=AsyncMock(return_value=result),
+    ):
+        response = await RuntimeAPI(mock_db, model_http_client=MagicMock()).handle(
+            PublicAPIRequest(text="查找圣地", locale="zh"), model=model
+        )
+
+    assert response.message != "3件の聖地が見つかりました。"
+    assert result.usage.requests == 1

--- a/apps/agent/agent/tests/unit/test_translation.py
+++ b/apps/agent/agent/tests/unit/test_translation.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic_ai.models import Model
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
 
 from agent.agents.translation import TranslationResult, translate_text, translate_title
 from agent.clients.catalog_client import (
@@ -14,6 +18,12 @@ from agent.clients.catalog_client import (
     ResolveResolved,
 )
 from agent.tests.eval.translation_eval_cases import CASES
+
+
+@dataclass(frozen=True)
+class _TranslationContext:
+    model: Model
+    usage: RunUsage
 
 
 def _catalog(outcome: ResolveResolved | ResolveNotFound) -> MagicMock:
@@ -43,6 +53,7 @@ def test_eval_cases_preserve_translation_kind() -> None:
 
 async def test_chinese_title_resolves_only_through_catalog() -> None:
     catalog = _catalog(_resolved())
+    ctx = _TranslationContext(TestModel(), RunUsage())
     agent = MagicMock()
     agent.run = AsyncMock()
 
@@ -52,6 +63,7 @@ async def test_chinese_title_resolves_only_through_catalog() -> None:
             target_locale="zh",
             kind="anime_title",
             catalog=catalog,
+            ctx=ctx,
         )
 
     catalog.resolve.assert_awaited_once_with("君の名は。")
@@ -67,6 +79,7 @@ async def test_english_title_and_place_use_toolless_llm(
     title: str, translated: str
 ) -> None:
     catalog = _catalog(_not_found())
+    ctx = _TranslationContext(TestModel(), RunUsage())
     agent = MagicMock()
     agent.run = AsyncMock(return_value=_agent_output(translated))
 
@@ -76,6 +89,7 @@ async def test_english_title_and_place_use_toolless_llm(
             target_locale="en",
             kind="anime_title" if title == "君の名は。" else "place_name",
             catalog=catalog,
+            ctx=ctx,
         )
 
     catalog.resolve.assert_not_awaited()
@@ -85,12 +99,13 @@ async def test_english_title_and_place_use_toolless_llm(
 
 async def test_model_cannot_claim_web_search_provenance() -> None:
     catalog = _catalog(_not_found())
+    ctx = _TranslationContext(TestModel(), RunUsage())
     agent = MagicMock()
     agent.run = AsyncMock(return_value=_agent_output("web_search"))
 
     with patch("agent.agents.translation.translation_agent", agent):
         result = await translate_title(
-            "unknown", target_locale="zh", kind="anime_title", catalog=catalog
+            "unknown", target_locale="zh", kind="anime_title", catalog=catalog, ctx=ctx
         )
 
     assert result.translated == "web_search"
@@ -100,12 +115,13 @@ async def test_model_cannot_claim_web_search_provenance() -> None:
 
 async def test_untranslated_fallback_reports_zero_confidence() -> None:
     catalog = _catalog(_not_found())
+    ctx = _TranslationContext(TestModel(), RunUsage())
     agent = MagicMock()
     agent.run = AsyncMock(side_effect=RuntimeError("model unavailable"))
 
     with patch("agent.agents.translation.translation_agent", agent):
         result = await translate_title(
-            "unknown", target_locale="zh", kind="anime_title", catalog=catalog
+            "unknown", target_locale="zh", kind="anime_title", catalog=catalog, ctx=ctx
         )
 
     assert result == TranslationResult("unknown", "unknown", "untranslated", 0.0)
@@ -116,12 +132,13 @@ async def test_chinese_place_name_bypasses_anime_catalog_collision() -> None:
         bangumi_id="3151", title="秋葉原電脳組", title_cn="秋叶原电脑组"
     )
     catalog = _catalog(ResolveResolved(outcome="resolved", match=collision))
+    ctx = _TranslationContext(TestModel(), RunUsage())
     agent = MagicMock()
     agent.run = AsyncMock(return_value=_agent_output("秋叶原"))
 
     with patch("agent.agents.translation.translation_agent", agent):
         result = await translate_title(
-            "秋葉原", target_locale="zh", kind="place_name", catalog=catalog
+            "秋葉原", target_locale="zh", kind="place_name", catalog=catalog, ctx=ctx
         )
 
     catalog.resolve.assert_not_awaited()
@@ -131,12 +148,13 @@ async def test_chinese_place_name_bypasses_anime_catalog_collision() -> None:
 
 async def test_successful_equal_model_output_keeps_llm_provenance() -> None:
     catalog = _catalog(_not_found())
+    ctx = _TranslationContext(TestModel(), RunUsage())
     agent = MagicMock()
     agent.run = AsyncMock(return_value=_agent_output("CLANNAD"))
 
     with patch("agent.agents.translation.translation_agent", agent):
         result = await translate_title(
-            "CLANNAD", target_locale="zh", kind="anime_title", catalog=catalog
+            "CLANNAD", target_locale="zh", kind="anime_title", catalog=catalog, ctx=ctx
         )
 
     assert result == TranslationResult("CLANNAD", "CLANNAD", "llm", 0.6)
@@ -144,12 +162,13 @@ async def test_successful_equal_model_output_keeps_llm_provenance() -> None:
 
 async def test_blank_model_output_is_untranslated() -> None:
     catalog = _catalog(_not_found())
+    ctx = _TranslationContext(TestModel(), RunUsage())
     agent = MagicMock()
     agent.run = AsyncMock(return_value=_agent_output("   "))
 
     with patch("agent.agents.translation.translation_agent", agent):
         result = await translate_title(
-            "CLANNAD", target_locale="zh", kind="anime_title", catalog=catalog
+            "CLANNAD", target_locale="zh", kind="anime_title", catalog=catalog, ctx=ctx
         )
 
     assert result == TranslationResult("CLANNAD", "CLANNAD", "untranslated", 0.0)
@@ -157,10 +176,11 @@ async def test_blank_model_output_is_untranslated() -> None:
 
 async def test_general_text_uses_toolless_llm() -> None:
     agent = MagicMock()
+    ctx = _TranslationContext(TestModel(), RunUsage())
     agent.run = AsyncMock(return_value=_agent_output("你好"))
 
     with patch("agent.agents.translation.translation_agent", agent):
-        result = await translate_text("hello", target_locale="zh")
+        result = await translate_text("hello", target_locale="zh", ctx=ctx)
 
     assert result == "你好"
     assert "deps" not in agent.run.await_args.kwargs
@@ -168,9 +188,10 @@ async def test_general_text_uses_toolless_llm() -> None:
 
 async def test_translate_text_returns_original_on_error() -> None:
     agent = MagicMock()
+    ctx = _TranslationContext(TestModel(), RunUsage())
     agent.run = AsyncMock(side_effect=RuntimeError("model unavailable"))
 
     with patch("agent.agents.translation.translation_agent", agent):
-        result = await translate_text("hello world", target_locale="zh")
+        result = await translate_text("hello world", target_locale="zh", ctx=ctx)
 
     assert result == "hello world"

--- a/apps/agent/agent/tests/unit/test_translation_security.py
+++ b/apps/agent/agent/tests/unit/test_translation_security.py
@@ -134,6 +134,7 @@ async def test_title_fallback_exception_group_returns_original() -> None:
             target_locale="zh",
             kind="anime_title",
             catalog=_catalog_miss(),
+            ctx=_parent_context(),
         )
 
     assert result.translated == "unknown"
@@ -146,6 +147,8 @@ async def test_text_fallback_exception_group_returns_original() -> None:
     agent.run = AsyncMock(side_effect=failure)
 
     with patch("agent.agents.translation.translation_agent", agent):
-        result = await translate_text("hello", target_locale="zh")
+        result = await translate_text(
+            "hello", target_locale="zh", ctx=_parent_context()
+        )
 
     assert result == "hello"


### PR DESCRIPTION
The metering hook priced the whole turn from the request's BYOK flag:

    scope  = scope_for_identity(user_id, user_type, is_byok=is_byok)
    prices = self._usage_prices() if scope != "byok" else UsagePrices(0.0, 0.0)

That is right for the turn's primary call — a BYOK user pays their own
provider. But the translation gate can fall back to the *platform* model, and
that call is billed to us. It was recorded at zero.

Real server-side cost, and invisible to the anonymous daily-budget breaker,
which reads exactly this table as its only data source. A leak the breaker
cannot see is one it cannot stop.

The root cause is that two different things were being read off one flag:
"did the user bring a key" and "who paid the provider for *this* call". The
fix separates them in the type system rather than special-casing the fallback
branch:

    UsagePayer = Literal["platform", "byok"]

    @dataclass(frozen=True)
    class AttributedUsage:
        usage: RunUsage
        payer: UsagePayer

    AgentResult.supplemental_usage: list[AttributedUsage]

Each usage record now carries its own payer. The translation gate appends
`AttributedUsage(usage, "platform")` when it falls back; `_attributed_usage`
labels the primary call from the request flag; `_record_attributed_usage`
prices per item. Nothing infers a payer from context any more.

Chosen over patching the fallback branch because the class of bug is
"inferred attribution", and only the type change makes the other instances
impossible rather than merely absent today.

Three tests, one per case that must stay distinguishable:
  BYOK, no fallback          -> zero cost      (must not regress)
  BYOK, platform fallback    -> platform price (the fix)
  non-BYOK                   -> platform price (must not regress)

Mutations, all killed:
  isolate_platform_usage=False                    -> 1 failed
  supplemental labelled "byok" (i.e. the bug)     -> 1 failed
  prices forced to zero unconditionally           -> 1 failed

A fourth attempt — giving `payer` a default of "byok" — survived, and did not
count: every construction site passes it explicitly, so the edit changed no
behaviour. Recorded because a survivor that turns out to be a bad mutation
looks identical to a weak test until you check which one it is.

The docstring that justified the old behaviour ("a BYOK turn's cost is always
zero — we did not pay the provider for it") is rewritten. Leaving it would have
left a comment asserting the rule this commit removes.

Gates: 1682 passed · ruff clean · ruff format clean · mypy no issues · test
file 144 lines.

Closes #532.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Correction — three claims above do not hold

Stating these plainly rather than quietly editing them, because each one
overstates what this PR accomplishes.

**1. "invisible to the anonymous daily-budget breaker."** The fallback cost is
recorded under scope `"user"`, not `"anon"`. BYOK is login-gated, so a BYOK
turn can never land in the anonymous bucket — the anon breaker was never the
right target and this PR does not change what it can see. What the PR fixes is
that the row existed at zero; it now carries the platform payer. That is
attribution, not breaker coverage.

**2. "Real server-side cost."** True in principle, $0.00 in practice today:
`MODEL_INPUT_COST_PER_MTOK_USD` / `..._OUTPUT_...` are set in no environment
(#517), so `_usage_prices()` returns zeros and *every* row — platform and BYOK
alike — prices at $0.00. Until #517 lands, this PR makes the ledger *correctly
shaped*, not correctly valued.

**3. "only the type change makes the other instances impossible."** Disproven
about a hundred lines away in the same file. `_server_title_translator` was a
second instance of the same inferred-attribution class — it minted a `RunUsage`
that nobody held, so the platform spend on internal title translation went
unrecorded entirely. The type alone did not stop it; it needed its own fix
(B1, commit `22b27524`), which threads an owned usage sink through and appends
`AttributedUsage(usage, "platform")` when the call actually consumed requests.

The type change is still the right shape — it makes the payer *expressible*
and forces each call site to state one. What it does not do is make omission a
compile error: a site that simply never appends to `supplemental_usage` still
type-checks. Making that a type error is the remaining work, tracked as B2.

## Also in this PR since the original description

- **B1** (`22b27524`) — platform spend on the injected title translator is now
  attributed instead of discarded.
- **B1 test** (`0d582fc7`) — the integration test that guarded this had its
  assertion flipped without its name or docstring following, leaving it
  claiming the opposite of what it checked. Renamed to
  `test_injected_title_translator_runs_on_the_server_model` and re-pointed at
  the intent (which model runs) rather than the mechanism (`ctx is None`).
  Mutation-verified both ways: reverting to `ctx=None` and swapping the model
  each fail it by name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved usage tracking for BYOK and platform-powered requests.
  * Translation activity is now attributed to the appropriate billing scope.
  * Added support for tracking supplemental usage from post-turn translations.

* **Bug Fixes**
  * Prevented BYOK credentials from being used by server-side translation requests.
  * Improved billing accuracy for text and title translation during BYOK requests.
  * Added safeguards to prevent credential and usage attribution leakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->