### PR TITLE
test(agent): prove BYOK probe timeout causally

### DIFF
--- a/apps/agent/agent/tests/integration/test_byok_probe_containment.py
+++ b/apps/agent/agent/tests/integration/test_byok_probe_containment.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+from pydantic_ai.models import Model
 
 from agent.interfaces.routes import byok as byok_route
 from agent.tests.integration._byok_probe_shared import (
@@ -101,24 +103,16 @@ class _OversizedStreamNoHeaderTransport(httpx.AsyncBaseTransport):
         return response
 
 
-class _SlowTransport(httpx.AsyncBaseTransport):
-    """Sleeps past the (patched, short) timeout before ever answering.
-
-    Records whether it was entered and whether it ran to completion, so the
-    timeout test can assert that the transport was cut off *mid-sleep* rather
-    than measuring how long the probe took. See that test for why.
-    """
-
-    def __init__(self, delay_seconds: float) -> None:
-        self._delay_seconds = delay_seconds
+class _CancellableProbeAgent:
+    def __init__(self) -> None:
         self.started = False
         self.completed = False
 
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+    async def run(self, message: object) -> None:
+        del message
         self.started = True
-        await asyncio.sleep(self._delay_seconds)
+        await asyncio.sleep(0)
         self.completed = True
-        return httpx.Response(200, content=_SMALL_OK_BODY, request=request)
 
 
 async def _probe_body(
@@ -220,34 +214,25 @@ async def test_a_connection_failure_collapses_to_provider_unreachable() -> None:
 async def test_the_probe_never_exceeds_its_timeout_ceiling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Patch the timeout constant down and confirm a slower transport is
-    actually cut off, proving the timeout enforces rather than being cosmetic.
-
-    Asserted on the transport's own state — entered but never finished — not
-    on elapsed wall-clock time. The earlier `elapsed < 1.0` form flaked in the
-    Neon CI lane: under load a 0.05s ceiling can still take over a second to
-    unwind, so the assertion measured the runner rather than the code. What it
-    was really trying to say is that the sleep never completed, and that is
-    now what it says. The repo's test rules ban timing-dependent asserts for
-    exactly this reason.
-    """
-    # Leave enough setup headroom for the deadline to fire inside the transport.
-    transport = _SlowTransport(delay_seconds=10.0)
-    monkeypatch.setattr(byok_route, "_PROBE_TIMEOUT_SECONDS", 3.0)
-    body = await _probe_body(transport)
-    assert body["error_code"] == "provider_unreachable"
-    assert transport.started is True
-    assert transport.completed is False
+    """Cancel after one event-loop checkpoint, without measuring real time."""
+    probe_agent = _CancellableProbeAgent()
+    monkeypatch.setattr(byok_route, "_PROBE_TIMEOUT_SECONDS", 0.0)
+    with patch.object(byok_route, "Agent", return_value=probe_agent):
+        result = await byok_route._run_probe(cast(Model, object()))
+    assert result.error_code == "provider_unreachable"
+    assert probe_agent.started is True
+    assert probe_agent.completed is False
 
 
-async def test_without_the_patched_timeout_the_slow_transport_would_have_succeeded() -> (
-    None
-):
-    """Control: proves the slow transport is a legitimate success shape at
-    the real 5s ceiling — the fast-timeout test above is the timeout firing,
-    not an unrelated fault in the fixture."""
-    body = await _probe_body(_SlowTransport(delay_seconds=0.01))
-    assert body == {"vision": True, "reachable": True, "error_code": None}
+async def test_without_the_patched_timeout_the_probe_agent_completes() -> None:
+    """Control: the fake agent succeeds when the real five-second ceiling applies."""
+    probe_agent = _CancellableProbeAgent()
+    with patch.object(byok_route, "Agent", return_value=probe_agent):
+        result = await byok_route._run_probe(cast(Model, object()))
+    assert result == byok_route.ProbeResult(
+        vision=True, reachable=True, error_code=None
+    )
+    assert probe_agent.completed is True
 
 
 def test_the_timeout_ceiling_constant_is_at_most_five_seconds() -> None:

--- a/apps/agent/agent/tests/integration/test_byok_probe_containment.py
+++ b/apps/agent/agent/tests/integration/test_byok_probe_containment.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import time
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -103,13 +102,22 @@ class _OversizedStreamNoHeaderTransport(httpx.AsyncBaseTransport):
 
 
 class _SlowTransport(httpx.AsyncBaseTransport):
-    """Sleeps past the (patched, short) timeout before ever answering."""
+    """Sleeps past the (patched, short) timeout before ever answering.
+
+    Records whether it was entered and whether it ran to completion, so the
+    timeout test can assert that the transport was cut off *mid-sleep* rather
+    than measuring how long the probe took. See that test for why.
+    """
 
     def __init__(self, delay_seconds: float) -> None:
         self._delay_seconds = delay_seconds
+        self.started = False
+        self.completed = False
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.started = True
         await asyncio.sleep(self._delay_seconds)
+        self.completed = True
         return httpx.Response(200, content=_SMALL_OK_BODY, request=request)
 
 
@@ -212,19 +220,24 @@ async def test_a_connection_failure_collapses_to_provider_unreachable() -> None:
 async def test_the_probe_never_exceeds_its_timeout_ceiling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Mock-clock style: patch the timeout constant down to a small value
-    and confirm a slower transport is actually cut off near THAT ceiling —
-    not near its own multi-second sleep — proving the timeout enforces
-    rather than being cosmetic. Real wall-clock time is asserted, bounded
-    well under the transport's sleep duration."""
-    monkeypatch.setattr(byok_route, "_PROBE_TIMEOUT_SECONDS", 0.05)
-    started = time.monotonic()
-    body = await _probe_body(_SlowTransport(delay_seconds=2.0))
-    elapsed = time.monotonic() - started
+    """Patch the timeout constant down and confirm a slower transport is
+    actually cut off, proving the timeout enforces rather than being cosmetic.
+
+    Asserted on the transport's own state — entered but never finished — not
+    on elapsed wall-clock time. The earlier `elapsed < 1.0` form flaked in the
+    Neon CI lane: under load a 0.05s ceiling can still take over a second to
+    unwind, so the assertion measured the runner rather than the code. What it
+    was really trying to say is that the sleep never completed, and that is
+    now what it says. The repo's test rules ban timing-dependent asserts for
+    exactly this reason.
+    """
+    # Leave enough setup headroom for the deadline to fire inside the transport.
+    transport = _SlowTransport(delay_seconds=10.0)
+    monkeypatch.setattr(byok_route, "_PROBE_TIMEOUT_SECONDS", 3.0)
+    body = await _probe_body(transport)
     assert body["error_code"] == "provider_unreachable"
-    assert elapsed < 1.0, (
-        f"probe took {elapsed:.2f}s — the 0.05s timeout ceiling did not enforce"
-    )
+    assert transport.started is True
+    assert transport.completed is False
 
 
 async def test_without_the_patched_timeout_the_slow_transport_would_have_succeeded() -> (

--- a/apps/agent/agent/tests/integration/test_byok_probe_containment.py
+++ b/apps/agent/agent/tests/integration/test_byok_probe_containment.py
@@ -17,12 +17,10 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
-from pydantic_ai.models import Model
 
 from agent.interfaces.routes import byok as byok_route
 from agent.tests.integration._byok_probe_shared import (
@@ -103,16 +101,38 @@ class _OversizedStreamNoHeaderTransport(httpx.AsyncBaseTransport):
         return response
 
 
-class _CancellableProbeAgent:
-    def __init__(self) -> None:
-        self.started = False
-        self.completed = False
+class _TimeoutControl:
+    CancelledError = asyncio.CancelledError
 
-    async def run(self, message: object) -> None:
-        del message
+    def __init__(self) -> None:
+        self.entries: list[tuple[float, asyncio.Timeout]] = []
+
+    def timeout(self, delay: float) -> asyncio.Timeout:
+        context = asyncio.timeout(None)
+        self.entries.append((delay, context))
+        return context
+
+    def expire_outer(self) -> None:
+        assert len(self.entries) == 2
+        self.entries[0][1].reschedule(asyncio.get_running_loop().time())
+
+
+class _TimeoutCancellationTransport(httpx.AsyncBaseTransport):
+    def __init__(self, control: _TimeoutControl) -> None:
+        self._control = control
+        self.started = False
+        self.cancelled = False
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        del request
         self.started = True
-        await asyncio.sleep(0)
-        self.completed = True
+        self._control.expire_outer()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        raise AssertionError("unreachable")
 
 
 async def _probe_body(
@@ -214,33 +234,33 @@ async def test_a_connection_failure_collapses_to_provider_unreachable() -> None:
 async def test_the_probe_never_exceeds_its_timeout_ceiling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cancel after one event-loop checkpoint, without measuring real time."""
-    probe_agent = _CancellableProbeAgent()
-    monkeypatch.setattr(byok_route, "_PROBE_TIMEOUT_SECONDS", 0.0)
-    with patch.object(byok_route, "Agent", return_value=probe_agent):
-        result = await byok_route._run_probe(cast(Model, object()))
-    assert result.error_code == "provider_unreachable"
-    assert probe_agent.started is True
-    assert probe_agent.completed is False
-
-
-async def test_without_the_patched_timeout_the_probe_agent_completes() -> None:
-    """Control: the fake agent succeeds when the real five-second ceiling applies."""
-    probe_agent = _CancellableProbeAgent()
-    with patch.object(byok_route, "Agent", return_value=probe_agent):
-        result = await byok_route._run_probe(cast(Model, object()))
-    assert result == byok_route.ProbeResult(
-        vision=True, reachable=True, error_code=None
-    )
-    assert probe_agent.completed is True
+    """Expire the real outer timeout after transport entry, without waiting."""
+    control = _TimeoutControl()
+    transport = _TimeoutCancellationTransport(control)
+    monkeypatch.setattr(byok_route, "asyncio", control)
+    body = await _probe_body(transport)
+    assert body == {
+        "vision": False,
+        "reachable": False,
+        "error_code": "provider_unreachable",
+    }
+    assert transport.started is True
+    assert transport.cancelled is True
+    assert [delay for delay, _ in control.entries] == [
+        byok_route._PROBE_TIMEOUT_SECONDS,
+        byok_route._PROBE_TIMEOUT_SECONDS,
+    ]
+    assert control.entries[0][1].expired() is True
+    assert control.entries[1][1].expired() is False
 
 
 def test_the_timeout_ceiling_constant_is_at_most_five_seconds() -> None:
-    """Direct value pin, independent of the monkeypatched behavioural test
-    above: `test_the_probe_never_exceeds_its_timeout_ceiling` overrides this
-    constant at test time, so it alone cannot catch the *default* silently
-    growing (e.g. 5.0 -> 500.0) in production — this test reads the real
-    module constant directly."""
+    """Pin the default independently of the behavioural duration threading.
+
+    The cancellation test proves both timeout contexts receive this constant,
+    but it deliberately controls when they expire. This assertion separately
+    prevents the production ceiling itself from growing silently.
+    """
     assert byok_route._PROBE_TIMEOUT_SECONDS <= 5.0
 
 


### PR DESCRIPTION
Summary
- Replace the flaky real elapsed-time assertion with a deterministic cancellation proof.
- Keep the real FastAPI, PydanticAI, OpenAI SDK, and httpx transport chain.
- Record both production timeout durations, then expire the real outer asyncio Timeout only after the transport has started.
- Assert the complete unreachable response, transport cancellation, and distinct outer versus inner timeout state.

Why this is deterministic
- The test timeout contexts start without a wall-clock deadline.
- The transport reschedules the real outer Timeout to the current loop time at a known await seam.
- CI scheduler speed cannot make the deadline fire before the transport starts.

Verification
- BYOK probe neighborhood: 30 passed.
- Containment file: 8 passed with focused coverage disabled.
- Repeated causal test: 25 of 25 passed in independent review.
- Ruff check and format check: passed.
- Canonical mypy target set: 137 source files passed.
- Independent final review: PASS, no P0-P2.

Closes #531.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved timeout and cancellation coverage for connection probing.
  - Added validation that configured timeouts remain within a safe five-second limit.
  - Updated tests to use deterministic timeout controls, reducing reliance on real-time delays and improving consistency across test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->