### PR TITLE
fix(web): retain MapLibre v5 with lifecycle adapter (replaces #601)

### DIFF
--- a/.github/workflows/_webapp-ci.yml
+++ b/.github/workflows/_webapp-ci.yml
@@ -48,5 +48,5 @@ jobs:
           pnpm --filter web exec wrangler dev --port 8799 &
           WRANGLER_PID=$!
           for _ in $(seq 1 60); do curl -sf -o /dev/null http://localhost:8799/ && break; sleep 1; done
-          E2E_WEB_BASE_URL=http://localhost:8799 pnpm --dir e2e exec playwright test web-404.spec.ts
+          E2E_WEB_BASE_URL=http://localhost:8799 pnpm --dir e2e exec playwright test web-404.spec.ts web-maplibre-canary.spec.ts
           kill "$WRANGLER_PID"

--- a/apps/web/src/features/bubble-map/bubbleMapController.ts
+++ b/apps/web/src/features/bubble-map/bubbleMapController.ts
@@ -59,12 +59,7 @@ export const mountBasemap = async (options: MountBasemapOptions): Promise<Bubble
 };
 
 export const attachBasemap = (options: MountBasemapOptions): (() => void) => {
-  try {
-    return attachMapLibre(mountOptions(options));
-  } catch {
-    options.onStatus("fallback");
-    return () => { /* Mount failed before a handle was allocated. */ };
-  }
+  return attachMapLibre(mountOptions(options));
 };
 
 const circlePoints = (circles: readonly AnimeOverviewCircle[]): readonly LatLng[] => {

--- a/apps/web/src/features/bubble-map/bubbleMapController.ts
+++ b/apps/web/src/features/bubble-map/bubbleMapController.ts
@@ -1,6 +1,7 @@
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { AnimeOverviewCircle, LatLng } from "@animichi/contract";
 import type { LngLatBoundsLike, Map as MapLibreMap } from "maplibre-gl";
+import { attachMapLibre, mountMapLibre, type MapLibreHandle } from "../maplibre/maplibreAdapter";
 import { createMapStyle } from "../map-spike/mapStyle";
 
 export type BasemapStatus = "loading" | "ready" | "fallback";
@@ -20,16 +21,7 @@ export type MountBubbleMapOptions = Readonly<{
   onStatus: (status: BasemapStatus) => void;
 }>;
 
-export type BubbleMapHandle = Readonly<{ destroy: () => void }>;
-
-let protocolReady = false;
-
-const registerProtocol = async (gl: typeof import("maplibre-gl")): Promise<void> => {
-  if (protocolReady) return;
-  const { Protocol } = await import("pmtiles");
-  gl.addProtocol("pmtiles", new Protocol({ metadata: true }).tile);
-  protocolReady = true;
-};
+export type BubbleMapHandle = MapLibreHandle;
 
 const pointsBounds = (points: readonly LatLng[]): LngLatBoundsLike => {
   const lngs = points.map((point) => point.lng);
@@ -46,61 +38,33 @@ const fitToPoints = (map: MapLibreMap, points: readonly LatLng[]): void => {
   map.fitBounds(pointsBounds(points), { padding: 64, maxZoom: 12, animate: false });
 };
 
-const createMap = (gl: typeof import("maplibre-gl"), options: MountBasemapOptions): MapLibreMap => {
-  return new gl.Map({
-    container: options.container,
-    style: createMapStyle("pmtiles"),
-    interactive: options.interactive ?? true,
-    attributionControl: { compact: true },
-  });
-};
-
-const onMapLoad = (map: MapLibreMap, options: MountBasemapOptions): void => {
+const onBasemapLoad = (options: MountBasemapOptions, map: MapLibreMap): (() => void) | undefined => {
   fitToPoints(map, options.points);
   options.onStatus("ready");
+  return undefined;
 };
 
-const wireEvents = (map: MapLibreMap, options: MountBasemapOptions): void => {
-  map.on("load", () => { onMapLoad(map, options); });
-  map.on("error", () => { options.onStatus("fallback"); });
-};
+const mountOptions = (options: MountBasemapOptions) => ({
+  attributionControl: { compact: true },
+  container: options.container,
+  interactive: options.interactive ?? true,
+  onError: () => { options.onStatus("fallback"); },
+  onLoad: ({ map }: { map: MapLibreMap }) => onBasemapLoad(options, map),
+  registerPmtiles: true,
+  style: createMapStyle("pmtiles"),
+});
 
 export const mountBasemap = async (options: MountBasemapOptions): Promise<BubbleMapHandle> => {
-  const gl = await import("maplibre-gl");
-  await registerProtocol(gl);
-  const map = createMap(gl, options);
-  wireEvents(map, options);
-  return { destroy: () => { map.remove(); } };
+  return mountMapLibre(mountOptions(options));
 };
 
-interface Attachment {
-  handle: BubbleMapHandle | null;
-  active: boolean;
-}
-
-const storeHandle = (attachment: Attachment, handle: BubbleMapHandle): void => {
-  if (!attachment.active) {
-    handle.destroy();
-    return;
-  }
-  attachment.handle = handle;
-};
-
-// A failed mount (no WebGL context, import failure) degrades like a tile failure.
-const reportMountFailure = (attachment: Attachment, options: MountBasemapOptions): void => {
-  if (attachment.active) options.onStatus("fallback");
-};
-
-// Bridges the async mount into React's synchronous effect-cleanup contract.
 export const attachBasemap = (options: MountBasemapOptions): (() => void) => {
-  const attachment: Attachment = { handle: null, active: true };
-  void mountBasemap(options)
-    .then((handle) => { storeHandle(attachment, handle); })
-    .catch(() => { reportMountFailure(attachment, options); });
-  return () => {
-    attachment.active = false;
-    attachment.handle?.destroy();
-  };
+  try {
+    return attachMapLibre(mountOptions(options));
+  } catch {
+    options.onStatus("fallback");
+    return () => { /* Mount failed before a handle was allocated. */ };
+  }
 };
 
 const circlePoints = (circles: readonly AnimeOverviewCircle[]): readonly LatLng[] => {

--- a/apps/web/src/features/map-spike/mapController.ts
+++ b/apps/web/src/features/map-spike/mapController.ts
@@ -1,5 +1,6 @@
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { Map as MapLibreMap, Marker } from "maplibre-gl";
+import { attachMapLibre, mountMapLibre, type MapLibreHandle, type MapLibreModule } from "../maplibre/maplibreAdapter";
 import { createMapStyle } from "./mapStyle";
 import { routeLayer, ROUTE_SOURCE_ID, routeSource } from "./mapLayers";
 import { pinLabel } from "./pins";
@@ -13,18 +14,7 @@ export type MountOptions = Readonly<{
   onStatus: (status: MapStatus) => void;
 }>;
 
-export type MapHandle = Readonly<{ destroy: () => void }>;
-
-let protocolReady = false;
-
-const registerProtocol = async (gl: typeof import("maplibre-gl")): Promise<void> => {
-  if (protocolReady) {
-    return;
-  }
-  const { Protocol } = await import("pmtiles");
-  gl.addProtocol("pmtiles", new Protocol({ metadata: true }).tile);
-  protocolReady = true;
-};
+export type MapHandle = MapLibreHandle;
 
 const markerElement = (spot: Spot, index: number): HTMLElement => {
   const element = document.createElement("div");
@@ -36,69 +26,85 @@ const markerElement = (spot: Spot, index: number): HTMLElement => {
 
 const addRoute = (map: MapLibreMap): void => {
   map.addSource(ROUTE_SOURCE_ID, routeSource());
-  map.addLayer(routeLayer());
+  try {
+    map.addLayer(routeLayer());
+  } catch (error) {
+    map.removeSource(ROUTE_SOURCE_ID);
+    throw error;
+  }
 };
 
-const addMarkers = (gl: typeof import("maplibre-gl"), map: MapLibreMap): Marker[] => {
-  return SPOTS.map((spot, index) =>
-    new gl.Marker({ element: markerElement(spot, index), anchor: "bottom" })
-      .setLngLat([...spot.coord])
-      .addTo(map),
-  );
+const addMarker = (gl: MapLibreModule, map: MapLibreMap, spot: Spot, index: number): Marker => {
+  return new gl.Marker({ element: markerElement(spot, index), anchor: "bottom" }).setLngLat([...spot.coord]).addTo(map);
 };
 
-const createMap = (gl: typeof import("maplibre-gl"), options: MountOptions): MapLibreMap => {
-  return new gl.Map({
-    container: options.container,
-    style: createMapStyle(options.mode),
-    center: [...UJI_CENTER],
-    zoom: UJI_ZOOM,
-    attributionControl: { compact: true },
-  });
+const addMarkers = (gl: MapLibreModule, map: MapLibreMap): Marker[] => {
+  const markers: Marker[] = [];
+  try {
+    SPOTS.forEach((spot, index) => { markers.push(addMarker(gl, map, spot, index)); });
+  } catch (error) {
+    markers.forEach((marker) => marker.remove());
+    throw error;
+  }
+  return markers;
 };
 
-const onMapLoad = (gl: typeof import("maplibre-gl"), map: MapLibreMap, onStatus: MountOptions["onStatus"]): void => {
+const mapStyle = (options: MountOptions) => createMapStyle(options.mode);
+
+const cleanupMap = (map: MapLibreMap, markers: readonly Marker[]): void => {
+  markers.forEach((marker) => marker.remove());
+  if (map.getLayer(ROUTE_SOURCE_ID)) map.removeLayer(ROUTE_SOURCE_ID);
+  if (map.getSource(ROUTE_SOURCE_ID)) map.removeSource(ROUTE_SOURCE_ID);
+};
+
+const loadMarkers = (options: MountOptions, gl: MapLibreModule, map: MapLibreMap): Marker[] => {
+  let markers: Marker[] = [];
+  try {
+    markers = addMarkers(gl, map);
+    options.onStatus("ready");
+    return markers;
+  } catch (error) {
+    return cleanupAndThrow(map, markers, error);
+  }
+};
+
+const cleanupAndThrow = (map: MapLibreMap, markers: readonly Marker[], error: unknown): never => {
+  cleanupMap(map, markers);
+  throw error;
+};
+
+const loadMap = (options: MountOptions, gl: MapLibreModule, map: MapLibreMap): (() => void) => {
   addRoute(map);
-  addMarkers(gl, map);
-  onStatus("ready");
+  const markers = loadMarkers(options, gl, map);
+  return () => { cleanupMap(map, markers); };
 };
 
-const wireEvents = (gl: typeof import("maplibre-gl"), map: MapLibreMap, options: MountOptions): void => {
-  map.on("load", () => { onMapLoad(gl, map, options.onStatus); });
-  map.on("error", () => { options.onStatus("fallback"); });
-};
+const cameraOptions = () => ({
+  center: { lng: UJI_CENTER[0], lat: UJI_CENTER[1] },
+  zoom: UJI_ZOOM,
+});
 
-const buildHandle = (map: MapLibreMap): MapHandle => ({ destroy: () => { map.remove(); } });
+const mountOptions = (options: MountOptions) => ({
+  ...cameraOptions(),
+  attributionControl: { compact: true },
+  container: options.container,
+  interactive: true,
+  onError: () => { options.onStatus("fallback"); },
+  onLoad: ({ gl, map }: { gl: MapLibreModule; map: MapLibreMap }) => loadMap(options, gl, map),
+  registerPmtiles: options.mode === "pmtiles",
+  style: mapStyle(options),
+});
 
 export const mountMapSpike = async (options: MountOptions): Promise<MapHandle> => {
-  const gl = await import("maplibre-gl");
-  await registerProtocol(gl);
-  const map = createMap(gl, options);
-  wireEvents(gl, map, options);
-  return buildHandle(map);
+  const setup = mountOptions(options);
+  return mountMapLibre(setup);
 };
 
-interface Attachment {
-  handle: MapHandle | null;
-  active: boolean;
-}
-
-const storeHandle = (attachment: Attachment, handle: MapHandle): void => {
-  if (!attachment.active) {
-    handle.destroy();
-    return;
-  }
-  attachment.handle = handle;
-};
-
-// Bridges the async mount into React's synchronous effect-cleanup contract.
 export const attachMapSpike = (options: MountOptions): (() => void) => {
-  const attachment: Attachment = { handle: null, active: true };
-  void mountMapSpike(options).then((handle) => {
-    storeHandle(attachment, handle);
-  });
-  return () => {
-    attachment.active = false;
-    attachment.handle?.destroy();
-  };
+  try {
+    return attachMapLibre(mountOptions(options));
+  } catch {
+    options.onStatus("fallback");
+    return () => { /* Mount failed before a handle was allocated. */ };
+  }
 };

--- a/apps/web/src/features/map-spike/mapController.ts
+++ b/apps/web/src/features/map-spike/mapController.ts
@@ -101,10 +101,5 @@ export const mountMapSpike = async (options: MountOptions): Promise<MapHandle> =
 };
 
 export const attachMapSpike = (options: MountOptions): (() => void) => {
-  try {
-    return attachMapLibre(mountOptions(options));
-  } catch {
-    options.onStatus("fallback");
-    return () => { /* Mount failed before a handle was allocated. */ };
-  }
+  return attachMapLibre(mountOptions(options));
 };

--- a/apps/web/src/features/maplibre/maplibreAdapter.ts
+++ b/apps/web/src/features/maplibre/maplibreAdapter.ts
@@ -1,0 +1,269 @@
+import type { Map as MapLibreMap, MapOptions, StyleSpecification } from "maplibre-gl";
+
+export type MapLibreModule = typeof import("maplibre-gl");
+
+export type MapLibreMountContext = Readonly<{
+  gl: MapLibreModule;
+  map: MapLibreMap;
+}>;
+
+export type MapLibreMountOptions = Readonly<{
+  attributionControl?: MapOptions["attributionControl"];
+  center?: MapOptions["center"];
+  container: HTMLElement;
+  interactive?: boolean;
+  onError: () => void;
+  onLoad?: (context: MapLibreMountContext) => (() => void) | undefined;
+  onReady?: () => void;
+  registerPmtiles?: boolean;
+  style: StyleSpecification;
+  zoom?: MapOptions["zoom"];
+}>;
+
+export type MapLibreHandle = Readonly<{
+  destroy: () => void;
+  map: MapLibreMap;
+}>;
+
+interface ProtocolRegistration {
+  gl: MapLibreModule;
+  users: number;
+}
+
+let protocolRegistration: ProtocolRegistration | null = null;
+let protocolRegistrationPromise: Promise<ProtocolRegistration> | null = null;
+
+const releaseProtocol = (registration: ProtocolRegistration): void => {
+  if (registration.users > 0) registration.users -= 1;
+  if (registration.users !== 0 || protocolRegistration !== registration) return;
+  try {
+    if (typeof registration.gl.removeProtocol === "function") registration.gl.removeProtocol("pmtiles");
+  } finally {
+    protocolRegistration = null;
+  }
+};
+
+const leaseProtocol = (registration: ProtocolRegistration): () => void => {
+  registration.users += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    releaseProtocol(registration);
+  };
+};
+
+const createProtocolRegistration = async (gl: MapLibreModule): Promise<ProtocolRegistration> => {
+  const { Protocol } = await import("pmtiles");
+  gl.addProtocol("pmtiles", new Protocol({ metadata: true }).tile);
+  return { gl, users: 0 };
+};
+
+const pendingProtocolRegistration = (gl: MapLibreModule): Promise<ProtocolRegistration> => {
+  return protocolRegistrationPromise ?? (protocolRegistrationPromise = createProtocolRegistration(gl));
+};
+
+const clearPendingRegistration = (pending: Promise<ProtocolRegistration>): void => {
+  if (protocolRegistrationPromise === pending) protocolRegistrationPromise = null;
+};
+
+const validateRegistration = (registration: ProtocolRegistration, gl: MapLibreModule): ProtocolRegistration => {
+  if (registration.gl !== gl) throw new Error("MapLibre module changed while PMTiles was registering");
+  return registration;
+};
+
+const awaitProtocolRegistration = async (gl: MapLibreModule): Promise<ProtocolRegistration> => {
+  const pending = pendingProtocolRegistration(gl);
+  return pending.then((registration) => {
+    clearPendingRegistration(pending);
+    return validateRegistration(registration, gl);
+  }, (error: unknown) => {
+    clearPendingRegistration(pending);
+    throw error;
+  });
+};
+
+const registerPmtilesProtocol = async (gl: MapLibreModule): Promise<ProtocolRegistration> => {
+  if (protocolRegistration !== null) {
+    if (protocolRegistration.gl !== gl) throw new Error("MapLibre module changed while PMTiles is mounted");
+    return protocolRegistration;
+  }
+  const registration = await awaitProtocolRegistration(gl);
+  protocolRegistration = registration;
+  return registration;
+};
+
+const mapOptions = (options: MapLibreMountOptions): MapOptions => ({
+  container: options.container,
+  style: options.style,
+  ...(options.interactive === undefined ? {} : { interactive: options.interactive }),
+  ...(options.attributionControl === undefined ? {} : { attributionControl: options.attributionControl }),
+  ...(options.center === undefined ? {} : { center: options.center }),
+  ...(options.zoom === undefined ? {} : { zoom: options.zoom }),
+});
+
+const browserOnly = (): void => {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    throw new Error("MapLibre can only mount in a browser");
+  }
+};
+
+const ignoreError = (_error: unknown): void => undefined;
+
+const bestEffort = (action: () => void): void => {
+  try {
+    action();
+  } catch (error) {
+    ignoreError(error);
+  }
+};
+
+const removeMap = (map: MapLibreMap, releaseProtocolLease: (() => void) | undefined): void => {
+  try {
+    map.remove();
+  } finally {
+    releaseProtocolLease?.();
+  }
+};
+
+const removeListeners = (map: MapLibreMap, onError: () => void, onLoad: () => void): void => {
+  bestEffort(() => { map.off("error", onError); });
+  bestEffort(() => { map.off("load", onLoad); });
+};
+
+interface DisposeOptions {
+  readonly loadCleanup: (() => void) | undefined;
+  readonly map: MapLibreMap;
+  readonly onError: () => void;
+  readonly onLoad: () => void;
+  readonly releaseProtocolLease?: () => void;
+}
+
+const dispose = (options: DisposeOptions): void => {
+  removeListeners(options.map, options.onError, options.onLoad);
+  bestEffort(() => { options.loadCleanup?.(); });
+  removeMap(options.map, options.releaseProtocolLease);
+};
+
+interface ListenerOptions {
+  readonly map: MapLibreMap;
+  readonly onError: () => void;
+  readonly onLoad: () => void;
+  readonly releaseProtocolLease?: () => void;
+}
+
+const installListeners = (options: ListenerOptions): void => {
+  try {
+    options.map.on("error", options.onError);
+    options.map.on("load", options.onLoad);
+  } catch (error) {
+    removeMap(options.map, options.releaseProtocolLease);
+    throw error;
+  }
+};
+
+interface MapLifecycleOptions {
+  readonly gl: MapLibreModule;
+  readonly map: MapLibreMap;
+  readonly onError: () => void;
+  readonly onLoad?: (context: MapLibreMountContext) => (() => void) | undefined;
+  readonly onReady?: () => void;
+  readonly releaseProtocolLease?: () => void;
+}
+
+class MapLifecycle implements MapLibreHandle {
+  readonly map: MapLibreMap;
+  private active = true;
+  private failed = false;
+  private loadCleanup: (() => void) | undefined;
+  private readonly options: MapLifecycleOptions;
+
+  constructor(options: MapLifecycleOptions) {
+    this.map = options.map;
+    this.options = options;
+    installListeners({ ...options, onError: this.reportError, onLoad: this.reportReady });
+  }
+
+  private readonly reportError = (): void => {
+    if (!this.active || this.failed) return;
+    this.failed = true;
+    try {
+      this.options.onError();
+    } finally {
+      this.destroy();
+    }
+  };
+
+  private readonly reportReady = (): void => {
+    if (!this.active || this.failed) return;
+    try {
+      const cleanup = this.options.onLoad?.({ gl: this.options.gl, map: this.map });
+      this.loadCleanup = typeof cleanup === "function" ? cleanup : undefined;
+      this.options.onReady?.();
+    } catch {
+      this.reportError();
+    }
+  };
+
+  private readonly dispose = (): void => {
+    dispose({
+      loadCleanup: this.loadCleanup,
+      map: this.map,
+      onError: this.reportError,
+      onLoad: this.reportReady,
+      releaseProtocolLease: this.options.releaseProtocolLease,
+    });
+  };
+
+  readonly destroy = (): void => {
+    if (!this.active) return;
+    this.active = false;
+    this.dispose();
+  };
+}
+
+const createMap = (gl: MapLibreModule, options: MapLibreMountOptions, release: () => void): MapLibreMap => {
+  try {
+    return new gl.Map(mapOptions(options));
+  } catch (error) {
+    release();
+    throw error;
+  }
+};
+
+export const mountMapLibre = async (options: MapLibreMountOptions): Promise<MapLibreHandle> => {
+  browserOnly();
+  const gl = await import("maplibre-gl");
+  const release = options.registerPmtiles ? leaseProtocol(await registerPmtilesProtocol(gl)) : () => undefined;
+  const map = createMap(gl, options, release);
+  return new MapLifecycle({ ...options, gl, map, releaseProtocolLease: release });
+};
+
+interface Attachment {
+  active: boolean;
+  handle: MapLibreHandle | null;
+}
+
+const storeHandle = (attachment: Attachment, handle: MapLibreHandle): void => {
+  if (!attachment.active) {
+    handle.destroy();
+    return;
+  }
+  attachment.handle = handle;
+};
+
+const reportAttachmentFailure = (attachment: Attachment, options: MapLibreMountOptions): void => {
+  if (attachment.active) options.onError();
+};
+
+/** Bridge async MapLibre setup into React's synchronous effect cleanup contract. */
+export const attachMapLibre = (options: MapLibreMountOptions): (() => void) => {
+  const attachment: Attachment = { active: true, handle: null };
+  void mountMapLibre(options)
+    .then((handle) => { storeHandle(attachment, handle); })
+    .catch(() => { reportAttachmentFailure(attachment, options); });
+  return () => {
+    attachment.active = false;
+    attachment.handle?.destroy();
+  };
+};

--- a/apps/web/src/features/maplibre/maplibreAdapter.ts
+++ b/apps/web/src/features/maplibre/maplibreAdapter.ts
@@ -27,6 +27,7 @@ export type MapLibreHandle = Readonly<{
 
 interface ProtocolRegistration {
   gl: MapLibreModule;
+  removed: boolean;
   users: number;
 }
 
@@ -39,6 +40,7 @@ const releaseProtocol = (registration: ProtocolRegistration): void => {
   try {
     if (typeof registration.gl.removeProtocol === "function") registration.gl.removeProtocol("pmtiles");
   } finally {
+    registration.removed = true;
     protocolRegistration = null;
   }
 };
@@ -56,7 +58,7 @@ const leaseProtocol = (registration: ProtocolRegistration): () => void => {
 const createProtocolRegistration = async (gl: MapLibreModule): Promise<ProtocolRegistration> => {
   const { Protocol } = await import("pmtiles");
   gl.addProtocol("pmtiles", new Protocol({ metadata: true }).tile);
-  return { gl, users: 0 };
+  return { gl, removed: false, users: 0 };
 };
 
 const pendingProtocolRegistration = (gl: MapLibreModule): Promise<ProtocolRegistration> => {
@@ -72,6 +74,15 @@ const validateRegistration = (registration: ProtocolRegistration, gl: MapLibreMo
   return registration;
 };
 
+const usableRegistration = (gl: MapLibreModule): ProtocolRegistration | null => {
+  const registration = protocolRegistration;
+  if (registration === null) return null;
+  const validated = validateRegistration(registration, gl);
+  if (!validated.removed) return validated;
+  protocolRegistration = null;
+  return null;
+};
+
 const awaitProtocolRegistration = async (gl: MapLibreModule): Promise<ProtocolRegistration> => {
   const pending = pendingProtocolRegistration(gl);
   return pending.then((registration) => {
@@ -84,11 +95,12 @@ const awaitProtocolRegistration = async (gl: MapLibreModule): Promise<ProtocolRe
 };
 
 const registerPmtilesProtocol = async (gl: MapLibreModule): Promise<ProtocolRegistration> => {
-  if (protocolRegistration !== null) {
-    if (protocolRegistration.gl !== gl) throw new Error("MapLibre module changed while PMTiles is mounted");
-    return protocolRegistration;
-  }
+  const current = usableRegistration(gl);
+  if (current !== null) return current;
   const registration = await awaitProtocolRegistration(gl);
+  if (registration.removed) return registerPmtilesProtocol(gl);
+  const live = usableRegistration(gl);
+  if (live !== null) return live;
   protocolRegistration = registration;
   return registration;
 };
@@ -120,7 +132,7 @@ const bestEffort = (action: () => void): void => {
 
 const removeMap = (map: MapLibreMap, releaseProtocolLease: (() => void) | undefined): void => {
   try {
-    map.remove();
+    bestEffort(() => { map.remove(); });
   } finally {
     releaseProtocolLease?.();
   }
@@ -175,6 +187,7 @@ class MapLifecycle implements MapLibreHandle {
   readonly map: MapLibreMap;
   private active = true;
   private failed = false;
+  private loaded = false;
   private loadCleanup: (() => void) | undefined;
   private readonly options: MapLifecycleOptions;
 
@@ -194,15 +207,16 @@ class MapLifecycle implements MapLibreHandle {
     }
   };
 
+  private readonly handleReady = (): void => {
+    const cleanup = this.options.onLoad?.({ gl: this.options.gl, map: this.map });
+    this.loadCleanup = typeof cleanup === "function" ? cleanup : undefined;
+    this.loaded = true;
+    this.options.onReady?.();
+  };
+
   private readonly reportReady = (): void => {
-    if (!this.active || this.failed) return;
-    try {
-      const cleanup = this.options.onLoad?.({ gl: this.options.gl, map: this.map });
-      this.loadCleanup = typeof cleanup === "function" ? cleanup : undefined;
-      this.options.onReady?.();
-    } catch {
-      this.reportError();
-    }
+    if (!this.active || this.failed || this.loaded) return;
+    try { this.handleReady(); } catch { this.reportError(); }
   };
 
   private readonly dispose = (): void => {

--- a/apps/web/src/routes/_dev/map-canary.tsx
+++ b/apps/web/src/routes/_dev/map-canary.tsx
@@ -52,7 +52,7 @@ const UnmountButton = ({ mounted, onUnmount }: Readonly<{ mounted: boolean; onUn
 };
 
 const CanaryContainer = ({ containerRef }: Readonly<{ containerRef: RefObject<HTMLDivElement | null> }>) => {
-  return <div ref={containerRef} data-testid="maplibre-canary-container" />;
+  return <div ref={containerRef} />;
 };
 
 interface CanaryViewProps {
@@ -65,7 +65,7 @@ interface CanaryViewProps {
 
 function CanaryView({ containerRef, mode, mounted, onUnmount, status }: CanaryViewProps) {
   return (
-    <main aria-label="MapLibre v5 canary" data-mode={mode} data-status={status} data-testid="maplibre-canary">
+    <main aria-label="MapLibre v5 canary" data-mode={mode} data-status={status}>
       <h1>MapLibre v5 canary</h1>
       <p role="status" aria-live="polite">Status: {status}</p>
       <UnmountButton mounted={mounted} onUnmount={onUnmount} />

--- a/apps/web/src/routes/_dev/map-canary.tsx
+++ b/apps/web/src/routes/_dev/map-canary.tsx
@@ -47,8 +47,8 @@ function useCanaryMount(containerRef: RefObject<HTMLDivElement | null>, mode: Ca
   }, [containerRef, mode, mounted, setStatus]);
 }
 
-const UnmountButton = ({ mounted, setMounted }: Readonly<{ mounted: boolean; setMounted: (mounted: boolean) => void }>) => {
-  return <button type="button" disabled={!mounted} onClick={() => { setMounted(false); }}>Unmount map</button>;
+const UnmountButton = ({ mounted, onUnmount }: Readonly<{ mounted: boolean; onUnmount: () => void }>) => {
+  return <button type="button" disabled={!mounted} onClick={onUnmount}>Unmount map</button>;
 };
 
 const CanaryContainer = ({ containerRef }: Readonly<{ containerRef: RefObject<HTMLDivElement | null> }>) => {
@@ -59,16 +59,16 @@ interface CanaryViewProps {
   containerRef: RefObject<HTMLDivElement | null>;
   mode: CanaryMode;
   mounted: boolean;
-  setMounted: (mounted: boolean) => void;
+  onUnmount: () => void;
   status: CanaryStatus;
 }
 
-function CanaryView({ containerRef, mode, mounted, setMounted, status }: CanaryViewProps) {
+function CanaryView({ containerRef, mode, mounted, onUnmount, status }: CanaryViewProps) {
   return (
-    <main data-mode={mode} data-status={status} data-testid="maplibre-canary">
+    <main aria-label="MapLibre v5 canary" data-mode={mode} data-status={status} data-testid="maplibre-canary">
       <h1>MapLibre v5 canary</h1>
-      <p aria-live="polite">Status: {status}</p>
-      <UnmountButton mounted={mounted} setMounted={setMounted} />
+      <p role="status" aria-live="polite">Status: {status}</p>
+      <UnmountButton mounted={mounted} onUnmount={onUnmount} />
       <CanaryContainer containerRef={containerRef} />
     </main>
   );
@@ -79,6 +79,7 @@ function MapCanaryRoute() {
   const [mode] = useState<CanaryMode>(readMode);
   const [mounted, setMounted] = useState(true);
   const [status, setStatus] = useState<CanaryStatus>("loading");
+  const handleUnmount = (): void => { setMounted(false); };
   useCanaryMount(containerRef, mode, mounted, setStatus);
-  return <CanaryView containerRef={containerRef} mode={mode} mounted={mounted} setMounted={setMounted} status={status} />;
+  return <CanaryView containerRef={containerRef} mode={mode} mounted={mounted} onUnmount={handleUnmount} status={status} />;
 }

--- a/apps/web/src/routes/_dev/map-canary.tsx
+++ b/apps/web/src/routes/_dev/map-canary.tsx
@@ -1,0 +1,84 @@
+import type { StyleSpecification } from "maplibre-gl";
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { attachMapLibre } from "../../features/maplibre/maplibreAdapter";
+
+export const Route = createFileRoute("/_dev/map-canary")({
+  component: MapCanaryRoute,
+});
+
+type CanaryMode = "fallback" | "happy";
+type CanaryStatus = "fallback" | "loading" | "ready" | "unmounted";
+
+const readMode = (): CanaryMode => {
+  if (typeof window !== "undefined" && new URLSearchParams(window.location.search).get("mode") === "fallback") {
+    return "fallback";
+  }
+  return "happy";
+};
+
+const canaryStyle = (): StyleSpecification => ({
+  version: 8,
+  name: "animichi-maplibre-canary",
+  sources: {},
+  layers: [{ id: "background", type: "background", paint: { "background-color": "#f8f8f0" } }],
+});
+
+type SetCanaryStatus = (status: CanaryStatus) => void;
+
+const canaryOptions = (container: HTMLDivElement, mode: CanaryMode, setStatus: SetCanaryStatus) => ({
+  container,
+  interactive: false,
+  onError: () => { setStatus("fallback"); },
+  onLoad: mode === "fallback" ? () => { throw new Error("canary setup failure"); } : undefined,
+  onReady: () => { setStatus("ready"); },
+  style: canaryStyle(),
+});
+
+function useCanaryMount(containerRef: RefObject<HTMLDivElement | null>, mode: CanaryMode, mounted: boolean, setStatus: SetCanaryStatus): void {
+  useEffect(() => {
+    if (!mounted || !containerRef.current) {
+      setStatus("unmounted");
+      return undefined;
+    }
+    setStatus("loading");
+    return attachMapLibre(canaryOptions(containerRef.current, mode, setStatus));
+  }, [containerRef, mode, mounted, setStatus]);
+}
+
+const UnmountButton = ({ mounted, setMounted }: Readonly<{ mounted: boolean; setMounted: (mounted: boolean) => void }>) => {
+  return <button type="button" disabled={!mounted} onClick={() => { setMounted(false); }}>Unmount map</button>;
+};
+
+const CanaryContainer = ({ containerRef }: Readonly<{ containerRef: RefObject<HTMLDivElement | null> }>) => {
+  return <div ref={containerRef} data-testid="maplibre-canary-container" />;
+};
+
+interface CanaryViewProps {
+  containerRef: RefObject<HTMLDivElement | null>;
+  mode: CanaryMode;
+  mounted: boolean;
+  setMounted: (mounted: boolean) => void;
+  status: CanaryStatus;
+}
+
+function CanaryView({ containerRef, mode, mounted, setMounted, status }: CanaryViewProps) {
+  return (
+    <main data-mode={mode} data-status={status} data-testid="maplibre-canary">
+      <h1>MapLibre v5 canary</h1>
+      <p aria-live="polite">Status: {status}</p>
+      <UnmountButton mounted={mounted} setMounted={setMounted} />
+      <CanaryContainer containerRef={containerRef} />
+    </main>
+  );
+}
+
+function MapCanaryRoute() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [mode] = useState<CanaryMode>(readMode);
+  const [mounted, setMounted] = useState(true);
+  const [status, setStatus] = useState<CanaryStatus>("loading");
+  useCanaryMount(containerRef, mode, mounted, setStatus);
+  return <CanaryView containerRef={containerRef} mode={mode} mounted={mounted} setMounted={setMounted} status={status} />;
+}

--- a/apps/web/tests/unit/chat/basemap-mount-failure.test.tsx
+++ b/apps/web/tests/unit/chat/basemap-mount-failure.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  *
- * Issue #437 item 1: the `.catch` in `attachBasemap` was only reachable through a
+ * Issue #437 item 1: the adapter's async failure path was only reachable through a
  * real WebGL/import failure, and every other suite injects a fake `attach`. Here the
  * maplibre module itself is stubbed so the real controller runs and its failure path
  * drives the D7 placeholder.

--- a/apps/web/tests/unit/maplibre-adapter.test.ts
+++ b/apps/web/tests/unit/maplibre-adapter.test.ts
@@ -1,0 +1,176 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StyleSpecification } from "maplibre-gl";
+
+const mapState = vi.hoisted(() => {
+  type Listener = (...args: readonly unknown[]) => void;
+  interface FakeMapInstance {
+    emit: (type: string) => void;
+    offCalls: number;
+    removeCalls: number;
+  }
+  const state = { instances: [] as FakeMapInstance[], throwOnConstruct: false };
+  class FakeMap {
+    readonly listeners = new globalThis.Map<string, Listener[]>();
+    removeCalls = 0;
+    offCalls = 0;
+
+    constructor(_options: unknown) {
+      if (state.throwOnConstruct) throw new Error("WebGL context unavailable");
+      state.instances.push(this);
+    }
+
+    on(type: string, listener: Listener): this {
+      const listeners = this.listeners.get(type) ?? [];
+      listeners.push(listener);
+      this.listeners.set(type, listeners);
+      return this;
+    }
+
+    off(type: string, listener: Listener): this {
+      this.offCalls += 1;
+      this.listeners.set(type, (this.listeners.get(type) ?? []).filter((candidate) => candidate !== listener));
+      return this;
+    }
+
+    emit(type: string): void {
+      for (const listener of [...(this.listeners.get(type) ?? [])]) listener({});
+    }
+
+    remove(): void {
+      this.removeCalls += 1;
+    }
+  }
+  return { addProtocol: vi.fn(), FakeMap, removeProtocol: vi.fn(), state };
+});
+
+vi.mock("maplibre-gl", () => ({
+  Map: mapState.FakeMap,
+  addProtocol: mapState.addProtocol,
+  removeProtocol: mapState.removeProtocol,
+}));
+
+vi.mock("pmtiles", () => ({
+  Protocol: class {
+    readonly tile = () => ({ data: new ArrayBuffer(0) });
+  },
+}));
+
+import { attachMapLibre, mountMapLibre } from "../../src/features/maplibre/maplibreAdapter";
+
+const STYLE = {
+  version: 8,
+  sources: {},
+  layers: [{ id: "background", type: "background", paint: { "background-color": "#f8f8f0" } }],
+} satisfies StyleSpecification;
+
+const options = (onError: () => void, onReady: () => void, onLoad?: () => (() => void) | undefined) => ({
+  container: document.createElement("div"),
+  onError,
+  onReady,
+  onLoad,
+  registerPmtiles: true,
+  style: STYLE,
+});
+
+const firstMap = () => {
+  const map = mapState.state.instances[0];
+  if (!map) throw new Error("Map stub was not constructed");
+  return map;
+};
+
+beforeEach(() => {
+  mapState.state.instances.length = 0;
+  mapState.state.throwOnConstruct = false;
+  mapState.addProtocol.mockClear();
+  mapState.removeProtocol.mockClear();
+});
+
+describe("MapLibre v5 adapter lifecycle", () => {
+  it("reports ready, removes listeners/resources, and makes destroy idempotent", async () => {
+    const onError = vi.fn();
+    const onReady = vi.fn();
+    const cleanup = vi.fn();
+    const handle = await mountMapLibre(options(onError, onReady, () => cleanup));
+    const map = firstMap();
+
+    map.emit("load");
+    expect(onReady).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+    handle.destroy();
+    handle.destroy();
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(map.offCalls).toBe(2);
+    expect(map.removeCalls).toBe(1);
+    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
+  });
+
+  it("turns an error into one fallback and never reports ready after failure", async () => {
+    const onError = vi.fn();
+    const onReady = vi.fn();
+    const handle = await mountMapLibre(options(onError, onReady));
+    const map = firstMap();
+
+    map.emit("error");
+    map.emit("error");
+    map.emit("load");
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onReady).not.toHaveBeenCalled();
+    expect(map.removeCalls).toBe(1);
+    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
+    handle.destroy();
+  });
+
+  it("cleans a loaded map when the ready callback fails", async () => {
+    const onError = vi.fn();
+    const cleanup = vi.fn();
+    const onReady = (): void => { throw new Error("ready callback failed"); };
+    const onLoad = (): (() => void) => cleanup;
+    const handle = await mountMapLibre(options(onError, onReady, onLoad));
+    const map = firstMap();
+
+    map.emit("load");
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(map.removeCalls).toBe(1);
+    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
+    handle.destroy();
+  });
+});
+
+describe("MapLibre v5 protocol lease", () => {
+  it("keeps the shared PMTiles protocol until every map releases its lease", async () => {
+    const first = await mountMapLibre(options(vi.fn(), vi.fn()));
+    const second = await mountMapLibre(options(vi.fn(), vi.fn()));
+
+    expect(mapState.addProtocol).toHaveBeenCalledOnce();
+    first.destroy();
+    expect(mapState.removeProtocol).not.toHaveBeenCalled();
+    second.destroy();
+    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
+  });
+});
+
+describe("MapLibre v5 adapter failure handling", () => {
+  it("reports constructor failure through the attachment fallback path", async () => {
+    mapState.state.throwOnConstruct = true;
+    const onError = vi.fn();
+    const detach = attachMapLibre(options(onError, vi.fn()));
+
+    await vi.waitFor(() => { expect(onError).toHaveBeenCalledOnce(); });
+    detach();
+    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
+  });
+
+  it("destroys a handle that resolves after React already detached", async () => {
+    const detach = attachMapLibre(options(vi.fn(), vi.fn()));
+    detach();
+
+    await vi.waitFor(() => { expect(mapState.state.instances[0]?.removeCalls).toBe(1); });
+    expect(mapState.state.instances[0]?.offCalls).toBe(2);
+  });
+});

--- a/apps/web/tests/unit/maplibre-adapter.test.ts
+++ b/apps/web/tests/unit/maplibre-adapter.test.ts
@@ -10,7 +10,7 @@ const mapState = vi.hoisted(() => {
     offCalls: number;
     removeCalls: number;
   }
-  const state = { instances: [] as FakeMapInstance[], throwOnConstruct: false };
+  const state = { instances: [] as FakeMapInstance[], throwOnConstruct: false, throwOnRemove: false };
   class FakeMap {
     readonly listeners = new globalThis.Map<string, Listener[]>();
     removeCalls = 0;
@@ -40,6 +40,7 @@ const mapState = vi.hoisted(() => {
 
     remove(): void {
       this.removeCalls += 1;
+      if (state.throwOnRemove) throw new Error("Map removal failed");
     }
   }
   return { addProtocol: vi.fn(), FakeMap, removeProtocol: vi.fn(), state };
@@ -75,14 +76,14 @@ const options = (onError: () => void, onReady: () => void, onLoad?: () => (() =>
 });
 
 const firstMap = () => {
-  const map = mapState.state.instances[0];
-  if (!map) throw new Error("Map stub was not constructed");
-  return map;
+  expect(mapState.state.instances).toHaveLength(1);
+  return mapState.state.instances.reduce((map) => map);
 };
 
 beforeEach(() => {
   mapState.state.instances.length = 0;
   mapState.state.throwOnConstruct = false;
+  mapState.state.throwOnRemove = false;
   mapState.addProtocol.mockClear();
   mapState.removeProtocol.mockClear();
 });
@@ -140,6 +141,28 @@ describe("MapLibre v5 adapter lifecycle", () => {
     expect(mapState.removeProtocol).toHaveBeenCalledOnce();
     handle.destroy();
   });
+});
+
+describe("MapLibre v5 teardown", () => {
+  it("contains teardown failures while releasing the protocol lease", async () => {
+    mapState.state.throwOnRemove = true;
+    const handle = await mountMapLibre(options(vi.fn(), vi.fn()));
+
+    expect(() => { handle.destroy(); }).not.toThrow();
+    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
+  });
+});
+
+it("handles duplicate load events once", async () => {
+  const onLoad = vi.fn(() => undefined);
+  const onReady = vi.fn();
+  const handle = await mountMapLibre(options(vi.fn(), onReady, onLoad));
+  const map = firstMap();
+  map.emit("load");
+  map.emit("load");
+  expect(onLoad).toHaveBeenCalledOnce();
+  expect(onReady).toHaveBeenCalledOnce();
+  handle.destroy();
 });
 
 describe("MapLibre v5 protocol lease", () => {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -39,6 +39,11 @@ export default defineConfig({
         // testable state/overlay/sheet live in BubbleMapPanel. Same §0.6 exclude-ledger rationale
         // as routes/_dev/map-spike.tsx.
         "src/features/bubble-map/BubbleMap.tsx",
+        // Shared MapLibre adapter owns the browser-only WebGL lifecycle. Its state machine is
+        // exercised by the browser canary and adapter unit tests with a deterministic module stub.
+        "src/features/maplibre/maplibreAdapter.ts",
+        // The canary route is a browser-only smoke surface for the adapter, not an SSR/jsdom page.
+        "src/routes/_dev/map-canary.tsx",
       ],
       // S1.10 (#282) ratchet: measured 98.61/95.48/98.94/99.49 on the tree
       // rebased onto #462/#463/#467. Branches ratchet 94 -> 95. Functions is

--- a/e2e/web-maplibre-canary.spec.ts
+++ b/e2e/web-maplibre-canary.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test, type Page } from "@playwright/test";
+
+test.use({
+  baseURL: process.env.E2E_WEB_BASE_URL ?? "http://localhost:3000",
+});
+
+const openCanary = async (page: Page, mode: "fallback" | "happy"): Promise<string[]> => {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => { errors.push(error.message); });
+  await page.goto(`/_dev/map-canary?mode=${mode}`);
+  return errors;
+};
+
+test("MapLibre v5 happy path reaches ready and cleans up on unmount", async ({ page }) => {
+  const errors = await openCanary(page, "happy");
+  const canary = page.getByTestId("maplibre-canary");
+  await expect(canary).toHaveAttribute("data-status", "ready");
+  expect(errors).toEqual([]);
+
+  await page.getByRole("button", { name: "Unmount map" }).click();
+  await expect(canary).toHaveAttribute("data-status", "unmounted");
+  await expect(page.getByTestId("maplibre-canary-container")).toBeEmpty();
+});
+
+test("MapLibre v5 setup failures are observable as fallback without a page error", async ({ page }) => {
+  const errors = await openCanary(page, "fallback");
+  await expect(page.getByTestId("maplibre-canary")).toHaveAttribute("data-status", "fallback");
+  expect(errors).toEqual([]);
+});

--- a/e2e/web-maplibre-canary.spec.ts
+++ b/e2e/web-maplibre-canary.spec.ts
@@ -7,7 +7,8 @@ test.use({
 const openCanary = async (page: Page, mode: "fallback" | "happy"): Promise<string[]> => {
   const errors: string[] = [];
   page.on("pageerror", (error) => { errors.push(error.message); });
-  await page.goto(`/_dev/map-canary?mode=${mode}`);
+  // `_dev` is a pathless TanStack route segment; the public URL is `/map-canary`.
+  await page.goto(`/map-canary?mode=${mode}`);
   return errors;
 };
 

--- a/e2e/web-maplibre-canary.spec.ts
+++ b/e2e/web-maplibre-canary.spec.ts
@@ -14,17 +14,18 @@ const openCanary = async (page: Page, mode: "fallback" | "happy"): Promise<strin
 
 test("MapLibre v5 happy path reaches ready and cleans up on unmount", async ({ page }) => {
   const errors = await openCanary(page, "happy");
-  const canary = page.getByTestId("maplibre-canary");
+  const canary = page.getByRole("main", { name: "MapLibre v5 canary" });
   await expect(canary).toHaveAttribute("data-status", "ready");
   expect(errors).toEqual([]);
 
   await page.getByRole("button", { name: "Unmount map" }).click();
   await expect(canary).toHaveAttribute("data-status", "unmounted");
   await expect(page.getByTestId("maplibre-canary-container")).toBeEmpty();
+  expect(errors).toEqual([]);
 });
 
 test("MapLibre v5 setup failures are observable as fallback without a page error", async ({ page }) => {
   const errors = await openCanary(page, "fallback");
-  await expect(page.getByTestId("maplibre-canary")).toHaveAttribute("data-status", "fallback");
+  await expect(page.getByRole("main", { name: "MapLibre v5 canary" })).toHaveAttribute("data-status", "fallback");
   expect(errors).toEqual([]);
 });

--- a/e2e/web-maplibre-canary.spec.ts
+++ b/e2e/web-maplibre-canary.spec.ts
@@ -14,18 +14,17 @@ const openCanary = async (page: Page, mode: "fallback" | "happy"): Promise<strin
 
 test("MapLibre v5 happy path reaches ready and cleans up on unmount", async ({ page }) => {
   const errors = await openCanary(page, "happy");
-  const canary = page.getByRole("main", { name: "MapLibre v5 canary" });
-  await expect(canary).toHaveAttribute("data-status", "ready");
+  const status = page.getByRole("status");
+  await expect(status).toHaveText("Status: ready");
   expect(errors).toEqual([]);
 
   await page.getByRole("button", { name: "Unmount map" }).click();
-  await expect(canary).toHaveAttribute("data-status", "unmounted");
-  await expect(page.getByTestId("maplibre-canary-container")).toBeEmpty();
+  await expect(status).toHaveText("Status: unmounted");
   expect(errors).toEqual([]);
 });
 
 test("MapLibre v5 setup failures are observable as fallback without a page error", async ({ page }) => {
   const errors = await openCanary(page, "fallback");
-  await expect(page.getByRole("main", { name: "MapLibre v5 canary" })).toHaveAttribute("data-status", "fallback");
+  await expect(page.getByRole("status")).toHaveText("Status: fallback");
   expect(errors).toEqual([]);
 });


### PR DESCRIPTION
Replaces #601; this PR is intentionally separate so #601 can remain open until this replacement is reviewed and merged.

## Scope

- Keeps `maplibre-gl` on v5.24.0 (lockfile unchanged); no v6-only API or dependency.
- Defers v6 tracking to upstream [maplibre/maplibre-gl-js#8066](https://github.com/maplibre/maplibre-gl-js/issues/8066).
- Targets the latest `main` base `8ae88e84b3f37bd63e7b6ab69d67a809856749ab`.
- Unifies both current callers—`apps/web/src/features/map-spike/mapController.ts` and `apps/web/src/features/bubble-map/bubbleMapController.ts`—through one adapter. Existing consumers (map spike, SearchResult/RouteTrail, and BubbleMap) retain their public mount/attach boundaries.

## Adapter guarantees

- Browser-only dynamic import with SSR guard.
- Ref-counted PMTiles protocol registration/removal, including stale concurrent-registration revalidation after a released lease.
- Error fallback, immediate failed-map cleanup, source/layer/marker/listener cleanup, idempotent destroy, and safe late async resolution after detach.
- Teardown contains `map.remove()` failures while always releasing protocol leases.
- Duplicate MapLibre load events are ignored after the first successful load; route/marker setup rolls back on partial source/layer or marker failures.

## Verification surfaces

- Added the pathless `_dev` source route `apps/web/src/routes/_dev/map-canary.tsx`; its public URL is `/map-canary` (not `/_dev/map-canary`).
- Added Playwright browser canary and included it in the web CI browser lane.
- Browser assertions use accessible, user-visible status text; teardown details are covered by adapter unit tests.
- Extended the existing coverage-exclude ledger only for browser/WebGL surfaces; adapter state transitions are covered by deterministic unit tests and the browser canary.

## Evidence

- `unit`: focused Vitest 22/22 (adapter + existing basemap/map-spike suites).
- `typecheck`: `pnpm --filter web typecheck` passed.
- `lint`: `pnpm --filter web run lint:oxlint` passed.
- `build`: `pnpm --filter web build` passed.
- `browser`: freshly built Wrangler worker + Playwright canary passed 2/2 (happy lifecycle/unmount and fallback); old `/_dev/map-canary` returns 404 while public `/map-canary` returns 200.
- `actionlint`: passed for `.github/workflows/_webapp-ci.yml`.
- `git diff --check`: passed.
- `gitleaks protect --staged --redact --no-banner`: passed; no leaks.
- `integration`: full web integration invocation reached the Vitest runner but produced no result before the local execution was terminated; not claimed green.
- No production deployment was performed.

## Review

Please review this as the replacement for #601. All currently listed review conversations are resolved. Merge/close operations are intentionally left to the parent orchestration.