### PR TITLE
fix: REAL review-bot findings from the comment backlog (batch 1)

### DIFF
--- a/apps/agent/agent/clients/gemini_vision.py
+++ b/apps/agent/agent/clients/gemini_vision.py
@@ -111,11 +111,16 @@ class GeminiVisionProvider:
         model: str = GEMINI_VISION_MODEL,
         base_url: str = _GEMINI_BASE_URL,
         timeout_seconds: float = 30.0,
+        client: httpx.AsyncClient | None = None,
     ) -> None:
         self._api_key = api_key
         self._model = model
         self._base_url = base_url
         self._timeout = timeout_seconds
+        self._client = client or (
+            httpx.AsyncClient(timeout=timeout_seconds) if api_key else None
+        )
+        self._owns_client = client is None and self._client is not None
 
     async def recognize(self, images: list[bytes], locale: str) -> VisionRecognition:
         """#502 P1-1: fail fast on a missing key rather than wasting a round
@@ -124,11 +129,16 @@ class GeminiVisionProvider:
         if not self._api_key:
             raise VisionProviderMisconfigured("GEMINI_API_KEY is not configured")
         url = f"{self._base_url}/models/{self._model}:generateContent"
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
-            response = await client.post(
-                url,
-                headers={"x-goog-api-key": self._api_key},
-                json=_payload(images, locale),
-            )
+        if self._client is None:
+            raise RuntimeError("Gemini HTTP client is not configured")
+        response = await self._client.post(
+            url,
+            headers={"x-goog-api-key": self._api_key},
+            json=_payload(images, locale),
+        )
         response.raise_for_status()
         return _parse_recognition(_response_text(response.json()))
+
+    async def aclose(self) -> None:
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()

--- a/apps/agent/agent/interfaces/routes/photo_search.py
+++ b/apps/agent/agent/interfaces/routes/photo_search.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Annotated, Literal, cast
 
+import httpx
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -94,9 +95,9 @@ class PhotoSearchRuntime:
 
 
 def build_photo_search_runtime(
-    settings: Settings, catalog: CatalogClientProtocol
+    settings: Settings, catalog: CatalogClientProtocol, client: httpx.AsyncClient
 ) -> PhotoSearchRuntime:
-    provider = GeminiVisionProvider(api_key=settings.gemini_api_key)
+    provider = GeminiVisionProvider(api_key=settings.gemini_api_key, client=client)
     return PhotoSearchRuntime(platform_provider=provider, catalog=catalog)
 
 
@@ -105,7 +106,10 @@ def _build_from_state(request: Request) -> PhotoSearchRuntime:
     catalog = getattr(request.app.state, "catalog_client", None)
     if not isinstance(catalog, CatalogClient):
         catalog = CatalogClient(base_url=settings.catalog_api_url)
-    return build_photo_search_runtime(settings, catalog)
+    client = getattr(request.app.state, "model_http_client", None)
+    if not isinstance(client, httpx.AsyncClient):
+        raise RuntimeError("photo-search requires the lifespan HTTP client")
+    return build_photo_search_runtime(settings, catalog, client)
 
 
 def _get_photo_runtime(request: Request) -> PhotoSearchRuntime:

--- a/apps/agent/agent/tests/unit/test_deploy_model_env_consistency.py
+++ b/apps/agent/agent/tests/unit/test_deploy_model_env_consistency.py
@@ -17,6 +17,7 @@ _REUSABLE_DEPLOY_WORKFLOW = (
     _REPO_ROOT / ".github" / "workflows" / "_deploy-component.yml"
 )
 _DOCKERFILE = _REPO_ROOT / "Dockerfile"
+_NON_SECRET_REQUIRED_KEYS = {"APP_ENV"}
 
 
 def _typescript_string_list(source: str, const_name: str) -> set[str]:
@@ -66,27 +67,22 @@ def _mapped_secret_names(source: str) -> set[str]:
     return {name for name, secret in mappings if name == secret}
 
 
-def test_container_required_keys_are_forwarded_and_deployed() -> None:
+def _required_deploy_keys() -> tuple[set[str], set[str], set[str]]:
     entrypoint = _ENTRYPOINT.read_text(encoding="utf-8")
     required = _typescript_string_list(entrypoint, "CONTAINER_REQUIRED_KEYS")
     forwarded = _typescript_string_list(entrypoint, "CONTAINER_ENV_KEYS")
     deploy = _DEPLOY_WORKFLOW.read_text(encoding="utf-8")
-    root_step = _named_workflow_step(deploy, "Deploy via Wrangler")
-    provisioned = _wrangler_secret_names(root_step)
+    provisioned = _wrangler_secret_names(
+        _named_workflow_step(deploy, "Deploy via Wrangler")
+    )
+    return required, forwarded, provisioned
 
-    # APP_ENV (issue #498) is a deliberate exception to the
-    # "every required key is a Wrangler *secret*" invariant below: it is a
-    # plain, non-secret `wrangler.toml` `[vars]`/`[env.*.vars]` value, not
-    # something `wrangler secret put` provisions. Cloudflare exposes both
-    # kinds identically on the container's `env` binding at runtime, so
-    # buildContainerEnvVars's fail-closed check on it is still meaningful —
-    # it just isn't wired through this workflow's `secrets: |` block, because
-    # nothing needs to push it there.
-    NON_SECRET_REQUIRED_KEYS = {"APP_ENV"}
 
+def test_container_required_keys_are_forwarded_and_deployed() -> None:
+    required, forwarded, provisioned = _required_deploy_keys()
     assert required
     assert required <= forwarded
-    assert required - NON_SECRET_REQUIRED_KEYS <= provisioned
+    assert required - _NON_SECRET_REQUIRED_KEYS <= provisioned
 
 
 def test_ci_root_deploys_match_manual_root_secrets() -> None:

--- a/apps/agent/agent/tests/unit/test_photo_search_route.py
+++ b/apps/agent/agent/tests/unit/test_photo_search_route.py
@@ -72,20 +72,28 @@ class _DownVisionProvider:
         raise httpx.ConnectError("connection refused")
 
 
-async def test_platform_vision_outage_degrades_to_clarify_not_500() -> None:
-    """The fallback/degrade edge must be reachable end-to-end through the route."""
+def _outage_app() -> FastAPI:
     app = _app()
     app.state.photo_search = PhotoSearchRuntime(
         platform_provider=_DownVisionProvider(),
         catalog=FakeCatalog(),
         quota=PhotoSearchQuota(clock=lambda: datetime(2026, 7, 26, tzinfo=UTC)),
     )
-    async with async_client(app) as client:
-        response = await client.post("/v1/photo-search", json=_body())
+    return app
+
+
+def _assert_clarify_response(response: httpx.Response) -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["intent"] == "clarify"
     assert payload["data"]["reason"] == "photo_unrecognized"
+
+
+async def test_platform_vision_outage_degrades_to_clarify_not_500() -> None:
+    """The fallback/degrade edge must be reachable end-to-end through the route."""
+    async with async_client(_outage_app()) as client:
+        response = await client.post("/v1/photo-search", json=_body())
+    _assert_clarify_response(response)
 
 
 async def test_unsupported_mime_type_is_a_clear_415() -> None:

--- a/apps/agent/agent/tests/unit/test_purge_cron_settings.py
+++ b/apps/agent/agent/tests/unit/test_purge_cron_settings.py
@@ -24,8 +24,6 @@ import pytest
 from agent.config.settings import get_settings
 from agent.scripts import purge_anon_quota_counts, purge_anonymous_sessions
 
-pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
-
 
 class _ReachedDatabase(Exception):
     """Raised the moment `_main` opens `SupabaseClient` — proof it got past

