### PR TITLE
deps(agent): update FastAPI to 0.141.1 (replace #622)

### DIFF
--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     # v2: Database (Postgres + PostGIS)
     "asyncpg>=0.31.0",
     # HTTP runtime adapter
-    "fastapi>=0.139.2",
+    "fastapi>=0.141.1",
     "uvicorn[standard]>=0.51.0",
     "ddgs>=9.14.1",
     "logfire[asyncpg,fastapi,httpx,variables]>=4.38.0",

--- a/apps/agent/uv.lock
+++ b/apps/agent/uv.lock
@@ -86,7 +86,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.12" },
     { name = "cryptography", marker = "extra == 'dev'", specifier = ">=46.0.0" },
     { name = "ddgs", specifier = ">=9.14.1" },
-    { name = "fastapi", specifier = ">=0.139.2" },
+    { name = "fastapi", specifier = ">=0.141.1" },
     { name = "google-genai", specifier = ">=2.14.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "idna", specifier = ">=3.15" },
@@ -957,7 +957,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.139.2"
+version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -966,9 +966,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/95/d3f0ae10836324a2eab98a52b61210ac609f08200bf4bb0dc8132d32f78a/fastapi-0.139.2.tar.gz", hash = "sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e", size = 423428, upload-time = "2026-07-16T15:06:17.912Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/c7/cb03251d9dfb177246a9809a76f189d21df32dbd4a845951881d11323b7f/fastapi-0.139.2-py3-none-any.whl", hash = "sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c", size = 130234, upload-time = "2026-07-16T15:06:19.557Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Replacement for #622

This replacement is rebased on `8503b331126e51836cb49626d0916311a65495f5` (latest `main`) and intentionally separates the safe FastAPI update from the incompatible Monty update.

### Changes
- Raise `apps/agent/pyproject.toml` FastAPI floor from `>=0.139.2` to `>=0.141.1`.
- Refresh `apps/agent/uv.lock` to FastAPI `0.141.1`; no unrelated dependency or application-code changes.
- Keep `pydantic-monty>=0.0.16,<0.0.19`.

### Monty compatibility disposition
PyPI's current `pydantic-monty` is `0.0.19`, but it no longer exports `MontyRepl`. The locked `pydantic-ai-harness==0.10.0` CodeMode and dynamic-workflow toolsets import and instantiate `MontyRepl`; `apps/agent/agent/tests/unit/test_codemode_spike.py` asserts that import contract. Removing the upper bound would therefore produce a deterministic import failure, so the Monty half of #622 is explicitly rejected pending a compatible harness release/migration.

### Verification
- `uv lock --check`: PASS
- `uv run ruff check agent/ scripts/`: PASS
- `uv run ruff format --check agent/ scripts/`: PASS
- `uv run mypy agent/agents/ agent/interfaces/ agent/domain/ agent/infrastructure/ agent/clients/ agent/tests/eval/ agent/scripts/purge_anonymous_sessions.py`: PASS (137 files)
- `NODE_OPTIONS=--no-experimental-webstorage uv run pytest agent/tests/unit/ -q --no-cov`: PASS (1688 passed)
- Targeted no-DB integration (BYOK taxonomy/redaction/gate suites): PASS (20 passed)
- Full `agent/tests/integration/`: BLOCKED before tests by the canonical Docker arm because Docker is unavailable in this environment; not reported as green.
- `gitleaks protect --staged --redact --no-banner`: PASS (no leaks)
- No deployment performed.

Please review/merge this PR as the replacement for #622; #622 remains open until this evidence is accepted.