### PR TITLE
docs: dispatch-codex skill — why 17 dispatches failed, and the monitor loop

### DIFF
--- a/.claude/skills/dispatch-codex/SKILL.md
+++ b/.claude/skills/dispatch-codex/SKILL.md
@@ -4,38 +4,57 @@ Invoke before handing any coding task to Codex. Everything here was learned the
 expensive way on 2026-07-30: **17 dispatches, zero that delivered end-to-end**,
 until the causes below were found. None of them was Codex being bad at code.
 
-## The one that explains most of the failures
+## Codex cannot commit. Plan the whole workflow around that.
 
-**Give Codex a `git clone`, never a linked worktree.**
-
-A linked worktree keeps its git metadata in the *parent* repo's
-`.git/worktrees/<name>/`, which is outside Codex's writable root. Reads work, so
-`git status` and `git diff` succeed and everything looks fine — then every
-`git add` dies with:
+Every `git add` fails, in every directory shape tried:
 
 ```
-fatal: Unable to create '.../.git/worktrees/<name>/index.lock': Operation not permitted
+fatal: Unable to create '.../.git/index.lock': Operation not permitted
 ```
 
-This is why "Codex never commits its work" looked like a discipline problem for
-a whole day. It was never able to.
+That is the sandbox refusing to write **anything under `.git`**, not a
+filesystem permission — the same path is writable from your own shell. Verify in
+one line before theorising: `touch <dir>/.git/probe && rm <dir>/.git/probe`.
+
+**Do not ask Codex to "commit as you go".** It cannot, it will hit the wall
+partway through, and — obeying the instruction — it stops there, leaving less
+finished work than if you had never asked.
+
+Instead:
+
+1. Ask for **all changes left in the working tree**, plus a written deliverable
+   (`TRIAGE.md`, a report file) for anything that is analysis rather than code.
+   A finding that exists only in the report can be lost; a file cannot.
+2. **You** commit, immediately, the moment the job stops. `git add -A` in the
+   target directory is the first thing you run, before reading anything.
+3. Then run the gates and review, as below.
+
+> **A correction, kept on purpose.** An earlier version of this skill blamed
+> linked-worktree metadata living outside the writable root, and told you to use
+> `git clone` instead. That was inferred from a single error message naming
+> `.git/worktrees/<name>/index.lock`, and it is **wrong**: a standalone clone
+> fails identically on its own in-tree `.git/index.lock`. The clone changed the
+> path in the error and nothing else. Kept because the reasoning was plausible
+> enough that someone will reconstruct it.
+
+A different failure with a similar flavour: `failed to initialize sqlite state
+runtime under ~/.codex`, which kills the run before it reads any code. A fresh
+working directory (hence a new broker) is the only fix found, and that one *is*
+about where you point it.
+
+### Prepare the environment either way
+
+Worktree or clone, build it fully before dispatching — the sandbox has no
+network (below):
 
 ```bash
-git clone --local --no-hardlinks -q . <dest>
-cd <dest> && git remote set-url origin <github url> && git fetch -q origin main
-git reset --hard origin/main && git checkout -b <branch>
+git worktree add -b <branch> <dest> origin/main
+cd <dest> && pnpm install --frozen-lockfile --ignore-scripts
+(cd apps/agent && uv sync)
 ```
 
-Two traps in that recipe:
-
-- `git clone --local .` clones your **local** `main`, which is very likely
-  stale. Reset to `origin/main` or Codex builds on the wrong base.
-- The clone has no `node_modules` / `.venv`. Install before dispatching — the
-  sandbox has no network (below).
-
-A related symptom with the same shape: `failed to initialize sqlite state
-runtime under ~/.codex`. That one kills the run before it reads any code, and a
-fresh broker (new working directory) is the only fix found so far.
+If you do clone, note `git clone --local .` copies your **local** `main`, which
+is very likely stale — reset to `origin/main` or Codex builds on the wrong base.
 
 ## The sandbox has no network
 
@@ -187,7 +206,8 @@ already exports.
 
 So: **take the code, verify everything.**
 
-1. Commit the output first — even in a clone, assume it may die mid-step.
+1. Commit the output first, yourself — Codex cannot, so an uncommitted tree is
+   the normal end state, not a sign the run went wrong.
 2. Run every gate yourself. Never trust a "gates pass" claim; one report said
    "Mypy: NOT RUN" while the summary read as success.
 3. Mutation-test the tests it wrote. Assert the mutation landed on the intended

