### PR TITLE
fix(web): declare @testing-library/user-event, orphaned by the frontend retirement

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "@tanstack/nitro-v2-vite-plugin": "^1.155.0",
     "@tanstack/router-generator": "1.167.21",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -2722,6 +2725,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -7711,6 +7720,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.3':
     dependencies:


### PR DESCRIPTION
`Web app CI` fails on `main` and on every PR that touches `apps/web`:

```
tests/unit/bubble-map/bubble-map-panel.test.tsx(6,23): error TS2307:
  Cannot find module '@testing-library/user-event'
```

Three `apps/web` tests import it. `apps/web/package.json` never declared it —
the only declaration in the workspace was in **`frontend/package.json`**, and
`.npmrc` sets `shamefully-hoist=true`, so the hoisted copy satisfied the import
and nobody noticed the package was borrowing a neighbour's dependency.

#537 deleted `frontend/` today, taking the declaration with it. Declared here,
where it is used.

## Why it looked fine locally and failed in CI

Both run the same `pnpm install --frozen-lockfile`, so the difference is not the
command. A working tree that predates the deletion still has the hoisted module
on disk, and a warm pnpm store still resolves it, so `typecheck` passes locally
and keeps passing until someone wipes `node_modules`. CI starts clean every
time, which is the whole point of CI and the only reason this surfaced at all.

Verified the way that distinction demands: removed `node_modules`, reinstalled
from the lockfile, and ran `pnpm --filter web typecheck` — exit 0 with the
declaration, the three TS2307 errors without it.

## The class of bug, since it will recur

`shamefully-hoist=true` makes cross-package dependency borrowing invisible: no
import path mentions `frontend/`, no lint rule fires, and the tests pass. The
coupling only exists in the install layout. Deleting a package therefore breaks
consumers that never referenced it by name — which is exactly the category the
#537 review was asked to look for, and exactly the one it could not see by
reading imports and Make targets.

Unblocks #574, #576 and #577, all of which were red on this and none of which
caused it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>