### PR TITLE
chore(web): upgrade AI SDK to latest (replaces #603/#605)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,7 @@
     "preview": "wrangler dev"
   },
   "dependencies": {
-    "@ai-sdk/react": "^3.0.227",
+    "@ai-sdk/react": "^4.0.50",
     "@orpc/client": "1.14.8",
     "@orpc/openapi-client": "1.14.8",
     "@orpc/tanstack-query": "1.14.8",
@@ -24,7 +24,7 @@
     "@tanstack/react-router": "^1.170.18",
     "@tanstack/react-router-with-query": "^1.130.17",
     "@tanstack/react-start": "^1.168.32",
-    "ai": "^6.0.225",
+    "ai": "^7.0.47",
     "animal-island-ui-tailwind": "^1.0.16",
     "better-auth": "^1.6.25",
     "maplibre-gl": "^5.24.0",

--- a/apps/web/src/features/chat/use-chat-session.ts
+++ b/apps/web/src/features/chat/use-chat-session.ts
@@ -16,7 +16,7 @@ import { sessionHeaders } from "./session-headers";
  */
 export type ChatUIMessage = UIMessage<unknown, { response: ChatDataPart }>;
 
-// ai@6.0.225 looks the schema up by the stripped name ("response") when
+// ai@7.0.47 looks the schema up by the stripped name ("response") when
 // validating whole messages but by the full chunk type ("data-response")
 // while streaming, so the schema is registered under both keys.
 const dataPartSchemas = {
@@ -194,7 +194,7 @@ function useTrackerReaders(ref: SessionRef) {
   return { sessionIdOf, lastHttpStatus, lastErrorCode, lastQuotaResetsAt };
 }
 
-/** A part-less turn boundary. Without it ai@6.0.225 continues the previous
+/** A part-less turn boundary. Without it ai@7.0.47 continues the previous
  * assistant message (`createStreamingUIMessageState` reuses an assistant
  * `lastMessage`) and the same-ID `response` part would overwrite the prior
  * card instead of appending the E1 living-document version. It carries no
@@ -208,7 +208,7 @@ type SendHelpers = Pick<UseChatHelpers<ChatUIMessage>, "sendMessage" | "setMessa
 
 /**
  * E2 bypass send (issue #273 S1.7): re-submit the conversation with only a
- * `selected_point_ids` body — no new user utterance. ai@6.0.225's
+ * `selected_point_ids` body — no new user utterance. ai@7.0.47's
  * `DefaultChatTransport` merges the per-call body (`{...resolvedBody,
  * ...options.body}`), so the field reaches `_optional_ids` unchanged.
  */

--- a/apps/web/src/features/chat/use-chat-session.ts
+++ b/apps/web/src/features/chat/use-chat-session.ts
@@ -16,8 +16,8 @@ import { sessionHeaders } from "./session-headers";
  */
 export type ChatUIMessage = UIMessage<unknown, { response: ChatDataPart }>;
 
-// ai@7.0.47 looks the schema up by the stripped name ("response") when
-// validating whole messages but by the full chunk type ("data-response")
+// AI SDK 7.x (verified at 7.0.47) looks the schema up by the stripped name
+// ("response") when validating whole messages but by the full chunk type ("data-response")
 // while streaming, so the schema is registered under both keys.
 const dataPartSchemas = {
   response: ChatResponseDataPart,
@@ -194,8 +194,8 @@ function useTrackerReaders(ref: SessionRef) {
   return { sessionIdOf, lastHttpStatus, lastErrorCode, lastQuotaResetsAt };
 }
 
-/** A part-less turn boundary. Without it ai@7.0.47 continues the previous
- * assistant message (`createStreamingUIMessageState` reuses an assistant
+/** A part-less turn boundary. Without the marker, AI SDK 7.x (verified at 7.0.47) continues the
+ * previous assistant message (`createStreamingUIMessageState` reuses an assistant
  * `lastMessage`) and the same-ID `response` part would overwrite the prior
  * card instead of appending the E1 living-document version. It carries no
  * user utterance — the server must not persist a user row for it (the
@@ -208,7 +208,7 @@ type SendHelpers = Pick<UseChatHelpers<ChatUIMessage>, "sendMessage" | "setMessa
 
 /**
  * E2 bypass send (issue #273 S1.7): re-submit the conversation with only a
- * `selected_point_ids` body — no new user utterance. ai@7.0.47's
+ * `selected_point_ids` body — no new user utterance. AI SDK 7.x (verified at 7.0.47)'s
  * `DefaultChatTransport` merges the per-call body (`{...resolvedBody,
  * ...options.body}`), so the field reaches `_optional_ids` unchanged.
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
   apps/web:
     dependencies:
       '@ai-sdk/react':
-        specifier: ^3.0.227
-        version: 3.0.227(react@19.2.8)(zod@4.4.3)
+        specifier: ^4.0.50
+        version: 4.0.50(react@19.2.8)(zod@4.4.3)
       '@orpc/client':
         specifier: 1.14.8
         version: 1.14.8(@opentelemetry/api@1.9.1)
@@ -83,8 +83,8 @@ importers:
         specifier: ^1.168.32
         version: 1.168.32(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       ai:
-        specifier: ^6.0.225
-        version: 6.0.225(zod@4.4.3)
+        specifier: ^7.0.47
+        version: 7.0.47(zod@4.4.3)
       animal-island-ui-tailwind:
         specifier: ^1.0.16
         version: 1.0.16(e7c774c7a5a9a33f5ea432ce9eba998a)
@@ -310,25 +310,31 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@3.0.149':
-    resolution: {integrity: sha512-+EVPEHqdJVJn0FZHBd6NyH4rvlTK7X79B6xFuW5bfZIP1G/7Y5OTEgxpL0hjOCAxDBG4ZFM6SZWnVBXxeR1x8w==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.36':
+    resolution: {integrity: sha512-N1P6bdW/aC5rxLeuGYgx3X4el3DoZy8UWlky+g+AeIZSmxaEi/AToHJL4cmZ6nCPHk1byqJWwC+PaOZG0hK0dw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.38':
-    resolution: {integrity: sha512-/HHGmtKllqjg1OLc023v9w9kK3laW7Z6TzfZukYQWCsGBbzB9p60zTvvpXFVcs44NZBVXL3viOa1HRKUbeee8g==}
-    engines: {node: '>=18'}
+  '@ai-sdk/mcp@2.0.22':
+    resolution: {integrity: sha512-j3jPwKFTffZCJzYGpN69yKu/y646uu2gWoEwh1jgVyYVpzfu6ErFU+YAd/+xTPxsUTx8FEIEUHTlEsDuOe+ytQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.14':
-    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.18':
+    resolution: {integrity: sha512-UBNCrkxS5llgN2/RXLBRkjCFTIuL6YB1Goq5c+yRecnznhtX4XPjTwLHz2hrsTltTVZ0rqVegtnwFXdPBkjDHA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/react@3.0.227':
-    resolution: {integrity: sha512-rqvfgQmgJiHmgVziMRdHlUeJQc+VXe4gHMxpHKWQkYKTtAOehJcgJ1GBJH/a7HaVc+q/2n/N2oCVXs1VwgfgtQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/react@4.0.50':
+    resolution: {integrity: sha512-fbC0V2WdCwZaioSJ0CGT/YnrhzpNbiDFqoBlrJ7HL0OY95sIUQrPDVlGYz489/hj4Lze4tr7RfPc8ghgc/5wcQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
@@ -2983,6 +2989,9 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -3005,9 +3014,9 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@6.0.225:
-    resolution: {integrity: sha512-TCkt/NxyZFyXyHeGO/4FMsdTIoCdwV/e78jG9iEHIjnwrAHYlqOwVj7WDFsNRqXUeoUefgbiOkNuE5k8jdpFRg==}
-    engines: {node: '>=18'}
+  ai@7.0.47:
+    resolution: {integrity: sha512-e0MpNtufu6JmcmwMUTgM1smCRkP5z014iPaKgnCm7kmMsTSIZbOJN2vglhPq0WIj/6x7ewVi6W0FyIR0pjaE3Q==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -4597,6 +4606,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -5627,28 +5640,39 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.149(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.36(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.38(zod@4.4.3)':
+  '@ai-sdk/mcp@2.0.22(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.14
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@4.4.3)
+      pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  '@ai-sdk/provider@3.0.14':
+  '@ai-sdk/provider-utils@5.0.18(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.28.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.4':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.227(react@19.2.8)(zod@4.4.3)':
+  '@ai-sdk/react@4.0.50(react@19.2.8)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
-      ai: 6.0.225(zod@4.4.3)
+      '@ai-sdk/mcp': 2.0.22(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@4.4.3)
+      ai: 7.0.47(zod@4.4.3)
       react: 19.2.8
       swr: 2.4.2(react@19.2.8)
       throttleit: 2.1.0
@@ -6425,7 +6449,8 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opentelemetry/api@1.9.1': {}
+  '@opentelemetry/api@1.9.1':
+    optional: true
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
@@ -8063,6 +8088,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@workflow/serde@4.1.0': {}
+
   abbrev@3.0.1: {}
 
   abort-controller@3.0.0:
@@ -8077,12 +8104,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.225(zod@4.4.3):
+  ai@7.0.47(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.149(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.36(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@4.4.3)
       zod: 4.4.3
 
   animal-island-ui-tailwind@1.0.16(e7c774c7a5a9a33f5ea432ce9eba998a):
@@ -9568,6 +9594,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Replaces Dependabot PRs #603 and #605 with one rebased, compatible dependency update.
- Upgrades `ai` from 6.0.225 to the current npm registry release `7.0.47`.
- Upgrades `@ai-sdk/react` from 3.0.227 to the current npm registry release `4.0.50`.
- Regenerates the workspace lockfile so both packages share `@ai-sdk/provider` 4.0.4 and `@ai-sdk/provider-utils` 5.0.18.
- Updates the `use-chat-session.ts` compatibility comments to the selected `ai@7.0.47` behavior. No runtime API migration was required: the current `Chat`, `DefaultChatTransport`, `dataPartSchemas`, and per-call body paths type-check and pass the existing contract tests.

## Verification

All commands ran in an independent worktree based on `origin/main` `8503b331126e51836cb49626d0916311a65495f5`; no production deploy was performed.

- `pnpm --filter web run typecheck` — PASS
- `pnpm --filter web run lint:oxlint` — PASS
- `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web test` — PASS (211 files, 1,595 tests; statements 98.48%, branches 95.27%, functions 98.63%, lines 99.51%)
- `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web run test:integration` — PASS (3 files, 18 tests)
- `pnpm --filter web run build` — PASS
- `E2E_WEB_BASE_URL=http://localhost:8799 pnpm --dir e2e exec playwright test web-404.spec.ts web-maplibre-canary.spec.ts` against a fresh Wrangler build — PASS (5 tests)
- diff secret scan: `gitleaks stdin --redact` — PASS (no leaks)
- `git diff --check` — PASS

The change is limited to `apps/web/package.json`, `pnpm-lock.yaml`, and the version-anchored comments in `apps/web/src/features/chat/use-chat-session.ts`.