--- a/.claude/skills/dispatch-codex/SKILL.md
+++ b/.claude/skills/dispatch-codex/SKILL.md
@@ -1,0 +1,133 @@
+# Dispatching Codex
+
+Invoke before handing any coding task to Codex. Everything here was learned the
+expensive way on 2026-07-30: **17 dispatches, zero that delivered end-to-end**,
+until the causes below were found. None of them was Codex being bad at code.
+
+## The one that explains most of the failures
+
+**Give Codex a `git clone`, never a linked worktree.**
+
+A linked worktree keeps its git metadata in the *parent* repo's
+`.git/worktrees/<name>/`, which is outside Codex's writable root. Reads work, so
+`git status` and `git diff` succeed and everything looks fine — then every
+`git add` dies with:
+
+```
+fatal: Unable to create '.../.git/worktrees/<name>/index.lock': Operation not permitted
+```
+
+This is why "Codex never commits its work" looked like a discipline problem for
+a whole day. It was never able to.
+
+```bash
+git clone --local --no-hardlinks -q . <dest>
+cd <dest> && git remote set-url origin <github url> && git fetch -q origin main
+git reset --hard origin/main && git checkout -b <branch>
+```
+
+Two traps in that recipe:
+
+- `git clone --local .` clones your **local** `main`, which is very likely
+  stale. Reset to `origin/main` or Codex builds on the wrong base.
+- The clone has no `node_modules` / `.venv`. Install before dispatching — the
+  sandbox has no network (below).
+
+A related symptom with the same shape: `failed to initialize sqlite state
+runtime under ~/.codex`. That one kills the run before it reads any code, and a
+fresh broker (new working directory) is the only fix found so far.
+
+## The sandbox has no network
+
+`git fetch`, `git push`, `gh`, `pnpm install`, `uv sync`, `pulumi preview` — all
+hang or fail. Consequences:
+
+- **Build the environment first.** Worktree/clone, correct base, all
+  dependencies, and verify the gates actually run before you dispatch.
+- **`gh` is unavailable**, so Codex cannot read PR comments or resolve threads.
+  Export what it needs to a file in the working directory and say so.
+- Put "if anything is missing, STOP and report — do not install, do not reach
+  the network" in the brief. **This instruction works.** Codex reliably stops
+  rather than improvising.
+
+## Getting the report back
+
+The forwarding wrapper times out around two minutes. Codex frequently runs eight
+to ten. A finished, correct report can therefore be lost entirely.
+
+The report is still on disk:
+
+```
+~/.claude/plugins/data/codex-openai-codex/state/<dir>/jobs/<task-id>.log
+```
+
+Ask for findings **incrementally** rather than in one final message, and read
+the log rather than trusting the wrapper's return value.
+
+## Judging whether it is alive
+
+Two hard signals, and only these:
+
+1. `stat -f %m` on the job log — is it still being written?
+2. A real `git status` diff in the target directory.
+
+Task IDs, the wrapper's return message, and `/codex:status` are **not**
+evidence. `ps | grep codex` is unreliable — it has missed live processes.
+
+```bash
+L=$(ls -t ~/.claude/plugins/data/codex-openai-codex/state/*/jobs/<id>*.log|head -1)
+until [ $(( $(date +%s) - $(stat -f %m "$L") )) -gt 120 ]; do sleep 30; done
+```
+
+## What the brief must contain
+
+- **Working directory, plus `pwd` / `git rev-parse --abbrev-ref HEAD` /
+  `git log --oneline -1` echoed back in the report.** Codex has written into the
+  wrong worktree before.
+- **Every gate command in full, with `uv run` / `pnpm run` prefixes, each one
+  run by you first.** A brief that says `mypy` instead of the real invocation
+  wastes a whole dispatch. In this repo bare `uv run mypy` fails with "Missing
+  target module" — the working command is the file list in `Makefile:87`.
+- **The current baseline numbers**, so a regression is visible.
+- **The house rules**, especially: no suppressions, the 1-10-50 caps, no `any`.
+  Say explicitly that *a suggestion which can only be satisfied by silencing a
+  rule is not to be actioned.*
+- **What "done" looks like as a file**, when the deliverable is analysis. A
+  triage with no written record is not deliverable, and asking for it in the
+  report is not enough — the report can be lost.
+
+## What to expect from the output
+
+The pattern is consistent: **the judgement is good, the process is not.**
+
+Real examples from one day — converging duplicated predicates, separating types
+instead of patching a branch, correctly distinguishing two identical-looking
+`is not None` checks with different meanings, and independently deriving that
+declaring a DNS record next to a Cloudflare-owned one would fight for
+ownership.
+
+And, the same day: pushing two functions over the line cap to satisfy a linter
+bot, deleting a module docstring that recorded why the tests existed, leaving an
+import of a symbol it had just removed, and hardcoding a value the library
+already exports.
+
+So: **take the code, verify everything.**
+
+1. Commit the output first — even in a clone, assume it may die mid-step.
+2. Run every gate yourself. Never trust a "gates pass" claim; one report said
+   "Mypy: NOT RUN" while the summary read as success.
+3. Mutation-test the tests it wrote. Assert the mutation landed on the intended
+   structure first — a mutation that fails to parse is a **false kill**, not a
+   passing test.
+4. Read the diff for house-rule violations, not just correctness.
+5. Check test *names* still describe their assertions. Codex flips an assertion
+   and leaves the name saying the opposite.
+
+## Do not
+
+- `codex exec --sandbox workspace-write` — blocked by the
+  `block-codex-exec-codewrite` hook.
+- Dispatch into a directory another agent is editing. Two writers in one tree
+  produced silent conflicts more than once.
+- Dispatch into a long-lived worktree. Delete and recreate, or clone fresh — old
+  brokers are the ones that fail to start.

--- a/.claude/skills/dispatch-codex/SKILL.md
+++ b/.claude/skills/dispatch-codex/SKILL.md
@@ -64,7 +64,39 @@ The report is still on disk:
 Ask for findings **incrementally** rather than in one final message, and read
 the log rather than trusting the wrapper's return value.
 
