### PR TITLE
fix(ci): upgrade all setup-uv calls with cache pruning

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,4 +17,6 @@ runs:
     - run: pnpm install --frozen-lockfile
       shell: bash
     - if: inputs.python == 'true'
-      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      with:
+        prune-cache: "true"

--- a/.github/scripts/test_dependabot_config.py
+++ b/.github/scripts/test_dependabot_config.py
@@ -13,6 +13,15 @@ GATE_STEP_ORDER = (
     "- name: Backend quality + tests",
     "- name: Web + worker quality",
 )
+SETUP_UV_RE = re.compile(r"^\s*(?:-\s+)?uses:\s*astral-sh/setup-uv@")
+SETUP_UV_PIN_RE = re.compile(
+    r"^\s*(?:-\s+)?uses:\s*astral-sh/setup-uv@([0-9a-f]{40})\s+#\s+(v\d+\.\d+\.\d+)\s*$"
+)
+PRUNE_CACHE_RE = re.compile(
+    r'^\s*prune-cache:\s*["\']?(true|false)["\']?\s*(?:#.*)?$'
+)
+SETUP_UV_SHA = "c771a70e6277c0a99b617c7a806ffedaca235ff9"
+SETUP_UV_VERSION = "v9.0.0"
 
 
 def ecosystem_blocks(name: str) -> list[str]:
@@ -47,6 +56,77 @@ def gate_step_positions() -> list[int]:
     return [workflow.index(marker) for marker in GATE_STEP_ORDER]
 
 
+def tracked_yaml_paths() -> list[Path]:
+    output = subprocess.check_output(
+        ["git", "ls-files", "-z", "--", "*.yml", "*.yaml"], cwd=REPO_ROOT
+    )
+    names = (name for name in output.decode("utf-8").split("\0") if name)
+    return [REPO_ROOT / name for name in names]
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def step_indent(lines: list[str], index: int) -> int:
+    if lines[index].lstrip().startswith("- "):
+        return indent_of(lines[index])
+    for previous in reversed(lines[:index]):
+        if previous.lstrip().startswith("- "):
+            return indent_of(previous)
+    raise AssertionError("setup-uv call is not inside a YAML step")
+
+
+def setup_uv_block(lines: list[str], index: int) -> list[str]:
+    parent_indent = step_indent(lines, index)
+    for end, line in enumerate(lines[index + 1 :], index + 1):
+        is_next_step = line.lstrip().startswith("- ")
+        if line.strip() and indent_of(line) <= parent_indent and is_next_step:
+            return lines[index:end]
+    return lines[index:]
+
+
+def prune_cache_values(block: list[str]) -> list[str]:
+    values: list[str] = []
+    for index, line in enumerate(block):
+        if line.strip() != "with:":
+            continue
+        with_indent = indent_of(line)
+        for candidate in block[index + 1 :]:
+            if candidate.strip() and indent_of(candidate) <= with_indent:
+                break
+            match = PRUNE_CACHE_RE.match(candidate)
+            if match:
+                values.append(match.group(1))
+    return values
+
+
+def setup_uv_pin_failure(line: str, location: str) -> str | None:
+    pin = SETUP_UV_PIN_RE.match(line)
+    if pin is None or pin.groups() != (SETUP_UV_SHA, SETUP_UV_VERSION):
+        return f"{location}: pin must be {SETUP_UV_SHA} ({SETUP_UV_VERSION})"
+    return None
+
+
+def setup_uv_call_failures(path: Path, lines: list[str], index: int) -> list[str]:
+    location = f"{path.relative_to(REPO_ROOT)}:{index + 1}"
+    pin_failure = setup_uv_pin_failure(lines[index], location)
+    failures = [pin_failure] if pin_failure else []
+    if prune_cache_values(setup_uv_block(lines, index)) != ["true"]:
+        failures.append(f"{location}: prune-cache must be true")
+    return failures
+
+
+def setup_uv_config_failures() -> list[str]:
+    failures: list[str] = []
+    for path in tracked_yaml_paths():
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if SETUP_UV_RE.match(line):
+                failures.extend(setup_uv_call_failures(path, lines, index))
+    return failures
+
+
 class DependabotConfigTest(unittest.TestCase):
     def test_npm_updates_cover_all_pnpm_lockfile_domains(self) -> None:
         npm_blocks = ecosystem_blocks("npm")
@@ -60,6 +140,9 @@ class DependabotWorkflowTest(unittest.TestCase):
     def test_node_dependencies_precede_cross_language_backend_tests(self) -> None:
         positions = gate_step_positions()
         self.assertEqual(positions, sorted(positions))
+
+    def test_every_setup_uv_call_explicitly_prunes_cache(self) -> None:
+        self.assertEqual(setup_uv_config_failures(), [])
 
 
 if __name__ == "__main__":

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -38,9 +38,10 @@ jobs:
           test ! -d frontend
 
       # ── Python setup ──
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "latest"
+          prune-cache: "true"
 
       - run: uv python install ${{ env.PYTHON_VERSION }}
 


### PR DESCRIPTION
## Summary

**Replaces #616.**

- upgrade both tracked `astral-sh/setup-uv` call sites to v9.0.0
- verify the official tag SHA `c771a70e6277c0a99b617c7a806ffedaca235ff9`
- explicitly set `prune-cache: "true"` at every call site
- add a config-as-data test that scans tracked YAML and fails on missing pruning or a mismatched pin

## Verification

- `python3 .github/scripts/test_dependabot_config.py` (3 tests passed)
- `actionlint .github/workflows/dependabot-agent.yml` (passed)
- Ruby YAML parse for both action/workflow files (passed)
- `git diff --check` (passed)
- `make check` attempted; blocked before lint completion because uv could not download `tqdm==4.68.4` through the local proxy (`Operation not permitted`).

## Follow-up

Dependabot dynamic run 30703505153 separately reports `dependency_file_not_found` (`No files found in /`) in the root uv security job. That root-directory issue is intentionally not mixed into this replacement. Keep #616 open until this PR is reviewed and merged; close it only after linking this replacement and its evidence.