### PR TITLE
ci: add stable S0.3 quality lanes and deployment gates

### DIFF
--- a/.github/scripts/assert-ci-needs.sh
+++ b/.github/scripts/assert-ci-needs.sh
@@ -5,7 +5,7 @@ lane="${1:?usage: assert-ci-needs.sh <lane> <statuses>}"
 statuses="${2:?usage: assert-ci-needs.sh <lane> <statuses>}"
 
 if [[ -z "$statuses" ]]; then
-  echo "::error title=${lane}::no upstream statuses were supplied"
+  echo "::error title=${lane}::no upstream statuses were supplied" >&2
   exit 1
 fi
 
@@ -13,7 +13,7 @@ for status in $statuses; do
   case "$status" in
     success|skipped) ;;
     *)
-      echo "::error title=${lane}::upstream CI job finished with status '${status}'"
+      echo "::error title=${lane}::upstream CI job finished with status '${status}'" >&2
       exit 1
       ;;
   esac

--- a/.github/scripts/assert-ci-needs.sh
+++ b/.github/scripts/assert-ci-needs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+lane="${1:?usage: assert-ci-needs.sh <lane> <statuses>}"
+statuses="${2:?usage: assert-ci-needs.sh <lane> <statuses>}"
+
+if [[ -z "$statuses" ]]; then
+  echo "::error title=${lane}::no upstream statuses were supplied"
+  exit 1
+fi
+
+for status in $statuses; do
+  case "$status" in
+    success|skipped) ;;
+    *)
+      echo "::error title=${lane}::upstream CI job finished with status '${status}'"
+      exit 1
+      ;;
+  esac
+done
+
+echo "${lane}: all upstream jobs are successful or intentionally skipped"

--- a/.github/scripts/assert-ci-needs.sh
+++ b/.github/scripts/assert-ci-needs.sh
@@ -4,12 +4,19 @@ set -euo pipefail
 lane="${1:?usage: assert-ci-needs.sh <lane> <statuses>}"
 statuses="${2:?usage: assert-ci-needs.sh <lane> <statuses>}"
 
-if [[ -z "$statuses" ]]; then
+read -r -a status_list <<< "$statuses"
+if [[ "${#status_list[@]}" -eq 0 ]]; then
   echo "::error title=${lane}::no upstream statuses were supplied" >&2
   exit 1
 fi
 
-for status in $statuses; do
+changes_status="${status_list[0]}"
+if [[ "$changes_status" != "success" ]]; then
+  echo "::error title=${lane}::path detection finished with status '${changes_status}'" >&2
+  exit 1
+fi
+
+for status in "${status_list[@]:1}"; do
   case "$status" in
     success|skipped) ;;
     *)

--- a/.github/scripts/assert-ci-needs.test.sh
+++ b/.github/scripts/assert-ci-needs.test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="$(dirname "$0")/assert-ci-needs.sh"
+
+"$script" smoke "success skipped"
+if "$script" smoke "skipped success"; then
+  echo "changes=skipped must fail" >&2
+  exit 1
+fi
+if "$script" smoke "failure skipped"; then
+  echo "changes=failure must fail" >&2
+  exit 1
+fi

--- a/.github/scripts/test_ci_contract.rb
+++ b/.github/scripts/test_ci_contract.rb
@@ -26,6 +26,10 @@ deploy_needs = Array(jobs.fetch("deploy-staging").fetch("needs"))
 missing = expected.keys - deploy_needs
 abort "deploy-staging is missing stable lanes: #{missing.join(', ')}" unless missing.empty?
 
+web_deploy_needs = Array(jobs.fetch("deploy-web-staging").fetch("needs"))
+missing = expected.keys - web_deploy_needs
+abort "deploy-web-staging is missing stable lanes: #{missing.join(', ')}" unless missing.empty?
+
 cross_stack = jobs.fetch("changes").fetch("outputs").fetch("cross_stack")
 abort "changes must expose cross_stack output" unless cross_stack.include?("cross_stack")
 
@@ -33,3 +37,5 @@ puts "CI contract: seven stable lanes and staging dependencies are present"
 
 ci_source = File.read(".github/workflows/ci.yml")
 abort "Codecov lane must defer changed-line calculation to codecov/patch" unless ci_source.include?("codecov/patch")
+abort "cross_stack filter must include browser-suite changes" unless ci_source.include?("e2e/**")
+abort "stable lanes must observe changes status" unless ci_source.scan("${{ needs.changes.result }}").length >= expected.length