-## Judging whether it is alive
+## Arm a monitor immediately after dispatching
+
+**The completion notification you get seconds after dispatching is not the
+task finishing.** It is the forwarder returning a task ID. The real work starts
+then and runs for another eight to ten minutes with nothing watching it. Treat
+that first notification as "queued", never as "done", and never report its
+contents as a result.
+
+So the step after every dispatch is to arm a wait. Not manual polling, and not
+sitting idle:
+
+```bash
+L=$(ls -t ~/.claude/plugins/data/codex-openai-codex/state/*/jobs/<task-id>*.log 2>/dev/null|head -1)
+until [ $(( $(date +%s) - $(stat -f %m "$L") )) -gt 120 ]; do sleep 30; done
+echo "stopped"; git -C <target> status --short; tail -40 "$L"
+```
+
+Run that with `run_in_background: true` so you keep working.
+
+**The condition must catch both endings.** Waiting only for a diff to appear
+means a run that dies before writing anything waits forever, and silence is
+then indistinguishable from progress. Log-goes-quiet covers finished *and*
+crashed; add the diff check only as an early exit:
+
+```bash
+until [ -n "$(git -C <target> status --porcelain)" ] \
+   || [ $(( $(date +%s) - $(stat -f %m "$L") )) -gt 120 ]; do sleep 15; done
+```
+
+The log may not exist for the first ~30 seconds. Guard for that, or the whole
+wait collapses immediately on an empty `$L`.
+
+### Judging liveness by hand
 
 Two hard signals, and only these:
 
@@ -72,12 +104,20 @@ Two hard signals, and only these:
 2. A real `git status` diff in the target directory.
 
 Task IDs, the wrapper's return message, and `/codex:status` are **not**
-evidence. `ps | grep codex` is unreliable — it has missed live processes.
+evidence. `ps | grep codex` is unreliable — it has missed live processes that
+were demonstrably still writing to their log.
 
-```bash
-L=$(ls -t ~/.claude/plugins/data/codex-openai-codex/state/*/jobs/<id>*.log|head -1)
-until [ $(( $(date +%s) - $(stat -f %m "$L") )) -gt 120 ]; do sleep 30; done
-```
+### While it runs
+
+Do not touch the target directory. Reading a half-written file leads to
+"correcting" work that was still in progress; two writers in one tree produced
+silent conflicts more than once. Pick up other work in a *different* directory,
+or wait.
+
+A quiet log is not the same as a finished job — check the tail before deciding.
+Codex sometimes stops deliberately (a missing command, a permission wall) and
+says so, which is a different outcome from a crash and calls for a different
+fix.
 
 ## What the brief must contain
 

--- a/.claude/skills/dispatch-codex/SKILL.md
+++ b/.claude/skills/dispatch-codex/SKILL.md
@@ -72,26 +72,60 @@ then and runs for another eight to ten minutes with nothing watching it. Treat
 that first notification as "queued", never as "done", and never report its
 contents as a result.
 
-So the step after every dispatch is to arm a wait. Not manual polling, and not
-sitting idle:
+So the step after every dispatch is to arm a watch. Not manual polling, and not
+sitting idle.
 
-```bash
-L=$(ls -t ~/.claude/plugins/data/codex-openai-codex/state/*/jobs/<task-id>*.log 2>/dev/null|head -1)
-until [ $(( $(date +%s) - $(stat -f %m "$L") )) -gt 120 ]; do sleep 30; done
-echo "stopped"; git -C <target> status --short; tail -40 "$L"
+**Use the `Monitor` tool, especially with more than one job in flight.** A
+backgrounded Bash `until` loop gives you one notification when it exits, which
+means one job per loop and nothing until each finishes. `Monitor` turns every
+stdout line into its own notification, so a single watch covers all concurrent
+jobs and reports whichever one moves:
+
+```
+Monitor({
+  description: "codex jobs: progress + stalls",
+  timeout_ms: 3600000,
+  persistent: false,
+  command: `
+    S=~/.claude/plugins/data/codex-openai-codex/state
+    while true; do
+      for L in $(ls -t $S/*/jobs/*.log 2>/dev/null | head -6); do
+        age=$(( $(date +%s) - $(stat -f %m "$L") ))
+        name=$(basename "$L" .log)
+        if [ "$age" -gt 120 ]; then
+          grep -q "^STOPPED $name$" /tmp/codex-seen 2>/dev/null && continue
+          echo "STOPPED $name" | tee -a /tmp/codex-seen
+        fi
+      done
+      sleep 30
+    done`,
+})
 ```
 
-Run that with `run_in_background: true` so you keep working.
+**The filter must match failure as well as success.** A watch that only greps
+for a completion marker stays silent through a crash, a hang, or a permission
+wall — and silence is indistinguishable from progress. Watching for *the log
+going quiet* covers finished and crashed alike, which is why the loop keys on
+mtime rather than on any particular line.
 
-**The condition must catch both endings.** Waiting only for a diff to appear
-means a run that dies before writing anything waits forever, and silence is
-then indistinguishable from progress. Log-goes-quiet covers finished *and*
-crashed; add the diff check only as an early exit:
+Two things that break these watches:
+
+- The log does not exist for the first ~30 seconds. An unguarded `stat` on an
+  empty path makes the condition true immediately and the watch reports a
+  finish that never happened.
+- Every stdout line becomes a message, so a watch must de-duplicate (the `seen`
+  file above) or one stalled job floods the conversation until the monitor is
+  auto-stopped for volume.
+
+A single-job Bash fallback, when `Monitor` is overkill:
 
 ```bash
 until [ -n "$(git -C <target> status --porcelain)" ] \
    || [ $(( $(date +%s) - $(stat -f %m "$L") )) -gt 120 ]; do sleep 15; done
 ```
+
+Note the diff check is only an early exit. Removing the mtime clause would make
+a run that dies before writing anything wait forever.
 
 The log may not exist for the first ~30 seconds. Guard for that, or the whole
 wait collapses immediately on an empty `$L`.

--- a/.claude/skills/use-codex/SKILL.md
+++ b/.claude/skills/use-codex/SKILL.md
@@ -289,13 +289,26 @@ fix.
 ## What the brief must contain
 
 - **Working directory, plus `pwd` / `git rev-parse --abbrev-ref HEAD` /
-  `git log --oneline -1` echoed back in the report.** Codex has written into the
-  wrong worktree before.
+  `git rev-parse --short HEAD` echoed back in the report.** Codex has written
+  into the wrong worktree before.
+
+  **Give the SHA, never an abbreviated commit message.** A brief that said
+  `# must be: 3ce90a50 infra(#529): WAF gate...` cost a whole dispatch: Codex
+  compared the ellipsis literally against the full subject line, called it a
+  mismatch, and stopped — correctly, by the instruction it was given. The SHA
+  is unambiguous; a truncated message is a trap you set for yourself.
+
 - **Every gate command in full, with `uv run` / `pnpm run` prefixes, each one
   run by you first.** A brief that says `mypy` instead of the real invocation
   wastes a whole dispatch. In this repo bare `uv run mypy` fails with "Missing
   target module" — the working command is the file list in `Makefile:87`.
