### PR TITLE
fix(agent): reject malformed BYOK header encoding

### DIFF
--- a/apps/agent/agent/agents/byok_models.py
+++ b/apps/agent/agent/agents/byok_models.py
@@ -90,6 +90,13 @@ def _decode(raw: bytes) -> str:
     return raw.decode("utf-8", errors="strict").strip()
 
 
+def _decode_header(raw: bytes, name: str) -> str:
+    try:
+        return _decode(raw)
+    except UnicodeDecodeError as exc:
+        raise ByokError("invalid_request", f"{name} must be valid UTF-8.") from exc
+
+
 def _require_known_provider(value: str | None) -> ByokProvider:
     if value not in BYOK_PROVIDERS:
         raise ByokError("invalid_request", "Unknown or missing X-BYOK-Provider.")
@@ -99,14 +106,14 @@ def _require_known_provider(value: str | None) -> ByokProvider:
 def _require_key(raw: bytes | None) -> str:
     if raw is None:
         raise ByokError("invalid_request", "X-BYOK-Key is required.")
-    key = _decode(raw)
+    key = _decode_header(raw, "X-BYOK-Key")
     if not key:
         raise ByokError("invalid_request", "X-BYOK-Key must not be blank.")
     return key
 
 
 def _require_base_url(raw: bytes | None, provider: ByokProvider) -> str | None:
-    text = _decode(raw) if raw is not None else ""
+    text = _decode_header(raw, "X-BYOK-Base-Url") if raw is not None else ""
     if provider != "openai-compatible":
         if text:
             raise ByokError(

--- a/apps/agent/agent/tests/unit/test_byok_credential_encoding.py
+++ b/apps/agent/agent/tests/unit/test_byok_credential_encoding.py
@@ -1,0 +1,33 @@
+"""Malformed byte-header coverage for BYOK credential parsing (#535)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.agents.byok_models import ByokError, parse_byok_credential
+
+pytestmark = pytest.mark.unit
+
+
+def test_invalid_utf8_key_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="anthropic",
+            key_header=b"\xff",
+            model_header=None,
+            base_url_header=None,
+        )
+    assert excinfo.value.code == "invalid_request"
+    assert excinfo.value.message == "X-BYOK-Key must be valid UTF-8."
+
+
+def test_invalid_utf8_base_url_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="openai-compatible",
+            key_header=b"not-a-real-api-key",
+            model_header="test-model",
+            base_url_header=b"https://example.test/\xff",
+        )
+    assert excinfo.value.code == "invalid_request"
+    assert excinfo.value.message == "X-BYOK-Base-Url must be valid UTF-8."

--- a/apps/agent/agent/tests/unit/test_byok_credential_parsing.py
+++ b/apps/agent/agent/tests/unit/test_byok_credential_parsing.py
@@ -88,6 +88,28 @@ def test_provider_present_key_missing_rejected() -> None:
     assert excinfo.value.code == "invalid_request"
 
 
+def test_invalid_utf8_key_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="anthropic",
+            key_header=b"\xff",
+            model_header=None,
+            base_url_header=None,
+        )
+    assert excinfo.value.code == "invalid_request"
+
+
+def test_invalid_utf8_base_url_rejected() -> None:
+    with pytest.raises(ByokError) as excinfo:
+        parse_byok_credential(
+            provider_header="openai-compatible",
+            key_header=b"not-a-real-api-key",
+            model_header="test-model",
+            base_url_header=b"https://example.test/\xff",
+        )
+    assert excinfo.value.code == "invalid_request"
+
+
 def test_unknown_provider_rejected() -> None:
     with pytest.raises(ByokError) as excinfo:
         parse_byok_credential(

--- a/apps/agent/agent/tests/unit/test_byok_credential_parsing.py
+++ b/apps/agent/agent/tests/unit/test_byok_credential_parsing.py
@@ -88,28 +88,6 @@ def test_provider_present_key_missing_rejected() -> None:
     assert excinfo.value.code == "invalid_request"
 
 
-def test_invalid_utf8_key_rejected() -> None:
-    with pytest.raises(ByokError) as excinfo:
-        parse_byok_credential(
-            provider_header="anthropic",
-            key_header=b"\xff",
-            model_header=None,
-            base_url_header=None,
-        )
-    assert excinfo.value.code == "invalid_request"
-
-
-def test_invalid_utf8_base_url_rejected() -> None:
-    with pytest.raises(ByokError) as excinfo:
-        parse_byok_credential(
-            provider_header="openai-compatible",
-            key_header=b"not-a-real-api-key",
-            model_header="test-model",
-            base_url_header=b"https://example.test/\xff",
-        )
-    assert excinfo.value.code == "invalid_request"
-
-
 def test_unknown_provider_rejected() -> None:
     with pytest.raises(ByokError) as excinfo:
         parse_byok_credential(


### PR DESCRIPTION
Summary
- Convert invalid UTF-8 BYOK key and base URL bytes into typed invalid_request errors.
- Keep error messages static so raw header bytes are never echoed.
- Split encoding coverage into a 33-line test file so every test file remains within the 200-line limit.

Scope
- This resolves only subitem 1 of 5 in #535.
- Refs #535. The parent issue must remain open for the other four items.

Verification
- Full Python unit suite: 1670 passed; coverage 88.28 percent.
- Focused credential parsing and encoding: 17 passed.
- Ruff check and format check: passed.
- Canonical mypy target set: 137 source files passed.
- Independent final review: PASS, no P0-P2.