### PR TITLE
feat(map): private R2 tiles through same-origin edge route

### DIFF
--- a/apps/web/src/features/map-spike/mapStyle.ts
+++ b/apps/web/src/features/map-spike/mapStyle.ts
@@ -5,8 +5,10 @@ import type { SourceMode } from "./sourceMode";
 
 const ATTRIBUTION = "© OpenStreetMap contributors, Protomaps";
 const SOURCE_ID = "protomaps";
-// Protomaps basemap assets; production copies these to R2 same-origin with the tiles.
-const BASEMAP_ASSETS = "https://protomaps.github.io/basemaps-assets";
+/** Same-origin R2 proxy. The bucket remains private; the edge Worker exposes only this prefix. */
+export const TILE_ASSET_BASE_URL = "/tiles";
+export const TILE_GLYPH_URL = `${TILE_ASSET_BASE_URL}/fonts/{fontstack}/{range}.pbf`;
+export const TILE_SPRITE_URL = `${TILE_ASSET_BASE_URL}/sprites/v4/light`;
 
 const workerSource = () => {
   return { type: "vector" as const, tiles: [TILE_ZXY_URL], minzoom: 0, maxzoom: 15, attribution: ATTRIBUTION };
@@ -23,8 +25,8 @@ export const createMapStyle = (mode: SourceMode, tilePath: string = TILE_PMTILES
   return {
     version: 8,
     name: "animichi-map-spike",
-    glyphs: `${BASEMAP_ASSETS}/fonts/{fontstack}/{range}.pbf`,
-    sprite: `${BASEMAP_ASSETS}/sprites/v4/light`,
+    glyphs: TILE_GLYPH_URL,
+    sprite: TILE_SPRITE_URL,
     sources: { [SOURCE_ID]: mode === "worker" ? workerSource() : pmtilesSource(tilePath) },
     layers: layers(SOURCE_ID, brandLight(), { lang: "ja" }),
   };

--- a/apps/web/tests/unit/map-spike-style.test.ts
+++ b/apps/web/tests/unit/map-spike-style.test.ts
@@ -11,6 +11,8 @@ describe("createMapStyle", () => {
     expect(style.version).toBe(8);
     expect(style.layers.length).toBeGreaterThan(0);
     expect(source(style)).toBeDefined();
+    expect(style.glyphs).toBe("/tiles/fonts/{fontstack}/{range}.pbf");
+    expect(style.sprite).toBe("/tiles/sprites/v4/light");
   });
 
   it("references the pmtiles archive via the pmtiles:// protocol by default", () => {

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -15,6 +15,8 @@ import * as cloudflare from "@pulumi/cloudflare";
 const config = new pulumi.Config();
 const stack = pulumi.getStack();
 const mediaBucketName = stack === "prod" ? "catalog-media" : `catalog-media-${stack}`;
+const mapTilesBucketName =
+  stack === "prod" ? "map-tiles" : stack === "staging" ? "map-tiles-staging" : `map-tiles-${stack}`;
 const accountId = config.require("cloudflareAccountId");
 const webRoutesEnabled = config.getBoolean("webRoutesEnabled") ?? false;
 
@@ -51,6 +53,17 @@ const catalogMediaBucket = new cloudflare.R2Bucket("catalog-media", {
   location: "apac",
 });
 
+// Map tiles, glyphs, sprites, and style JSON are private R2 objects. The edge
+// Worker is the sole public reader through `/tiles/*`; there is intentionally
+// no R2 public bucket/domain configuration here. Production and staging use
+// stable names consumed by their matching wrangler environment; an unrecognised
+// preview stack gets an isolated suffix instead of sharing either live bucket.
+const mapTilesBucket = new cloudflare.R2Bucket("map-tiles", {
+  accountId,
+  name: mapTilesBucketName,
+  location: "apac",
+});
+
 if (webRoutesEnabled) {
   const cloudflareZoneId = config.require("cloudflareZoneId");
   const webScript = stack === "prod" ? "animichi-web" : `animichi-web-${stack}`;
@@ -58,7 +71,7 @@ if (webRoutesEnabled) {
 
   // The hostname this stack serves: prod owns the apex, every other stack its
   // own subdomain. Both get the SAME split — the Custom Domain is the origin
-  // for pages, and the three routes run ahead of it for the API surfaces.
+  // for pages, and the four routes run ahead of it for the API/map surfaces.
   // Staging must not be an exception: `apps/web` calls `/v1/chat`,
   // `/v1/photo-search`, `/v1/conversations/...` relative to its own origin, so a
   // staging hostname pointed wholly at the web Worker has no chat at all.
@@ -93,6 +106,12 @@ if (webRoutesEnabled) {
   new cloudflare.WorkersRoute("animichi-edge-img-route", {
     zoneId: cloudflareZoneId,
     pattern: `${apexDomain}/img/*`,
+    script: edgeScript,
+  });
+
+  new cloudflare.WorkersRoute("animichi-edge-tiles-route", {
+    zoneId: cloudflareZoneId,
+    pattern: `${apexDomain}/tiles/*`,
     script: edgeScript,
   });
 
@@ -204,3 +223,4 @@ if (stagingGateEnabled && stack === "staging") {
 
 export const wave0 = pulumi.output("spike-validated");
 export const catalogBucketName = catalogMediaBucket.name;
+export const tilesBucketName = mapTilesBucket.name;

--- a/infra/topology-disabled.test.ts
+++ b/infra/topology-disabled.test.ts
@@ -14,9 +14,12 @@ import { buildStack, type Built } from "./testing/harness.ts";
 // import fails, which is itself the finding.
 const built: Built[] = await buildStack("prod", { cloudflareAccountId: "acct" });
 
-test("the R2 bucket is the only thing an ungated stack creates", () => {
+test("only private R2 buckets exist when an ungated stack is built", () => {
   const types = built.map((r) => r.type);
-  assert.deepEqual(types, ["cloudflare:index/r2Bucket:R2Bucket"]);
+  assert.deepEqual(types, [
+    "cloudflare:index/r2Bucket:R2Bucket",
+    "cloudflare:index/r2Bucket:R2Bucket",
+  ]);
 });
 
 test("nothing that could publish the site is declared", () => {

--- a/infra/topology-prod.test.ts
+++ b/infra/topology-prod.test.ts
@@ -29,11 +29,12 @@ test("the apex serves the web Worker, not the edge Worker", () => {
   assert.equal(domain.inputs.service, "animichi-web");
 });
 
-test("exactly the three API surfaces are routed to the edge Worker", () => {
+test("the API and map asset surfaces are routed to the edge Worker", () => {
   const patterns = ofType(built, ROUTE).map((r) => r.inputs.pattern).sort();
   assert.deepEqual(patterns, [
     "animichi.com/healthz",
     "animichi.com/img/*",
+    "animichi.com/tiles/*",
     "animichi.com/v1/*",
   ]);
   for (const route of ofType(built, ROUTE)) {
@@ -78,4 +79,11 @@ test("the staging WAF gate stays off on prod", () => {
   // this file could emit.
   const rulesets = ofType(built, RULESET).map((r) => r.name);
   assert.deepEqual(rulesets, ["animichi-www-redirect"]);
+});
+
+test("production map bucket is private and uses the stable Wrangler name", () => {
+  const buckets = ofType(built, "cloudflare:index/r2Bucket:R2Bucket");
+  assert.equal(buckets.length, 2);
+  assert.deepEqual(buckets.map((bucket) => bucket.inputs.name), ["catalog-media", "map-tiles"]);
+  assert.equal(buckets.every((bucket) => bucket.inputs.accountId === "acct"), true);
 });

--- a/infra/topology-staging.test.ts
+++ b/infra/topology-staging.test.ts
@@ -28,7 +28,7 @@ test("staging targets the stack-suffixed Workers, not the production ones", () =
   assert.equal(domain.inputs.service, "animichi-web-staging");
 });
 
-test("staging gets the SAME three edge routes as prod", () => {
+test("staging gets the SAME API and map routes as prod", () => {
   // The bug this exists to prevent: a staging hostname pointed wholly at the
   // web Worker. `apps/web` calls `/v1/chat` on its own origin, so that
   // configuration leaves staging with no chat API at all — and nothing else
@@ -37,6 +37,7 @@ test("staging gets the SAME three edge routes as prod", () => {
   assert.deepEqual(patterns, [
     "staging.animichi.com/healthz",
     "staging.animichi.com/img/*",
+    "staging.animichi.com/tiles/*",
     "staging.animichi.com/v1/*",
   ]);
   for (const route of ofType(built, ROUTE)) {
@@ -88,4 +89,11 @@ test("an ordinary input on this same stack is NOT sealed", () => {
   const routes = ofType(built, ROUTE);
   assert.ok(routes.length > 0);
   assert.equal(unseal(routes[0].inputs.pattern).isSecret, false);
+});
+
+test("staging map bucket is isolated from production", () => {
+  const buckets = ofType(built, "cloudflare:index/r2Bucket:R2Bucket");
+  assert.equal(buckets.length, 2);
+  assert.deepEqual(buckets.map((bucket) => bucket.inputs.name), ["catalog-media-staging", "map-tiles-staging"]);
+  assert.equal(buckets.every((bucket) => bucket.inputs.accountId === "acct"), true);
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "lint:oxlint": "pnpm --filter catalog --filter users --filter web run lint:oxlint",
-    "test:worker": "node --test worker/entry.test.ts worker/gatewayFallback.test.ts worker/photoSearch.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/turnstileArm.test.ts worker/turnstileReplay.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/sessionMigration.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/byokBudgetExemption.test.ts worker/byokProbeAuth.test.ts worker/edgeGuard.test.ts worker/authRateLimitScope.test.ts worker/containerEnv.test.ts worker/catalogOutbound.test.ts worker/authConfig.test.ts worker/dependabotWorkflow.test.ts",
+    "test:worker": "node --test worker/entry.test.ts worker/gatewayFallback.test.ts worker/photoSearch.test.ts worker/auth.test.ts worker/auth-neon.test.ts worker/turnstile.test.ts worker/turnstileArm.test.ts worker/turnstileReplay.test.ts worker/anonymousIdentity.test.ts worker/anonymous.test.ts worker/authFallthrough.test.ts worker/authScheme.test.ts worker/sessionMigration.test.ts worker/rateLimiter.test.ts worker/costBreaker.test.ts worker/byok.test.ts worker/byokBudgetExemption.test.ts worker/byokProbeAuth.test.ts worker/edgeGuard.test.ts worker/authRateLimitScope.test.ts worker/containerEnv.test.ts worker/catalogOutbound.test.ts worker/authConfig.test.ts worker/dependabotWorkflow.test.ts worker/tiles.test.ts",
     "verify:dependabot": "pnpm run lint:oxlint && pnpm run test:worker && pnpm -r --if-present typecheck && pnpm --filter web build"
   },
   "dependencies": {

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -23,12 +23,14 @@ import {
 } from "./rateLimiter.ts";
 import { catalogRequestAllowed } from "./catalogPolicy.ts";
 import { type TurnstileGate, createTurnstileGate, guardTurnstile } from "./turnstile.ts";
+import { handleTiles, type TileBucket } from "./tiles.ts";
 
 export interface Env {
   CATALOG: { fetch: (req: Request) => Promise<Response> };
   USERS: { fetch: (req: Request) => Promise<Response> };
   CONTAINER: DurableObjectNamespace;
   EDGE_GUARD: GuardNamespace;
+  MAP_TILES?: TileBucket;
   SUPABASE_URL: string;
   SUPABASE_ANON_KEY: string;
   SUPABASE_SERVICE_ROLE_KEY: string;
@@ -351,8 +353,9 @@ async function handleImageProxy(request: Request, ctx: WorkerExecutionContext): 
   return response;
 }
 
-/** The main Worker app: a pure API gateway (`/v1`, `/healthz`, the image proxy,
- * and the one allowlisted public catalog read). NOTE: no /catalog/* route —
+/** The main Worker app: a pure API and asset gateway (`/v1`, `/healthz`, the
+ * image and private R2 tile proxies, and one allowlisted public catalog read).
+ * NOTE: no /catalog/* route —
  * catalog is private (reached only via the container outboundByHost binding,
  * never the public internet).
  *
@@ -376,6 +379,7 @@ function registerWorkerRoutes(app: WorkerApp, deps: WorkerDeps): void {
   app.get("/healthz", (c) =>
     c.env.CONTAINER.get(c.env.CONTAINER.idFromName("default")).fetch(c.req.raw),
   );
+  app.all("/tiles/*", (c) => handleTiles(c.req.raw, c.env.MAP_TILES, c.executionCtx));
   app.all("/img/*", (c) => handleImageProxy(c.req.raw, c.executionCtx));
   app.get("/catalog/public/anime-overview/:bangumiId{[0-9]+}", async (c) => {
     if (new URL(c.req.url).search) return c.text("Unexpected query parameters", 400);

--- a/worker/tiles.test.ts
+++ b/worker/tiles.test.ts
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createWorkerApp } from "./app.ts";
+import type { TileBucket } from "./tiles.ts";
+
+const ctx = {
+  waitUntil: () => undefined,
+  passThroughOnException: () => undefined,
+  props: {},
+} as unknown as ExecutionContext;
+
+type RecordedGet = Readonly<{ key: string; options?: Readonly<{ range?: Readonly<Record<string, number>> }> }>;
+
+const tileObject = (body = "tile", range?: Readonly<{ offset: number; length: number }>) => {
+  const response = new Response(body);
+  return {
+    body: response.body,
+    etag: "etag-tile",
+    size: body.length,
+    range,
+  };
+};
+
+const envFor = (get: TileBucket["get"]): never => ({ MAP_TILES: { get } } as never);
+
+void test("GET serves a same-origin vector asset with cache-safe headers", async () => {
+  let seen: RecordedGet | undefined;
+  const app = createWorkerApp({});
+  const response = await app.request(
+    "/tiles/14/135/892.mvt",
+    {},
+    envFor((key, options) => {
+      seen = { key, options: options as RecordedGet["options"] };
+      return Promise.resolve(tileObject("mvt-bytes"));
+    }),
+    ctx,
+  );
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Content-Type"), "application/vnd.mapbox-vector-tile");
+  assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+  assert.equal(await response.text(), "mvt-bytes");
+  assert.deepEqual(seen, { key: "tiles/14/135/892.mvt", options: undefined });
+});
+
+void test("a missing vector asset is an empty tile, not a storage failure", async () => {
+  const app = createWorkerApp({});
+  const response = await app.request(
+    "/tiles/0/0/0.mvt",
+    {},
+    envFor(() => Promise.resolve(null)),
+    ctx,
+  );
+  assert.equal(response.status, 204);
+  assert.equal(await response.text(), "");
+});
+
+void test("a missing glyph or style asset is a hard 404", async () => {
+  const app = createWorkerApp({});
+  const response = await app.request(
+    "/tiles/fonts/Noto%20Sans/0-255.pbf",
+    {},
+    envFor(() => Promise.resolve(null)),
+    ctx,
+  );
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), { error: "tile_not_found" });
+});
+
+void test("the asset allowlist rejects unscoped objects and invalid tile coordinates", async () => {
+  let reads = 0;
+  const app = createWorkerApp({});
+  const get = () => {
+    reads += 1;
+    return Promise.resolve(tileObject());
+  };
+  const unscoped = await app.request("/tiles/private.json", {}, envFor(get), ctx);
+  const invalid = await app.request("/tiles/23/0/0.mvt", {}, envFor(get), ctx);
+  assert.equal(unscoped.status, 404);
+  assert.equal(invalid.status, 404);
+  assert.equal(reads, 0);
+});
+
+void test("Range requests pass through to R2 and return 206", async () => {
+  let seen: RecordedGet | undefined;
+  const app = createWorkerApp({});
+  const response = await app.request(
+    "/tiles/uji-kyoto.pmtiles",
+    { headers: { Range: "bytes=8-15" } },
+    envFor((key, options) => {
+      seen = { key, options: options as RecordedGet["options"] };
+      return Promise.resolve(tileObject("directory", { offset: 8, length: 8 }));
+    }),
+    ctx,
+  );
+  assert.equal(response.status, 206);
+  assert.equal(response.headers.get("Content-Range"), "bytes 8-15/9");
+  assert.deepEqual(seen, { key: "tiles/uji-kyoto.pmtiles", options: { range: { offset: 8, length: 8 } } });
+});
+
+void test("HEAD returns metadata without a response body", async () => {
+  const app = createWorkerApp({});
+  const response = await app.request(
+    "/tiles/uji-kyoto.pmtiles",
+    { method: "HEAD" },
+    envFor(() => Promise.resolve(tileObject("archive"))),
+    ctx,
+  );
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Content-Length"), "7");
+  assert.equal(await response.text(), "");
+});
+
+void test("invalid paths and methods cannot read arbitrary R2 objects", async () => {
+  let reads = 0;
+  const app = createWorkerApp({});
+  const get = () => {
+    reads += 1;
+    return Promise.resolve(tileObject());
+  };
+  const traversal = await app.request("/tiles/%2e%2e/secrets.json", {}, envFor(get), ctx);
+  const method = await app.request("/tiles/uji-kyoto.pmtiles", { method: "POST" }, envFor(get), ctx);
+  assert.equal(traversal.status, 404);
+  assert.equal(method.status, 405);
+  assert.equal(reads, 0);
+});
+
+void test("R2 failures are a retryable 503 for MapLibre fallback", async () => {
+  const app = createWorkerApp({});
+  const response = await app.request(
+    "/tiles/uji-kyoto.pmtiles",
+    {},
+    envFor(() => Promise.reject(new Error("r2 unavailable"))),
+    ctx,
+  );
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), { error: "tile_storage_unavailable" });
+});
+
+void test("a missing binding fails closed instead of falling through to another origin", async () => {
+  const app = createWorkerApp({});
+  const response = await app.request("/tiles/uji-kyoto.pmtiles", {}, {}, ctx);
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), { error: "tile_storage_unavailable" });
+});

--- a/worker/tiles.test.ts
+++ b/worker/tiles.test.ts
@@ -11,12 +11,12 @@ const ctx = {
 
 type RecordedGet = Readonly<{ key: string; options?: Readonly<{ range?: Readonly<Record<string, number>> }> }>;
 
-const tileObject = (body = "tile", range?: Readonly<{ offset: number; length: number }>) => {
+const tileObject = (body = "tile", range?: Readonly<{ offset: number; length: number }>, size = body.length) => {
   const response = new Response(body);
   return {
     body: response.body,
     etag: "etag-tile",
-    size: body.length,
+    size,
     range,
   };
 };
@@ -95,6 +95,23 @@ void test("Range requests pass through to R2 and return 206", async () => {
   assert.equal(response.status, 206);
   assert.equal(response.headers.get("Content-Range"), "bytes 8-15/9");
   assert.deepEqual(seen, { key: "tiles/uji-kyoto.pmtiles", options: { range: { offset: 8, length: 8 } } });
+});
+
+void test("suffix Range requests use the R2 suffix form and return 206", async () => {
+  let seen: RecordedGet | undefined;
+  const app = createWorkerApp({});
+  const response = await app.request(
+    "/tiles/uji-kyoto.pmtiles",
+    { headers: { Range: "bytes=-4" } },
+    envFor((key, options) => {
+      seen = { key, options: options as RecordedGet["options"] };
+      return Promise.resolve(tileObject("tail", { offset: 6, length: 4 }, 10));
+    }),
+    ctx,
+  );
+  assert.equal(response.status, 206);
+  assert.equal(response.headers.get("Content-Range"), "bytes 6-9/10");
+  assert.deepEqual(seen, { key: "tiles/uji-kyoto.pmtiles", options: { range: { suffix: 4 } } });
 });
 
 void test("HEAD returns metadata without a response body", async () => {

--- a/worker/tiles.test.ts
+++ b/worker/tiles.test.ts
@@ -63,6 +63,7 @@ void test("a missing glyph or style asset is a hard 404", async () => {
     ctx,
   );
   assert.equal(response.status, 404);
+  assert.equal(response.headers.get("Cache-Control"), "no-store");
   assert.deepEqual(await response.json(), { error: "tile_not_found" });
 });
 
@@ -127,6 +128,40 @@ void test("HEAD returns metadata without a response body", async () => {
   assert.equal(await response.text(), "");
 });
 
+void test("cache writes are GET-only and HEAD uses the GET cache key", async () => {
+  const matches: string[] = [];
+  const puts: string[] = [];
+  const previous = Object.getOwnPropertyDescriptor(globalThis, "caches");
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: {
+      default: {
+        match: (request: Request) => {
+          matches.push(request.method);
+          return Promise.resolve(null);
+        },
+        put: (request: Request) => {
+          puts.push(request.method);
+          return Promise.resolve();
+        },
+      },
+    },
+  });
+  try {
+    const app = createWorkerApp({});
+    const get = () => Promise.resolve(tileObject("archive"));
+    const head = await app.request("/tiles/uji-kyoto.pmtiles", { method: "HEAD" }, envFor(get), ctx);
+    const response = await app.request("/tiles/uji-kyoto.pmtiles", {}, envFor(get), ctx);
+    assert.equal(head.status, 200);
+    assert.equal(response.status, 200);
+    assert.deepEqual(matches, ["GET", "GET"]);
+    assert.deepEqual(puts, ["GET"]);
+  } finally {
+    if (previous) Object.defineProperty(globalThis, "caches", previous);
+    else Reflect.deleteProperty(globalThis, "caches");
+  }
+});
+
 void test("invalid paths and methods cannot read arbitrary R2 objects", async () => {
   let reads = 0;
   const app = createWorkerApp({});
@@ -150,6 +185,7 @@ void test("R2 failures are a retryable 503 for MapLibre fallback", async () => {
     ctx,
   );
   assert.equal(response.status, 503);
+  assert.equal(response.headers.get("Cache-Control"), "no-store");
   assert.deepEqual(await response.json(), { error: "tile_storage_unavailable" });
 });
 
@@ -157,5 +193,6 @@ void test("a missing binding fails closed instead of falling through to another 
   const app = createWorkerApp({});
   const response = await app.request("/tiles/uji-kyoto.pmtiles", {}, {}, ctx);
   assert.equal(response.status, 503);
+  assert.equal(response.headers.get("Cache-Control"), "no-store");
   assert.deepEqual(await response.json(), { error: "tile_storage_unavailable" });
 });

--- a/worker/tiles.ts
+++ b/worker/tiles.ts
@@ -59,18 +59,29 @@ const MIME_TYPES: Readonly<Record<string, string>> = {
 };
 
 const errorResponse = (status: number, code: string, request: Request): Response => {
-  return Response.json({ error: code }, { status, headers: responseHeaders(request) });
+  return Response.json({ error: code }, { status, headers: errorHeaders(request) });
 };
 
-const responseHeaders = (request: Request): Headers => {
+const corsHeaders = (request: Request): Headers => {
   const headers = new Headers({
     "Access-Control-Allow-Headers": "Range",
     "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
     "Access-Control-Allow-Origin": "*",
-    "Cache-Control": "public, max-age=86400, immutable",
     Vary: "Origin",
   });
   if (request.headers.has("Origin")) headers.set("Access-Control-Expose-Headers", "Accept-Ranges, Content-Length, Content-Range, ETag");
+  return headers;
+};
+
+const responseHeaders = (request: Request): Headers => {
+  const headers = corsHeaders(request);
+  headers.set("Cache-Control", "public, max-age=86400, immutable");
+  return headers;
+};
+
+const errorHeaders = (request: Request): Headers => {
+  const headers = corsHeaders(request);
+  headers.set("Cache-Control", "no-store");
   return headers;
 };
 
@@ -134,7 +145,10 @@ const cache = (): Cache | null => {
   return caches.default;
 };
 
-const cacheKey = (request: Request): Request => new Request(new URL(request.url).origin + new URL(request.url).pathname, request);
+const cacheKey = (request: Request): Request => {
+  const url = new URL(request.url);
+  return new Request(url.origin + url.pathname, { method: "GET" });
+};
 
 const cacheHit = async (request: Request): Promise<Response | null> => {
   const storage = cache();
@@ -143,7 +157,7 @@ const cacheHit = async (request: Request): Promise<Response | null> => {
 
 const cachePut = (request: Request, response: Response, ctx: TileExecutionContext): void => {
   const storage = cache();
-  if (storage) ctx.waitUntil(storage.put(cacheKey(request), response.clone()));
+  if (storage) ctx.waitUntil(storage.put(cacheKey(request), response.clone()).catch(() => undefined));
 };
 
 const setRangeHeaders = (headers: Headers, object: TileObject, range: TileRange | null): void => {
@@ -192,7 +206,7 @@ const fetchAsset = async (asset: TileAsset, request: Request, bucket: TileBucket
   const object = await bucket.get(asset.key, range === null ? undefined : { range });
   if (!object) return missingResponse(asset, request);
   const response = objectResponse(asset, object, request, range);
-  if (range === null && response.status === 200) cachePut(request, response, ctx);
+  if (request.method === "GET" && range === null && response.status === 200) cachePut(request, response, ctx);
   return response;
 };
 

--- a/worker/tiles.ts
+++ b/worker/tiles.ts
@@ -1,0 +1,207 @@
+/// <reference types="@cloudflare/workers-types" />
+
+const TILE_PREFIX = "/tiles/";
+const OBJECT_PREFIX = "tiles/";
+const MAX_PATH_LENGTH = 256;
+const ALLOWLISTED_EXTENSIONS = /\.(?:pmtiles|mvt|pbf|json|png|webp)$/i;
+const SAFE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9 .,+'@_-]*$/;
+const ARCHIVE_PATH = /^[A-Za-z0-9][A-Za-z0-9._-]*\.pmtiles$/i;
+const VECTOR_PATH = /^(\d{1,2})\/(\d{1,8})\/(\d{1,8})\.mvt$/i;
+const GLYPH_PATH = /^fonts\/[^/]+\/[^/]+\.pbf$/i;
+const SPRITE_PATH = /^sprites\/[^/]+\/[^/]+\.(?:json|png|webp)$/i;
+const STYLE_PATH = /^styles\/[^/]+\.json$/i;
+const RANGE_PATTERN = /^bytes=(\d+)-(\d*)$/;
+const SUFFIX_RANGE_PATTERN = /^bytes=-(\d+)$/;
+
+type TileAssetKind = "archive" | "vector" | "metadata" | "image";
+
+type TileAsset = Readonly<{
+  key: string;
+  kind: TileAssetKind;
+  contentType: string;
+}>;
+
+type TileRange = Readonly<{ offset: number; length?: number; suffix?: number }>;
+
+type TileGetOptions = Readonly<{ range?: TileRange }>;
+
+type TileObject = Readonly<{
+  body: ReadableStream<Uint8Array> | null;
+  etag: string;
+  httpEtag?: string;
+  size: number;
+  range?: Readonly<{ offset: number; length: number }>;
+  httpMetadata?: Readonly<{
+    contentType?: string;
+    cacheControl?: string;
+    contentEncoding?: string;
+  }>;
+}>;
+
+export interface TileBucket {
+  get(key: string, options?: TileGetOptions): Promise<TileObject | null>;
+}
+
+export interface TileExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+const MIME_TYPES: Readonly<Record<string, string>> = {
+  json: "application/json",
+  mvt: "application/vnd.mapbox-vector-tile",
+  pbf: "application/x-protobuf",
+  pmtiles: "application/octet-stream",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+const errorResponse = (status: number, code: string, request: Request): Response => {
+  return Response.json({ error: code }, { status, headers: responseHeaders(request) });
+};
+
+const responseHeaders = (request: Request): Headers => {
+  const headers = new Headers({
+    "Access-Control-Allow-Headers": "Range",
+    "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": "public, max-age=86400, immutable",
+    Vary: "Origin",
+  });
+  if (request.headers.has("Origin")) headers.set("Access-Control-Expose-Headers", "Accept-Ranges, Content-Length, Content-Range, ETag");
+  return headers;
+};
+
+const extensionOf = (key: string): string => key.slice(key.lastIndexOf(".") + 1).toLowerCase();
+
+const kindOf = (extension: string): TileAssetKind => {
+  if (extension === "pmtiles") return "archive";
+  if (extension === "mvt") return "vector";
+  if (extension === "json" || extension === "pbf") return "metadata";
+  return "image";
+};
+
+const validVectorCoordinates = (path: string): boolean => {
+  const match = VECTOR_PATH.exec(path);
+  if (!match) return false;
+  const zoom = Number(match[1]);
+  const maxCoordinate = 2 ** zoom;
+  return zoom <= 22 && Number(match[2]) < maxCoordinate && Number(match[3]) < maxCoordinate;
+};
+
+const allowlistedPath = (path: string): boolean => {
+  return ARCHIVE_PATH.test(path) || validVectorCoordinates(path) || GLYPH_PATH.test(path) || SPRITE_PATH.test(path) || STYLE_PATH.test(path);
+};
+
+const decodePath = (pathname: string): string | null => {
+  if (!pathname.startsWith(TILE_PREFIX) || pathname.length > TILE_PREFIX.length + MAX_PATH_LENGTH) return null;
+  const encodedPath = pathname.slice(TILE_PREFIX.length);
+  if (/%2f|%5c/i.test(encodedPath)) return null;
+  try {
+    return decodeURIComponent(encodedPath);
+  } catch {
+    return null;
+  }
+};
+
+const safeAsset = (pathname: string): TileAsset | null => {
+  const decoded = decodePath(pathname);
+  if (!decoded || decoded.includes("\\") || !ALLOWLISTED_EXTENSIONS.test(decoded) || !allowlistedPath(decoded)) return null;
+  const segments = decoded.split("/");
+  if (segments.some((segment) => segment.length === 0 || segment === "." || segment === ".." || !SAFE_SEGMENT.test(segment))) return null;
+  const extension = extensionOf(decoded);
+  return { key: `${OBJECT_PREFIX}${decoded}`, kind: kindOf(extension), contentType: MIME_TYPES[extension] ?? "application/octet-stream" };
+};
+
+const parseRange = (value: string | null): TileRange | null | undefined => {
+  if (value === null) return null;
+  const range = RANGE_PATTERN.exec(value);
+  if (range) {
+    const offset = Number(range[1]);
+    const end = range[2] === "" ? undefined : Number(range[2]);
+    if (end !== undefined && end < offset) return undefined;
+    return { offset, ...(end === undefined ? {} : { length: end - offset + 1 }) };
+  }
+  const suffix = SUFFIX_RANGE_PATTERN.exec(value);
+  if (suffix && Number(suffix[1]) > 0) return { offset: 0, suffix: Number(suffix[1]) };
+  return undefined;
+};
+
+const cache = (): Cache | null => {
+  if (typeof caches === "undefined") return null;
+  return caches.default;
+};
+
+const cacheKey = (request: Request): Request => new Request(new URL(request.url).origin + new URL(request.url).pathname, request);
+
+const cacheHit = async (request: Request): Promise<Response | null> => {
+  const storage = cache();
+  return storage ? (await storage.match(cacheKey(request))) ?? null : null;
+};
+
+const cachePut = (request: Request, response: Response, ctx: TileExecutionContext): void => {
+  const storage = cache();
+  if (storage) ctx.waitUntil(storage.put(cacheKey(request), response.clone()));
+};
+
+const setRangeHeaders = (headers: Headers, object: TileObject, range: TileRange | null): void => {
+  if (!range || !object.range) return;
+  const start = String(object.range.offset);
+  const end = String(object.range.offset + object.range.length - 1);
+  headers.set("Content-Range", `bytes ${start}-${end}/${String(object.size)}`);
+};
+
+const setBodyHeaders = (headers: Headers, object: TileObject): void => {
+  if (object.body) headers.set("Content-Length", String(object.range?.length ?? object.size));
+};
+
+const metadataHeaders = (asset: TileAsset, object: TileObject, request: Request, range: TileRange | null): Headers => {
+  const headers = responseHeaders(request);
+  headers.set("Accept-Ranges", "bytes");
+  headers.set("Content-Type", object.httpMetadata?.contentType ?? asset.contentType);
+  headers.set("ETag", object.httpEtag ?? object.etag);
+  if (object.httpMetadata?.contentEncoding) headers.set("Content-Encoding", object.httpMetadata.contentEncoding);
+  setRangeHeaders(headers, object, range);
+  setBodyHeaders(headers, object);
+  return headers;
+};
+
+const methodResponse = (request: Request): Response | null => {
+  if (request.method === "OPTIONS") return new Response(null, { status: 204, headers: responseHeaders(request) });
+  if (request.method === "GET" || request.method === "HEAD") return null;
+  return errorResponse(405, "tile_method_not_allowed", request);
+};
+
+const missingResponse = (asset: TileAsset, request: Request): Response => {
+  return asset.kind === "vector" ? new Response(null, { status: 204, headers: responseHeaders(request) }) : errorResponse(404, "tile_not_found", request);
+};
+
+const objectResponse = (asset: TileAsset, object: TileObject, request: Request, range: TileRange | null): Response => {
+  const status = range && object.range ? 206 : 200;
+  const body = request.method === "HEAD" ? null : object.body;
+  return new Response(body, { status, headers: metadataHeaders(asset, object, request, range) });
+};
+
+const fetchAsset = async (asset: TileAsset, request: Request, bucket: TileBucket, ctx: TileExecutionContext): Promise<Response> => {
+  const range = parseRange(request.headers.get("Range"));
+  if (range === undefined) return errorResponse(416, "tile_range_not_satisfiable", request);
+  const cached = range === null ? await cacheHit(request) : null;
+  if (cached) return new Response(request.method === "HEAD" ? null : cached.body, { status: cached.status, headers: cached.headers });
+  const object = await bucket.get(asset.key, range === null ? undefined : { range });
+  if (!object) return missingResponse(asset, request);
+  const response = objectResponse(asset, object, request, range);
+  if (range === null && response.status === 200) cachePut(request, response, ctx);
+  return response;
+};
+
+export async function handleTiles(request: Request, bucket: TileBucket | undefined, ctx: TileExecutionContext): Promise<Response> {
+  const method = methodResponse(request);
+  if (method) return method;
+  const asset = safeAsset(new URL(request.url).pathname);
+  if (!asset) return errorResponse(404, "tile_not_found", request);
+  if (!bucket) return errorResponse(503, "tile_storage_unavailable", request);
+  try {
+    return await fetchAsset(asset, request, bucket, ctx);
+  } catch {
+    return errorResponse(503, "tile_storage_unavailable", request);
+  }
+}

--- a/worker/tiles.ts
+++ b/worker/tiles.ts
@@ -21,7 +21,10 @@ type TileAsset = Readonly<{
   contentType: string;
 }>;
 
-type TileRange = Readonly<{ offset: number; length?: number; suffix?: number }>;
+type TileRange =
+  | Readonly<{ offset: number; length?: number }>
+  | Readonly<{ offset?: number; length: number }>
+  | Readonly<{ suffix: number }>;
 
 type TileGetOptions = Readonly<{ range?: TileRange }>;
 
@@ -122,7 +125,7 @@ const parseRange = (value: string | null): TileRange | null | undefined => {
     return { offset, ...(end === undefined ? {} : { length: end - offset + 1 }) };
   }
   const suffix = SUFFIX_RANGE_PATTERN.exec(value);
-  if (suffix && Number(suffix[1]) > 0) return { offset: 0, suffix: Number(suffix[1]) };
+  if (suffix && Number(suffix[1]) > 0) return { suffix: Number(suffix[1]) };
   return undefined;
 };
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,13 +2,14 @@
 # https://developers.cloudflare.com/workers/containers/
 #
 # Architecture (issue #537 retired the bundled Next.js app; `apps/web` owns
-# every HTML surface now, so this Worker is API + image proxy only):
+# every HTML surface now, so this Worker is API + asset proxy only):
 #   worker/entry.ts → /v1/* (container proxy) + /v1/users/* (users Worker)
-#                   + /img/* (image proxy) + /healthz + one public catalog read
+#                   + /img/* (image proxy) + /tiles/* (private R2 proxy)
+#                   + /healthz + one public catalog read
 #                   → everything else: JSON 404, no page renderer
 #
 # ROUTES: none here, deliberately. This Worker's hostnames are declared in
-# Pulumi (`infra/index.ts`) as of #541 — `animichi.com/v1/*`, `/img/*` and
+# Pulumi (`infra/index.ts`) as of #541 — `animichi.com/v1/*`, `/img/*`, `/tiles/*` and
 # `/healthz`, with the apex itself going to `apps/web` via a Custom Domain.
 # The repo rule is "routes belong to Pulumi, worker code belongs to wrangler";
 # an earlier version of this file claimed `animichi.com/*` here, which is what
@@ -112,6 +113,15 @@ service = "catalog"
 binding = "USERS"
 service = "users"
 
+# Map assets remain private in R2.  The edge Worker is the only public reader;
+# `/tiles/*` is routed to this Worker by Pulumi once the web hostname is enabled.
+# Local/default and staging deliberately point at the staging bucket so a
+# command without an explicit production environment cannot read production
+# map data.
+[[r2_buckets]]
+binding = "MAP_TILES"
+bucket_name = "map-tiles-staging"
+
 [[containers]]
 name = "animichi-runtimecontainer"
 class_name = "RuntimeContainer"
@@ -197,6 +207,10 @@ service = "catalog"
 binding = "USERS"
 service = "users"
 
+[[env.production.r2_buckets]]
+binding = "MAP_TILES"
+bucket_name = "map-tiles"
+
 [[env.production.containers]]
 class_name = "RuntimeContainer"
 image = "./Dockerfile"
@@ -240,6 +254,10 @@ routes = []
 # else) is meant to expose.
 workers_dev = true
 preview_urls = false
+
+[[env.staging.r2_buckets]]
+binding = "MAP_TILES"
+bucket_name = "map-tiles-staging"
 
 [env.staging.vars]
 # Forwarded to the container as APP_ENV (issue #498) — required, see


### PR DESCRIPTION
## Summary
- add a private R2 MAP_TILES binding for default/staging (map-tiles-staging) and production (map-tiles)
- route same-origin /tiles/* through the edge Worker and Pulumi-managed hostname routes; the R2 buckets have no public URL
- proxy only approved PMTiles, ZXY MVT, glyph, sprite, and style paths with traversal/coordinate validation, Range/HEAD support, immutable success caching, non-cacheable errors, and explicit failure semantics
- point the MapLibre style glyph and sprite URLs at same-origin /tiles/*

## Contract and safety
- valid missing .mvt objects return 204 (bbox outside coverage / empty tile)
- missing glyph, sprite, style, or PMTiles objects return 404
- missing binding or R2 errors return 503 tile_storage_unavailable so the client can remain on its illustrated fallback
- malformed range returns 416; unsupported methods return 405
- errors use Cache-Control: no-store; only GET 200 non-Range responses are cached under a normalized GET key, while HEAD reads metadata without writing
- no credentials or bucket-public-access settings are added

## Test-type evidence
- unit | worker: 11 tile route/cache tests (allowlist, traversal, z/x/y bounds, missing vector, missing assets, Range/206 including suffix ranges, HEAD, GET-only cache writes, methods, missing binding, storage failure)
- unit | worker: pnpm run test:worker — 251 passed
- unit | web: pnpm --filter web test — passed; coverage 98.48% statements / 95.27% branches / 98.63% functions / 99.51% lines
- unit | web: map style same-origin glyph/sprite assertions — 4 passed
- integration | web: pnpm --filter web run test:integration — 18 passed
- integration | infra: pnpm --dir infra test — 17 passed
- static | infra: pnpm --dir infra run typecheck — passed
- static | worker/web: oxlint with warnings denied — passed
- static | workflow: actionlint — passed
- security | diff: git diff --check and staged gitleaks — passed
- Wrangler config parser tests pass in the worker suite. wrangler types parsed all three environments and bindings; runtime type generation is blocked in this sandbox by listen EPERM, not by the config.

## Live verification still required (not claimed here)
1. CI/Pulumi preview and approved staging apply must create private map-tiles-staging and map-tiles buckets and the /tiles/* route.
2. Upload the PMTiles archive and matching fonts/, sprites/, and optional styles/ objects to staging; verify no public R2 endpoint is enabled.
3. From the staging web origin, verify PMTiles Range 206 + ETag, a valid empty bbox 204, glyph/sprite/style 200, missing-object 404, and simulated/observed storage-failure 503.
4. Run the browser map fallback/cold-load probe against populated staging assets, then repeat after the production environment approval.

No local deploy or asset upload was performed.