-- **The current baseline numbers**, so a regression is visible.
+- **Baseline numbers measured in *this* directory**, so a regression is visible.
+
+  Never copy them from a sibling clone. "agent unit: 1668 passed" was carried
+  over from a tree that already had another batch of fixes applied; the clean
+  base is 1666, so the next run looked like it had deleted two tests and cost a
+  detour to disprove. A count reads like an objective fact and is only true of
+  the tree it was taken from.
 - **The house rules**, especially: no suppressions, the 1-10-50 caps, no `any`.
   Say explicitly that *a suggestion which can only be satisfied by silencing a
   rule is not to be actioned.*

--- a/.claude/skills/use-codex/SKILL.md
+++ b/.claude/skills/use-codex/SKILL.md
@@ -52,7 +52,7 @@ writing bad code.
 
 Sometimes `git add` fails:
 
-```
+```text
 fatal: Unable to create '.../.git/index.lock': Operation not permitted
 ```
 
@@ -86,76 +86,55 @@ boundaries — the worker-lint run split "add the gate" from "fix the violations
 without being told to. When it does not, it fails loudly at a boundary and you
 salvage. Both are better than not asking.
 
-That is the sandbox refusing to write **anything under `.git`**, not a
-filesystem permission — the same path is writable from your own shell. Verify in
-one line before theorising: `touch <dir>/.git/probe && rm <dir>/.git/probe`.
-
-Measured directly, 2026-07-30, plugin 1.0.7, in a standalone clone:
+When it does fail, it fails hard rather than flakily — measured 2026-07-30 in a
+clone where it did fail:
 
 | from inside Codex | result |
 |---|---|
 | `git add <file>` | `Operation not permitted`, exit 128 |
 | `touch .git/probe-file` | `Operation not permitted`, exit 1 |
-| `git config --local user.probe test` | `could not lock config file .git/config`, exit 255 |
+| `git config --local user.probe test` | `could not lock config file`, exit 255 |
 | `ls -ld .git` | succeeds |
 
-The last two are what make the rule precise: `git config` writes `.git/config`,
-not the index, and it fails too — so this is not index locking, it is the whole
-directory. Reads and listing are allowed.
-
-Re-run that probe after any plugin upgrade before assuming the rule still holds.
-It was re-run on the 1.0.6 → 1.0.7 upgrade, which included upstream's `db52e28`
-("Remove shell expansion for git commands") and looked likely to change it.
-It did not.
+`git config` writes `.git/config`, not the index, and it fails too — so when the
+block is on, the whole directory is unwritable, not just the lock. Reads are
+fine. Useful to know because it rules out "retry and it will work": in a run
+where writes are blocked, they stay blocked.
 
 ### There is a way around it. Do not use it.
 
-The block is keyed on the literal path `.git`. Rename the metadata directory
-and pass `--git-dir`, and Codex commits without complaint — tested 2026-07-30,
-commit created successfully in a clone whose `.git` had been renamed to
-`gitstore`. `touch gitstore/anything` also succeeds. So the control is shallow:
-one `mv` defeats it.
+The block is keyed on the literal path `.git`. Rename the metadata directory and
+pass `--git-dir`, and Codex commits without complaint — tested, a commit landed
+in a clone whose `.git` had been renamed to `gitstore`, and
+`touch gitstore/anything` succeeded too. So the control is shallow: one `mv`
+defeats it.
 
 **Knowing a control is shallow is not a reason to route around it.** What that
 directory protects is not tidiness:
 
 - **`.git/hooks/` is executable code that runs on every commit.** Write access
-  there is persistent arbitrary execution outside the sandbox. This is the real
+  there is persistent arbitrary execution outside the sandbox. That is the real
   reason the rule exists.
-- History rewriting, ref updates, and remote changes all live there. An agent
-  that can touch them can decouple "the diff I reviewed" from "what is in the
-  repository".
+- History rewriting, ref updates and remote changes all live there. An agent
+  able to touch them can decouple the diff that was reviewed from what lands in
+  the repository.
 
-What the workaround buys is one `git add -A` typed by the operator — the same
+Against that, the workaround saves one `git add -A` typed by the operator — the
 step that, on the day this was written, caught a function pushed over the line
 cap, a missing import, an assertion flipped without renaming its test, and a
-staging config that would have left the environment with no chat API and no
-failing test to show for it.
+staging config that would have shipped with no chat API and no failing test.
 
-The general shape, worth keeping: **when a constraint blocks you, ask why it
-exists before asking how to get around it.** The instinct here ran the other
-way for two rounds, and only turned around when a security check objected.
+The transferable part: **when a constraint blocks you, ask why it exists before
+asking how to get around it.** The instinct here ran the other way for two
+rounds and only turned around when a security check objected.
 
-**Do not ask Codex to "commit as you go".** It cannot, it will hit the wall
-partway through, and — obeying the instruction — it stops there, leaving less
-finished work than if you had never asked.
+> **Two corrections, kept on purpose.** This section first blamed linked-worktree
+> metadata living outside the writable root and prescribed a standalone clone —
+> inferred from one error message, and wrong: a clone fails identically. It then
+> said the sandbox blocks all `.git` writes always — also wrong, disproved by the
+> successes in the table above. Both are recorded because each was plausible
+> enough to be reconstructed by the next person from the same evidence.
 
-Instead:
-
-1. Ask for **all changes left in the working tree**, plus a written deliverable
-   (`TRIAGE.md`, a report file) for anything that is analysis rather than code.
-   A finding that exists only in the report can be lost; a file cannot.
-2. **You** commit, immediately, the moment the job stops. `git add -A` in the
-   target directory is the first thing you run, before reading anything.
-3. Then run the gates and review, as below.
-
-> **A correction, kept on purpose.** An earlier version of this skill blamed
-> linked-worktree metadata living outside the writable root, and told you to use
-> `git clone` instead. That was inferred from a single error message naming
-> `.git/worktrees/<name>/index.lock`, and it is **wrong**: a standalone clone
-> fails identically on its own in-tree `.git/index.lock`. The clone changed the
-> path in the error and nothing else. Kept because the reasoning was plausible
-> enough that someone will reconstruct it.
 
 A different failure with a similar flavour: `failed to initialize sqlite state
 runtime under ~/.codex`, which kills the run before it reads any code. A fresh
@@ -196,7 +175,7 @@ to ten. A finished, correct report can therefore be lost entirely.
 
 The report is still on disk:
 
-```
+```text
 ~/.claude/plugins/data/codex-openai-codex/state/<dir>/jobs/<task-id>.log
 ```
 
