### PR TITLE
fix(deploy): use the locked Wrangler version

### DIFF
--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -509,7 +509,10 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.112.0"
+          # The setup action already installed the Wrangler declared by this
+          # workspace package. The pinned wrangler-action reuses that version
+          # when this input is omitted; duplicating it here made a Dependabot
+          # update fall into the action's mutating `pnpm add` fallback.
           # #516: without this, the action's own lockfile-based
           # auto-detection (dist/index.mjs:detectPackageManager) only looks
           # for a lockfile INSIDE `workingDirectory` — every pnpm workspace
@@ -595,7 +598,7 @@ jobs:
               echo "::warning::$name is empty/unset for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT — skipping the push (the preflight step already validated it is safe to skip here)."
               continue
             fi
-            printf '%s' "$value" | npx --yes wrangler@4.112.0 secret put "$name" --env "$TARGET_ENVIRONMENT"
+            printf '%s' "$value" | pnpm exec wrangler secret put "$name" --env "$TARGET_ENVIRONMENT"
           done <<< "$POST_DEPLOY_SECRETS"
       # Real per-component smoke checks (issue #484). `web` and `root` are
       # each self-contained (no dependency on other components in the same

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,7 +141,9 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.112.0"
+          # Reuse the workspace-locked Wrangler installed above. An explicit
+          # duplicate version can drift and trigger wrangler-action's
+          # mutating package-install fallback inside a frozen workspace.
           # #516: workers/catalog has no lockfile of its own (pnpm workspace
           # member — the lockfile lives at repo root), so the action's
           # auto-detection falls back to npm, which then chokes on
@@ -167,7 +169,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.112.0"
           # #516: same lockfile-detection fallback bug as catalog above.
           packageManager: pnpm
           workingDirectory: workers/users
@@ -189,7 +190,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.112.0"
           # root's implicit workingDirectory (repo root) does have its own
           # lockfile, so auto-detection already resolves to pnpm correctly
           # here — set explicitly anyway so this doesn't silently start
@@ -245,5 +245,5 @@ jobs:
               echo "::warning::$name is empty/unset for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT — skipping the push (the preflight step already validated it is safe to skip here)."
               continue
             fi
-            printf '%s' "$value" | npx --yes wrangler@4.112.0 secret put "$name" --env "$TARGET_ENVIRONMENT"
+            printf '%s' "$value" | pnpm exec wrangler secret put "$name" --env "$TARGET_ENVIRONMENT"
           done <<< "$POST_DEPLOY_SECRETS"

--- a/worker/dependabotWorkflow.test.ts
+++ b/worker/dependabotWorkflow.test.ts
@@ -6,6 +6,18 @@ import { fileURLToPath } from "node:url";
 const ROOT = fileURLToPath(new URL("../", import.meta.url));
 const WORKFLOW = readFileSync(`${ROOT}.github/workflows/dependabot-agent.yml`, "utf8");
 const PACKAGE_JSON = readFileSync(`${ROOT}package.json`, "utf8");
