### PR TITLE
fix(deploy): restore root container config validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@cloudflare/workers-types": "^5.20260718.1",
     "@types/node": "^26.1.1",
     "oxlint": "~1.74.0",
-    "oxlint-tsgolint": "~0.25.0"
+    "oxlint-tsgolint": "~0.25.0",
+    "wrangler": "4.112.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       oxlint-tsgolint:
         specifier: ~0.25.0
         version: 0.25.0
+      wrangler:
+        specifier: 4.112.0
+        version: 4.112.0(@cloudflare/workers-types@5.20260718.1)(@types/node@26.1.1)
 
   apps/web:
     dependencies:

--- a/worker/authConfig.test.ts
+++ b/worker/authConfig.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -7,6 +8,12 @@ const ROOT = fileURLToPath(new URL("../", import.meta.url));
 const WRANGLER = readFileSync(`${ROOT}wrangler.toml`, "utf8");
 const ENV_BLOCKS = ["[vars]", "[env.production.vars]", "[env.staging.vars]"];
 const TOP_LEVEL = WRANGLER.slice(0, WRANGLER.indexOf("\n[vars]\n"));
+const READ_CONFIG_SCRIPT = `
+process.env.WRANGLER_WRITE_LOGS = "false";
+const { unstable_readConfig } = await import("wrangler");
+const config = unstable_readConfig({ config: process.argv[1], env: process.argv[2] });
+process.stdout.write(String(config.name));
+`;
 
 function blockFor(header: string): string {
   const start = WRANGLER.indexOf(`\n${header}\n`) + 1;
@@ -23,7 +30,15 @@ function countMatches(source: string, pattern: RegExp): number {
   return source.match(pattern)?.length ?? 0;
 }
 
-test("Neon Auth vars stay on their intended Wrangler paths", () => {
+function parsedWorkerName(environment: string): string {
+  return execFileSync(
+    process.execPath,
+    ["--input-type=module", "--eval", READ_CONFIG_SCRIPT, `${ROOT}wrangler.toml`, environment],
+    { encoding: "utf8" },
+  );
+}
+
+void test("Neon Auth vars stay on their intended Wrangler paths", () => {
   for (const header of ENV_BLOCKS) {
     const block = blockFor(header);
     assert.equal(hasAssignment(block, "NEON_AUTH_ENABLED", "false"), true, `${header} must keep Neon Auth off`);
@@ -31,13 +46,24 @@ test("Neon Auth vars stay on their intended Wrangler paths", () => {
   }
 });
 
-test("bare Wrangler deploy has no target, while named environments keep theirs", () => {
+void test("bare Wrangler deploy has no target, while named environments keep theirs", () => {
   assert.equal(/^name\s*=/m.test(TOP_LEVEL), false, "top-level Wrangler config must not select a deploy target");
+  assert.equal(hasAssignment(blockFor("[[containers]]"), "name", "animichi-runtimecontainer"), true);
   assert.equal(hasAssignment(blockFor("[env.production]"), "name", "animichi"), true);
   assert.equal(hasAssignment(blockFor("[env.staging]"), "name", "animichi-staging"), true);
 });
 
-test("ci.yml keeps both JWKS secret paths complete", () => {
+void test("named Wrangler environments pass the real config parser", () => {
+  const environments = [
+    ["staging", "animichi-staging"],
+    ["production", "animichi"],
+  ] as const;
+  for (const [environment, expectedName] of environments) {
+    assert.equal(parsedWorkerName(environment), expectedName);
+  }
+});
+
+void test("ci.yml keeps both JWKS secret paths complete", () => {
   const workflowText = readFileSync(`${ROOT}.github/workflows/ci.yml`, "utf8");
   assert.equal(countMatches(workflowText, /^\s+NEON_AUTH_JWKS_URL\s*$/gm), 2, "ci.yml JWKS secret lists must stay complete");
   assert.equal(
@@ -49,7 +75,7 @@ test("ci.yml keeps both JWKS secret paths complete", () => {
   assert.equal(workflowText.includes("NEON_AUTH_ISSUER"), false, "ci.yml must not turn the public issuer into a secret");
 });
 
-test("deploy.yml keeps its JWKS secret path complete", () => {
+void test("deploy.yml keeps its JWKS secret path complete", () => {
   const workflowText = readFileSync(`${ROOT}.github/workflows/deploy.yml`, "utf8");
   assert.equal(countMatches(workflowText, /^\s+NEON_AUTH_JWKS_URL\s*$/gm), 1, "deploy.yml JWKS secret list must stay complete");
   assert.equal(
@@ -61,7 +87,7 @@ test("deploy.yml keeps its JWKS secret path complete", () => {
   assert.equal(workflowText.includes("NEON_AUTH_ISSUER"), false, "deploy.yml must not turn the public issuer into a secret");
 });
 
-test("_deploy-component.yml keeps its JWKS declaration and paths complete", () => {
+void test("_deploy-component.yml keeps its JWKS declaration and paths complete", () => {
   const workflowText = readFileSync(`${ROOT}.github/workflows/_deploy-component.yml`, "utf8");
   assert.equal(countMatches(workflowText, /^\s+NEON_AUTH_JWKS_URL:\s*$/gm), 1, "_deploy-component.yml must declare JWKS");
   assert.equal(

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -113,6 +113,7 @@ binding = "USERS"
 service = "users"
 
 [[containers]]
+name = "animichi-runtimecontainer"
 class_name = "RuntimeContainer"
 image = "./Dockerfile"
 max_instances = 3


### PR DESCRIPTION
## Summary

- name the default RuntimeContainer resource without restoring a top-level Worker deploy target
- pin the root Wrangler parser to the same 4.112.0 version used by CI
- test staging and production with the real Wrangler config parser

## Why

The first main run after #590 failed in Deploy root staging before secret upload. Wrangler validates the top-level containers table before selecting the named environment, and the default container had neither a name nor a top-level Worker name from which to derive one.

This keeps bare deploy targetless while making named-environment config valid again.

## Validation

- pnpm exec oxlint --type-aware --deny-warnings worker/authConfig.test.ts
- node --test worker/authConfig.test.ts: 6 passed
- pnpm run test:worker: 238 passed
- full Dependabot verification gate passed locally
- git diff --check

No local deploy was run. Regression follow-up to #590.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Assigned a consistent name to the runtime container.
  * Added Wrangler tooling for local configuration validation.

* **Tests**
  * Expanded deployment configuration checks to verify container and environment-specific worker names.
  * Improved workflow test coverage for deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->