### PR TITLE
test(agent): replace bare warning filters

### DIFF
--- a/apps/agent/agent/tests/unit/test_cron_settings.py
+++ b/apps/agent/agent/tests/unit/test_cron_settings.py
@@ -124,7 +124,6 @@ class TestGetSettingsSingletonIsUnaffected:
 
         assert get_settings.cache_info().currsize == 0
 
-    @pytest.mark.filterwarnings("ignore::UserWarning")
     def test_get_settings_still_raises_after_a_purge_cron_settings_call(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/apps/agent/agent/tests/unit/test_settings.py
+++ b/apps/agent/agent/tests/unit/test_settings.py
@@ -167,18 +167,6 @@ class TestAPIKeyValidation:
         missing = settings.validate_api_keys()
         assert missing == []
 
-    @pytest.mark.filterwarnings("ignore::UserWarning")
-    def test_validate_api_keys_missing_openai_compat_when_fallback_enabled(self):
-        """Fallback provider requires compat config when using openai fallback."""
-        settings = Settings(
-            gemini_api_key="test_key",
-            fallback_agent_model="openai:gpt-5.4",
-            openai_compat_base_url="",
-            openai_compat_api_key="",
-        )
-        missing = settings.validate_api_keys()
-        assert "OPENAI_COMPAT_BASE_URL" in missing
-
     def test_get_runtime_config_includes_provider_fields(self):
         """Runtime config should expose non-secret provider settings."""
         settings = Settings(

--- a/apps/agent/agent/tests/unit/test_settings_warnings.py
+++ b/apps/agent/agent/tests/unit/test_settings_warnings.py
@@ -1,0 +1,16 @@
+"""Warning contracts for application settings (#535)."""
+
+import pytest
+
+from agent.config.settings import Settings
+
+
+def test_fallback_validation_warns_and_reports_missing_compat_url() -> None:
+    with pytest.warns(UserWarning, match="OPENAI_COMPAT_BASE_URL"):
+        settings = Settings(
+            gemini_api_key="test_key",
+            fallback_agent_model="openai:gpt-5.4",
+            openai_compat_base_url="",
+            openai_compat_api_key="",
+        )
+    assert "OPENAI_COMPAT_BASE_URL" in settings.validate_api_keys()


### PR DESCRIPTION
## Summary
- remove the bare UserWarning filters from settings tests
- assert the real OPENAI_COMPAT_BASE_URL warning with pytest.warns
- split the warning case into a small test file so every test file remains below 200 lines

## Verification
- 23 focused settings tests passed with --no-cov
- Ruff check and format check passed
- independent review found no P0-P2 regression

Refs #535 (sub-item 5/5). The parent issue remains open until all five findings are merged.