### PR TITLE
fix(web): tolerate deferred save storage failures

### DIFF
--- a/apps/web/src/features/chat/save/createOnLogin.ts
+++ b/apps/web/src/features/chat/save/createOnLogin.ts
@@ -1,8 +1,7 @@
 import type { SaveRouteInput } from "@animichi/contract";
 import { saveRouteRequest } from "../../../api/hooks/use-save-route";
 import type { SaveRouteRequest } from "../../../api/hooks/use-save-route";
-import { clearDeferredSave, readDeferredSave, writeDeferredSave } from "./deferredSave";
-import type { DeferredSaveIntent } from "./deferredSave";
+import { takeDeferredSave, writeDeferredSave } from "./deferredSave";
 
 /**
  * Create-on-login (OQ-9 ruling (b)): the post-login replay creates a **fresh**
@@ -22,25 +21,15 @@ export function toSaveInput(intent: Readonly<{ pointIds: readonly string[]; titl
 export type DeferredReplayOutcome = "none" | "saved" | "failed";
 
 /**
- * Replay the deferred save exactly once after a login. A login that was **not**
- * initiated by a save tap finds no intent and issues no request. The entry is
- * claimed (deleted) before the request goes out so two tabs cannot both save it,
- * and restored on failure — so a failed replay is never silently dropped.
+ * Replay only after `takeDeferredSave` has removed the live intent. A blocked
+ * claim sends no request; a failed request restores the original intent and
+ * timestamp so it can be retried without extending the TTL.
  */
