### PR TITLE
fix(agent): keep purge summaries best-effort

### DIFF
--- a/apps/agent/agent/scripts/purge_anon_quota_counts.py
+++ b/apps/agent/agent/scripts/purge_anon_quota_counts.py
@@ -53,9 +53,19 @@ def _write_step_summary(*, count: int, dry_run: bool) -> None:
     if not summary_path:
         return
     label = "eligible" if dry_run else "removed"
-    Path(summary_path).open("a", encoding="utf-8").write(
-        f"anon-quota-count purge: {label}={count}\n"
+    _append_step_summary(
+        Path(summary_path), f"anon-quota-count purge: {label}={count}\n"
     )
+
+
+def _append_step_summary(path: Path, line: str) -> None:
+    try:
+        with path.open("a", encoding="utf-8") as summary:
+            summary.write(line)
+    except OSError as exc:
+        logger.warning(
+            "anon_quota_step_summary_write_failed", error_type=type(exc).__name__
+        )
 
 
 async def _main(dry_run: bool) -> None:

--- a/apps/agent/agent/scripts/purge_anonymous_sessions.py
+++ b/apps/agent/agent/scripts/purge_anonymous_sessions.py
@@ -112,7 +112,18 @@ def _write_step_summary(report: PurgeReport) -> None:
         f"anonymous-session purge: purged={report.purged} "
         f"raced={report.raced} failed={report.failed}\n"
     )
-    Path(summary_path).open("a", encoding="utf-8").write(line)
+    _append_step_summary(Path(summary_path), line)
+
+
+def _append_step_summary(path: Path, line: str) -> None:
+    try:
+        with path.open("a", encoding="utf-8") as summary:
+            summary.write(line)
+    except OSError as exc:
+        logger.warning(
+            "anonymous_session_step_summary_write_failed",
+            error_type=type(exc).__name__,
+        )
 
 
 async def _main(dry_run: bool) -> None:

--- a/apps/agent/agent/tests/unit/test_purge_step_summary.py
+++ b/apps/agent/agent/tests/unit/test_purge_step_summary.py
@@ -1,0 +1,87 @@
+"""Regression tests for best-effort purge job summaries (issue #535)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import NoReturn
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.scripts import purge_anon_quota_counts, purge_anonymous_sessions
+
+_DB = MagicMock()
+_PRIVATE_ERROR = "private-summary-path"
+
+
+class _Client:
+    def __init__(self, dsn: str) -> None:
+        self.dsn = dsn
+
+    async def __aenter__(self) -> MagicMock:
+        return _DB
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        supabase_db_url="postgresql://local/test",
+        anon_daily_message_count_retention_days=30,
+        anonymous_session_retention_days=30,
+    )
+
+
+def _raise_summary_error(*args: object, **kwargs: object) -> NoReturn:
+    raise OSError(_PRIVATE_ERROR)
+
+
+def _fail_summary_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", "/private/summary")
+    monkeypatch.setattr(Path, "open", _raise_summary_error)
+
+
+def test_quota_summary_error_is_best_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fail_summary_open(monkeypatch)
+    log = MagicMock()
+    monkeypatch.setattr(purge_anon_quota_counts, "logger", log)
+    purge_anon_quota_counts._write_step_summary(count=4, dry_run=False)
+    assert _PRIVATE_ERROR not in str(log.mock_calls)
+    log.warning.assert_called_once_with(
+        "anon_quota_step_summary_write_failed", error_type="OSError"
+    )
+
+
+def test_session_summary_error_is_best_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fail_summary_open(monkeypatch)
+    log = MagicMock()
+    monkeypatch.setattr(purge_anonymous_sessions, "logger", log)
+    report = purge_anonymous_sessions.PurgeReport(purged=4, raced=1, failed=0)
+    purge_anonymous_sessions._write_step_summary(report)
+    assert _PRIVATE_ERROR not in str(log.mock_calls)
+    log.warning.assert_called_once_with(
+        "anonymous_session_step_summary_write_failed", error_type="OSError"
+    )
+
+
+async def test_quota_main_survives_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    purge = AsyncMock(return_value=4)
+    monkeypatch.setattr(purge_anon_quota_counts, "purge_anon_quota_counts", purge)
+    monkeypatch.setattr(purge_anon_quota_counts, "SupabaseClient", _Client)
+    monkeypatch.setattr(purge_anon_quota_counts, "get_purge_cron_settings", _settings)
+    _fail_summary_open(monkeypatch)
+    await purge_anon_quota_counts._main(dry_run=False)
+    purge.assert_awaited_once_with(_DB, retention_days=30, dry_run=False)
+
+
+async def test_session_main_survives_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    report = purge_anonymous_sessions.PurgeReport(purged=4, raced=1, failed=0)
+    purge = AsyncMock(return_value=report)
+    monkeypatch.setattr(purge_anonymous_sessions, "purge_anonymous_sessions", purge)
+    monkeypatch.setattr(purge_anonymous_sessions, "SupabaseClient", _Client)
+    monkeypatch.setattr(purge_anonymous_sessions, "get_purge_cron_settings", _settings)
+    _fail_summary_open(monkeypatch)
+    await purge_anonymous_sessions._main(dry_run=False)
+    purge.assert_awaited_once_with(_DB, retention_days=30, dry_run=False)

--- a/apps/agent/agent/tests/unit/test_purge_step_summary.py
+++ b/apps/agent/agent/tests/unit/test_purge_step_summary.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
-from typing import NoReturn
+from typing import NoReturn, Protocol
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -13,6 +14,12 @@ from agent.scripts import purge_anon_quota_counts, purge_anonymous_sessions
 
 _DB = MagicMock()
 _PRIVATE_ERROR = "private-summary-path"
+_PROGRAMMING_ERROR = "summary-programming-error"
+_PURGE_ERROR = "purge-database-error"
+
+
+class _SummaryModule(Protocol):
+    _write_step_summary: Callable[..., None]
 
 
 class _Client:
@@ -38,9 +45,36 @@ def _raise_summary_error(*args: object, **kwargs: object) -> NoReturn:
     raise OSError(_PRIVATE_ERROR)
 
 
+def _raise_programming_error(*args: object, **kwargs: object) -> NoReturn:
+    raise RuntimeError(_PROGRAMMING_ERROR)
+
+
 def _fail_summary_open(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITHUB_STEP_SUMMARY", "/private/summary")
     monkeypatch.setattr(Path, "open", _raise_summary_error)
+
+
+def _fail_summary_with_programming_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", "/private/summary")
+    monkeypatch.setattr(Path, "open", _raise_programming_error)
+
+
+def _configure_quota_main(monkeypatch: pytest.MonkeyPatch, purge: AsyncMock) -> None:
+    monkeypatch.setattr(purge_anon_quota_counts, "purge_anon_quota_counts", purge)
+    monkeypatch.setattr(purge_anon_quota_counts, "SupabaseClient", _Client)
+    monkeypatch.setattr(purge_anon_quota_counts, "get_purge_cron_settings", _settings)
+
+
+def _configure_session_main(monkeypatch: pytest.MonkeyPatch, purge: AsyncMock) -> None:
+    monkeypatch.setattr(purge_anonymous_sessions, "purge_anonymous_sessions", purge)
+    monkeypatch.setattr(purge_anonymous_sessions, "SupabaseClient", _Client)
+    monkeypatch.setattr(purge_anonymous_sessions, "get_purge_cron_settings", _settings)
+
+
+def _spy_summary(monkeypatch: pytest.MonkeyPatch, module: _SummaryModule) -> MagicMock:
+    summary = MagicMock(wraps=module._write_step_summary)
+    monkeypatch.setattr(module, "_write_step_summary", summary)
+    return summary
 
 
 def test_quota_summary_error_is_best_effort(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,22 +100,53 @@ def test_session_summary_error_is_best_effort(monkeypatch: pytest.MonkeyPatch) -
     )
 
 
+def test_quota_summary_propagates_non_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fail_summary_with_programming_error(monkeypatch)
+    with pytest.raises(RuntimeError, match=_PROGRAMMING_ERROR):
+        purge_anon_quota_counts._write_step_summary(count=4, dry_run=False)
+
+
+def test_session_summary_propagates_non_os_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fail_summary_with_programming_error(monkeypatch)
+    report = purge_anonymous_sessions.PurgeReport(purged=4, raced=1, failed=0)
+    with pytest.raises(RuntimeError, match=_PROGRAMMING_ERROR):
+        purge_anonymous_sessions._write_step_summary(report)
+
+
 async def test_quota_main_survives_summary(monkeypatch: pytest.MonkeyPatch) -> None:
     purge = AsyncMock(return_value=4)
-    monkeypatch.setattr(purge_anon_quota_counts, "purge_anon_quota_counts", purge)
-    monkeypatch.setattr(purge_anon_quota_counts, "SupabaseClient", _Client)
-    monkeypatch.setattr(purge_anon_quota_counts, "get_purge_cron_settings", _settings)
+    _configure_quota_main(monkeypatch, purge)
+    summary = _spy_summary(monkeypatch, purge_anon_quota_counts)
     _fail_summary_open(monkeypatch)
     await purge_anon_quota_counts._main(dry_run=False)
-    purge.assert_awaited_once_with(_DB, retention_days=30, dry_run=False)
+    summary.assert_called_once_with(count=4, dry_run=False)
 
 
 async def test_session_main_survives_summary(monkeypatch: pytest.MonkeyPatch) -> None:
     report = purge_anonymous_sessions.PurgeReport(purged=4, raced=1, failed=0)
     purge = AsyncMock(return_value=report)
-    monkeypatch.setattr(purge_anonymous_sessions, "purge_anonymous_sessions", purge)
-    monkeypatch.setattr(purge_anonymous_sessions, "SupabaseClient", _Client)
-    monkeypatch.setattr(purge_anonymous_sessions, "get_purge_cron_settings", _settings)
+    _configure_session_main(monkeypatch, purge)
+    summary = _spy_summary(monkeypatch, purge_anonymous_sessions)
     _fail_summary_open(monkeypatch)
     await purge_anonymous_sessions._main(dry_run=False)
-    purge.assert_awaited_once_with(_DB, retention_days=30, dry_run=False)
+    summary.assert_called_once_with(report)
+
+
+async def test_quota_main_propagates_purge_os_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    purge = AsyncMock(side_effect=OSError(_PURGE_ERROR))
+    _configure_quota_main(monkeypatch, purge)
+    with pytest.raises(OSError, match=_PURGE_ERROR):
+        await purge_anon_quota_counts._main(dry_run=False)
+
+
+async def test_session_main_propagates_purge_os_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    purge = AsyncMock(side_effect=OSError(_PURGE_ERROR))
+    _configure_session_main(monkeypatch, purge)
+    with pytest.raises(OSError, match=_PURGE_ERROR):
+        await purge_anonymous_sessions._main(dry_run=False)


### PR DESCRIPTION
## Summary
- make both purge step-summary writers use context-managed append and contain only summary I/O OSError failures
- keep purge/database failures observable and log only fixed event names plus exception types
- add symmetric mutation-proof tests for exception scope, summary wiring, and exact arguments

## Verification
- 8 focused tests passed
- all three named mutations fail the tests: widened catch, swallowed purge OSError, removed summary call
- Ruff check/format and canonical mypy passed
- earlier full agent suite: 1672 passed, 88.42% coverage
- independent final review: PASS

Refs #535 (sub-item 4/5). The parent issue remains open until all five findings are merged.