--- a/.github/scripts/test_ci_contract.rb
+++ b/.github/scripts/test_ci_contract.rb
@@ -29,3 +29,6 @@ cross_stack = jobs.fetch("changes").fetch("outputs").fetch("cross_stack")
 abort "changes must expose cross_stack output" unless cross_stack.include?("cross_stack")
 
 puts "CI contract: seven stable lanes and staging dependencies are present"
+
+ci_source = File.read(".github/workflows/ci.yml")
+abort "Codecov lane must defer changed-line calculation to codecov/patch" unless ci_source.include?("codecov/patch")

--- a/.github/scripts/test_ci_contract.rb
+++ b/.github/scripts/test_ci_contract.rb
@@ -19,6 +19,7 @@ expected.each do |job_id, name|
   job = jobs.fetch(job_id)
   abort "#{job_id} must expose '#{name}'" unless job.fetch("name") == name
   abort "#{job_id} must always run to publish a required context" unless job.fetch("if").include?("always()")
+  abort "#{job_id} must fail when path detection fails" unless Array(job.fetch("needs")).include?("changes")
 end
 
 deploy_needs = Array(jobs.fetch("deploy-staging").fetch("needs"))

--- a/.github/scripts/test_ci_contract.rb
+++ b/.github/scripts/test_ci_contract.rb
@@ -42,3 +42,15 @@ abort "stable lanes must observe changes status" unless ci_source.scan("${{ need
 
 gate_script = File.read(".github/scripts/assert-ci-needs.sh")
 abort "lane status checker must require changes success" unless gate_script.include?("changes_status")
+
+%w[_python-ci.yml _ts-ci.yml _webapp-ci.yml].each do |workflow_name|
+  source = File.read(".github/workflows/#{workflow_name}")
+  abort "#{workflow_name} must grant Codecov OIDC" unless source.include?("id-token: write")
+  abort "#{workflow_name} must fail when Codecov upload fails" unless source.include?("fail_ci_if_error: true")
+  abort "#{workflow_name} must use Codecov OIDC" unless source.include?("use_oidc: true")
+end
+
+%w[ci-agent ci-catalog ci-users ci-web].each do |job_id|
+  permissions = jobs.fetch(job_id).fetch("permissions")
+  abort "#{job_id} must grant Codecov OIDC" unless permissions.fetch("id-token") == "write"
+end

--- a/.github/scripts/test_ci_contract.rb
+++ b/.github/scripts/test_ci_contract.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+workflow = YAML.safe_load(File.read(".github/workflows/ci.yml"))
+jobs = workflow.fetch("jobs")
+
+expected = {
+  "web-ci-gate" => "Web CI",
+  "backend-ci-gate" => "Backend CI",
+  "agent-ci-gate" => "Agent CI",
+  "infra-db-ci-gate" => "Infra & DB CI",
+  "cross-stack-e2e-gate" => "Cross-stack E2E",
+  "repository-quality-gate" => "Repository Quality",
+  "codecov-patch-gate" => "Codecov Patch"
+}
+
+expected.each do |job_id, name|
+  job = jobs.fetch(job_id)
+  abort "#{job_id} must expose '#{name}'" unless job.fetch("name") == name
+  abort "#{job_id} must always run to publish a required context" unless job.fetch("if").include?("always()")
+end
+
+deploy_needs = Array(jobs.fetch("deploy-staging").fetch("needs"))
+missing = expected.keys - deploy_needs
+abort "deploy-staging is missing stable lanes: #{missing.join(', ')}" unless missing.empty?
+
+cross_stack = jobs.fetch("changes").fetch("outputs").fetch("cross_stack")
+abort "changes must expose cross_stack output" unless cross_stack.include?("cross_stack")
+
+puts "CI contract: seven stable lanes and staging dependencies are present"

--- a/.github/scripts/test_ci_contract.rb
+++ b/.github/scripts/test_ci_contract.rb
@@ -39,3 +39,6 @@ ci_source = File.read(".github/workflows/ci.yml")
 abort "Codecov lane must defer changed-line calculation to codecov/patch" unless ci_source.include?("codecov/patch")
 abort "cross_stack filter must include browser-suite changes" unless ci_source.include?("e2e/**")
 abort "stable lanes must observe changes status" unless ci_source.scan("${{ needs.changes.result }}").length >= expected.length
+
+gate_script = File.read(".github/scripts/assert-ci-needs.sh")
+abort "lane status checker must require changes success" unless gate_script.include?("changes_status")

--- a/.github/scripts/test_codecov_patch.rb
+++ b/.github/scripts/test_codecov_patch.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+config = YAML.safe_load(File.read("codecov.yml"))
+target = config.dig("coverage", "status", "patch", "default", "target")
+informational = config.dig("coverage", "status", "patch", "default", "informational")
+
+abort "Codecov patch target must remain 95%, got #{target.inspect}" unless target == "95%"
+abort "Codecov patch status must be blocking" if informational == true
+
+puts "Codecov patch policy: target=#{target}, informational=#{informational || false}"

--- a/.github/workflows/_cross-stack-e2e.yml
+++ b/.github/workflows/_cross-stack-e2e.yml
@@ -24,7 +24,9 @@ jobs:
         run: pnpm --filter web test:integration
 
       - name: Install Playwright browser
-        run: pnpm --dir e2e --config.ignore-scripts=true exec playwright install --with-deps chromium
+        run: |
+          test -x node_modules/.bin/playwright
+          node_modules/.bin/playwright install --with-deps chromium
 
       - name: Exercise emitted Worker routes
         shell: bash

--- a/.github/workflows/_cross-stack-e2e.yml
+++ b/.github/workflows/_cross-stack-e2e.yml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm --filter web test:integration
 
       - name: Install Playwright browser
-        run: pnpm --ignore-scripts --dir e2e exec playwright install --with-deps chromium
+        run: pnpm --dir e2e --config.ignore-scripts=true exec playwright install --with-deps chromium
 
       - name: Exercise emitted Worker routes
         shell: bash

--- a/.github/workflows/_cross-stack-e2e.yml
+++ b/.github/workflows/_cross-stack-e2e.yml
@@ -1,0 +1,43 @@
+# Reusable emitted-worker browser smoke lane. It deliberately runs against the
+# same `.output` artifact that the web deploy workflow publishes, not a Vite
+# dev server, so route/asset regressions fail before staging promotion.
+name: _cross-stack-e2e
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+jobs:
+  cross-stack-e2e:
+    name: Cross-stack E2E runner
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Build emitted web Worker
+        run: pnpm --filter web test:integration
+
+      - name: Install Playwright browser
+        run: pnpm --dir e2e exec playwright install --with-deps chromium
+
+      - name: Exercise emitted Worker routes
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm --filter web exec wrangler dev --port 8799 &
+          wrangler_pid=$!
+          trap 'kill "$wrangler_pid" 2>/dev/null || true' EXIT
+          for _ in $(seq 1 60); do
+            if curl -sf -o /dev/null http://localhost:8799/; then
+              break
+            fi
+            sleep 1
+          done
+          curl -sf -o /dev/null http://localhost:8799/ || exit 1
+          E2E_WEB_BASE_URL=http://localhost:8799 pnpm --dir e2e exec playwright test web-404.spec.ts web-maplibre-canary.spec.ts

--- a/.github/workflows/_cross-stack-e2e.yml
+++ b/.github/workflows/_cross-stack-e2e.yml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm --filter web test:integration
 
       - name: Install Playwright browser
-        run: pnpm --dir e2e exec playwright install --with-deps chromium
+        run: pnpm --ignore-scripts --dir e2e exec playwright install --with-deps chromium
 
       - name: Exercise emitted Worker routes
         shell: bash

--- a/.github/workflows/_python-ci.yml
+++ b/.github/workflows/_python-ci.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 env:
   PYTHON_VERSION: "3.11"
@@ -72,4 +73,5 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: apps/${{ inputs.app }}/coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+          use_oidc: true

--- a/.github/workflows/_ts-ci.yml
+++ b/.github/workflows/_ts-ci.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   ts-ci:
@@ -53,4 +54,5 @@ jobs:
         with:
           files: workers/${{ inputs.component }}/coverage/lcov.info
           flags: ${{ inputs.component }}
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+          use_oidc: true

--- a/.github/workflows/_webapp-ci.yml
+++ b/.github/workflows/_webapp-ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   webapp-ci:
@@ -37,7 +38,8 @@ jobs:
         with:
           files: apps/web/coverage/lcov.info
           flags: web
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+          use_oidc: true
 
       # Runs the browser AC (branded 404) against the same artifact the integration step built.
       - name: Install Playwright browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,6 +500,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # This stable context is a policy/upload precondition, not a local
+      # reimplementation of Codecov's changed-line calculation. The real 95%
+      # patch verdict is the external `codecov/patch` status produced after the
+      # component uploads; the repository ruleset must require both contexts.
       - name: Verify component coverage results
         env:
           STATUSES: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
     name: Agent component CI
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.agent == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/_python-ci.yml
     with:
       app: agent
@@ -113,6 +116,9 @@ jobs:
     name: Catalog CI
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.catalog == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/_ts-ci.yml
     with:
       component: catalog
@@ -121,6 +127,9 @@ jobs:
     name: Users CI
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.users == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/_ts-ci.yml
     with:
       component: users
@@ -147,6 +156,9 @@ jobs:
     name: Web component CI
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.web == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/_webapp-ci.yml
 
   ci-worker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,6 +497,8 @@ jobs:
         run: bash .github/scripts/assert-ci-needs.sh "Repository Quality" "$STATUSES"
       - name: Verify CI contract
         run: ruby .github/scripts/test_ci_contract.rb
+      - name: Verify lane failure paths
+        run: bash .github/scripts/assert-ci-needs.test.sh
 
   codecov-patch-gate:
     name: Codecov Patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
 
   web-ci-gate:
     name: Web CI
-    needs: [ci-web]
+    needs: [changes, ci-web]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -398,11 +398,12 @@ jobs:
       - name: Verify Web component result
         env:
           STATUSES: ${{ needs.ci-web.result }}
-        run: bash .github/scripts/assert-ci-needs.sh "Web CI" "$STATUSES"
+          CHANGES_STATUS: ${{ needs.changes.result }}
+        run: bash .github/scripts/assert-ci-needs.sh "Web CI" "$CHANGES_STATUS $STATUSES"
 
   backend-ci-gate:
     name: Backend CI
-    needs: [ci-catalog, ci-users, contract-openapi-drift, ci-worker]
+    needs: [changes, ci-catalog, ci-users, contract-openapi-drift, ci-worker]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -412,6 +413,7 @@ jobs:
       - name: Verify backend component results
         env:
           STATUSES: >-
+            ${{ needs.changes.result }}
             ${{ needs.ci-catalog.result }}
             ${{ needs.ci-users.result }}
             ${{ needs.contract-openapi-drift.result }}
@@ -420,7 +422,7 @@ jobs:
 
   agent-ci-gate:
     name: Agent CI
-    needs: [ci-agent, agent-eval-smoke]
+    needs: [changes, ci-agent, agent-eval-smoke]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -430,13 +432,14 @@ jobs:
       - name: Verify agent component results
         env:
           STATUSES: >-
+            ${{ needs.changes.result }}
             ${{ needs.ci-agent.result }}
             ${{ needs.agent-eval-smoke.result }}
         run: bash .github/scripts/assert-ci-needs.sh "Agent CI" "$STATUSES"
 
   infra-db-ci-gate:
     name: Infra & DB CI
-    needs: [ci-infra, db-validate]
+    needs: [changes, ci-infra, db-validate]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -446,6 +449,7 @@ jobs:
       - name: Verify infra and migration results
         env:
           STATUSES: >-
+            ${{ needs.changes.result }}
             ${{ needs.ci-infra.result }}
             ${{ needs.db-validate.result }}
         run: bash .github/scripts/assert-ci-needs.sh "Infra & DB CI" "$STATUSES"
@@ -461,7 +465,7 @@ jobs:
 
   cross-stack-e2e-gate:
     name: Cross-stack E2E
-    needs: [ci-cross-stack-e2e]
+    needs: [changes, ci-cross-stack-e2e]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -470,12 +474,14 @@ jobs:
           persist-credentials: false
       - name: Verify cross-stack result
         env:
-          STATUSES: ${{ needs.ci-cross-stack-e2e.result }}
+          STATUSES: >-
+            ${{ needs.changes.result }}
+            ${{ needs.ci-cross-stack-e2e.result }}
         run: bash .github/scripts/assert-ci-needs.sh "Cross-stack E2E" "$STATUSES"
 
   repository-quality-gate:
     name: Repository Quality
-    needs: [security, agnix]
+    needs: [changes, security, agnix]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -485,6 +491,7 @@ jobs:
       - name: Verify repository-quality component results
         env:
           STATUSES: >-
+            ${{ needs.changes.result }}
             ${{ needs.security.result }}
             ${{ needs.agnix.result }}
         run: bash .github/scripts/assert-ci-needs.sh "Repository Quality" "$STATUSES"
@@ -493,7 +500,7 @@ jobs:
 
   codecov-patch-gate:
     name: Codecov Patch
-    needs: [ci-agent, ci-catalog, ci-users, ci-web, ci-worker]
+    needs: [changes, ci-agent, ci-catalog, ci-users, ci-web, ci-worker]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -507,6 +514,7 @@ jobs:
       - name: Verify component coverage results
         env:
           STATUSES: >-
+            ${{ needs.changes.result }}
             ${{ needs.ci-agent.result }}
             ${{ needs.ci-catalog.result }}
             ${{ needs.ci-users.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       neon_agent: ${{ steps.f.outputs.neon_agent }}
       neon_catalog: ${{ steps.f.outputs.neon_catalog }}
       neon_migrations: ${{ steps.f.outputs.neon_migrations }}
+      cross_stack: ${{ steps.f.outputs.cross_stack }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -92,12 +93,16 @@ jobs:
             neon_agent: ['apps/agent/**']
             neon_catalog: ['workers/catalog/**']
             neon_migrations: ['db/migrations/**']
+            # The cross-stack browser lane exercises emitted apps/web output
+            # and the edge-facing worker together. Keep its scope broad enough
+            # to catch contract and deployment wiring changes.
+            cross_stack: ['apps/**', 'worker/**', 'workers/**', 'packages/contract/**', 'db/**', 'infra/**', '.github/workflows/**', '.github/actions/**']
 
   # ── Stage 1: Component CI (reusable workflows, all parallel) ──
   # affected-only on PRs; full run on push/tag.
 
   ci-agent:
-    name: Agent CI
+    name: Agent component CI
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.agent == 'true' }}
     uses: ./.github/workflows/_python-ci.yml
@@ -124,7 +129,7 @@ jobs:
     name: Contract OpenAPI drift
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.contract == 'true' }}
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.contract == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -139,13 +144,13 @@ jobs:
           git diff --cached --exit-code -- packages/contract/openapi.json packages/contract/users-openapi.json
 
   ci-web:
