### PR TITLE
fix(web): remove direct hookable dependency (replaces #604)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,7 +45,6 @@
     "@vitejs/plugin-react": "^6.0.4",
     "@vitest/coverage-istanbul": "4.1.10",
     "h3": "^1.15.11",
-    "hookable": "^5.5.3",
     "jsdom": "^29.1.1",
     "jsonc-parser": "^3.3.1",
     "msw": "2.15.0",

--- a/apps/web/src/server/noindex-plugin.ts
+++ b/apps/web/src/server/noindex-plugin.ts
@@ -34,11 +34,11 @@ function applyNoindexHeader(event: H3Event): void {
   setResponseHeader(event, "X-Robots-Tag", "noindex, nofollow");
 }
 
-type NoindexHookHost = {
+interface NoindexHookHost {
   hooks: {
     hook: (name: "beforeResponse", callback: NitroRuntimeHooks["beforeResponse"]) => unknown;
   };
-};
+}
 
 export function registerNoindexHook(nitroApp: NoindexHookHost): void {
   nitroApp.hooks.hook("beforeResponse", applyNoindexHeader);

--- a/apps/web/src/server/noindex-plugin.ts
+++ b/apps/web/src/server/noindex-plugin.ts
@@ -1,5 +1,5 @@
 import { type H3Event, setResponseHeader } from "h3";
-import type { NitroApp, NitroAppPlugin } from "nitropack/types";
+import type { NitroAppPlugin, NitroRuntimeHooks } from "nitropack/types";
 
 // Nitro runtime plugin: staging/preview must never become the canonical site
 // while animichi.com has no DNS (issue #538), so every response from a
@@ -34,7 +34,13 @@ function applyNoindexHeader(event: H3Event): void {
   setResponseHeader(event, "X-Robots-Tag", "noindex, nofollow");
 }
 
-export function registerNoindexHook(nitroApp: Pick<NitroApp, "hooks">): void {
+type NoindexHookHost = {
+  hooks: {
+    hook: (name: "beforeResponse", callback: NitroRuntimeHooks["beforeResponse"]) => unknown;
+  };
+};
+
+export function registerNoindexHook(nitroApp: NoindexHookHost): void {
   nitroApp.hooks.hook("beforeResponse", applyNoindexHeader);
 }
 

--- a/apps/web/tests/unit/noindex-header.test.ts
+++ b/apps/web/tests/unit/noindex-header.test.ts
@@ -1,16 +1,36 @@
 import { createApp, createRouter, defineEventHandler, setResponseStatus, toWebHandler } from "h3";
-import { createHooks } from "hookable";
 import type { NitroRuntimeHooks } from "nitropack/types";
 import { describe, expect, it } from "vitest";
 import noindexPlugin, { registerNoindexHook } from "../../src/server/noindex-plugin";
 
 type WorkerEnv = Record<string, string>;
 
+type BeforeResponseHook = NitroRuntimeHooks["beforeResponse"];
+
+type TestHooks = {
+  hook: (name: "beforeResponse", callback: BeforeResponseHook) => void;
+  callHook: (
+    name: "beforeResponse",
+    event: Parameters<BeforeResponseHook>[0],
+    response: Parameters<BeforeResponseHook>[1],
+  ) => Promise<void>;
+};
+
+function createTestHooks(): TestHooks {
+  const handlers: BeforeResponseHook[] = [];
+  return {
+    hook: (_name, callback) => handlers.push(callback),
+    callHook: async (_name, event, response) => {
+      for (const handler of handlers) await handler(event, response);
+    },
+  };
+}
+
 // Mirrors the wiring nitropack 2.13.4 uses in dist/runtime/internal/app.mjs:
 // plugins register on nitroApp.hooks, and the h3 app's onBeforeResponse calls
 // hooks.callHook("beforeResponse", event, response) for every response.
 function buildHandler(cloudflare?: Record<string, unknown>): (request: Request) => Promise<Response> {
-  const hooks = createHooks<NitroRuntimeHooks>();
+  const hooks = createTestHooks();
   registerNoindexHook({ hooks });
   const app = createApp({
     onRequest: (event) => {

--- a/apps/web/tests/unit/noindex-header.test.ts
+++ b/apps/web/tests/unit/noindex-header.test.ts
@@ -7,14 +7,14 @@ type WorkerEnv = Record<string, string>;
 
 type BeforeResponseHook = NitroRuntimeHooks["beforeResponse"];
 
-type TestHooks = {
+interface TestHooks {
   hook: (name: "beforeResponse", callback: BeforeResponseHook) => void;
   callHook: (
     name: "beforeResponse",
     event: Parameters<BeforeResponseHook>[0],
     response: Parameters<BeforeResponseHook>[1],
   ) => Promise<void>;
-};
+}
 
 function createTestHooks(): TestHooks {
   const handlers: BeforeResponseHook[] = [];

--- a/apps/web/tests/unit/noindex-header.test.ts
+++ b/apps/web/tests/unit/noindex-header.test.ts
@@ -21,7 +21,7 @@ function createTestHooks(): TestHooks {
   return {
     hook: (_name, callback) => handlers.push(callback),
     callHook: async (_name, event, response) => {
-      for (const handler of handlers) await handler(event, response);
+      for (const handler of [...handlers]) await handler(event, response);
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,6 @@ importers:
       h3:
         specifier: ^1.15.11
         version: 1.15.11
-      hookable:
-        specifier: ^5.5.3
-        version: 5.5.3
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)


### PR DESCRIPTION
## Replacement for #604

Closes the scope of [#604](https://github.com/lifeodyssey/animichi/pull/604) after rebasing onto `origin/main` at `cbe9fbae`.

### Caller inventory

- `apps/web/src/**`: no runtime import or reference to `hookable`.
- `apps/web/tests/unit/noindex-header.test.ts`: the sole explicit caller, using `createHooks` only to exercise `registerNoindexHook`.
- `nitropack@2.13.4` retains `hookable@5.5.3` as a production transitive dependency. Its lockfile package/snapshot entries are intentionally retained; this PR removes only the direct web declaration and importer entry.

### Changes

- Remove the direct `apps/web` devDependency and its importer entry.
- Replace the test-only hookable instance with a minimal collector whose callback type is exactly `NitroRuntimeHooks["beforeResponse"]`.
- Narrow `registerNoindexHook` to the hook capability it consumes; the runtime Nitro hook contract and emitted behavior are unchanged.

### Evidence

- `pnpm install --frozen-lockfile --lockfile-only`: passed (lockfile up to date).
- `pnpm --filter web typecheck`: passed.
- `pnpm --filter web run lint:oxlint`: passed.
- `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web exec vitest run --config vitest.config.ts tests/unit/noindex-header.test.ts`: 10/10 passed.
- `pnpm --filter web build`: passed.
- `git diff --check` and staged Gitleaks scan: passed.
- Full web integration suite remains red on existing environment assumptions (`localStorage` is undefined in Node integration setup: 12 failures); unrelated chat tests also timed out/failed in the full Vitest run. These are recorded blockers, not reported as green.
- The temporary clone was used for all edits; the root worktree has no tracked or untracked changes from this PR. A local dependency-install attempt briefly recreated the root `node_modules` directory before being stopped; no repository files were changed and no node_modules content is committed.

Do not merge until CI and review conversations are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an internal development dependency from the web application.
  * Simplified server response-hook integration and associated test infrastructure.
* **Bug Fixes**
  * Improved compatibility and type safety for response processing without changing expected behavior.
* **Tests**
  * Updated automated coverage to use a lightweight local hook implementation while preserving existing response handling checks.
* **User Impact**
  * No visible changes to the application experience are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->