--- a/apps/web/src/components/auth/useAuthCallback.ts
+++ b/apps/web/src/components/auth/useAuthCallback.ts
@@ -188,9 +188,10 @@ function derivedState(state: AuthCallbackState, migration: MigrationState): Auth
  */
 export function useAuthCallback(
   establish: Establish = getAuthToken, replay: Replay = replayDeferredSave,
-  migrate: Migrate | undefined = migrateAnonymousSession, expectsMigration = false,
+  migrate?: Migrate, expectsMigration = false,
 ): AuthCallbackSession {
-  return useCallbackSession({ establish, replay, migrate, expectsMigration });
+  const resolvedMigrate = migrate ?? migrateAnonymousSession;
+  return useCallbackSession({ establish, replay, migrate: resolvedMigrate, expectsMigration });
 }
 
 function useCallbackSession(c: Collaborators): AuthCallbackSession {

--- a/docs/iterations/iter5/progress.md
+++ b/docs/iterations/iter5/progress.md
@@ -32,12 +32,22 @@ working method, the confirmed traps, and four decisions still waiting on the own
 ### Merged
 - `#435` S1.4 search content shapes + static map (C3a/C3b)
 - `#436` S1.9 Cloudflare Turnstile edge gate — dormant as of this entry; **wired by #447** (see below)
+- `#447` arms the merged Turnstile gate for anonymous `/v1` traffic; the gate
+  resolves the anonymous identity first, then challenges before rate limiting
+  or container forwarding.
 - `#439` S1.5 route card (TimedItinerary, map promotion, Walk CTA seam)
 - `#438` S1.8 anonymous access + edge rate limiting + daily budget breaker
 - `#440` S1.13 L0 smoke gate — classified actionable failures; delivers `#434`'s fix (issue stays open: non-default-branch merges don't fire `Closes`)
 - `#442` `#303` CatalogClient connection reuse
 - `#430` C1 — tool lifecycle on pydantic-ai's official event stream
 - `#433`, `#431` earlier in the session
