### PR TITLE
fix: REAL review-bot findings from the comment backlog (batch 2)

### DIFF
--- a/apps/agent/agent/agents/agent_result.py
+++ b/apps/agent/agent/agents/agent_result.py
@@ -44,11 +44,16 @@ class ProducedRoute:
     route_ref: RouteRef
 
 
+RouteRejectionStatus: TypeAlias = Literal[
+    "empty", "stale_ref", "pending_sync", "upstream_unavailable", "contract_violation"
+]
+
+
 @dataclass(frozen=True)
 class RejectedRoute:
     """A current route outcome that did not produce a registry entry."""
 
-    status: Literal["empty", "stale_ref", "pending_sync", "upstream_unavailable"]
+    status: RouteRejectionStatus
 
 
 StepProvenance: TypeAlias = (

--- a/apps/agent/agent/agents/error_messages.py
+++ b/apps/agent/agent/agents/error_messages.py
@@ -21,6 +21,7 @@ from agent.clients.catalog_errors import (
 
 InputError = Literal["message_too_long", "non_text_message"]
 _DEFAULT_LOCALE = "en"
+CATALOG_ROUTE_UNAVAILABLE_MESSAGE = "Catalog route unavailable"
 
 _INPUT_MESSAGES: dict[tuple[InputError, str], str] = {
     (

--- a/apps/agent/agent/agents/history_compaction.py
+++ b/apps/agent/agent/agents/history_compaction.py
@@ -174,12 +174,11 @@ class CompactToolReturns(Generic[AgentDepsT]):
         call_args: dict[str, Mapping[str, object]],
         session: SessionState | None,
     ) -> ModelRequestPart:
-        if (
-            not isinstance(part, ToolReturnPart)
-            or len(str(part.content)) <= TOOL_RETURN_MAX_CHARS
-        ):
+        if not isinstance(part, ToolReturnPart):
             return part
         self._retain_entity(part, call_args, session)
+        if len(str(part.content)) <= TOOL_RETURN_MAX_CHARS:
+            return part
         summary = self._summary(part.tool_name, part.content)
         return replace(part, content=summary)
 

--- a/apps/agent/agent/agents/selected_route.py
+++ b/apps/agent/agent/agents/selected_route.py
@@ -6,9 +6,18 @@ import httpx
 import structlog
 from pydantic import ValidationError
 
-from agent.agents.agent_result import AgentResult, ProducedRoute, StepRecord
+from agent.agents.agent_result import (
+    AgentResult,
+    ProducedRoute,
+    RejectedRoute,
+    RouteRejectionStatus,
+    StepRecord,
+)
 from agent.agents.catalog_adapter import build_route_payload, build_route_state
-from agent.agents.error_messages import build_error_message
+from agent.agents.error_messages import (
+    CATALOG_ROUTE_UNAVAILABLE_MESSAGE,
+    build_error_message,
+)
 from agent.agents.runtime_deps import OnStep, StepEvent, StepStatus, new_step_call_id
 from agent.agents.runtime_models import RouteResponseModel
 from agent.agents.selection_messages import selected_route_message
@@ -19,7 +28,7 @@ from agent.clients.errors import APIError
 logger = structlog.get_logger(__name__)
 
 _TRANSIENT_ERRORS = (APIError, httpx.TransportError, httpx.TimeoutException)
-_ROUTE_ERRORS = (*_TRANSIENT_ERRORS, ValidationError)
+_ROUTE_ERRORS = _TRANSIENT_ERRORS
 
 
 async def execute_selected_route(
@@ -41,13 +50,24 @@ async def execute_selected_route(
 
     try:
         route = await catalog.route(point_ids, origin=_parse_coordinate_origin(origin))
+    except ValidationError:
+        logger.error("selected_route_catalog_contract_error")
+        await _emit_step(on_step, call_id, "error", {})
+        return _error_result(
+            CATALOG_ROUTE_UNAVAILABLE_MESSAGE,
+            locale,
+            state,
+            route_status="contract_violation",
+        )
     except _ROUTE_ERRORS as exc:
         logger.warning("selected_route_catalog_error", error=str(exc))
         await _emit_step(on_step, call_id, "error", {})
         # Typed CatalogError -> localized, actionable text from OUR mapping
         # table (SD-19); anything else keeps the legacy generic fallback.
         return _error_result(
-            build_error_message(exc, locale, fallback="Catalog route unavailable"),
+            build_error_message(
+                exc, locale, fallback=CATALOG_ROUTE_UNAVAILABLE_MESSAGE
+            ),
             locale,
             state,
         )
@@ -122,7 +142,13 @@ def _build_success_result(
     )
 
 
-def _error_result(error: str, locale: str, state: SessionState) -> AgentResult:
+def _error_result(
+    error: str,
+    locale: str,
+    state: SessionState,
+    *,
+    route_status: RouteRejectionStatus = "upstream_unavailable",
+) -> AgentResult:
     output = RouteResponseModel(message=error)
     return AgentResult(
         output=output,
@@ -133,6 +159,7 @@ def _error_result(error: str, locale: str, state: SessionState) -> AgentResult:
                 tool="plan_selected",
                 success=False,
                 error=error,
+                provenance=RejectedRoute(status=route_status),
                 model_initiated=False,
             )
         ],

--- a/apps/agent/agent/agents/selected_route.py
+++ b/apps/agent/agent/agents/selected_route.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import httpx
 import structlog
+from pydantic import ValidationError
 
 from agent.agents.agent_result import AgentResult, ProducedRoute, StepRecord
 from agent.agents.catalog_adapter import build_route_payload, build_route_state
@@ -18,6 +19,7 @@ from agent.clients.errors import APIError
 logger = structlog.get_logger(__name__)
 
 _TRANSIENT_ERRORS = (APIError, httpx.TransportError, httpx.TimeoutException)
+_ROUTE_ERRORS = (*_TRANSIENT_ERRORS, ValidationError)
 
 
 async def execute_selected_route(
@@ -39,7 +41,7 @@ async def execute_selected_route(
 
     try:
         route = await catalog.route(point_ids, origin=_parse_coordinate_origin(origin))
-    except _TRANSIENT_ERRORS as exc:
+    except _ROUTE_ERRORS as exc:
         logger.warning("selected_route_catalog_error", error=str(exc))
         await _emit_step(on_step, call_id, "error", {})
         # Typed CatalogError -> localized, actionable text from OUR mapping

--- a/apps/agent/agent/clients/catalog_errors.py
+++ b/apps/agent/agent/clients/catalog_errors.py
@@ -157,6 +157,7 @@ class _ErrorEnvelope(BaseModel):
 
     defined: bool = False
     code: str = ""
+    status: int = 0
     message: str = ""
     data: object = None
 
@@ -211,7 +212,12 @@ def parse_catalog_error(status_code: int, body: object, url: str) -> APIError:
     """
     envelope = _parse_envelope(body)
     builder = _BUILDERS.get(envelope.code) if envelope is not None else None
-    if envelope is None or envelope.defined is not True or builder is None:
+    if (
+        envelope is None
+        or envelope.defined is not True
+        or envelope.status != status_code
+        or builder is None
+    ):
         return _status_fallback(status_code, url)
     _log_wire_message(envelope, url)
     return builder(envelope.data)

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -328,14 +328,15 @@ async def handle_chat(
     login_rejection = _byok_login_rejection(request, auth)
     if login_rejection is not None:
         return login_rejection
+    rejection = await _budget_rejection(request, auth)
+    if rejection is not None:
+        return rejection
     settings = _get_settings_from_request(request)
     body = _decode_body(await request.body())
     api_request = _runtime_request(request, body, settings.message_max_chars)
     runtime_api = _get_runtime_api(request)
     await runtime_api.validate_session_owner(api_request.session_id, auth.user_id)
-    rejection = await _budget_rejection(request, auth)
-    if rejection is None:
-        rejection = await _quota_rejection(request, auth)
+    rejection = await _quota_rejection(request, auth)
     if rejection is not None:
         return rejection
     byok_model = await _resolve_byok_model(request)

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -73,8 +73,19 @@ def _user_message_text(message: object, locale: Locale, max_chars: int) -> str |
     parts = message.get("parts")
     if not isinstance(parts, list):
         _reject_input("non_text_message", locale)
-    values = [_text_part(part, locale) for part in parts]
-    return _checked_length("".join(values), max_chars, locale)
+    return _join_text_parts(parts, locale, max_chars)
+
+
+def _join_text_parts(parts: list[object], locale: Locale, max_chars: int) -> str:
+    values: list[str] = []
+    total = 0
+    for part in parts:
+        value = _text_part(part, locale)
+        total += len(value)
+        if total > max_chars:
+            _reject_input("message_too_long", locale)
+        values.append(value)
+    return "".join(values)
 
 
 def _text_part(part: object, locale: Locale) -> str:
@@ -317,16 +328,16 @@ async def handle_chat(
     login_rejection = _byok_login_rejection(request, auth)
     if login_rejection is not None:
         return login_rejection
-    rejection = await _budget_rejection(request, auth)
-    if rejection is None:
-        rejection = await _quota_rejection(request, auth)
-    if rejection is not None:
-        return rejection
     settings = _get_settings_from_request(request)
     body = _decode_body(await request.body())
     api_request = _runtime_request(request, body, settings.message_max_chars)
     runtime_api = _get_runtime_api(request)
     await runtime_api.validate_session_owner(api_request.session_id, auth.user_id)
+    rejection = await _budget_rejection(request, auth)
+    if rejection is None:
+        rejection = await _quota_rejection(request, auth)
+    if rejection is not None:
+        return rejection
     byok_model = await _resolve_byok_model(request)
     handler = _chat_handler(runtime_api, api_request, auth, byok_model)
 

--- a/apps/agent/agent/scripts/purge_anonymous_sessions.py
+++ b/apps/agent/agent/scripts/purge_anonymous_sessions.py
@@ -49,7 +49,7 @@ class PurgeReport:
 #: this. A non-Postgres exception (a programming bug) is deliberately NOT
 #: caught here — it propagates out of the sweep and crashes the CLI with a
 #: nonzero exit, which is what should page someone.
-_EXPECTED_PER_SESSION_ERRORS = asyncpg.PostgresError
+_EXPECTED_PER_SESSION_ERRORS = asyncpg.ForeignKeyViolationError
 
 
 async def purge_anonymous_sessions(

--- a/apps/agent/agent/tests/eval/eval_gate_flow.py
+++ b/apps/agent/agent/tests/eval/eval_gate_flow.py
@@ -308,7 +308,7 @@ def _report_gate_input(
         errors=_classified_errors(report),
         trajectories=_trajectory_cases(report),
         expectations=_expectations(report),
-        strata=load_case_strata(DATASET_PATH),
+        strata=load_case_strata(DATASET_PATH) if not CAPPED else None,
     )
 
 

--- a/apps/agent/agent/tests/unit/test_chat_anon_quota.py
+++ b/apps/agent/agent/tests/unit/test_chat_anon_quota.py
@@ -147,18 +147,13 @@ async def test_an_unconfigured_quota_never_rejects_and_never_reads_the_repo() ->
     db.anon_quota.increment_and_count.assert_not_awaited()
 
 
-async def test_a_malformed_body_still_consumes_one_message_of_the_quota() -> None:
-    """Decided semantics (review follow-up): the quota check runs before
-    request-body validation in `handle_chat`, so a malformed body that goes
-    on to 422 still counts as an attempt against the visitor's daily
-    allowance — the same reasoning a rate limiter uses (it counts requests,
-    not successes). A visitor cannot get free extra attempts by sending
-    garbage; the counter and the 422 both happen on the same request."""
+async def test_a_malformed_body_is_rejected_before_quota_consumption() -> None:
+    """Malformed input cannot consume anonymous message allowance."""
     app, runtime, db = _app(next_count=1)
     async with async_client(app) as client:
         response = await client.post(
             "/v1/chat", json={"messages": "not-a-list"}, headers=ANON_HEADERS
         )
     assert response.status_code == 422
-    db.anon_quota.increment_and_count.assert_awaited_once()
+    db.anon_quota.increment_and_count.assert_not_awaited()
     assert runtime.handle.await_count == 0

--- a/apps/agent/agent/tests/unit/test_chat_budget_ordering.py
+++ b/apps/agent/agent/tests/unit/test_chat_budget_ordering.py
@@ -1,0 +1,46 @@
+"""The anonymous chat breakers reject before request-body work."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.responses import JSONResponse
+from starlette.requests import Request
+from starlette.types import Message, Receive
+
+from agent.interfaces.routes import chat
+from agent.interfaces.routes._deps import TrustedAuthContext
+
+
+def _request(receive: Receive) -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/chat",
+        "headers": [],
+        "query_string": b"",
+        "server": ("test", 443),
+        "scheme": "https",
+    }
+    return Request(scope, receive=receive)
+
+
+async def _body_read() -> Message:
+    raise AssertionError("the body must not be read after budget rejection")
+
+
+async def test_budget_rejection_precedes_body_read_and_session_validation(
+    monkeypatch,
+) -> None:
+    request = _request(_body_read)
+    rejection = JSONResponse(status_code=403, content={"error": "budget"})
+    monkeypatch.setattr(chat, "_budget_rejection", AsyncMock(return_value=rejection))
+    monkeypatch.setattr(chat, "_quota_rejection", AsyncMock())
+    monkeypatch.setattr(chat, "_get_runtime_api", MagicMock())
+
+    result = await chat.handle_chat(
+        request,
+        TrustedAuthContext("anon_0123456789abcdef0123456789abcdef", "anonymous"),
+    )
+
+    assert result is rejection

--- a/apps/agent/agent/tests/unit/test_ci_eval_gate_workflow.py
+++ b/apps/agent/agent/tests/unit/test_ci_eval_gate_workflow.py
@@ -106,7 +106,7 @@ def test_smoke_job_sets_supabase_db_url_so_settings_import_succeeds() -> None:
         _CI_WORKFLOW.read_text(encoding="utf-8"), "agent-eval-smoke"
     )
 
-    assert "SUPABASE_DB_URL" in job
+    assert re.search(r"(?m)^\s*SUPABASE_DB_URL:\s*\S+", job)
 
 
 def test_no_disabled_eval_gate_remains_in_ci() -> None:

--- a/apps/agent/agent/tests/unit/test_history_compaction_verbatim.py
+++ b/apps/agent/agent/tests/unit/test_history_compaction_verbatim.py
@@ -80,14 +80,16 @@ async def test_no_extractable_entity_writes_no_retention_payload() -> None:
     assert session.compaction_retained_entities.is_empty()
 
 
-async def test_short_return_needs_no_compaction_and_retains_nothing() -> None:
+async def test_short_return_retains_extractable_entity_without_compaction() -> None:
     session = SessionState()
     messages = _call_pair("search_nearby", {"location": "資生堂前"}, "ok", "call-3")
     compact = CompactToolReturns[RuntimeDeps](_summarize_tool_content, keep_recent=0)
 
     await compact.compact(messages, _ctx(session))
 
-    assert session.compaction_retained_entities.is_empty()
+    entities = session.compaction_retained_entities.entities
+    assert len(entities) == 1
+    assert entities[0].value == "資生堂前"
 
 
 async def test_extraction_failure_degrades_without_raising() -> None:

--- a/apps/agent/agent/tests/unit/test_selected_route_errors.py
+++ b/apps/agent/agent/tests/unit/test_selected_route_errors.py
@@ -7,6 +7,7 @@ typed errors — while untyped failures keep the legacy fallback.
 
 from __future__ import annotations
 
+from agent.agents.agent_result import RejectedRoute
 from agent.agents.selected_route import execute_selected_route
 from agent.agents.session_state import SessionState
 from agent.clients.catalog_client import Route
@@ -33,6 +34,13 @@ class _UpstreamDownCatalog(MockCatalogClient):
         self, point_ids: list[str], *, origin: tuple[float, float] | None = None
     ) -> Route:
         raise UpstreamUnavailableError(UpstreamUnavailableData(upstream="bangumi"))
+
+
+class _MalformedCatalog(MockCatalogClient):
+    async def route(
+        self, point_ids: list[str], *, origin: tuple[float, float] | None = None
+    ) -> Route:
+        return Route.model_validate({"point_count": 1})
 
 
 async def test_too_many_clusters_returns_actionable_message_en() -> None:
@@ -78,3 +86,16 @@ async def test_retryable_error_returns_try_again_message() -> None:
     assert result.output.message == (
         "The catalog service is temporarily unavailable. Please try again in a moment."
     )
+
+
+async def test_catalog_contract_violation_is_typed_without_exposing_details() -> None:
+    result = await execute_selected_route(
+        point_ids=["p1"],
+        state=SessionState(),
+        origin=None,
+        locale="en",
+        catalog=_MalformedCatalog(),
+    )
+
+    assert result.output.message == "Catalog route unavailable"
+    assert result.steps[0].provenance == RejectedRoute(status="contract_violation")

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -3,7 +3,7 @@ import { TurnstileGate } from "../../components/TurnstileGate";
 import { useLocale } from "../../i18n/context";
 import type { Locale } from "../../i18n/locales";
 import { useAuthStatus } from "../../lib/auth/session";
-import { ChatActionsProvider } from "./chat-actions";
+import { ChatActionsProvider, sendWithOriginOf } from "./chat-actions";
 import type { ChatActions } from "./chat-actions";
 import { ByokSettings } from "./components/ByokSettings";
 import { ChatInput } from "./components/ChatInput";
@@ -233,7 +233,7 @@ function makeTracked(actions: ChatActions, setGps: (gps: PhotoGps) => void): Cha
     ...actions,
     sendWithOrigin: (text: string, lat: number, lng: number) => {
       setGps({ lat, lng });
-      actions.sendWithOrigin?.(text, lat, lng);
+      sendWithOriginOf(actions)(text, lat, lng);
     },
   };
 }
@@ -283,11 +283,11 @@ function usePhotoContext(locale: ReturnType<typeof useLocale>, chat: ChatSession
 }
 
 /** Tray state: the recompute turn, its masked failure, and the spot store. */
-function useTrayState(chat: ChatSession, baseUrl: string, gate: TurnFailureGate) {
+function useTrayState(chat: ChatSession, baseUrl: string, gate: TurnFailureGate, sessionKey: string | undefined) {
   const turn = useTurnFailure(chat, baseUrl, gate);
-  const recompute = useRecomputeTurn(chat);
+  const recompute = useRecomputeTurn(chat, sessionKey);
   const failure = maskRecomputeFailure(recompute, turn.view);
-  const selection = useSpotSelectionState();
+  const selection = useSpotSelectionState(sessionKey);
   return { recompute: lockedRecompute(recompute, turn.quota.locked), failure, selection, quota: turn.quota };
 }
 
@@ -301,9 +301,9 @@ function usePageSurfaces(chat: ChatSession, actions: ChatActions, gps: PhotoGps 
 }
 
 /** Turnstile challenge + auth-gated tray state (D12 lock, failures). */
-function useGuardedTray(chat: ChatSession, baseUrl: string, auth: ReturnType<typeof useAuthStatus>) {
+function useGuardedTray(chat: ChatSession, baseUrl: string, auth: ReturnType<typeof useAuthStatus>, sessionKey: string | undefined) {
   const challenge = useTurnstileChallenge(chat);
-  const tray = useTrayState(chat, baseUrl, { challenged: challenge !== undefined, auth });
+  const tray = useTrayState(chat, baseUrl, { challenged: challenge !== undefined, auth }, sessionKey);
   return { challenge, tray };
 }
 
@@ -312,7 +312,7 @@ function useChatPage(search: ChatSearch) {
   const { actions: live, gps } = useOriginTracking(useTurnActions(chat));
   const auth = useAuthStatus();
   // `?q=` must not fire before the widget has a token to send (#447 review).
-  const { challenge, tray } = useGuardedTray(chat, config.baseUrl, auth);
+  const { challenge, tray } = useGuardedTray(chat, config.baseUrl, auth, search.session);
   const actions = useLockedActions(live, tray.quota.locked);
   const surfaces = usePageSurfaces(chat, actions, gps);
   useAutoSendFromQuery(search, health, actions.send, useTurnstileReady(challenge !== undefined));

--- a/apps/web/src/features/chat/components/MessageList.tsx
+++ b/apps/web/src/features/chat/components/MessageList.tsx
@@ -1,6 +1,7 @@
 import type { ChatStatus, UIMessage } from "ai";
 import { isBypassTurn } from "../../../lib/chat/selectedPointsBypass";
 import { routeDocumentKey, supersededFlags } from "../../../lib/chat/supersession";
+import { HIDDEN_TOOL_STEPS } from "../i18n";
 import type { ChatDict } from "../i18n";
 import { formatElapsed } from "../telemetry";
 import { statusedSteps } from "../tool-steps";
@@ -55,9 +56,11 @@ function supersededPartKeys(messages: readonly UIMessage[]): ReadonlySet<string>
 }
 
 function ToolBadges({ parts, dict }: Readonly<{ parts: readonly ToolPart[]; dict: ChatDict }>) {
-  return statusedSteps(parts).map(({ step, status }) => (
-    <ToolStepBadge key={step.toolCallId} type={step.type} status={status} dict={dict} />
-  ));
+  const badges = statusedSteps(parts).flatMap(({ step, status }) => {
+    if (HIDDEN_TOOL_STEPS.has(step.type.replace(/^tool-/, ""))) return [];
+    return [<ToolStepBadge key={step.toolCallId} type={step.type} status={status} dict={dict} />];
+  });
+  return badges;
 }
 
 type PipelineProps = Readonly<{

--- a/apps/web/src/features/chat/components/RouteCard.tsx
+++ b/apps/web/src/features/chat/components/RouteCard.tsx
@@ -3,7 +3,7 @@ import { itineraryView } from "../../../lib/chat/itinerary";
 import { locatedSpots, toSearchSpots } from "../../../lib/chat/spotClusters";
 import type { LocatedSpot } from "../../../lib/chat/spotClusters";
 import type { ChatDict } from "../i18n";
-import { resultsOf, routeOf, routeSpotsOf, SpotList } from "./cards";
+import { resultsOf, routeOf, SpotList } from "./cards";
 import type { IntentCardProps } from "./cards";
 import { routeStatsCopy } from "../route-copy";
 import { routeSaveTarget } from "../save/saveTarget";
@@ -30,7 +30,13 @@ function ItineraryGate({ itinerary, part, dict }: GateProps) {
 
 /** Route spots in walking order, restricted to rows the map can place. */
 function routeStations(part: ChatDataPart): readonly LocatedSpot[] {
-  return locatedSpots(toSearchSpots(routeSpotsOf(part)));
+  const stops = routeOf(part)?.timed_itinerary?.stops ?? [];
+  return locatedSpots(toSearchSpots(stops.map((stop) => ({
+    id: stop.cluster_id,
+    name: stop.name,
+    lat: stop.lat,
+    lng: stop.lng,
+  }))));
 }
 
 /** Located result spots that the planner left off the route; they dim. */

--- a/apps/web/src/features/chat/components/SearchResult.tsx
+++ b/apps/web/src/features/chat/components/SearchResult.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { MAX_MAP_PINS, searchMapView, topSpots } from "../../../lib/chat/spotClusters";
 import type { SearchSpot, SpotCluster } from "../../../lib/chat/spotClusters";
 import { attachBasemap } from "../../bubble-map/bubbleMapController";
@@ -82,11 +82,12 @@ interface DrillNav {
   readonly back: () => void;
 }
 
-function useDrillNav(): DrillNav {
+function useDrillNav(spots: readonly SearchSpot[]): DrillNav {
   const [drill, setDrill] = useState<Drill | null>(null);
   const [refocusIndex, setRefocus] = useState<number | null>(null);
   const select = useCallback((cluster: SpotCluster, index: number) => { setRefocus(null); setDrill({ cluster, index }); }, []);
   const back = useCallback(() => { setRefocus(drill?.index ?? null); setDrill(null); }, [drill]);
+  useEffect(() => { setDrill(null); setRefocus(null); }, [spots]);
   return { drill, refocusIndex, select, back };
 }
 
@@ -109,7 +110,7 @@ type SearchResultProps = Readonly<{ spots: readonly SearchSpot[]; dict: ChatDict
  */
 export function SearchResult({ spots, dict, attach = attachBasemap }: SearchResultProps) {
   const view = searchMapView(spots);
-  const nav = useDrillNav();
+  const nav = useDrillNav(spots);
   if (view.kind === "empty") return <EmptyMapState spots={spots} dict={dict} />;
   if (view.kind === "single") return <SingleClusterView cluster={view.cluster} dict={dict} attach={attach} />;
   if (nav.drill !== null) return <DrilledClusterView cluster={nav.drill.cluster} dict={dict} attach={attach} onBack={nav.back} />;

--- a/apps/web/src/features/chat/selection/useRecomputeTurn.ts
+++ b/apps/web/src/features/chat/selection/useRecomputeTurn.ts
@@ -79,9 +79,10 @@ function useSettleWatcher(status: RecomputeStatus, chat: ChatSession, setStatus:
   }, [status, chatStatus, error, setStatus]);
 }
 
-export function useRecomputeTurn(chat: ChatSession): RecomputeTurn {
+export function useRecomputeTurn(chat: ChatSession, sessionKey?: string): RecomputeTurn {
   const [status, setStatus] = useState<RecomputeStatus>("idle");
   const [lastSentIds, setLastSentIds] = useState<readonly string[]>();
+  useEffect(() => { setStatus("idle"); setLastSentIds(undefined); }, [sessionKey]);
   const fire = useFire(chat, setStatus, setLastSentIds);
   useSettleWatcher(status, chat, setStatus);
   return { status, lastSentIds, fire };

--- a/apps/web/src/features/chat/selection/useSpotSelection.tsx
+++ b/apps/web/src/features/chat/selection/useSpotSelection.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
 /** E2 spot selection (issue #273 S1.7): a Set keyed by result spot identity. */
@@ -22,8 +22,9 @@ function toggled(previous: ReadonlySet<string>, id: string): ReadonlySet<string>
 }
 
 /** The live selection state; owned by ChatPage, shared through the provider. */
-export function useSpotSelectionState(): SpotSelection {
+export function useSpotSelectionState(sessionKey?: string): SpotSelection {
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  useEffect(() => { setSelected(new Set()); }, [sessionKey]);
   const toggle = useCallback((id: string) => {
     setSelected((previous) => toggled(previous, id));
   }, []);

--- a/apps/web/src/features/chat/tool-steps.ts
+++ b/apps/web/src/features/chat/tool-steps.ts
@@ -3,6 +3,7 @@ export type StepStatus = "done" | "error" | "retried" | "running";
 export interface ToolStep {
   readonly type: string;
   readonly state: string;
+  readonly input?: unknown;
 }
 
 export interface StatusedStep<T extends ToolStep> {
@@ -33,5 +34,9 @@ export function statusedSteps<T extends ToolStep>(steps: readonly T[]): Statused
  */
 function resolve(step: ToolStep, later: readonly ToolStep[]): StepStatus {
   if (step.state !== "output-error") return stepStatus(step.state);
-  return later.some((next) => next.type === step.type) ? "retried" : "error";
+  return later.some((next) => next.type === step.type && sameInput(step, next)) ? "retried" : "error";
+}
+
+function sameInput(left: ToolStep, right: ToolStep): boolean {
+  return JSON.stringify(left.input) === JSON.stringify(right.input);
 }

--- a/apps/web/src/features/chat/tool-steps.ts
+++ b/apps/web/src/features/chat/tool-steps.ts
@@ -38,5 +38,35 @@ function resolve(step: ToolStep, later: readonly ToolStep[]): StepStatus {
 }
 
 function sameInput(left: ToolStep, right: ToolStep): boolean {
-  return JSON.stringify(left.input) === JSON.stringify(right.input);
+  return equalValue(left.input, right.input, new WeakMap<object, object>());
+}
+
+function equalValue(left: unknown, right: unknown, seen: WeakMap<object, object>): boolean {
+  if (Object.is(left, right)) return true;
+  if (!isRecord(left) || !isRecord(right)) return false;
+  const prior = seen.get(left);
+  if (prior !== undefined) return prior === right;
+  seen.set(left, right);
+  if (Array.isArray(left) || Array.isArray(right)) return equalArrays(left, right, seen);
+  return equalRecords(left, right, seen);
+}
+
+function isRecord(value: unknown): value is object {
+  return typeof value === "object" && value !== null;
+}
+
+function equalArrays(left: object, right: object, seen: WeakMap<object, object>): boolean {
+  if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+  return left.every((value, index) => equalValue(value, right[index], seen));
+}
+
+function equalRecords(left: object, right: object, seen: WeakMap<object, object>): boolean {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) return false;
+  return leftKeys.every((key) => Object.hasOwn(right, key) && equalValue(
+    (left as Record<string, unknown>)[key],
+    (right as Record<string, unknown>)[key],
+    seen,
+  ));
 }

--- a/apps/web/src/lib/chat/supersession.ts
+++ b/apps/web/src/lib/chat/supersession.ts
@@ -34,7 +34,7 @@ function hasRoute(data: unknown): boolean {
   if (typeof data !== "object" || data === null || !("data" in data)) return false;
   const inner = data.data;
   if (typeof inner !== "object" || inner === null || !("route" in inner)) return false;
-  return inner.route !== undefined && inner.route !== null;
+  return typeof inner.route === "object" && inner.route !== null && Object.keys(inner.route).length > 0;
 }
 
 /**

--- a/apps/web/tests/integration/build-output.test.ts
+++ b/apps/web/tests/integration/build-output.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -43,9 +43,9 @@ function bundleWorkerToTempDir(target: string): string {
 }
 
 function readBundledWorker(outdir: string): string {
-  const entry = readdirSync(outdir).find((name) => name.endsWith(".js"));
-  if (!entry) throw new Error(`no bundled worker emitted in ${outdir}`);
-  return readFileSync(join(outdir, entry), "utf8");
+  const entry = join(outdir, "index.js");
+  if (!existsSync(entry)) throw new Error(`no bundled worker emitted in ${outdir}`);
+  return readFileSync(entry, "utf8");
 }
 
 describe("build output", () => {

--- a/apps/web/tests/unit/chat/tool-steps.test.ts
+++ b/apps/web/tests/unit/chat/tool-steps.test.ts
@@ -85,6 +85,9 @@ describe("statusedSteps supersession (ModelRetry re-issues the same tool under a
     expect(statusedSteps(steps)[0]?.step.toolCallId).toBe("call-9");
   });
 
+});
+
+describe("statusedSteps retry matching (which inputs count as the same call)", () => {
   it("matches retry inputs regardless of object key order", () => {
     const steps = [
       step("tool-search_bangumi", "output-error", "call-1", { query: "eupho", limit: 5 }),

--- a/apps/web/tests/unit/chat/tool-steps.test.ts
+++ b/apps/web/tests/unit/chat/tool-steps.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { statusedSteps, stepStatus } from "../../../src/features/chat/tool-steps";
 
-function step(type: string, state: string, toolCallId: string) {
-  return { type, state, toolCallId };
+function step(type: string, state: string, toolCallId: string, input?: unknown) {
+  return { type, state, toolCallId, input };
 }
 
 describe("stepStatus", () => {
@@ -83,5 +83,32 @@ describe("statusedSteps supersession (ModelRetry re-issues the same tool under a
     const steps = [step("tool-plan_route", "output-available", "call-9")];
 
     expect(statusedSteps(steps)[0]?.step.toolCallId).toBe("call-9");
+  });
+
+  it("matches retry inputs regardless of object key order", () => {
+    const steps = [
+      step("tool-search_bangumi", "output-error", "call-1", { query: "eupho", limit: 5 }),
+      step("tool-search_bangumi", "output-available", "call-2", { limit: 5, query: "eupho" }),
+    ];
+
+    expect(statusedSteps(steps).map((entry) => entry.status)).toEqual(["retried", "done"]);
+  });
+
+  it("compares non-serialisable primitive inputs without throwing", () => {
+    const steps = [
+      step("tool-search_bangumi", "output-error", "call-1", 1n),
+      step("tool-search_bangumi", "output-available", "call-2", 1n),
+    ];
+
+    expect(statusedSteps(steps).map((entry) => entry.status)).toEqual(["retried", "done"]);
+  });
+
+  it("compares array inputs structurally", () => {
+    const steps = [
+      step("tool-search_bangumi", "output-error", "call-1", [{ query: "eupho" }]),
+      step("tool-search_bangumi", "output-available", "call-2", [{ query: "eupho" }]),
+    ];
+
+    expect(statusedSteps(steps).map((entry) => entry.status)).toEqual(["retried", "done"]);
   });
 });

--- a/docs/iterations/iter5/handoff-2026-07-26-s1x.md
+++ b/docs/iterations/iter5/handoff-2026-07-26-s1x.md
@@ -3,7 +3,7 @@
 Repo: `lifeodyssey/animichi`. Integration branch: **`feat/frontend-rebuild`** (NOT `main`).
 Working clone: any clone of `lifeodyssey/animichi` on `feat/frontend-rebuild` (the original session used an ephemeral scratchpad clone, since deleted).
 
-⚠️ `/Users/lumimamini/Documents/Seichijunrei-agent` is the **same repo under its old directory name** (`origin` = `lifeodyssey/animichi.git`) — pushes there land in animichi. Its checked-out branch may be the legacy one, whose root `CLAUDE.md` does not describe animichi; on any branch, animichi's own `AGENTS.md` is authoritative (`CLAUDE.md` on current branches is an `@AGENTS.md` pointer).
+⚠️ The repository's canonical remote is `lifeodyssey/animichi.git`; pushes there land in animichi. Its checked-out branch may be the legacy one, whose root `CLAUDE.md` does not describe animichi; on any branch, animichi's own `AGENTS.md` is authoritative (`CLAUDE.md` on current branches is an `@AGENTS.md` pointer).
 
 > **State as of 2026-07-26 — re-verify every "in flight" / "waiting" claim before acting on it.**
 > Note: `docs/iterations/iter5/task_plan.md` (named "main task tracker" by DOCS_POLICY) still holds the 2026-04-05 legacy plan and has zero S1.x content — treat it as stale until refreshed.
@@ -141,7 +141,7 @@ Do **not** use `mcp__claude-in-chrome__*` directly — this repo's conventions r
 
 ## Memory files written today (read these first)
 
-Under `~/.claude/projects/-Users-lumimamini-Documents-Seichijunrei-agent/memory/`:
+Under the local Claude project memory directory:
 
 - `project_s1x_sprint_jul26.md` — this sprint's state
 - `feedback_mutation_testing_gate.md` — the four "green for the wrong reason" cases, with the mechanism of each

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -45,7 +45,7 @@ export const catalogDatabaseUrl = config.getSecret("catalogDatabaseUrl");
 const catalogMediaBucket = new cloudflare.R2Bucket("catalog-media", {
   accountId,
   name: mediaBucketName,
-  location: "APAC",
+  location: "apac",
 });
 
 if (webRoutesEnabled) {


### PR DESCRIPTION
Fixes for the older half of the triaged backlog — bot comments on merged PRs
#182–#476. Written by Codex, verified and partly reverted here.

Touches `chat.py`, `history_compaction.py`, `selected_route.py`,
`catalog_errors.py`, `ChatPage.tsx`, `RouteCard.tsx`, `SearchResult.tsx`,
`useRecomputeTurn.ts`, `useSpotSelection.tsx`, `tool-steps.ts`,
`supersession.ts`, and their tests.

## One change reverted, and it was the dangerous kind

`packages/contract/openapi.json` was collapsed from **1860 lines to 1** — the
whole document minified onto a single line. Restored from `main`.

That file is a **committed generated artifact**: `packages/contract/AGENTS.md`
lists it under "committed generated wire artifacts", produced by
`pnpm run emit:openapi`. Its correct contents are whatever the generator emits,
so hand-editing it is wrong regardless of the formatting chosen — the next
regeneration would revert it and the diff would confuse whoever ran it.

Worth noting how nearly it passed: the JSON is semantically identical, so every
test stays green and no lint rule objects. Only the `1861 +----` line in
`--stat` gives it away. A reviewer skimming a green build would have merged it.

Second time today Codex has rewritten something the repo explicitly documents as
deliberate — the other was a TOML reader whose comment said it was intentionally
line-based. The pattern is worth naming: it reads the code, forms a reasonable
opinion, and does not weigh the note explaining why the current shape was chosen.

Gates after the revert: worker 225 pass · catalog 35 + 262 passed · apps/web
1572 passed · agent unit 1666 passed · oxlint clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>