### PR TITLE
fix(ci): install Node before Dependabot backend tests

### DIFF
--- a/.github/scripts/test_dependabot_config.py
+++ b/.github/scripts/test_dependabot_config.py
@@ -5,6 +5,14 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parents[2]
 CONFIG = REPO_ROOT / ".github/dependabot.yml"
+WORKFLOW = REPO_ROOT / ".github/workflows/dependabot-agent.yml"
+GATE_STEP_ORDER = (
+    "- uses: pnpm/action-setup@",
+    "- uses: actions/setup-node@",
+    "- run: pnpm install --frozen-lockfile --ignore-scripts",
+    "- name: Backend quality + tests",
+    "- name: Web + worker quality",
+)
 
 
 def ecosystem_blocks(name: str) -> list[str]:
@@ -34,6 +42,11 @@ def pnpm_lockfile_domains() -> list[str]:
     return sorted("/" if parent == "." else f"/{parent}" for parent in parents)
 
 
+def gate_step_positions() -> list[int]:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    return [workflow.index(marker) for marker in GATE_STEP_ORDER]
+
+
 class DependabotConfigTest(unittest.TestCase):
     def test_npm_updates_cover_all_pnpm_lockfile_domains(self) -> None:
         npm_blocks = ecosystem_blocks("npm")
@@ -41,6 +54,12 @@ class DependabotConfigTest(unittest.TestCase):
         self.assertEqual(
             sorted(configured_directories(npm_blocks[0])), pnpm_lockfile_domains()
         )
+
+
+class DependabotWorkflowTest(unittest.TestCase):
+    def test_node_dependencies_precede_cross_language_backend_tests(self) -> None:
+        positions = gate_step_positions()
+        self.assertEqual(positions, sorted(positions))
 
 
 if __name__ == "__main__":

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -49,20 +49,6 @@ jobs:
       - run: uv sync --python "$PYTHON_VERSION" --all-extras --locked --no-build --no-install-project
         working-directory: apps/agent
 
-      # ── Backend checks ──
-      - name: Backend quality + tests
-        id: backend
-        working-directory: apps/agent
-        env:
-          SUPABASE_DB_URL: postgresql://test:test@127.0.0.1:5432/test
-          MIMO_API_KEY: test-only
-        run: |
-          uv run --no-build --no-sync ruff format --check agent/
-          uv run --no-build --no-sync ruff check agent/
-          uv run --no-build --no-sync mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/
-          uv run --no-build --no-sync python -m pytest agent/tests/unit/ -v --no-cov
-          uv run --no-build --no-sync python -c "from agent.interfaces.fastapi_service import create_fastapi_app; print('fastapi OK')"
-
       # ── Node setup (pnpm workspace; the web package lives in apps/web) ──
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
@@ -80,6 +66,22 @@ jobs:
       # token. pnpm 10 already blocks them absent an `onlyBuiltDependencies`
       # allowlist; the flag keeps that true if one is ever added.
       - run: pnpm install --frozen-lockfile --ignore-scripts
+
+      # ── Backend checks ──
+      # The wire-contract unit tests execute the TypeScript parser through tsx,
+      # so the workspace toolchain must be installed before this Python suite.
+      - name: Backend quality + tests
+        id: backend
+        working-directory: apps/agent
+        env:
+          SUPABASE_DB_URL: postgresql://test:test@127.0.0.1:5432/test
+          MIMO_API_KEY: test-only
+        run: |
+          uv run --no-build --no-sync ruff format --check agent/
+          uv run --no-build --no-sync ruff check agent/
+          uv run --no-build --no-sync mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/
+          uv run --no-build --no-sync python -m pytest agent/tests/unit/ -v --no-cov
+          uv run --no-build --no-sync python -c "from agent.interfaces.fastapi_service import create_fastapi_app; print('fastapi OK')"
 
       # ── TypeScript workspace checks ──
       - name: Web + worker quality


### PR DESCRIPTION
## Summary

- install the pnpm workspace before the Dependabot backend suite
- keep the existing backend commands unchanged
- add a structural regression test that locks the cross-language gate order

## Why

The Python wire-contract unit tests execute Node with tsx. On a clean Dependabot runner, the backend suite currently starts before setup-node and pnpm install, so test_chat_wire_contract.py fails with ERR_MODULE_NOT_FOUND for tsx. PR #596 exposed the ordering defect.

## Verification

- regression test failed before the workflow reorder and passed after it
- python3 .github/scripts/test_dependabot_config.py: 2 passed
- actionlint: passed
- zizmor --offline: no findings
- targeted wire-contract tests: 12 passed
- backend unit tests: 1668 passed
- Ruff, mypy, FastAPI import: passed
- pnpm run verify:dependabot: passed, including worker tests, typechecks, lint, and web production build
- make check: lint, typecheck, and 1668 coverage tests passed; integration startup was blocked before test execution because this machine has Atlas 1.2.4 while the repository requires 0.30.0

## Risk

Low and isolated to step ordering. Permissions, secrets, triggers, dependency versions, and test commands are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automated verification so Node and pnpm dependencies are installed before backend quality checks run.
  * Improved workflow sequencing for tests that rely on the TypeScript toolchain.

* **Tests**
  * Added validation to ensure dependency setup steps occur in the expected order before cross-language backend tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->