+
+### #447 Turnstile activation detail
+
+The merged #436 gate was dormant until #447 wired it into the anonymous `/v1`
+path. The edge resolves an anonymous identity first, then challenges before
+rate limiting or container forwarding; anonymous access remains a 401 when the
+feature is disabled.
 
 Closed with evidence rather than reimplemented: `#256` (S1.1), `#258` (S1.2).
 

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -225,9 +225,10 @@ Routing defined by `wrangler.toml`:
 
 Issue #537 removed the bundled Next.js app and with it the `[assets]` binding: this Worker
 has **no** HTML surface. `apps/web` deploys as its own Worker and owns every page. The root
-Worker's `routes` still claim `animichi.com/*` — narrowing that and pointing the apex at
-`apps/web` is issue #541 (DNS + routes), which must land before `animichi.com` gets a DNS
-record.
+Worker's `routes` still claim `animichi.com/*`, so the apex has not yet been cut over to the
+web Worker. Until issue #541 changes the DNS and route ownership, the root Worker owns the
+apex request but returns its JSON 404 for page paths; `apps/web` owns HTML only on its own
+Worker hostname. That cutover must land before `animichi.com` gets a DNS record.
 
 ## Deploy Sequence
 
@@ -304,6 +305,7 @@ Do not use version tags as a deploy trigger for the current pipeline.
 **CF Worker routing** (`worker/app.ts`):
 - `/v1/*` and `/healthz` → `CONTAINER` (Durable Object → FastAPI service on port 8080)
 - `/v1/users/*` → `USERS` service binding
