### PR TITLE
fix(#506): inject the VITE_* build vars — production login is broken without them

### DIFF
--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -293,6 +293,29 @@ jobs:
           if [ "$missing" = "1" ]; then
             exit 1
           fi
+      - name: Preflight - Vite build environment
+        if: ${{ inputs.build_filter != '' }}
+        env:
+          TARGET_COMPONENT: ${{ inputs.component }}
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
+          VITE_TURNSTILE_SITE_KEY: ${{ vars.VITE_TURNSTILE_SITE_KEY }}
+          VITE_NEON_AUTH_BASE_URL: ${{ vars.VITE_NEON_AUTH_BASE_URL }}
+        run: |
+          # One explicit check per variable. Vite inlines these at build time, so
+          # an empty value ships a permanently broken feature rather than a
+          # runtime error anyone can fix afterwards.
+          #
+          # Names only in the log, never values: these are not secrets (Vite puts
+          # them in a public bundle by definition), but there is no reason to
+          # copy deploy configuration into a world-readable Actions log.
+          if [ -z "${VITE_TURNSTILE_SITE_KEY}" ]; then
+            echo "::error::VITE_TURNSTILE_SITE_KEY is empty/unset for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT. Refusing to build: anonymous chat cannot pass the edge challenge without it."
+            exit 1
+          fi
+          if [ -z "${VITE_NEON_AUTH_BASE_URL}" ]; then
+            echo "::error::VITE_NEON_AUTH_BASE_URL is empty/unset for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT. Refusing to build: magic-link sign-in would render as 'not configured' with no runtime remedy."
+            exit 1
+          fi
       - name: Build component
         if: ${{ inputs.build_filter != '' }}
         env:

--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -55,8 +55,6 @@ on:
         required: false
       CORS_ALLOWED_ORIGIN:
         required: false
-      NEXT_PUBLIC_MAPBOX_TOKEN:
-        required: false
       TURNSTILE_SECRET:
         required: false
       ANON_ID_SECRET:
@@ -299,9 +297,12 @@ jobs:
         if: ${{ inputs.build_filter != '' }}
         env:
           BUILD_FILTER: ${{ inputs.build_filter }}
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
+          VITE_SITE_ORIGIN: ${{ vars.VITE_SITE_ORIGIN }}
+          VITE_CATALOG_URL: ${{ vars.VITE_CATALOG_URL }}
+          VITE_USERS_URL: ${{ vars.VITE_USERS_URL }}
+          VITE_AGENT_URL: ${{ vars.VITE_AGENT_URL }}
+          VITE_TURNSTILE_SITE_KEY: ${{ vars.VITE_TURNSTILE_SITE_KEY }}
+          VITE_NEON_AUTH_BASE_URL: ${{ vars.VITE_NEON_AUTH_BASE_URL }}
         run: pnpm --filter "$BUILD_FILTER" build
       - name: Atlas migrate
         # NOTE: secrets context is NOT allowed in step `if:` (GitHub compile-time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,6 @@ jobs:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
-      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
       TURNSTILE_SECRET: ${{ secrets.TURNSTILE_SECRET }}
       ANON_ID_SECRET: ${{ secrets.ANON_ID_SECRET }}
     concurrency: deploy-root-staging
@@ -597,7 +596,6 @@ jobs:
       GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
       CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
-      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
       TURNSTILE_SECRET: ${{ secrets.TURNSTILE_SECRET }}
       ANON_ID_SECRET: ${{ secrets.ANON_ID_SECRET }}
     concurrency: deploy-root-prod

--- a/apps/web/tests/unit/deploy-vite-env.test.ts
+++ b/apps/web/tests/unit/deploy-vite-env.test.ts
@@ -20,10 +20,32 @@ const buildStep = buildStepMatch?.[0] ?? "";
 const injectedNames = new Set(
   [...buildStep.matchAll(/^\s+(VITE_[A-Z0-9_]+): \$\{\{ vars\.\1 \}\}$/gm)].map((match) => match[1]),
 );
+const preflightMatch = /- name: Preflight - Vite build environment[\s\S]*?(?=\n {6}- name: )/.exec(
+  workflow,
+);
+const preflightStep = preflightMatch?.[0] ?? "";
+const preflightedNames = new Set(
+  [...preflightStep.matchAll(/if \[ -z "\$\{(VITE_[A-Z0-9_]+)\}" \]/g)].map((match) => match[1]),
+);
+
+// Required means "an empty value ships a broken feature", not "the code crashes
+// without it". Both of these degrade gracefully at runtime — which is precisely
+// why they need a build-time gate: the degradation is invisible in CI and
+// surfaces as a dead sign-in form in production (#506).
+//
+// The four omitted names (VITE_SITE_ORIGIN, VITE_CATALOG_URL, VITE_USERS_URL,
+// VITE_AGENT_URL) fall back to the current origin, which is correct for a
+// same-origin deploy — empty there is a real configuration, not a hole.
+const requiredViteNames = ["VITE_NEON_AUTH_BASE_URL", "VITE_TURNSTILE_SITE_KEY"];
 
 describe("deploy workflow Vite build environment", () => {
   it("injects every VITE_* read by apps/web/src", () => {
     expect(buildStep).not.toBe("");
     expect([...readNames].sort()).toEqual([...injectedNames].sort());
+  });
+
+  it("preflights every required VITE_* value before the build", () => {
+    expect(preflightStep).not.toBe("");
+    expect([...preflightedNames].sort()).toEqual([...requiredViteNames].sort());
   });
 });

--- a/apps/web/tests/unit/deploy-vite-env.test.ts
+++ b/apps/web/tests/unit/deploy-vite-env.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  fileURLToPath(new URL("../../../../.github/workflows/_deploy-component.yml", import.meta.url)),
+  "utf8",
+);
+const sourceFiles = import.meta.glob("../../src/**/*.{ts,tsx}", {
+  eager: true,
+  import: "default",
+  query: "?raw",
+});
+const source = Object.values(sourceFiles).join("\n");
+const readNames = new Set(
+  [...source.matchAll(/\b(?:env|import\.meta\.env)\.(VITE_[A-Z0-9_]+)/g)].map((match) => match[1]),
+);
+const buildStepMatch = /- name: Build component[\s\S]*?run: pnpm --filter [^\n]+ build/.exec(workflow);
+const buildStep = buildStepMatch?.[0] ?? "";
+const injectedNames = new Set(
+  [...buildStep.matchAll(/^\s+(VITE_[A-Z0-9_]+): \$\{\{ vars\.\1 \}\}$/gm)].map((match) => match[1]),
+);
+
+describe("deploy workflow Vite build environment", () => {
+  it("injects every VITE_* read by apps/web/src", () => {
+    expect(buildStep).not.toBe("");
+    expect([...readNames].sort()).toEqual([...injectedNames].sort());
+  });
+});