@@ -220,7 +199,7 @@ means one job per loop and nothing until each finishes. `Monitor` turns every
 stdout line into its own notification, so a single watch covers all concurrent
 jobs and reports whichever one moves:
 
-```
+```text
 Monitor({
   description: "codex jobs: progress + stalls",
   timeout_ms: 3600000,
@@ -259,12 +238,27 @@ Two things that break these watches:
 A single-job Bash fallback, when `Monitor` is overkill:
 
 ```bash
-until [ -n "$(git -C <target> status --porcelain)" ] \
-   || [ $(( $(date +%s) - $(stat -f %m "$L") )) -gt 120 ]; do sleep 15; done
+S=~/.claude/plugins/data/codex-openai-codex/state
+TARGET=/path/to/clone            # the directory Codex was pointed at
+until [ -n "$(git -C "$TARGET" status --porcelain)" ]; do
+  L=$(ls -t $S/*/jobs/*.log 2>/dev/null | head -1)
+  [ -n "$L" ] && [ $(( $(date +%s) - $(stat -f %m "$L") )) -gt 120 ] && break
+  sleep 15
+done
+git -C "$TARGET" log --oneline -3; git -C "$TARGET" status --short
 ```
 
-Note the diff check is only an early exit. Removing the mtime clause would make
-a run that dies before writing anything wait forever.
+`$L` is resolved **inside** the loop, not before it: the log does not exist for
+the first ~30 seconds, and an unguarded `stat` on an empty path makes the
+condition true immediately, reporting a finish that never happened. The `-n "$L"`
+guard is what keeps the wait alive through that window.
+
+The diff check is the early exit and the mtime check is the real terminator.
+Drop the mtime clause and a run that dies before writing anything waits forever.
+
+An earlier version of this snippet used `$L` without ever assigning it — caught
+by a review bot on the pull request that introduced it. Documentation that
+cannot run is worse than none, because it is copied.
 
 The log may not exist for the first ~30 seconds. Guard for that, or the whole
 wait collapses immediately on an empty `$L`.

--- a/.claude/skills/use-codex/SKILL.md
+++ b/.claude/skills/use-codex/SKILL.md
@@ -1,8 +1,52 @@
-# Dispatching Codex
+---
+name: use-codex
+description: >
+  How to use OpenAI Codex from Claude Code — which transport to use, how not to
+  burn quota, and how to actually get finished work back out. Read before
+  delegating a coding task, requesting a Codex review, or generating an image.
+  Merges and supersedes the machine-local `~/.claude/skills/use-codex`.
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+---
 
-Invoke before handing any coding task to Codex. Everything here was learned the
-expensive way on 2026-07-30: **17 dispatches, zero that delivered end-to-end**,
-until the causes below were found. None of them was Codex being bad at code.
+# Using Codex from Claude Code
+
+## Never run the raw CLI concurrently or in a loop
+
+The most expensive rule here, and it predates the rest. Two raw `codex` CLI
+processes fight over the same ChatGPT Codex websocket and fail with `403` /
+`429` — **connection contention, not a resettable rate limit** — while each one
+still burns quota. A single call is fine; a second concurrent one is not, and
+retrying the failure just spends more. The `guard-codex.sh` PreToolUse hook
+enforces this and will block a second invocation or a looped one.
+
+Post-mortem: on 2026-06-03 landing work ran image generations concurrently
+inside a background retry loop. Cascading 403/429, ~235 PNGs piled up in
+`~/.codex/generated_images/`, quota burned, and the owner's own Codex sessions
+were disrupted. **None of the retries helped.**
+
+## Which transport
+
+- **Code, review, diagnosis** → the managed plugin: `/codex:rescue`,
+  `/codex:review`, `/codex:adversarial-review`; manage with `/codex:status`,
+  `/codex:result`, `/codex:cancel`. It serialises work over one app-server
+  connection, so it cannot hit the contention above. Never drive the raw CLI to
+  edit code — tried, abandoned as slow and unpredictable, and blocked by the
+  `block-codex-exec-codewrite` hook.
+- **Images** → `/codex:imagegen`, also managed. **This changed on 2026-07-30**:
+  the fork `lifeodyssey/codex-plugin-cc` adds that command, and the local
+  marketplace now points there (plugin 1.0.7). The older note — "verified that
+  the companion cannot generate images, so use a single raw call" — was true of
+  upstream 1.0.6 and is now **superseded**. If `/codex:imagegen` is missing, the
+  marketplace has drifted back to upstream; fix that rather than reaching for
+  the raw CLI.
+
+Everything below is about getting finished work out of a dispatch. It was
+learned on 2026-07-30 across ~17 dispatches, none of which delivered
+end-to-end until these causes were found — and none of the causes was Codex
+writing bad code.
 
 ## Codex cannot commit. Plan the whole workflow around that.
 
@@ -15,6 +59,24 @@ fatal: Unable to create '.../.git/index.lock': Operation not permitted
 That is the sandbox refusing to write **anything under `.git`**, not a
 filesystem permission — the same path is writable from your own shell. Verify in
 one line before theorising: `touch <dir>/.git/probe && rm <dir>/.git/probe`.
+
+Measured directly, 2026-07-30, plugin 1.0.7, in a standalone clone:
+
+| from inside Codex | result |
+|---|---|
+| `git add <file>` | `Operation not permitted`, exit 128 |
+| `touch .git/probe-file` | `Operation not permitted`, exit 1 |
+| `git config --local user.probe test` | `could not lock config file .git/config`, exit 255 |
+| `ls -ld .git` | succeeds |
+
+The last two are what make the rule precise: `git config` writes `.git/config`,
+not the index, and it fails too — so this is not index locking, it is the whole
+directory. Reads and listing are allowed.
+
+Re-run that probe after any plugin upgrade before assuming the rule still holds.
+It was re-run on the 1.0.6 → 1.0.7 upgrade, which included upstream's `db52e28`
+("Remove shell expansion for git commands") and looked likely to change it.
+It did not.
 
 **Do not ask Codex to "commit as you go".** It cannot, it will hit the wall
 partway through, and — obeying the instruction — it stops there, leaving less

--- a/.claude/skills/use-codex/SKILL.md
+++ b/.claude/skills/use-codex/SKILL.md
@@ -78,6 +78,34 @@ It was re-run on the 1.0.6 → 1.0.7 upgrade, which included upstream's `db52e28
 ("Remove shell expansion for git commands") and looked likely to change it.
 It did not.
 
+### There is a way around it. Do not use it.
+
+The block is keyed on the literal path `.git`. Rename the metadata directory
+and pass `--git-dir`, and Codex commits without complaint — tested 2026-07-30,
+commit created successfully in a clone whose `.git` had been renamed to
+`gitstore`. `touch gitstore/anything` also succeeds. So the control is shallow:
+one `mv` defeats it.
+
+**Knowing a control is shallow is not a reason to route around it.** What that
+directory protects is not tidiness:
+
+- **`.git/hooks/` is executable code that runs on every commit.** Write access
+  there is persistent arbitrary execution outside the sandbox. This is the real
+  reason the rule exists.
+- History rewriting, ref updates, and remote changes all live there. An agent
+  that can touch them can decouple "the diff I reviewed" from "what is in the
+  repository".
+
+What the workaround buys is one `git add -A` typed by the operator — the same
+step that, on the day this was written, caught a function pushed over the line
+cap, a missing import, an assertion flipped without renaming its test, and a
+staging config that would have left the environment with no chat API and no
+failing test to show for it.
+
+The general shape, worth keeping: **when a constraint blocks you, ask why it
+exists before asking how to get around it.** The instinct here ran the other
+way for two rounds, and only turned around when a security check objected.
+
 **Do not ask Codex to "commit as you go".** It cannot, it will hit the wall
 partway through, and — obeying the instruction — it stops there, leaving less
 finished work than if you had never asked.

--- a/.claude/skills/use-codex/SKILL.md
+++ b/.claude/skills/use-codex/SKILL.md
@@ -48,13 +48,43 @@ learned on 2026-07-30 across ~17 dispatches, none of which delivered
 end-to-end until these causes were found — and none of the causes was Codex
 writing bad code.
 
-## Codex cannot commit. Plan the whole workflow around that.
+## Whether Codex can commit is inconsistent. Always check; salvage what it left.
 
-Every `git add` fails, in every directory shape tried:
+Sometimes `git add` fails:
 
 ```
 fatal: Unable to create '.../.git/index.lock': Operation not permitted
 ```
+
+Sometimes it does not. Observed on one afternoon, same plugin, all standalone
+clones with an ordinary `.git`:
+
+| time | clone | outcome |
+|---|---|---|
+| 19:38, 19:43 | `codex-worker-lint` | **two commits, succeeded** |
+| ~19:32 | `codex-comments` | failed on `index.lock` |
+| 20:03 | `codex-committest` | failed on `index.lock` |
+
+No theory yet fits. Directory shape does not explain it — clone versus linked
+worktree was proposed and disproved, then "the sandbox blocks all `.git` writes"
+was proposed and disproved by the successes above. **Three confident causal
+rules, all wrong, all from small samples.** Do not add a fourth from one more
+observation.
+
+The operating rule does not depend on knowing why, which is why it is the thing
+to remember:
+
+1. When the job stops, run `git -C <target> log --oneline -3` **and**
+   `git -C <target> status --short`.
+2. Commit anything uncommitted yourself, immediately.
+3. Then gates and review, as below.
+
+That is correct whether it committed or not, so it never needs revising.
+
+**Keep asking for commits in the brief.** When it works you get sensible
+boundaries — the worker-lint run split "add the gate" from "fix the violations"
+without being told to. When it does not, it fails loudly at a boundary and you
+salvage. Both are better than not asking.
 
 That is the sandbox refusing to write **anything under `.git`**, not a
 filesystem permission — the same path is writable from your own shell. Verify in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,9 @@ integrated — **do not add new Supabase-auth code**; see the ADR / rebuild-spec
   quality → `/health` · brainstorm → `/office-hours`. TDD: `/backend-tdd` (Python), `/frontend-tdd` (React).
 - **Codex** — delegate code-writing / deep investigation via **`codex:codex-rescue`** (Skill, or Agent
   `subagent_type="codex:codex-rescue"`). **Read `.claude/skills/dispatch-codex/SKILL.md` first** — it
-  is short, and skipping it costs whole dispatches. The three that matter most: give Codex a
-  **`git clone`, never a linked worktree** (worktree git metadata is outside its writable root, so
-  every `git add` fails); **its sandbox has no network**, so build the environment and verify the
+  is short, and skipping it costs whole dispatches. The three that matter most: **Codex cannot commit** — its sandbox
+  refuses every write under `.git`, in a worktree or a clone alike, so ask for changes left in the
+  working tree and commit them yourself the moment the job stops; **its sandbox has no network**, so build the environment and verify the
   gates yourself before dispatching; and **the wrapper times out before Codex finishes**, so read
   the report from `~/.claude/plugins/data/codex-openai-codex/state/*/jobs/*.log`, not the return
   value. Expect sound judgement and a broken process: commit its output, then verify everything.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,18 +70,18 @@ integrated — **do not add new Supabase-auth code**; see the ADR / rebuild-spec
   ship/PR → `/ship` · qa → `/qa` · review → `/review` · docs → `/document-release` · retro → `/retro` ·
   design system → `/design-consultation` · visual → `/design-review` · architecture → `/plan-eng-review` ·
   quality → `/health` · brainstorm → `/office-hours`. TDD: `/backend-tdd` (Python), `/frontend-tdd` (React).
-- **Codex** — delegate code-writing / deep investigation via **`codex:codex-rescue`** (Skill, or Agent
-  `subagent_type="codex:codex-rescue"`). **Read `.claude/skills/dispatch-codex/SKILL.md` first** — it
-  is short, and skipping it costs whole dispatches. The three that matter most: **Codex cannot commit** — its sandbox
-  refuses every write under `.git`, in a worktree or a clone alike, so ask for changes left in the
-  working tree and commit them yourself the moment the job stops; **its sandbox has no network**, so build the environment and verify the
-  gates yourself before dispatching; and **the wrapper times out before Codex finishes**, so read
-  the report from `~/.claude/plugins/data/codex-openai-codex/state/*/jobs/*.log`, not the return
-  value. Expect sound judgement and a broken process: commit its output, then verify everything.
-  **Arm a `Monitor` right after dispatching** — the notification that arrives seconds later is the
-  forwarder returning an ID, not the job finishing; key the watch on the job log going quiet, which
-  catches a crash as well as a clean finish. **Never** `codex exec --sandbox workspace-write` (hook
-  `block-codex-exec-codewrite` blocks it).
+- **Codex** — delegate code-writing / deep investigation via **`codex:codex-rescue`**; review via
+  `/codex:review`; images via `/codex:imagegen`. **Read `.claude/skills/use-codex/SKILL.md` first** —
+  short, and skipping it costs whole dispatches. Four facts it exists for: **never run the raw CLI
+  concurrently or in a loop** (403/429 is connection contention, not a rate limit — retrying burns
+  quota; hook `guard-codex.sh` enforces it, and `block-codex-exec-codewrite` blocks raw code edits);
+  **Codex cannot commit** — its sandbox refuses every write under `.git`, worktree or clone alike, so
+  ask for changes left in the working tree and commit them yourself the moment the job stops;
+  **its sandbox has no network**, so build the environment and verify the gates yourself first;
+  and **the forwarder returns before Codex finishes**, so arm a `Monitor` keyed on the job log going
+  quiet and read the report from `~/.claude/plugins/data/codex-openai-codex/state/*/jobs/*.log`
+  rather than the return value. Expect sound judgement and a broken process — commit its output,
+  then re-run every gate yourself.
 - **Web browsing** → `/browse` (gstack). Never `mcp__claude-in-chrome__*`.
 - **CodeGraph** — `.codegraph/` is initialized; follow the **global** CodeGraph rules in `~/.claude/CLAUDE.md`
   (spawn an Explore agent for exploration; only lightweight `codegraph_*` lookups in the main session).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,15 @@ integrated — **do not add new Supabase-auth code**; see the ADR / rebuild-spec
   ship/PR → `/ship` · qa → `/qa` · review → `/review` · docs → `/document-release` · retro → `/retro` ·
   design system → `/design-consultation` · visual → `/design-review` · architecture → `/plan-eng-review` ·
   quality → `/health` · brainstorm → `/office-hours`. TDD: `/backend-tdd` (Python), `/frontend-tdd` (React).
-- **Codex** — delegate code-writing / deep investigation to Codex via **`/codex`** (`use-codex`) or
-  **`codex:codex-rescue`** (Skill, or Agent `subagent_type="codex:codex-rescue"`) — the managed app-server
-  runtime. **Never** `codex exec --sandbox workspace-write` (hook `block-codex-exec-codewrite` blocks it).
+- **Codex** — delegate code-writing / deep investigation via **`codex:codex-rescue`** (Skill, or Agent
+  `subagent_type="codex:codex-rescue"`). **Read `.claude/skills/dispatch-codex/SKILL.md` first** — it
+  is short, and skipping it costs whole dispatches. The three that matter most: give Codex a
+  **`git clone`, never a linked worktree** (worktree git metadata is outside its writable root, so
+  every `git add` fails); **its sandbox has no network**, so build the environment and verify the
+  gates yourself before dispatching; and **the wrapper times out before Codex finishes**, so read
+  the report from `~/.claude/plugins/data/codex-openai-codex/state/*/jobs/*.log`, not the return
+  value. Expect sound judgement and a broken process: commit its output, then verify everything.
+  **Never** `codex exec --sandbox workspace-write` (hook `block-codex-exec-codewrite` blocks it).
 - **Web browsing** → `/browse` (gstack). Never `mcp__claude-in-chrome__*`.
 - **CodeGraph** — `.codegraph/` is initialized; follow the **global** CodeGraph rules in `~/.claude/CLAUDE.md`
   (spawn an Explore agent for exploration; only lightweight `codegraph_*` lookups in the main session).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,10 @@ integrated — **do not add new Supabase-auth code**; see the ADR / rebuild-spec
   gates yourself before dispatching; and **the wrapper times out before Codex finishes**, so read
   the report from `~/.claude/plugins/data/codex-openai-codex/state/*/jobs/*.log`, not the return
   value. Expect sound judgement and a broken process: commit its output, then verify everything.
-  **Never** `codex exec --sandbox workspace-write` (hook `block-codex-exec-codewrite` blocks it).
+  **Arm a `Monitor` right after dispatching** — the notification that arrives seconds later is the
+  forwarder returning an ID, not the job finishing; key the watch on the job log going quiet, which
+  catches a crash as well as a clean finish. **Never** `codex exec --sandbox workspace-write` (hook
+  `block-codex-exec-codewrite` blocks it).
 - **Web browsing** → `/browse` (gstack). Never `mcp__claude-in-chrome__*`.
 - **CodeGraph** — `.codegraph/` is initialized; follow the **global** CodeGraph rules in `~/.claude/CLAUDE.md`
   (spawn an Explore agent for exploration; only lightweight `codegraph_*` lookups in the main session).


### PR DESCRIPTION
docs(dispatch-codex): the step after dispatching is arming a monitor

The skill said how to judge whether Codex is alive but not what to do the
moment after handing it work, which is where the time actually leaks.

**The notification that arrives seconds after dispatching is not completion.**
It is the forwarder returning a task ID; the real run starts then and takes
another eight to ten minutes. Treating it as "done" is how a finished review
got discarded earlier today — nothing was listening when the report landed.

The monitor's exit condition needs care. Waiting for a diff to appear means a
run that dies before writing anything waits forever, and silence then looks
exactly like progress. Log-goes-quiet covers finished and crashed alike; the
diff check belongs only as an early exit. Also guard the first ~30 seconds
before the log file exists, or an empty path collapses the wait immediately.

Two more things learned by doing them wrong: do not read or edit the target
directory while it runs — that is how work-in-progress got "corrected" and two
writers collided in one tree. And a quiet log is not automatically a finished
job; read the tail, because a deliberate STOP on a missing command is a
different outcome from a crash and needs a different fix.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

docs: write down why Codex dispatches kept failing

17 dispatches on 2026-07-30, none delivering end-to-end. The causes were all
environmental, and none of them was Codex writing bad code — which is why they
took a full day to find. Recording them so the next session does not.

**The big one: linked worktrees make committing impossible.** A linked worktree
keeps its git metadata in the parent repo's `.git/worktrees/<name>/`, outside
Codex's writable root. Reads succeed, so `git status` and `git diff` look
healthy, and then every `git add` fails on `index.lock`. "Codex never commits
its work" read as a discipline problem all day; it was never able to. Use a
standalone clone, where `.git` is inside the working directory.

**The sandbox has no network**, so the environment must be built and the gates
verified before dispatch — and `gh` is unavailable, which means anything from
GitHub has to be exported to a file first.

**The forwarding wrapper times out around two minutes while Codex runs eight to
ten.** One review finished correctly and was thrown away because nothing was
listening. The report is on disk under the plugin's state directory; read it
there rather than trusting the return value. "Zero complete deliveries" was the
wrong conclusion — it was zero successful *receipts*.

The skill also records what the output is actually like, with both sides named:
sound structural judgement (converging duplicated predicates, correctly telling
apart two identical-looking `is not None` checks, deriving a Cloudflare resource
ownership conflict unprompted) alongside a broken process (functions pushed over
the line cap to satisfy a linter bot, a module docstring deleted along with the
history it recorded, an import left behind pointing at a deleted symbol).

Both halves matter. The first is why it is worth dispatching; the second is why
every gate gets re-run by hand and every test it writes gets mutation-tested.

`AGENTS.md` carries a pointer plus the three facts that cost the most, since a
pointer nobody follows is worth nothing. 128 lines, within its own ~200 cap.

Docs only. No code, no gates affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for using Codex across code review, diagnosis, and image-generation workflows.
  * Clarified operational requirements for preparing environments, monitoring job progress, locating reports, and handling failures.
  * Documented restrictions around concurrent execution, sandbox access, repository changes, and network availability.
  * Updated routing references and clarified expected outputs, review gates, and troubleshooting steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->