-/** Claim before sending: two tabs completing a login concurrently would
- * otherwise both read the same intent and create two rows. The loser finds
- * nothing. */
-function claimDeferredSave(now: number): DeferredSaveIntent | undefined {
-  const intent = readDeferredSave(now);
-  if (intent !== undefined) clearDeferredSave();
-  return intent;
-}
-
 export async function replayDeferredSave(
   request: SaveRouteRequest = saveRouteRequest,
   now: number = Date.now(),
 ): Promise<DeferredReplayOutcome> {
-  const intent = claimDeferredSave(now);
+  const intent = takeDeferredSave(now);
   if (intent === undefined) return "none";
   const saved = await request(toSaveInput(intent)).then(() => true, () => false);
   // A failure restores the entry with its ORIGINAL timestamp, so a retry never

--- a/apps/web/src/features/chat/save/createOnLogin.ts
+++ b/apps/web/src/features/chat/save/createOnLogin.ts
@@ -22,18 +22,18 @@ export type DeferredReplayOutcome = "none" | "saved" | "failed";
 
 /**
  * Replay only after `takeDeferredSave` has removed the live intent. A blocked
- * claim sends no request; a failed request restores the original intent and
- * timestamp so it can be retried without extending the TTL.
+ * claim reports failure without sending; a failed request restores the original
+ * intent and timestamp so it can be retried without extending the TTL.
  */
 export async function replayDeferredSave(
   request: SaveRouteRequest = saveRouteRequest,
   now: number = Date.now(),
 ): Promise<DeferredReplayOutcome> {
-  const intent = takeDeferredSave(now);
-  if (intent === undefined) return "none";
-  const saved = await request(toSaveInput(intent)).then(() => true, () => false);
+  const claim = takeDeferredSave(now);
+  if (claim.kind !== "claimed") return claim.kind === "failed" ? "failed" : "none";
+  const saved = await request(toSaveInput(claim.intent)).then(() => true, () => false);
   // A failure restores the entry with its ORIGINAL timestamp, so a retry never
   // silently extends the TTL.
-  if (!saved) writeDeferredSave(intent, intent.createdAt);
+  if (!saved) writeDeferredSave(claim.intent, claim.intent.createdAt);
   return saved ? "saved" : "failed";
 }

--- a/apps/web/src/features/chat/save/deferredSave.ts
+++ b/apps/web/src/features/chat/save/deferredSave.ts
@@ -29,7 +29,7 @@ export type DeferredSaveClaim =
   | { readonly kind: "claimed"; readonly intent: DeferredSaveIntent }
   | { readonly kind: "failed" };
 
-/** SSR and privacy-locked browsers have no usable store; both read as "no intent". */
+/** Return `undefined` when the storage accessor or operation cannot be used. */
 function withStore<Result>(operation: (storage: Storage) => Result): Result | undefined {
   try {
     return operation(globalThis.localStorage);
@@ -57,13 +57,26 @@ function parse(raw: string): DeferredSaveIntent | undefined {
   }
 }
 
+function isLive(intent: DeferredSaveIntent | undefined, now: number): intent is DeferredSaveIntent {
+  return intent !== undefined && now - intent.createdAt <= DEFERRED_SAVE_TTL_MS;
+}
+
+function removeForClaim(storage: Storage): boolean {
+  try {
+    storage.removeItem(DEFERRED_SAVE_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function takeFromStore(storage: Storage, now: number): DeferredSaveClaim {
   const raw = storage.getItem(DEFERRED_SAVE_KEY);
   if (raw === null) return { kind: "absent" };
   const intent = parse(raw);
-  storage.removeItem(DEFERRED_SAVE_KEY);
-  if (intent === undefined || now - intent.createdAt > DEFERRED_SAVE_TTL_MS) return { kind: "absent" };
-  return { kind: "claimed", intent };
+  const live = isLive(intent, now);
+  if (!removeForClaim(storage)) return live ? { kind: "failed" } : { kind: "absent" };
+  return live ? { kind: "claimed", intent } : { kind: "absent" };
 }
 
 export function clearDeferredSave(): void {
@@ -89,7 +102,7 @@ export function readDeferredSave(now: number = Date.now()): DeferredSaveIntent |
   const raw = withStore((storage) => storage.getItem(DEFERRED_SAVE_KEY));
   if (raw === null || raw === undefined) return undefined;
   const intent = parse(raw);
-  if (intent === undefined || now - intent.createdAt > DEFERRED_SAVE_TTL_MS) {
+  if (!isLive(intent, now)) {
     clearDeferredSave();
     return undefined;
   }
@@ -98,6 +111,7 @@ export function readDeferredSave(now: number = Date.now()): DeferredSaveIntent |
 
 /** Distinguish a safe claim from absence and storage failure. */
 export function takeDeferredSave(now: number = Date.now()): DeferredSaveClaim {
+  if (!("localStorage" in globalThis)) return { kind: "absent" };
   return withStore((storage) => takeFromStore(storage, now)) ?? { kind: "failed" };
 }
 

--- a/apps/web/src/features/chat/save/deferredSave.ts
+++ b/apps/web/src/features/chat/save/deferredSave.ts
@@ -52,6 +52,15 @@ function parse(raw: string): DeferredSaveIntent | undefined {
   }
 }
 
+function takeFromStore(storage: Storage, now: number): DeferredSaveIntent | undefined {
+  const raw = storage.getItem(DEFERRED_SAVE_KEY);
+  if (raw === null) return undefined;
+  const intent = parse(raw);
+  storage.removeItem(DEFERRED_SAVE_KEY);
+  if (intent === undefined || now - intent.createdAt > DEFERRED_SAVE_TTL_MS) return undefined;
+  return intent;
+}
+
 export function clearDeferredSave(): void {
   withStore((storage) => {
     storage.removeItem(DEFERRED_SAVE_KEY);
@@ -80,6 +89,11 @@ export function readDeferredSave(now: number = Date.now()): DeferredSaveIntent |
     return undefined;
   }
   return intent;
+}
+
+/** Consume a live intent only after its removal succeeds. */
+export function takeDeferredSave(now: number = Date.now()): DeferredSaveIntent | undefined {
+  return withStore((storage) => takeFromStore(storage, now));
 }
 
 /**

--- a/apps/web/src/features/chat/save/deferredSave.ts
+++ b/apps/web/src/features/chat/save/deferredSave.ts
@@ -24,6 +24,11 @@ export interface DeferredSaveIntent {
   readonly createdAt: number;
 }
 
+export type DeferredSaveClaim =
+  | { readonly kind: "absent" }
+  | { readonly kind: "claimed"; readonly intent: DeferredSaveIntent }
+  | { readonly kind: "failed" };
+
 /** SSR and privacy-locked browsers have no usable store; both read as "no intent". */
 function withStore<Result>(operation: (storage: Storage) => Result): Result | undefined {
   try {
@@ -52,13 +57,13 @@ function parse(raw: string): DeferredSaveIntent | undefined {
   }
 }
 
-function takeFromStore(storage: Storage, now: number): DeferredSaveIntent | undefined {
+function takeFromStore(storage: Storage, now: number): DeferredSaveClaim {
   const raw = storage.getItem(DEFERRED_SAVE_KEY);
-  if (raw === null) return undefined;
+  if (raw === null) return { kind: "absent" };
   const intent = parse(raw);
   storage.removeItem(DEFERRED_SAVE_KEY);
-  if (intent === undefined || now - intent.createdAt > DEFERRED_SAVE_TTL_MS) return undefined;
-  return intent;
+  if (intent === undefined || now - intent.createdAt > DEFERRED_SAVE_TTL_MS) return { kind: "absent" };
+  return { kind: "claimed", intent };
 }
 
 export function clearDeferredSave(): void {
@@ -91,9 +96,9 @@ export function readDeferredSave(now: number = Date.now()): DeferredSaveIntent |
   return intent;
 }
 
-/** Consume a live intent only after its removal succeeds. */
-export function takeDeferredSave(now: number = Date.now()): DeferredSaveIntent | undefined {
-  return withStore((storage) => takeFromStore(storage, now));
+/** Distinguish a safe claim from absence and storage failure. */
+export function takeDeferredSave(now: number = Date.now()): DeferredSaveClaim {
+  return withStore((storage) => takeFromStore(storage, now)) ?? { kind: "failed" };
 }
 
 /**

--- a/apps/web/src/features/chat/save/deferredSave.ts
+++ b/apps/web/src/features/chat/save/deferredSave.ts
@@ -24,10 +24,10 @@ export interface DeferredSaveIntent {
   readonly createdAt: number;
 }
 
-/** SSR and privacy-locked browsers have no store; both read as "no intent". */
-function store(): Storage | undefined {
+/** SSR and privacy-locked browsers have no usable store; both read as "no intent". */
+function withStore<Result>(operation: (storage: Storage) => Result): Result | undefined {
   try {
-    return globalThis.localStorage;
+    return operation(globalThis.localStorage);
   } catch {
     return undefined;
   }
@@ -53,7 +53,9 @@ function parse(raw: string): DeferredSaveIntent | undefined {
 }
 
 export function clearDeferredSave(): void {
-  store()?.removeItem(DEFERRED_SAVE_KEY);
+  withStore((storage) => {
+    storage.removeItem(DEFERRED_SAVE_KEY);
+  });
 }
 
 /** Stash the intent behind the login wall; `now` is injectable for tests. */
@@ -62,13 +64,15 @@ export function writeDeferredSave(
   now: number = Date.now(),
 ): void {
   const entry: DeferredSaveIntent = { pointIds: [...intent.pointIds], title: intent.title, createdAt: now };
-  store()?.setItem(DEFERRED_SAVE_KEY, JSON.stringify(entry));
+  withStore((storage) => {
+    storage.setItem(DEFERRED_SAVE_KEY, JSON.stringify(entry));
+  });
 }
 
 /** The live intent, or `undefined` — a missing, malformed or expired entry is
  * erased rather than left to accumulate on a shared device. */
 export function readDeferredSave(now: number = Date.now()): DeferredSaveIntent | undefined {
-  const raw = store()?.getItem(DEFERRED_SAVE_KEY);
+  const raw = withStore((storage) => storage.getItem(DEFERRED_SAVE_KEY));
   if (raw === null || raw === undefined) return undefined;
   const intent = parse(raw);
   if (intent === undefined || now - intent.createdAt > DEFERRED_SAVE_TTL_MS) {

--- a/apps/web/tests/unit/chat/deferred-save-storage-getter.test.ts
+++ b/apps/web/tests/unit/chat/deferred-save-storage-getter.test.ts
@@ -1,20 +1,65 @@
 /**
  * @vitest-environment jsdom
  */
-import { expect, it, vi } from "vitest";
+import { afterEach, assert, expect, it, vi } from "vitest";
+import {
+  DEFERRED_SAVE_KEY,
+  DEFERRED_SAVE_TTL_MS,
+  writeDeferredSave,
+} from "../../../src/features/chat/save/deferredSave";
 import { replayDeferredSave } from "../../../src/features/chat/save/createOnLogin";
 
-it("reports a failed replay when the localStorage getter is blocked", async () => {
+function localStorageDescriptor(): PropertyDescriptor {
   const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  assert(descriptor !== undefined, "jsdom localStorage descriptor is missing");
+  return descriptor;
+}
+
+const LOCAL_STORAGE_DESCRIPTOR = localStorageDescriptor();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(globalThis, "localStorage", LOCAL_STORAGE_DESCRIPTOR);
+  localStorage.clear();
+});
+
+it("reports a failed replay when the localStorage getter is blocked", async () => {
   const getter = vi.spyOn(globalThis, "localStorage", "get").mockImplementation(() => {
     throw new DOMException("blocked", "SecurityError");
   });
   const request = vi.fn();
-  try {
-    expect(await replayDeferredSave(request, 1_000)).toBe("failed");
-    expect(request).not.toHaveBeenCalled();
-  } finally {
-    getter.mockRestore();
-  }
-  expect(Object.getOwnPropertyDescriptor(globalThis, "localStorage")).toEqual(descriptor);
+  expect(await replayDeferredSave(request, 1_000)).toBe("failed");
+  expect(request).not.toHaveBeenCalled();
+  getter.mockRestore();
+  expect(Object.getOwnPropertyDescriptor(globalThis, "localStorage")).toEqual(LOCAL_STORAGE_DESCRIPTOR);
+  expect(() => globalThis.localStorage.getItem(DEFERRED_SAVE_KEY)).not.toThrow();
+});
+
+it("treats an SSR environment with no localStorage property as absent", async () => {
+  expect(Reflect.deleteProperty(globalThis, "localStorage")).toBe(true);
+  const request = vi.fn();
+  expect(await replayDeferredSave(request, 1_000)).toBe("none");
+  expect(request).not.toHaveBeenCalled();
+});
+
+it("treats malformed data as absent when best-effort cleanup is blocked", async () => {
+  localStorage.setItem(DEFERRED_SAVE_KEY, "{not json");
+  vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+    throw new DOMException("blocked", "SecurityError");
+  });
+  const request = vi.fn();
+  expect(await replayDeferredSave(request, 1_000)).toBe("none");
+  expect(request).not.toHaveBeenCalled();
+  expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBe("{not json");
+});
+
+it("treats expired data as absent when best-effort cleanup is blocked", async () => {
+  writeDeferredSave({ pointIds: ["p1"], title: "宇治" }, 1_000);
+  vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+    throw new DOMException("blocked", "SecurityError");
+  });
+  const request = vi.fn();
+  expect(await replayDeferredSave(request, 1_000 + DEFERRED_SAVE_TTL_MS + 1)).toBe("none");
+  expect(request).not.toHaveBeenCalled();
+  expect(localStorage.getItem(DEFERRED_SAVE_KEY)).not.toBeNull();
 });

--- a/apps/web/tests/unit/chat/deferred-save-storage-getter.test.ts
+++ b/apps/web/tests/unit/chat/deferred-save-storage-getter.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { expect, it, vi } from "vitest";
+import { replayDeferredSave } from "../../../src/features/chat/save/createOnLogin";
+
+it("reports a failed replay when the localStorage getter is blocked", async () => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  const getter = vi.spyOn(globalThis, "localStorage", "get").mockImplementation(() => {
+    throw new DOMException("blocked", "SecurityError");
+  });
+  const request = vi.fn();
+  try {
+    expect(await replayDeferredSave(request, 1_000)).toBe("failed");
+    expect(request).not.toHaveBeenCalled();
+  } finally {
+    getter.mockRestore();
+  }
+  expect(Object.getOwnPropertyDescriptor(globalThis, "localStorage")).toEqual(descriptor);
+});

--- a/apps/web/tests/unit/chat/deferred-save.test.ts
+++ b/apps/web/tests/unit/chat/deferred-save.test.ts
@@ -96,6 +96,16 @@ describe("S1 hardening: storage method failures degrade to no intent", () => {
     expect(clearDeferredSave).not.toThrow();
   });
 
+  it("does not replay a live intent when claiming it is blocked", async () => {
+    writeDeferredSave(INTENT, 1_000);
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    const request = vi.fn().mockResolvedValue({ id: "r1" });
+    expect(await replayDeferredSave(request, 1_100)).toBe("none");
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("returns no malformed intent when cleanup is blocked", () => {
     localStorage.setItem(DEFERRED_SAVE_KEY, "{not json");
     vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {

--- a/apps/web/tests/unit/chat/deferred-save.test.ts
+++ b/apps/web/tests/unit/chat/deferred-save.test.ts
@@ -12,6 +12,7 @@ import {
 import { replayDeferredSave } from "../../../src/features/chat/save/createOnLogin";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   localStorage.clear();
 });
 
@@ -68,6 +69,47 @@ describe("AC5: an intent older than the TTL is ignored and cleared", () => {
     writeDeferredSave(INTENT, 1_000);
     expect(readDeferredSave(1_000 + DEFERRED_SAVE_TTL_MS + 1)).toBeUndefined();
     expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
+  });
+});
+
+describe("S1 hardening: storage method failures degrade to no intent", () => {
+  it("does not throw when setItem is blocked at call time", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    expect(() => {
+      writeDeferredSave(INTENT, 1_000);
+    }).not.toThrow();
+  });
+
+  it("reads no intent when getItem is blocked at call time", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    expect(readDeferredSave(1_000)).toBeUndefined();
+  });
+
+  it("does not throw when removeItem is blocked at call time", () => {
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    expect(clearDeferredSave).not.toThrow();
+  });
+
+  it("returns no malformed intent when cleanup is blocked", () => {
+    localStorage.setItem(DEFERRED_SAVE_KEY, "{not json");
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    expect(readDeferredSave(1_000)).toBeUndefined();
+  });
+
+  it("returns no expired intent when cleanup is blocked", () => {
+    writeDeferredSave(INTENT, 1_000);
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    expect(readDeferredSave(1_000 + DEFERRED_SAVE_TTL_MS + 1)).toBeUndefined();
   });
 });
 

--- a/apps/web/tests/unit/chat/deferred-save.test.ts
+++ b/apps/web/tests/unit/chat/deferred-save.test.ts
@@ -40,9 +40,11 @@ describe("AC4: the deferred intent lives in namespaced localStorage", () => {
     expect(readDeferredSave(1_000)).toBeUndefined();
   });
 
-  it("treats a malformed entry as absent AND erases it", () => {
+  it("treats a malformed entry as absent AND erases it", async () => {
     localStorage.setItem(DEFERRED_SAVE_KEY, '{"pointIds":"nope"}');
-    expect(readDeferredSave(1_000)).toBeUndefined();
+    const request = vi.fn();
+    expect(await replayDeferredSave(request, 1_000)).toBe("none");
+    expect(request).not.toHaveBeenCalled();
     expect(localStorage.getItem(DEFERRED_SAVE_KEY)).toBeNull();
   });
 
@@ -72,7 +74,7 @@ describe("AC5: an intent older than the TTL is ignored and cleared", () => {
   });
 });
 
-describe("S1 hardening: storage method failures degrade to no intent", () => {
+describe("S1 hardening: storage method failures do not escape", () => {
   it("does not throw when setItem is blocked at call time", () => {
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new DOMException("blocked", "SecurityError");
@@ -82,11 +84,14 @@ describe("S1 hardening: storage method failures degrade to no intent", () => {
     }).not.toThrow();
   });
 
-  it("reads no intent when getItem is blocked at call time", () => {
+  it("reads no intent but reports a failed claim when getItem is blocked", async () => {
     vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
       throw new DOMException("blocked", "SecurityError");
     });
     expect(readDeferredSave(1_000)).toBeUndefined();
+    const request = vi.fn();
+    expect(await replayDeferredSave(request, 1_000)).toBe("failed");
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("does not throw when removeItem is blocked at call time", () => {
@@ -102,7 +107,7 @@ describe("S1 hardening: storage method failures degrade to no intent", () => {
       throw new DOMException("blocked", "SecurityError");
     });
     const request = vi.fn().mockResolvedValue({ id: "r1" });
-    expect(await replayDeferredSave(request, 1_100)).toBe("none");
+    expect(await replayDeferredSave(request, 1_100)).toBe("failed");
     expect(request).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- guard both localStorage acquisition and get/set/remove calls without changing non-destructive reads
- model deferred replay as absent, claimed, or failed so a live intent is sent only after successful removal
- report blocked storage as failed, never silently as none, and keep malformed/expired cleanup best-effort
- add mutation coverage for a throwing localStorage property getter and method-level DOMException failures

## Verification
- 46 focused unit/integration checks passed in final independent review
- apps/web type-aware oxlint and typecheck passed
- earlier single-worker full web suite: 1581/1581 tests, coverage above all ratchets, production build passed
- independent final review: PASS

Refs #535 (sub-item 2/5). The parent issue remains open until this final sub-item is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving deferred chat actions after login.
  * Prevented duplicate replay attempts by safely claiming saved actions before processing.
  * Restored deferred actions when replay requests fail.
  * Added safer handling for unavailable, expired, malformed, or inaccessible browser storage.

* **Tests**
  * Expanded coverage for storage failures, cleanup behavior, expiration, malformed entries, and failed replay requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->