### PR DESCRIPTION
`grep VITE_TURNSTILE_SITE_KEY` and `grep VITE_NEON_AUTH_BASE_URL` returned **zero hits across `.github/workflows/`**. The build step injected only `NEXT_PUBLIC_*`, left over from the Next.js package retired in #537.

Vite inlines `import.meta.env.VITE_*` **at build time**. A variable absent during the build is not missing at runtime — it is baked in as `undefined`, permanently, in the artefact that ships. Magic-link login reports `not_configured` in production and no amount of runtime configuration can rescue it. This blocks launch.

## Six variables, not the two in the issue

The brief said to grep `import.meta.env` across `apps/web/src` rather than work from the issue's two names, because a partial fix here is indistinguishable from a complete one until someone tries the feature that got missed. The full set:

`VITE_SITE_ORIGIN` · `VITE_CATALOG_URL` · `VITE_USERS_URL` · `VITE_AGENT_URL` · `VITE_TURNSTILE_SITE_KEY` · `VITE_NEON_AUTH_BASE_URL`

All six are plain vars, not secrets, and the reasoning is per-variable rather than blanket: the origins and service URLs are public routing configuration; a Turnstile **site** key is public by design (the *secret* key is the server half and is not here); `VITE_NEON_AUTH_BASE_URL` names a public endpoint and authenticates nobody. Nothing client-side that could authenticate anyone is injected — which matters because this repository is public and anything inlined by Vite is readable in the shipped bundle by definition.

`NEXT_PUBLIC_*` injection removed from `_deploy-component.yml` and `ci.yml`; verified by grep that no executable consumer remains.

## The gate, and proof it is one

`apps/web/tests/unit/deploy-vite-env.test.ts` scans `apps/web/src` for Vite reads and requires exact parity with the names the deploy workflow injects.

A parity test that cannot fail is worse than none, so it was mutation-tested **in both directions**:

- Removed `VITE_TURNSTILE_SITE_KEY` from the workflow → `FAIL … injects every VITE_* read by apps/web/src`, exit 1.
- Added a fresh `import.meta.env.VITE_PROBE_NOT_INJECTED` read to `src/api/config.ts` → same test fails, exit 1.

Restored, 1573 pass. So it catches drift from either side: an injection dropped from the workflow, and a new variable introduced in code without one.

## Gates

`test:worker` 225 pass, exit 0 · `apps/web` **1573** passed (1572 + the new gate), exit 0 · web `lint:oxlint` exit 0 · catalog `lint:oxlint` exit 0.

Codex could not complete two gates inside its sandbox — the full web command hit `localStorage is not available because --localstorage-file was not provided`, and aggregate lint hit an IPC `EPERM`. Both re-run here, both clean. It reported the limitation rather than claiming a pass, which is why they got re-run at all.

## Not verified

GitHub Actions workflows cannot be executed locally, so the injection is asserted structurally (the parity gate) rather than observed. Whether the corresponding values are actually provisioned in the staging and production environments is a separate question this PR does not answer — the gate proves the workflow *asks* for them.

Closes #506.
