### PR TITLE
fix(#511): give the BYOK probe one deadline instead of three nested ones

### DIFF
--- a/apps/agent/agent/agents/byok_models.py
+++ b/apps/agent/agent/agents/byok_models.py
@@ -201,6 +201,10 @@ async def _build_openai_compatible(
     credential: ByokCredential, *, transport_wrapper: TransportWrapper | None
 ) -> ByokModel:
     await _validate_openai_base_url(credential.base_url)
+    # No `await` between this construction and the return: the probe route runs
+    # this inside `asyncio.timeout`, and cancellation is only delivered at an
+    # await point. An await added below would let the deadline fire after the
+    # client exists but before the caller can hold it, leaking the connection.
     client = build_guarded_async_client(transport_wrapper=transport_wrapper)
     sdk_client = AsyncOpenAI(
         base_url=credential.base_url,

--- a/apps/agent/agent/interfaces/routes/byok.py
+++ b/apps/agent/agent/interfaces/routes/byok.py
@@ -324,12 +324,16 @@ async def handle_byok_probe(
         return _error_response(
             "invalid_request", "X-BYOK-* headers are required.", status_code=400
         )
+    byok_model = None
     try:
-        byok_model = await _resolve_probe_model(credential)
+        async with asyncio.timeout(_PROBE_TIMEOUT_SECONDS):
+            byok_model = await _resolve_probe_model(credential)
+            result = await _run_probe(byok_model.model)
     except _RouteRejection as rejection:
         return rejection.response
-    try:
-        result = await _run_probe(byok_model.model)
+    except TimeoutError:
+        return _probe_response(_unreachable_result())
     finally:
-        await byok_model.client.aclose()
+        if byok_model is not None:
+            await byok_model.client.aclose()
     return _probe_response(result)

--- a/apps/agent/agent/tests/integration/test_byok_probe_deadline.py
+++ b/apps/agent/agent/tests/integration/test_byok_probe_deadline.py
@@ -1,0 +1,54 @@
+"""Regression coverage for the BYOK probe's whole-operation deadline."""
+
+from __future__ import annotations
+
+import socket
+import threading
+
+import pytest
+
+from agent.interfaces.routes import byok as byok_route
+from agent.tests.integration._byok_probe_shared import (
+    BYOK_HEADERS,
+    HUMAN_HEADERS,
+    app,
+    post_probe,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def test_dns_resolution_cannot_extend_the_probe_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The route deadline covers preflight DNS, not only the model request."""
+    started = threading.Event()
+    completed = threading.Event()
+    release = threading.Event()
+    real_getaddrinfo = socket.getaddrinfo
+
+    def slow_getaddrinfo(
+        host: str, port: int, *args: object, **kwargs: object
+    ) -> list[tuple[object, ...]]:
+        if host != "byok.example.test":
+            return real_getaddrinfo(host, port, *args, **kwargs)
+        started.set()
+        release.wait()
+        completed.set()
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", slow_getaddrinfo)
+    monkeypatch.setattr(byok_route, "_PROBE_TIMEOUT_SECONDS", 0.05)
+
+    response = await post_probe(app(), HUMAN_HEADERS | BYOK_HEADERS)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "vision": False,
+        "reachable": False,
+        "error_code": "provider_unreachable",
+    }
+    assert started.is_set()
+    assert not completed.is_set()
+    release.set()
+    completed.wait()

--- a/apps/agent/agent/tests/integration/test_byok_probe_deadline.py
+++ b/apps/agent/agent/tests/integration/test_byok_probe_deadline.py
@@ -23,6 +23,7 @@ pytestmark = pytest.mark.integration
 
 _HOST = "byok.example.test"
 _PUBLIC_IP = "8.8.8.8"
+_CALLBACK_TIMEOUT_SECONDS = 1.0
 _CLEANUP_TIMEOUT_SECONDS = 1.0
 _UNREACHABLE_BODY = {
     "vision": False,
@@ -46,6 +47,8 @@ class _ControlledAsyncio:
     def __init__(self) -> None:
         self._loop = asyncio.get_running_loop()
         self._outer_timeout: asyncio.Timeout | None = None
+        self._reschedule_finished = threading.Event()
+        self._reschedule_error: RuntimeError | None = None
 
     def timeout(self, _delay: float | None) -> asyncio.Timeout:
         timeout = asyncio.timeout(None)
@@ -53,14 +56,27 @@ class _ControlledAsyncio:
             self._outer_timeout = timeout
         return timeout
 
+    @property
+    def reschedule_succeeded(self) -> bool:
+        return self._reschedule_finished.is_set() and self._reschedule_error is None
+
     def expire_outer_timeout(self) -> None:
         timeout = self._outer_timeout
         if timeout is None:
             raise RuntimeError("The shared probe timeout was not entered.")
         self._loop.call_soon_threadsafe(self._reschedule_now, timeout)
+        if not self._reschedule_finished.wait(timeout=_CALLBACK_TIMEOUT_SECONDS):
+            raise RuntimeError("The shared probe timeout callback did not finish.")
+        if self._reschedule_error is not None:
+            raise self._reschedule_error
 
     def _reschedule_now(self, timeout: asyncio.Timeout) -> None:
-        timeout.reschedule(self._loop.time())
+        try:
+            timeout.reschedule(self._loop.time())
+        except RuntimeError as exc:
+            self._reschedule_error = exc
+        finally:
+            self._reschedule_finished.set()
 
 
 class _BlockingGetAddrInfo:
@@ -102,19 +118,20 @@ class _BlockingGetAddrInfo:
 
 def _install_resolver(
     monkeypatch: pytest.MonkeyPatch, blocked_resolution: int
-) -> _BlockingGetAddrInfo:
+) -> tuple[_BlockingGetAddrInfo, _ControlledAsyncio]:
     controlled_asyncio = _ControlledAsyncio()
     resolver = _BlockingGetAddrInfo(
         blocked_resolution, controlled_asyncio.expire_outer_timeout
     )
     monkeypatch.setattr(socket, "getaddrinfo", resolver)
     monkeypatch.setattr(byok_route, "asyncio", controlled_asyncio)
-    return resolver
+    return resolver, controlled_asyncio
 
 
 def _assert_deadline_result(
     response: httpx.Response,
     resolver: _BlockingGetAddrInfo,
+    controlled_asyncio: _ControlledAsyncio,
     blocked_resolution: int,
 ) -> None:
     assert response.status_code == 200
@@ -122,6 +139,7 @@ def _assert_deadline_result(
     assert resolver.call_count == blocked_resolution
     assert resolver.started.is_set()
     assert not resolver.completed.is_set()
+    assert controlled_asyncio.reschedule_succeeded
 
 
 @pytest.mark.parametrize(
@@ -134,9 +152,11 @@ async def test_shared_deadline_cancels_each_dns_resolution(
     blocked_resolution: int,
 ) -> None:
     """The route's one deadline causally cancels DNS calls one, two, and three."""
-    resolver = _install_resolver(monkeypatch, blocked_resolution)
+    resolver, controlled_asyncio = _install_resolver(monkeypatch, blocked_resolution)
     try:
         response = await post_probe(app(), HUMAN_HEADERS | BYOK_HEADERS)
-        _assert_deadline_result(response, resolver, blocked_resolution)
+        _assert_deadline_result(
+            response, resolver, controlled_asyncio, blocked_resolution
+        )
     finally:
         resolver.cleanup()

--- a/apps/agent/agent/tests/integration/test_byok_probe_deadline.py
+++ b/apps/agent/agent/tests/integration/test_byok_probe_deadline.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import socket
 import threading
+from collections.abc import Callable
+from typing import TypeAlias
 
+import httpx
 import pytest
 
 from agent.interfaces.routes import byok as byok_route
@@ -17,38 +21,122 @@ from agent.tests.integration._byok_probe_shared import (
 
 pytestmark = pytest.mark.integration
 
+_HOST = "byok.example.test"
+_PUBLIC_IP = "8.8.8.8"
+_CLEANUP_TIMEOUT_SECONDS = 1.0
+_UNREACHABLE_BODY = {
+    "vision": False,
+    "reachable": False,
+    "error_code": "provider_unreachable",
+}
 
-async def test_dns_resolution_cannot_extend_the_probe_deadline(
-    monkeypatch: pytest.MonkeyPatch,
+_SocketAddress: TypeAlias = (
+    tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes]
+)
+_GetAddrInfoResult: TypeAlias = list[
+    tuple[socket.AddressFamily, socket.SocketKind, int, str, _SocketAddress]
+]
+
+
+class _ControlledAsyncio:
+    """Expires the route's outer timeout at the selected DNS boundary."""
+
+    CancelledError = asyncio.CancelledError
+
+    def __init__(self) -> None:
+        self._loop = asyncio.get_running_loop()
+        self._outer_timeout: asyncio.Timeout | None = None
+
+    def timeout(self, _delay: float | None) -> asyncio.Timeout:
+        timeout = asyncio.timeout(None)
+        if self._outer_timeout is None:
+            self._outer_timeout = timeout
+        return timeout
+
+    def expire_outer_timeout(self) -> None:
+        timeout = self._outer_timeout
+        if timeout is None:
+            raise RuntimeError("The shared probe timeout was not entered.")
+        self._loop.call_soon_threadsafe(self._reschedule_now, timeout)
+
+    def _reschedule_now(self, timeout: asyncio.Timeout) -> None:
+        timeout.reschedule(self._loop.time())
+
+
+class _BlockingGetAddrInfo:
+    def __init__(
+        self, blocked_resolution: int, expire_deadline: Callable[[], None]
+    ) -> None:
+        self._blocked_resolution = blocked_resolution
+        self._expire_deadline = expire_deadline
+        self._real_getaddrinfo = socket.getaddrinfo
+        self.started = threading.Event()
+        self.completed = threading.Event()
+        self.release = threading.Event()
+        self.call_count = 0
+
+    def __call__(
+        self,
+        host: bytes | str | None,
+        port: bytes | str | int | None,
+        family: int = 0,
+        type: int = 0,
+        proto: int = 0,
+        flags: int = 0,
+    ) -> _GetAddrInfoResult:
+        if host != _HOST or not isinstance(port, int):
+            return self._real_getaddrinfo(host, port, family, type, proto, flags)
+        self.call_count += 1
+        if self.call_count == self._blocked_resolution:
+            self.started.set()
+            self._expire_deadline()
+            self.release.wait()
+            self.completed.set()
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (_PUBLIC_IP, port))]
+
+    def cleanup(self) -> None:
+        self.release.set()
+        if self.started.is_set():
+            self.completed.wait(timeout=_CLEANUP_TIMEOUT_SECONDS)
+
+
+def _install_resolver(
+    monkeypatch: pytest.MonkeyPatch, blocked_resolution: int
+) -> _BlockingGetAddrInfo:
+    controlled_asyncio = _ControlledAsyncio()
+    resolver = _BlockingGetAddrInfo(
+        blocked_resolution, controlled_asyncio.expire_outer_timeout
+    )
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+    monkeypatch.setattr(byok_route, "asyncio", controlled_asyncio)
+    return resolver
+
+
+def _assert_deadline_result(
+    response: httpx.Response,
+    resolver: _BlockingGetAddrInfo,
+    blocked_resolution: int,
 ) -> None:
-    """The route deadline covers preflight DNS, not only the model request."""
-    started = threading.Event()
-    completed = threading.Event()
-    release = threading.Event()
-    real_getaddrinfo = socket.getaddrinfo
-
-    def slow_getaddrinfo(
-        host: str, port: int, *args: object, **kwargs: object
-    ) -> list[tuple[object, ...]]:
-        if host != "byok.example.test":
-            return real_getaddrinfo(host, port, *args, **kwargs)
-        started.set()
-        release.wait()
-        completed.set()
-        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port))]
-
-    monkeypatch.setattr(socket, "getaddrinfo", slow_getaddrinfo)
-    monkeypatch.setattr(byok_route, "_PROBE_TIMEOUT_SECONDS", 0.05)
-
-    response = await post_probe(app(), HUMAN_HEADERS | BYOK_HEADERS)
-
     assert response.status_code == 200
