### PR TITLE
infra: WAF gate for the staging hostname, behind a default-off flag

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from "@playwright/test";
 
+// Staging sits behind a Cloudflare WAF rule that blocks anything without this
+// header (see the staging gate in `infra/index.ts`). Spread conditionally so a
+// local run against :3001 sends no header at all — an empty `x-staging-key`
+// would not match the rule anyway, and a header that is present but wrong is
+// harder to diagnose than one that is absent.
+const stagingGateToken = process.env.STAGING_GATE_TOKEN;
+
 export default defineConfig({
   testDir: ".",
   testMatch: "*.spec.ts",
@@ -11,6 +18,7 @@ export default defineConfig({
     headless: true,
     screenshot: "only-on-failure",
     trace: "on-first-retry",
+    ...(stagingGateToken ? { extraHTTPHeaders: { "x-staging-key": stagingGateToken } } : {}),
   },
   projects: [
     {

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -22,7 +22,7 @@ bindings remain in Wrangler; route ownership stays here. Root guide: `../AGENTS.
 
 ## Key files + entrypoints
 
-- `index.ts` — R2 media bucket, optional web/edge routes, exported catalog DB secret.
+- `index.ts` — R2 media bucket, optional web/edge routes, staging WAF gate, and exported catalog DB secret.
 - `Pulumi.yaml` — project metadata and base encrypted config.
 - `Pulumi.staging.yaml` · `Pulumi.prod.yaml` — live environment stacks.
 - `../.github/workflows/_deploy-component.yml` — Pulumi `up` and Worker deploy sequence.
@@ -34,6 +34,8 @@ bindings remain in Wrangler; route ownership stays here. Root guide: `../AGENTS.
   mandatory human gate.
 - `webRoutesEnabled` defaults false. Enabling it is the route cutover and requires zone/domain
   config; do not flip it as routine cleanup.
+- `stagingGateEnabled` defaults false. Enabling it requires `stagingDomain` and the
+  `stagingGateToken` secret.
 - No Hyperdrive: catalog reaches Neon over `@neondatabase/serverless` HTTP.
 - **`pulumi stack export` runs unmodified before every `pulumi up`** (rollback backup, #485;
   `_deploy-component.yml`'s "Pulumi stack export" step), then is copied to the **R2 bucket the

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -79,5 +79,64 @@ if (webRoutesEnabled) {
   });
 }
 
+// ── Staging: WAF gate ─────────────────────────────────────────────────────────
+// staging runs the same app as production *with anonymous access on*
+// (`ANON_ACCESS_ENABLED = "true"`, root wrangler.toml), so there is no login to
+// keep strangers out. A WAF custom rule gates the hostname instead.
+//
+// Why WAF and not Cloudflare Access: Access would do the same job, but the
+// Playwright suite runs against staging and would need a service token. A
+// header is cheaper. Both sit ahead of the Worker either way — custom rules run
+// in `http_request_firewall_custom`, and Cloudflare's own docs are explicit
+// that "Workers runs after the Cloudflare WAF and Cloudflare Access". A blocked
+// request never reaches our code and is not billed as a Worker invocation.
+//
+// Two ways in: the `animichi_staging` cookie (set once per browser by hand) or
+// the `x-staging-key` header (CI, curl). No regex — `matches` is Business+ and
+// this zone is on Free, which allows 5 custom rules.
+//
+// This only works because `workers_dev = false` everywhere (#539): a
+// `*.workers.dev` hostname is not on the zone and would bypass the WAF outright.
+const stagingGateEnabled = config.getBoolean("stagingGateEnabled") ?? false;
+
+// The stack check keeps this resource meaningful only on staging, even if the
+// flag is accidentally enabled on another stack.
+if (stagingGateEnabled && stack === "staging") {
+  const gateZoneId = config.require("cloudflareZoneId");
+  const stagingDomain = config.require("stagingDomain");
+  const gateToken = config.requireSecret("stagingGateToken");
+
+  // `pulumi.interpolate` already propagates secretness from `gateToken`, so the
+  // explicit `pulumi.secret` is belt-and-braces — kept because the cost of
+  // being wrong here is high and asymmetric. Per `AGENTS.md`, every `pulumi up`
+  // is preceded by a `pulumi stack export` copied into R2; a value that is not
+  // marked secret lands in that object in the clear. This repository is public,
+  // so the token must never be reconstructible from anything we publish.
+  // Parenthesised deliberately. Cloudflare's own examples omit them and rely on
+  // `not` binding tighter than `and`, which is correct — but the two failure
+  // modes of getting this wrong are "block every request to staging" and "block
+  // none of them", and neither is visible until the rule is live. Explicit
+  // grouping costs nothing and removes the question.
+  const gateExpression = pulumi.secret(
+    pulumi.interpolate`(http.host eq "${stagingDomain}") and not (http.cookie contains "animichi_staging=${gateToken}") and not (any(http.request.headers["x-staging-key"][*] eq "${gateToken}"))`,
+  );
+
+  new cloudflare.Ruleset("staging-access-gate", {
+    zoneId: gateZoneId,
+    name: "staging access gate",
+    kind: "zone",
+    phase: "http_request_firewall_custom",
+    description: "Restrict the staging hostname to holders of the gate token.",
+    rules: [
+      {
+        action: "block",
+        expression: gateExpression,
+        description: "Block staging traffic carrying neither the gate cookie nor the gate header",
+        enabled: true,
+      },
+    ],
+  });
+}
+
 export const wave0 = pulumi.output("spike-validated");
 export const catalogBucketName = catalogMediaBucket.name;

--- a/infra/package.json
+++ b/infra/package.json
@@ -2,6 +2,9 @@
   "name": "infra",
   "private": true,
   "main": "index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
   "dependencies": {
     "@pulumi/pulumi": "^3.0.0",
     "@pulumi/cloudflare": "^6.0.0"

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "types": ["node"],
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": ["index.ts"]
+}


### PR DESCRIPTION
staging runs the same app as production with anonymous access ON
(`ANON_ACCESS_ENABLED = "true"`), so no login keeps strangers off it. A
Cloudflare WAF custom rule gates the hostname instead: Block unless the request
carries the `animichi_staging` cookie or the `x-staging-key` header.

WAF over Cloudflare Access because the Playwright suite runs against staging
and Access would need a service token for it. Both sit ahead of the Worker
regardless — custom rules run in `http_request_firewall_custom`, and
Cloudflare's docs state plainly that "Workers runs after the Cloudflare WAF and
Cloudflare Access", corroborated by the Workers metrics doc: requests blocked
by WAF are not counted as invocations. So a blocked request costs nothing.

This only works because `workers_dev = false` everywhere (#539). A
`*.workers.dev` hostname is not on the zone and does not traverse the zone's
WAF — with previews still published, the rule would have been decoration.

Kept off by default (`stagingGateEnabled`, plus a `stack === "staging"` guard)
because the DNS records it depends on do not exist yet (#538 / #541).

## The token must not leak, and this repo is public

`config.requireSecret` for the value, and the composed expression is wrapped in
`pulumi.secret`. The wrap is belt-and-braces — `pulumi.interpolate` already
propagates secretness — but `infra/AGENTS.md` documents that every `pulumi up`
is preceded by a `pulumi stack export` copied into R2, and an unmarked value
lands in that object in the clear. Cheap insurance against a later refactor
that drops the interpolate.

The expression is parenthesised even though Cloudflare's own examples rely on
`not` binding tighter than `and`. Getting the parse wrong yields either "block
everything on staging" or "block nothing", and neither is visible until the
rule is live.

## infra/ had no typecheck at all

Discovered while trying to verify this: `infra/` ships `typescript` as a
devDependency but has no `tsconfig.json` and no script, so `tsc` there exited 1
with usage text. Nothing has ever type-checked the file that owns DNS, routes,
R2 — and now a Block rule on a zone.

Added a minimal `tsconfig.json` (`types: ["node"]` is load-bearing: without it
TypeScript pulls in hoisted `@types/mdx` from the workspace root and fails on
JSX namespaces) and a `typecheck` script. Mutation-verified that the new gate
is not theatre: `phase: 42` and `rules: "not-an-array"` each produce a named
TS2322 at the right line; the clean tree exits 0.

CI still runs nothing for `infra/` — deliberately not wired here, because #548
is mid-flight in `.github/workflows/` and a second conflict there costs more
than the delay. Filing separately.

E2E sends the header only when `STAGING_GATE_TOKEN` is set, so a local run
against :3001 is untouched. Verified the config still loads: 44 tests in 9
files, unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Refs #529, #538, #541. Does not close them — the gate is off until DNS exists and an operator enables it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional access gate for staging environments.
  * Staging traffic can now be restricted to requests containing the configured access credential.
  * Automated staging checks support authenticated access when the gate is enabled.

* **Documentation**
  * Clarified staging gate configuration requirements and behavior.
  * Documented that the gate is disabled by default and requires the staging domain and access credential when enabled.

* **Chores**
  * Added infrastructure type-checking configuration to improve deployment validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->