+const DEPLOY_WORKFLOWS = ["_deploy-component.yml", "deploy.yml"].map((name) =>
+  readFileSync(`${ROOT}.github/workflows/${name}`, "utf8"),
+);
+interface PackageManifest {
+  devDependencies?: Record<string, string>;
+}
+const DEPLOY_PACKAGES = [
+  "package.json",
+  "apps/web/package.json",
+  "workers/catalog/package.json",
+  "workers/users/package.json",
+].map((name) => JSON.parse(readFileSync(`${ROOT}${name}`, "utf8")) as PackageManifest);
 
 function stepNamed(name: string): string {
   const start = WORKFLOW.indexOf(`      - name: ${name}\n`);
@@ -14,11 +26,28 @@ function stepNamed(name: string): string {
   return WORKFLOW.slice(start, next === -1 ? undefined : next);
 }
 
-test("Dependabot gate checks repository structure without assuming uv is preinstalled", () => {
+function wranglerActionSteps(workflow: string): string[] {
+  return workflow
+    .split(/\n(?= {6}- )/)
+    .filter((step) => /^\s+uses: cloudflare\/wrangler-action@/m.test(step));
+}
+
+function assertUsesLockedWrangler(workflow: string): void {
+  const steps = wranglerActionSteps(workflow);
+  assert.notEqual(steps.length, 0);
+  assert.doesNotMatch(workflow, /wranglerVersion:/);
+  assert.doesNotMatch(workflow, /\bnpx\b[^\n]*\bwrangler(?:@|\b)/);
+  for (const step of steps) {
+    assert.equal(step.match(/^\s+packageManager:/gm)?.length, 1);
+    assert.match(step, /^\s+packageManager:\s+pnpm\s*$/m);
+  }
+}
+
+void test("Dependabot gate checks repository structure without assuming uv is preinstalled", () => {
   assert.equal(stepNamed("Verify gate contract").includes("command -v uv"), false);
 });
 
-test("Dependabot installs locked Python wheels without running build scripts", () => {
+void test("Dependabot installs locked Python wheels without running build scripts", () => {
   const safeSync =
     /- run: uv sync --python "\$PYTHON_VERSION" --all-extras --locked --no-build --no-install-project\n\s+working-directory: apps\/agent/g;
   assert.equal(WORKFLOW.match(safeSync)?.length, 1);
@@ -26,26 +55,36 @@ test("Dependabot installs locked Python wheels without running build scripts", (
   assert.doesNotMatch(WORKFLOW, /uv run (?!--no-build --no-sync)/);
 });
 
-test("Dependabot uses the shared Node verification command", () => {
+void test("Dependabot uses the shared Node verification command", () => {
   assert.match(PACKAGE_JSON, /"verify:dependabot": "[^"]*typecheck[^"]*web build"/);
   assert.equal(WORKFLOW.match(/pnpm run verify:dependabot/g)?.length, 1);
 });
 
-test("Dependabot reports success only for two successful quality outcomes", () => {
+void test("deploy workflows use the locked workspace Wrangler", () => {
+  DEPLOY_WORKFLOWS.forEach(assertUsesLockedWrangler);
+});
+
+void test("deploy packages declare Wrangler", () => {
+  DEPLOY_PACKAGES.forEach((manifest) => {
+    assert.equal(typeof manifest.devDependencies?.wrangler, "string");
+  });
+});
+
+void test("Dependabot reports success only for two successful quality outcomes", () => {
   const report = stepNamed("Report verification outcomes");
   assert.match(report, /\[ "\$BACKEND_OUTCOME" = "success" \] && \[ "\$WEB_OUTCOME" = "success" \]/);
   assert.match(report, /verification incomplete/);
   assert.doesNotMatch(WORKFLOW, /continue-on-error/);
 });
 
-test("Dependabot leaves verified upgrades for manual review", () => {
+void test("Dependabot leaves verified upgrades for manual review", () => {
   const allGreen = /gate_contract_ok == 'success' &&\n\s+needs\.verify\.outputs\.backend_ok == 'success' &&\n\s+needs\.verify\.outputs\.web_ok == 'success'/;
   assert.match(WORKFLOW, allGreen);
   assert.match(stepNamed("Report verified upgrade"), /ready for manual review/);
   assert.doesNotMatch(WORKFLOW, /gh pr merge/);
 });
 
-test("Dependabot reports incomplete verification without an autonomous writer", () => {
+void test("Dependabot reports incomplete verification without an autonomous writer", () => {
   const report = stepNamed("Report incomplete or failed verification");
   assert.match(WORKFLOW, /!cancelled\(\)/);
   assert.match(WORKFLOW, /github\.event\.pull_request\.user\.login == 'dependabot\[bot\]'/);
@@ -58,7 +97,7 @@ test("Dependabot reports incomplete verification without an autonomous writer", 
   assert.doesNotMatch(WORKFLOW, /claude-code-action|anthropic_api_key|Agent Fix/);
 });
 
-test("Dependabot runs tests from source without installing the local project", () => {
+void test("Dependabot runs tests from source without installing the local project", () => {
   const backend = stepNamed("Backend quality + tests");
   assert.match(backend, /uv run --no-build --no-sync python -m pytest/);
   assert.match(backend, /SUPABASE_DB_URL: postgresql:\/\/test:test@127\.0\.0\.1:5432\/test/);


### PR DESCRIPTION
## Why

Main staging run 30582671862, root job 91008198349 failed before any Cloudflare API call:

- the workspace lock resolved Wrangler 4.114.0
- the deploy workflows still passed wranglerVersion 4.112.0
- the pinned wrangler-action treated that as a mismatch and attempted pnpm add
- pnpm rejected the root mutation with ERR_PNPM_ADDING_TO_ROOT

This was exposed by the Wrangler update in #600.

## What

- remove the four duplicated wranglerVersion inputs
- reuse the Wrangler already installed from the frozen pnpm workspace
- replace both one-off npx secret commands with pnpm exec wrangler
- add a contract test that checks each Wrangler Action step uses pnpm, rejects version and npx escape hatches, and verifies all four package manifests declare Wrangler

## Verification

- targeted workflow tests: 9/9
- worker tests: 240/240
- pnpm run verify:dependabot: passed
- type-aware oxlint: passed
- actionlint: passed
- zizmor --offline: no findings
- pnpm exec wrangler --version resolved 4.114.0 from root, apps/web, workers/catalog, and workers/users
- independent read-only review: PASS, no remaining P0-P2
- no local deployment performed

## Rollout boundary

The next real staging run should no longer enter the action package-install fallback. It may then reach the separately known Cloudflare token permission gate; this PR does not weaken or bypass that external control.