### PR TITLE
fix(web): expose clarify option data states

### DIFF
--- a/apps/web/src/features/chat/components/ClarifyCard.tsx
+++ b/apps/web/src/features/chat/components/ClarifyCard.tsx
@@ -17,6 +17,7 @@ type Phase =
   | { readonly kind: "open" }
   | { readonly kind: "chosen"; readonly id: string }
   | { readonly kind: "rephrase" };
+type OptionState = "available" | "selected" | "unselected" | "dismissed";
 
 function reasonOf(part: ChatDataPart): string | undefined {
   const data = part.data;
@@ -27,10 +28,15 @@ function candidateKey(candidate: Candidate): string {
   return candidate.id ?? candidate.title ?? "";
 }
 
+function optionState(phase: Phase, key: string): OptionState {
+  if (phase.kind === "open") return "available";
+  if (phase.kind === "rephrase") return "dismissed";
+  return phase.id === key ? "selected" : "unselected";
+}
+
 function optionClass(phase: Phase, key: string): string {
-  const faded =
-    phase.kind === "rephrase" || (phase.kind === "chosen" && phase.id !== key);
-  return faded ? "chat-clarify__option chat-clarify__option--faded" : "chat-clarify__option";
+  const state = optionState(phase, key);
+  return state === "selected" || state === "available" ? "chat-clarify__option" : "chat-clarify__option chat-clarify__option--faded";
 }
 
 type OptionProps = Readonly<{
@@ -43,7 +49,7 @@ function CandidateOption({ candidate, phase, onChoose }: OptionProps) {
   const key = candidateKey(candidate);
   return (
     <li>
-      <button type="button" className={optionClass(phase, key)} disabled={phase.kind !== "open"} onClick={() => { onChoose(candidate); }}>
+      <button type="button" className={optionClass(phase, key)} data-state={optionState(phase, key)} disabled={phase.kind !== "open"} onClick={() => { onChoose(candidate); }}>
         {candidate.title}
       </button>
     </li>

--- a/apps/web/tests/unit/chat/clarify-card.test.tsx
+++ b/apps/web/tests/unit/chat/clarify-card.test.tsx
@@ -23,13 +23,21 @@ const FIVE_CANDIDATES = [
   { id: "5", title: "劇場版 響け!" },
 ];
 
-function renderClarify(data: Record<string, unknown>, send = vi.fn()) {
-  render(
-    <ChatActionsProvider actions={{ send, regenerate: vi.fn() }}>
+function clarifyElement(data: Record<string, unknown>, send = vi.fn(), cardKey = "clarify") {
+  return (
+    <ChatActionsProvider key={cardKey} actions={{ send, regenerate: vi.fn() }}>
       <DataPartCard data={{ intent: "clarify", data }} dict={dict} />
-    </ChatActionsProvider>,
+    </ChatActionsProvider>
   );
+}
+
+function renderClarify(data: Record<string, unknown>, send = vi.fn()) {
+  render(clarifyElement(data, send));
   return send;
+}
+
+function optionState(name: string): string | null {
+  return screen.getByRole("button", { name }).getAttribute("data-state");
 }
 
 describe("ClarifyCard (C2, AC1)", () => {
@@ -40,24 +48,32 @@ describe("ClarifyCard (C2, AC1)", () => {
     expect(screen.getByRole("button", { name: dict.clarify.escapeHatch })).toBeTruthy();
   });
 
-  it("sends the chosen candidate and fades the rest", () => {
+  it("marks each initial candidate as available", () => {
+    renderClarify({ candidates: FIVE_CANDIDATES.slice(0, 2) });
+    expect(optionState("響け!ユーフォニアム")).toBe("available");
+    expect(optionState("響け!ユーフォニアム2")).toBe("available");
+  });
+
+  it("marks the chosen candidate selected and the rest unselected", () => {
     const send = renderClarify({ candidates: FIVE_CANDIDATES.slice(0, 4) });
     fireEvent.click(screen.getByRole("button", { name: "リズと青い鳥" }));
     expect(send).toHaveBeenCalledWith("リズと青い鳥");
-    const chosen = screen.getByRole("button", { name: "リズと青い鳥" });
-    expect(chosen.className).not.toContain("--faded");
+    expect(optionState("リズと青い鳥")).toBe("selected");
     const other = screen.getByRole("button", { name: "響け!ユーフォニアム" });
-    expect(other.className).toContain("chat-clarify__option--faded");
+    expect(optionState("響け!ユーフォニアム")).toBe("unselected");
     expect(other.hasAttribute("disabled")).toBe(true);
   });
 
-  it("escape hatch fades everything and invites a rephrase without sending", () => {
-    const send = renderClarify({ candidates: FIVE_CANDIDATES.slice(0, 2) });
+  it("dismisses candidates for rephrase and resets a newly keyed card", () => {
+    const data = { candidates: FIVE_CANDIDATES.slice(0, 2) };
+    const send = vi.fn();
+    const view = render(clarifyElement(data, send, "message-1:data-response:0"));
     fireEvent.click(screen.getByRole("button", { name: dict.clarify.escapeHatch }));
     expect(send).not.toHaveBeenCalled();
     expect(screen.getByText(dict.clarify.rephraseHint)).toBeTruthy();
-    const option = screen.getByRole("button", { name: "響け!ユーフォニアム" });
-    expect(option.className).toContain("chat-clarify__option--faded");
+    expect(optionState("響け!ユーフォニアム")).toBe("dismissed");
+    view.rerender(clarifyElement(data, send, "message-2:data-response:0"));
+    expect(optionState("響け!ユーフォニアム")).toBe("available");
   });
 });
 


### PR DESCRIPTION
## Summary
- expose semantic data-state values for clarify candidates: available, selected, unselected, dismissed
- derive DOM state and existing fade styling from one phase-to-state function
- pin production-style keyed remount so a new clarification card resets to available

## Validation
- TDD red: 3 of 7 focused tests failed before the data-state implementation
- focused ClarifyCard tests: 7/7 passed
- TypeScript typecheck passed
- type-aware oxlint with deny-warnings passed
- production Vite/Nitro build passed
- independent P0-P2 review: PASS
- diff check clean; only ClarifyCard and its unit test changed

Refs #446. This resolves only the ClarifyCard data-state subitem; it does not close the broader photo-search issue.