-    name: Web app CI
+    name: Web component CI
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.web == 'true' }}
     uses: ./.github/workflows/_webapp-ci.yml
 
   ci-worker:
-    name: Edge worker tests
+    name: Edge worker component CI
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.worker == 'true' }}
@@ -157,7 +162,7 @@ jobs:
       - run: pnpm run test:worker
 
   ci-infra:
-    name: Infra CI
+    name: Infra component CI
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.infra == 'true' }}
@@ -375,6 +380,138 @@ jobs:
         run: pnpm run test:spike
         working-directory: workers/catalog
 
+  # ── Stable required contexts ─────────────────────────────────
+  # Component jobs above remain affected-only on pull requests. These lane
+  # jobs are the branch-protection contract: every lane is created on every
+  # workflow run and accepts an intentionally skipped component as green.
+  # A failed or cancelled component still fails its lane and blocks promotion.
+
+  web-ci-gate:
+    name: Web CI
+    needs: [ci-web]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify Web component result
+        env:
+          STATUSES: ${{ needs.ci-web.result }}
+        run: bash .github/scripts/assert-ci-needs.sh "Web CI" "$STATUSES"
+
+  backend-ci-gate:
+    name: Backend CI
+    needs: [ci-catalog, ci-users, contract-openapi-drift, ci-worker]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify backend component results
+        env:
+          STATUSES: >-
+            ${{ needs.ci-catalog.result }}
+            ${{ needs.ci-users.result }}
+            ${{ needs.contract-openapi-drift.result }}
+            ${{ needs.ci-worker.result }}
+        run: bash .github/scripts/assert-ci-needs.sh "Backend CI" "$STATUSES"
+
+  agent-ci-gate:
+    name: Agent CI
+    needs: [ci-agent, agent-eval-smoke]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify agent component results
+        env:
+          STATUSES: >-
+            ${{ needs.ci-agent.result }}
+            ${{ needs.agent-eval-smoke.result }}
+        run: bash .github/scripts/assert-ci-needs.sh "Agent CI" "$STATUSES"
+
+  infra-db-ci-gate:
+    name: Infra & DB CI
+    needs: [ci-infra, db-validate]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify infra and migration results
+        env:
+          STATUSES: >-
+            ${{ needs.ci-infra.result }}
+            ${{ needs.db-validate.result }}
+        run: bash .github/scripts/assert-ci-needs.sh "Infra & DB CI" "$STATUSES"
+
+  # The reusable workflow is intentionally broad and is independently
+  # path-filtered by `changes.cross_stack`; its result is folded into a stable
+  # lane below so documentation-only PRs still receive a required check.
+  ci-cross-stack-e2e:
+    name: Cross-stack E2E component
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.cross_stack == 'true' }}
+    uses: ./.github/workflows/_cross-stack-e2e.yml
+
+  cross-stack-e2e-gate:
+    name: Cross-stack E2E
+    needs: [ci-cross-stack-e2e]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify cross-stack result
+        env:
+          STATUSES: ${{ needs.ci-cross-stack-e2e.result }}
+        run: bash .github/scripts/assert-ci-needs.sh "Cross-stack E2E" "$STATUSES"
+
+  repository-quality-gate:
+    name: Repository Quality
+    needs: [security, agnix]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify repository-quality component results
+        env:
+          STATUSES: >-
+            ${{ needs.security.result }}
+            ${{ needs.agnix.result }}
+        run: bash .github/scripts/assert-ci-needs.sh "Repository Quality" "$STATUSES"
+      - name: Verify CI contract
+        run: ruby .github/scripts/test_ci_contract.rb
+
+  codecov-patch-gate:
+    name: Codecov Patch
+    needs: [ci-agent, ci-catalog, ci-users, ci-web, ci-worker]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify component coverage results
+        env:
+          STATUSES: >-
+            ${{ needs.ci-agent.result }}
+            ${{ needs.ci-catalog.result }}
+            ${{ needs.ci-users.result }}
+            ${{ needs.ci-web.result }}
+            ${{ needs.ci-worker.result }}
+        run: bash .github/scripts/assert-ci-needs.sh "Codecov Patch" "$STATUSES"
+      - name: Verify patch coverage policy
+        run: ruby .github/scripts/test_codecov_patch.rb
+
   # ── Stage 3: Deploy (CI-green gated, push-main promotion path) ──
   # Promotion: push main → CI → staging → post-staging (api) → prod (human gate) → post-prod.
   # A single push to main drives the full pipeline; no separate tag trigger needed.