+- `/catalog/public/anime-overview/:id` → allowlisted anonymous catalog read
 - `/img/*` → image proxy + cache
 - Everything else → JSON `404 not_found` (no asset/page fallback since #537)
 

--- a/scripts/local-login.sh
+++ b/scripts/local-login.sh
@@ -48,7 +48,8 @@ for m in d['messages']:
 
   if [ -n "$LINK" ]; then
     # Rewrite the callback origin to the local web app.
-    LOCAL_LINK=$(echo "$LINK" | sed -E "s|^https?://[^/]+|${LOCAL_WEB_ORIGIN}|")
+    LINK_PATH="/${LINK#*://*/}"
+    LOCAL_LINK="${LOCAL_WEB_ORIGIN%/}${LINK_PATH}"
     echo ""
     echo "✅ Magic link found!"
     echo ""

--- a/scripts/local-login.sh
+++ b/scripts/local-login.sh
@@ -17,6 +17,7 @@ EMAIL="${1:-dev@seichijunrei.test}"
 SUPABASE_URL="http://127.0.0.1:54321"
 ANON_KEY="sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH"
 MAILPIT_URL="http://localhost:54324"
+LOCAL_WEB_ORIGIN="${LOCAL_WEB_ORIGIN:-http://localhost:3000}"
 
 echo "Sending magic link to: $EMAIL"
 
@@ -46,8 +47,8 @@ for m in d['messages']:
 " 2>/dev/null)
 
   if [ -n "$LINK" ]; then
-    # Rewrite production URL to local — Edge Function may default to prod SITE_URL
-    LOCAL_LINK=$(echo "$LINK" | sed 's|https://seichijunrei\.zhenjia\.org|http://localhost:3000|g')
+    # Rewrite the callback origin to the local web app.
+    LOCAL_LINK=$(echo "$LINK" | sed -E "s|^https?://[^/]+|${LOCAL_WEB_ORIGIN}|")
     echo ""
     echo "✅ Magic link found!"
     echo ""

--- a/scripts/local-login.test.sh
+++ b/scripts/local-login.test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/local-login.sh"
+MOCK_BIN="$(mktemp -d)"
+CAPTURE="$(mktemp)"
+trap 'rm -rf "$MOCK_BIN" "$CAPTURE"' EXIT
+
+cat >"${MOCK_BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"/auth/v1/otp"* ]]; then
+  exit 0
+fi
+printf '{}\n'
+EOF
+
+cat >"${MOCK_BIN}/python3" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'https://auth.example.test/auth/v1/verify?token=fixture&next=local\path'
+EOF
+
+cat >"${MOCK_BIN}/open" <<'EOF'
+#!/usr/bin/env bash
+printf '%s' "$1" >"${LOCAL_LOGIN_CAPTURE}"
+EOF
+
+cat >"${MOCK_BIN}/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "${MOCK_BIN}/curl" "${MOCK_BIN}/python3" "${MOCK_BIN}/open" "${MOCK_BIN}/sleep"
+
+LOCAL_WEB_ORIGIN='http://local&host\dev' \
+LOCAL_LOGIN_CAPTURE="${CAPTURE}" \
+PATH="${MOCK_BIN}:${PATH}" \
+  bash "${SCRIPT}" fixture@example.test >/dev/null
+
+expected='http://local&host\dev/auth/v1/verify?token=fixture&next=local\path'
+actual="$(<"${CAPTURE}")"
+[[ "${actual}" == "${expected}" ]] || {
+  printf 'expected rewritten URL %q, got %q\n' "${expected}" "${actual}" >&2
+  exit 1
+}
+printf 'PASS local-login origin rewrite\n'

--- a/scripts/local-login.test.sh
+++ b/scripts/local-login.test.sh
@@ -32,12 +32,12 @@ EOF
 
 chmod +x "${MOCK_BIN}/curl" "${MOCK_BIN}/python3" "${MOCK_BIN}/open" "${MOCK_BIN}/sleep"
 
-LOCAL_WEB_ORIGIN='http://local&host\dev' \
+LOCAL_WEB_ORIGIN='https://local&host\dev' \
 LOCAL_LOGIN_CAPTURE="${CAPTURE}" \
 PATH="${MOCK_BIN}:${PATH}" \
   bash "${SCRIPT}" fixture@example.test >/dev/null
 
-expected='http://local&host\dev/auth/v1/verify?token=fixture&next=local\path'
+expected='https://local&host\dev/auth/v1/verify?token=fixture&next=local\path'
 actual="$(<"${CAPTURE}")"
 [[ "${actual}" == "${expected}" ]] || {
   printf 'expected rewritten URL %q, got %q\n' "${expected}" "${actual}" >&2

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -360,11 +360,13 @@ async function handleImageProxy(request: Request, ctx: WorkerExecutionContext): 
  * Next.js homepage here; `apps/web` owns every HTML surface now. Unmatched
  * paths answer `NOT_FOUND_BODY` instead of a page — see its comment for why
  * that is a hard 404 and not a friendly 200. */
-export function createWorkerApp(deps: {
+type WorkerApp = Hono<{ Bindings: Env }>;
+interface WorkerDeps {
   authenticate?: (request: Request, env: Env, ctx: WorkerExecutionContext) => Promise<AuthResult>;
   turnstileGate?: TurnstileGate;
-}): Hono<{ Bindings: Env }> {
-  const app = new Hono<{ Bindings: Env }>();
+}
+
+function registerWorkerRoutes(app: WorkerApp, deps: WorkerDeps): void {
   app.notFound(() => Response.json(NOT_FOUND_BODY, { status: 404 }));
   const authenticate = deps.authenticate ?? ((req, env, ctx) => realAuthenticate(req, env, fetch, ctx));
   // One gate per app instance, built outside the request handler so its
@@ -375,7 +377,7 @@ export function createWorkerApp(deps: {
     c.env.CONTAINER.get(c.env.CONTAINER.idFromName("default")).fetch(c.req.raw),
   );
   app.all("/img/*", (c) => handleImageProxy(c.req.raw, c.executionCtx));
-  app.get("/catalog/public/anime-overview/:bangumiId{[0-9]+}", (c) => {
+  app.get("/catalog/public/anime-overview/:bangumiId{[0-9]+}", async (c) => {
     if (new URL(c.req.url).search) return c.text("Unexpected query parameters", 400);
     return forwardPublicCatalog(c.env, c.req.raw);
   });
@@ -418,5 +420,10 @@ export function createWorkerApp(deps: {
     if (anonymous !== null) return anonymous;
     return c.json(UNAUTHORIZED_BODY, 401);
   });
+}
+
+export function createWorkerApp(deps: WorkerDeps): WorkerApp {
+  const app = new Hono<{ Bindings: Env }>();
+  registerWorkerRoutes(app, deps);
   return app;
 }


### PR DESCRIPTION
Fixes for findings triaged REAL and left unaddressed on merged PRs. Written by
Codex, verified and partly reverted here.

**`gemini_vision.py` — a per-request `httpx.AsyncClient`.** The repo's F7
convention is one shared client per client class, created lazily and closed by
the FastAPI lifespan, never per request. `GeminiVisionProvider` built a fresh
one inside the request path. It now takes an injected client, and
`photo_search.py` hands it the lifespan-owned `model_http_client`.

Checked the part that makes this a fix rather than a relabelling: the injected
client's lifecycle belongs to the lifespan, which already closes it
(`fastapi_service.py:149`). `_owns_client` is false when injected, so the
provider's own `aclose()` is a no-op and nothing double-closes. And a missing
lifespan client raises rather than silently constructing one — the failure mode
that would have quietly restored the old behaviour.

**`worker/app.ts`** — `createWorkerApp` split into typed `WorkerDeps` plus a
`registerWorkerRoutes` helper, bringing it under the function-length cap now
that `worker/` is inside the lint gate (#552).

Plus smaller fixes in `useAuthCallback.ts`, `local-login.sh`,
`test_deploy_model_env_consistency.py`, `test_photo_search_route.py`,
`test_purge_cron_settings.py`, and two docs.

## One change reverted

Codex rewrote `workers/catalog/test/wrangler-private.worker.test.ts`, replacing
its line-based TOML reader with a regex `sectionBody` helper that returns an
empty string — the test failed. Reverted to the version on `main`.

Worth naming why it was a bad change beyond being broken: that file carries a
comment stating the parser is **deliberately** line-based, because the point is
to assert on the file a human edits rather than take on a TOML dependency. The
rewrite went against a stated design decision sitting three lines above it.

Also worth recording how it was diagnosed, because the first guess was wrong. I
had made a one-line `.match` → `.exec` edit in that file to clear an oxlint
`prefer-regexp-exec` error, so the obvious suspect was me. Three-way control —
my version, Codex's version, `main`'s version — showed **my edit and Codex's
both failed and `main` passed**. Without the control I would have spent the time
fixing something I had not broken.

Whatever finding prompted that rewrite is therefore still open. It is one of the
26 and is not addressed here.

Gates: catalog 35 + 262 passed · worker 225 pass · agent unit 1666 passed ·
oxlint clean · ruff clean · ruff format clean · mypy no issues in 137 files ·
apps/web 1572 passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved photo-search reliability during vision service outages, returning a clarification response instead of an internal server error.
  - Fixed reuse and cleanup of vision service connections for more consistent requests.

- **Developer Experience**
  - Local login now supports configurable web-app origins for different development environments.

- **Documentation**
  - Clarified production routing and cutover behavior.
  - Documented the publicly available anonymous catalog endpoint and Turnstile request flow.

- **Refactor**
  - Simplified application route registration and authentication callback handling without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->