-    assert response.json() == {
-        "vision": False,
-        "reachable": False,
-        "error_code": "provider_unreachable",
-    }
-    assert started.is_set()
-    assert not completed.is_set()
-    release.set()
-    completed.wait()
+    assert response.json() == _UNREACHABLE_BODY
+    assert resolver.call_count == blocked_resolution
+    assert resolver.started.is_set()
+    assert not resolver.completed.is_set()
+
+
+@pytest.mark.parametrize(
+    "blocked_resolution",
+    [1, 2, 3],
+    ids=["route-preflight", "model-validation", "guarded-transport"],
+)
+async def test_shared_deadline_cancels_each_dns_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    blocked_resolution: int,
+) -> None:
+    """The route's one deadline causally cancels DNS calls one, two, and three."""
+    resolver = _install_resolver(monkeypatch, blocked_resolution)
+    try:
+        response = await post_probe(app(), HUMAN_HEADERS | BYOK_HEADERS)
+        _assert_deadline_result(response, resolver, blocked_resolution)
+    finally:
+        resolver.cleanup()


### PR DESCRIPTION
The probe promised a 5s ceiling and could take three times that. An
`openai-compatible` credential resolves egress **three** times, not twice as the
issue reported:

1. route preflight — `byok.py` → `validate_base_url()` → `default_resolve()`
2. model construction — `byok_models.py:_validate_openai_base_url()`, again
3. the guarded transport, at connect time