@@ -383,7 +520,7 @@ jobs:
   # push main → staging
   deploy-staging:
     name: Deploy staging
-    needs: [ci-agent, ci-catalog, ci-web, ci-worker, db-validate, security]
+    needs: [agent-ci-gate, backend-ci-gate, web-ci-gate, infra-db-ci-gate, cross-stack-e2e-gate, repository-quality-gate, codecov-patch-gate]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/_deploy-component.yml
     with:
@@ -404,7 +541,7 @@ jobs:
 
   deploy-web-staging:
     name: Deploy web staging
-    needs: [ci-agent, ci-catalog, ci-web, ci-worker, db-validate, security]
+    needs: [agent-ci-gate, backend-ci-gate, web-ci-gate, infra-db-ci-gate, cross-stack-e2e-gate, repository-quality-gate, codecov-patch-gate]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/_deploy-component.yml
     with:
@@ -421,7 +558,7 @@ jobs:
 
   deploy-users-staging:
     name: Deploy users staging
-    needs: [deploy-staging, ci-users]
+    needs: [deploy-staging]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/_deploy-component.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
             # The cross-stack browser lane exercises emitted apps/web output
             # and the edge-facing worker together. Keep its scope broad enough
             # to catch contract and deployment wiring changes.
-            cross_stack: ['apps/**', 'worker/**', 'workers/**', 'packages/contract/**', 'db/**', 'infra/**', '.github/workflows/**', '.github/actions/**']
+            cross_stack: ['apps/**', 'worker/**', 'workers/**', 'packages/contract/**', 'db/**', 'infra/**', 'e2e/**', '.github/workflows/**', '.github/actions/**']
 
   # ── Stage 1: Component CI (reusable workflows, all parallel) ──
   # affected-only on PRs; full run on push/tag.

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -277,8 +277,13 @@ only start when `github.event_name == 'push'` and `github.ref == 'refs/heads/mai
 
 On a push to `main`, the current promotion chain is:
 
-1. component CI, worker tests, DB migration dry-run, and security jobs run first. The agnix job is
-   warn-only and is intentionally outside the deploy `needs:` chain.
+1. The seven stable required lanes run first: `Web CI`, `Backend CI`, `Agent CI`, `Infra & DB CI`,
+   `Cross-stack E2E`, `Repository Quality`, and `Codecov Patch`. Their component jobs remain
+   affected-only on pull requests, while each stable lane is always created and treats an
+   intentionally skipped component as green. A failed or cancelled component fails its lane and
+   blocks promotion. The `agnix` check remains warn-only inside `Repository Quality`; its warning
+   policy is explicit and does not mask failures from the security reusable workflow or CI contract
+   test.
 2. `deploy-staging` calls `_deploy-component.yml` with `component: catalog`,
    `environment: staging`, and `pulumi_stack: staging`.
 3. `_deploy-component.yml` runs with `environment: ${{ inputs.environment }}`. It checks out the

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -283,7 +283,9 @@ On a push to `main`, the current promotion chain is:
    intentionally skipped component as green. A failed or cancelled component fails its lane and
    blocks promotion. The `agnix` check remains warn-only inside `Repository Quality`; its warning
    policy is explicit and does not mask failures from the security reusable workflow or CI contract
-   test.
+   test. `Codecov Patch` is deliberately only the stable upload/policy precondition: it does not
+   calculate changed-line coverage locally. The GitHub ruleset must require the external Codecov
+   `codecov/patch` status as the real 95% changed-line verdict as well as this stable context.
 2. `deploy-staging` calls `_deploy-component.yml` with `component: catalog`,
    `environment: staging`, and `pulumi_stack: staging`.
 3. `_deploy-component.yml` runs with `environment: ${{ inputs.environment }}`. It checks out the

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -286,6 +286,8 @@ On a push to `main`, the current promotion chain is:
    test. `Codecov Patch` is deliberately only the stable upload/policy precondition: it does not
    calculate changed-line coverage locally. The GitHub ruleset must require the external Codecov
    `codecov/patch` status as the real 95% changed-line verdict as well as this stable context.
+   Coverage upload jobs use GitHub OIDC and fail closed when Codecov cannot authenticate or publish;
+   they do not silently accept a tokenless upload failure.
 2. `deploy-staging` calls `_deploy-component.yml` with `component: catalog`,
    `environment: staging`, and `pulumi_stack: staging`.
 3. `_deploy-component.yml` runs with `environment: ${{ inputs.environment }}`. It checks out the


### PR DESCRIPTION
## S0.3 CI convergence

- Adds stable required contexts: `Web CI`, `Backend CI`, `Agent CI`, `Infra & DB CI`, `Cross-stack E2E`, `Repository Quality`, and `Codecov Patch`.
- Aggregate lanes are always created and treat only intentional component `skipped` results as green; path detection itself must be `success`, and failure/cancellation fails the lane.
- Staging deploy jobs depend on all stable lanes, including `deploy-web-staging`.
- Adds emitted-worker cross-stack browser smoke and CI/Codecov contract checks; `e2e/**` changes trigger the cross-stack lane.
- Coverage upload workflows use GitHub OIDC and `fail_ci_if_error: true`; tokenless Codecov failures cannot be silently accepted.

### Evidence

- actionlint 1.7.12 — PASS
- shellcheck — PASS
- Ruby CI contract + Codecov OIDC contract — PASS
- failure-path shell contract (changes skipped/failure rejected) — PASS
- emitted Wrangler + Playwright — 5/5 PASS
- staged gitleaks, diff check, and pre-commit — PASS
- PR CI run 30715020334 — 26 checks passed; stable lanes, CodeQL, security, and Sonar passed
- This PR intentionally changes only workflow/docs files, so affected component coverage uploads are skipped. The first component-touching PR must verify authenticated OIDC upload and the external `codecov/patch` 95% verdict before that context is added to the ruleset.
- `make check` remains blocked in the agent uv dependency download path by sandbox network/Operation not permitted; not reported green
- No live GitHub ruleset update, staging deploy, production deploy, R2 object upload, or Cloudflare live probe was performed

### AC mapping

- `integration`: emitted Worker, Playwright, CI contracts, package gates
- `browser`: Playwright web 404/map canary
- `api`: ruleset and external Codecov status remain root/GitHub verification work
- `eval`: not applicable to workflow wiring