### PR TITLE
style(ci): satisfy the current Ruff import format

### DIFF
--- a/.github/scripts/test_dependabot_config.py
+++ b/.github/scripts/test_dependabot_config.py
@@ -3,7 +3,6 @@ import subprocess
 import unittest
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).parents[2]
 CONFIG = REPO_ROOT / ".github/dependabot.yml"
 


### PR DESCRIPTION
## Summary

- remove the extra blank line that Ruff 0.16.1 reports as I001
- keep the Dependabot topology guard behavior unchanged

## Why

The first main CI run after #589 passed the new Dependabot pnpm coverage job, then Agent CI failed because ruff-action currently resolves Ruff 0.16.1 while the local recovery environment had Ruff 0.15.21. Ruff 0.16.1 formats the import-to-constant boundary with one blank line.

## Validation

- Ruff 0.16.1 check: pass
- Ruff 0.16.1 format --check: pass
- python3 .github/scripts/test_dependabot_config.py: pass
- git diff --check

One-line formatting-only follow-up to #589.