Only step 3 sat inside a timeout (`_run_probe`'s own 5s). Steps 1 and 2 each
carried their own independent `anyio.fail_after(5s)` on the DNS resolve, outside
any outer bound — so a slow resolver could burn 5s three times over while the
documented ceiling counted only the last one. Anthropic and Gemini credentials
only hit resolution 3 and were never affected.

## No resolution was removed

The redundancy is not accidental and each layer closes a different window:
preflight blocks SSRF/private/metadata/own-infra targets before any client
exists; model validation is defence in depth before SDK construction; the
guarded transport pins the IP **at connect time**, which is the only one that
closes the DNS-rebinding/TOCTOU window (#284 T4) and refuses redirects (T5).

Deleting the duplicate would have been the smaller diff and the wrong one. The
fix wraps resolution and probe in a single `asyncio.timeout`, so the three share
one deadline rather than each getting a fresh one.

**Behaviour change worth stating:** a probe against a genuinely slow resolver
that previously succeeded at ~12s now fails at 5s with `unreachable`. That is
the documented contract being enforced, not a regression — but it is a change,
and someone will eventually see it.

## An invariant this fix now depends on

`asyncio.timeout` delivers cancellation at await points. `_build_openai_compatible`
constructs the guarded client and then returns with **no await in between**, so
the deadline cannot fire after the client exists but before the caller holds it
— which is what keeps `finally: if byok_model is not None: aclose()` from
leaking a connection. That safety is a property of the current statement order,
not of the structure, so an added await there would reopen it silently. Comment
added at that line naming the constraint.

## Mutation-verified

Removing the outer `asyncio.timeout`: the deadline test **does not converge
inside 90s** and has to be killed. Restored: **passes in 0.10s**. The gap is the
bug itself — nested timeouts stacking with nothing bounding the total.

The test asserts on resolver state (`started.is_set()` / `not completed.is_set()`),
never wall-clock duration, following the pattern #557 established for the same
route.

## Gates

agent unit + the new integration test **1669 passed** exit 0 · ruff clean ·
ruff format clean · mypy clean (110 files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - BYOK connection checks now enforce a timeout across the entire operation, including initial network resolution.
  - Timed-out or unreachable providers now return a consistent unavailable result.
  - Improved cleanup ensures temporary connections are closed even when a check times out.

- **Tests**
  - Added coverage verifying that DNS resolution cannot extend the BYOK probe deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->