### PR TITLE
docs(iter6): Wave 3 design docs — C2/C4/C5/L1 (owner-approved)

### DIFF
--- a/docs/iterations/README.md
+++ b/docs/iterations/README.md
@@ -9,6 +9,11 @@ Use this directory for:
 - retrospective notes tied to a specific iteration
 
 Current active iteration artifacts:
+- `docs/iterations/iter6/README.md` — iter6 cleanup campaign index + Wave 3 design docs
+  (`design-C2-app-ts-split.md` / `design-C4-type-convergence.md` /
+  `design-C5-clean-arch-both-sides.md` / `design-L1-lint-enforcement.md`)
+
+Previous iteration (iter5):
 - `docs/iterations/iter5/task_plan.md`
 - `docs/iterations/iter5/progress.md`
 - `docs/iterations/iter5/findings.md`

--- a/docs/iterations/iter6/README.md
+++ b/docs/iterations/iter6/README.md
@@ -1,0 +1,16 @@
+# iter6 — cleanup campaign
+
+计划与决策记录:[../iter5/plan-2026-08-03-cleanup-campaign.md](../iter5/plan-2026-08-03-cleanup-campaign.md)
+Milestone:iter6 — cleanup campaign(#635-#655 + #665 + #666)
+
+## Wave 3 设计稿(owner 批准 2026-08-03)
+
+| 卡 | 设计稿 | 要点 |
+|---|---|---|
+| C2 #652 | [design-C2-app-ts-split.md](./design-C2-app-ts-split.md) | 信任域拆分 + 显式信任链管道 + 顺序守卫测试 + Admitted 类型锁 |
+| C4 #654 | [design-C4-type-convergence.md](./design-C4-type-convergence.md) | 9 张窄 Protocol(无 helper 层);第一批 = #663 修复 |
+| C5 #666 | [design-C5-clean-arch-both-sides.md](./design-C5-clean-arch-both-sides.md) | 两侧 Clean Arch 归位:9 用例迁 application + import-linter / oxlint 依赖红线 |
+| L1 #655 | [design-L1-lint-enforcement.md](./design-L1-lint-enforcement.md) | 1-10-50 全 workspace 强制;46 破线文件一次拆完;先修两个执法真空 |
+
+方法论授权(owner):两侧统一 TDD / DDD(战略层)/ SOLID / OOP / Clean Architecture;
+战术 DDD 不在授权内;依赖规则一律机器守卫。

--- a/docs/iterations/iter6/design-C2-app-ts-split.md
+++ b/docs/iterations/iter6/design-C2-app-ts-split.md
@@ -2,11 +2,20 @@
 
 **结论:按"信任域"拆模块 + 单一组装点,叠加两道顺序保险(owner 2026-08-03 批准):**
 1. **显式信任链管道**:`/v1` 匿名路径的闸门序列做成一个 `as const` 数组值
-   `V1_TRUST_CHAIN = [resolveIdentity, challengeAnonymous, enforceRateLimit, enforceBudget]`,
-   每个 stage 为纯函数 `(ctx) => Continue | ShortCircuit(Response)`;组装层只做 reduce。
-2. **顺序守卫测试**:断言 `V1_TRUST_CHAIN.map(s => s.name)` 等于期望序列,**变异验证**(换序/删项必红)。
+   `V1_TRUST_CHAIN = [resolveIdentity, challengeAnonymous, enforceRateLimit, enforceBudget]`。
+   每个 stage 是**异步、有副作用**的:`(ctx) => Promise<Continue | ShortCircuit(Response)>`
+   (现实现逐闸 await:siteverify fetch、EDGE_GUARD KV 限流计数、预算 latch 读写——不假装纯函数);
+   依赖(env/gate/guard)经 ctx 显式注入,组装层做顺序 async reduce(逐 stage await,
+   首个 ShortCircuit 即停)。错误语义随现状:限流卫兵 fail-open、预算断路器仅对显式判定 fail-closed,
+   stage 抛出的异常不吞、上抛到 Hono 错误边界。
+2. **顺序守卫测试**:每个 stage 带字面量 `id` 字段(稳定 ID,不用 `Function.name`——
+   bundling/minification 下函数名不可靠),断言 `V1_TRUST_CHAIN.map(s => s.id)` 等于期望序列,
+   **变异验证**(换序/删项/改 id 必红)。
 3. **`Admitted` 类型锁(半剂量 type-state)**:`forwardV1`/`anonymousForward` 的签名改为只接受
-   branded 类型 `Admitted`(唯一产源 = 信任链走完的出口);跳过闸门直接转发 = 编译不过。
+   branded 类型 `Admitted`;跳过闸门直接转发 = 编译不过。铸造出口**逐信任路径显式枚举**
+   (public `/v1` 实测不走信任链——app.ts:397 在 authenticate 之前直接 `forwardV1`):
+   ①匿名信任链走完的出口;②`authenticate` 成功出口;③`admitPublic(pathname)`——仅在
+   `isPublicV1` 谓词守卫内可调的 public 准入构造器。三个出口都在 trust-chain.ts,别处造不出。
    仅锁"最后一道门",不给每个 stage 做全量 type-state(单人仓仪式成本不摊)。
 
 迁移与拆分同一 PR 分两个 commit(先 `git mv` 保 blame,再拆);管道化+类型锁为第三个 commit,可独立 revert。
@@ -18,6 +27,7 @@
 - 迁移触点(全部实测):`wrangler.toml:59 main="worker/entry.ts"`(+注释 6/26/272)、根 package.json `test:worker`(26 个文件逐一列名)、`ci.yml:90/92/99/263` path-filter、`worker/tsconfig.json include:["*.ts"]`、`pnpm-workspace.yaml`("worker" 条目已注明 future workers/edge)。
 
 ## 方案对比
+
 | | A. Hono 惯用分层(routes/ + middleware/) | B. 信任域模块 + 单一组装点(推荐) | C. 只搬目录不拆 |
 |---|---|---|---|
 | 形态 | `routes/v1.ts` `routes/proxy.ts` 各自 `new Hono()` 子 app,`app.route()` 挂载;auth 做成 middleware | app.ts 只剩组装(<100 行);策略/流程各自成模块,仍是纯函数 | `git mv` 完事 |
@@ -31,8 +41,8 @@
 - `env.ts` — `Env`、`WorkerExecutionContext`(~20 行)
 - `routing-policy.ts` — `PUBLIC_V1`/`ANON_V1`/`AUTH_RATE_LIMITED_*` 表 + `isPublicV1/isAnonymousV1/isAuthRateLimited/decodedForRouting/normalizeV1Path`(纯函数,#464 percent-decode 注释随行,~100 行)
 - `forward.ts` — `forwardV1`/`forwardPublicCatalog`/`publicCatalogHeaders`/`catalogOutbound`/`authenticatedForward`(~110 行)
-- `anonymous-flow.ts` — `handleAnonymousV1` + `anonymousForward/guardBudget/withAnonymousCookie/rateLimitedResponse`(~90 行)
-- `trust-chain.ts`(v2 新增)— `V1_TRUST_CHAIN` 数组 + stage 类型 + `Admitted` branded 类型与其唯一构造出口(~40 行)
+- `anonymous-flow.ts` — `handleAnonymousV1` + `anonymousForward/guardBudget/withAnonymousCookie/rateLimitedResponse`(~90 行)。**生命周期不变量(必须随拆分保留)**:`turnstileGate` 每 app 实例**恰好一份**——构造留在组装层 `registerWorkerRoutes`(app.ts),以参数注入 `handleAnonymousV1`;pass-window 因此在同 isolate 的**跨请求间共享**,这是访客不被逐条消息重复挑战的前提。anonymous-flow.ts 自己**不得** `createTurnstileGate()`(每请求新建 = pass-window 失效 = 静默回归)。
+- `trust-chain.ts`(v2 新增)— `V1_TRUST_CHAIN` 数组 + stage 类型(含字面量 `id`)+ `Admitted` branded 类型与其三个显式铸造出口(匿名链出口/authenticate 出口/`admitPublic`)(~50 行)
 - `session-migrate.ts` — `SESSION_MIGRATE_PATH` + `handleSessionMigrate` + #507 裁决注释(~45 行)
 - `image-proxy.ts` — `handleImageProxy`(~30 行)
 - `responses.ts` — `UNAUTHORIZED_BODY/NOT_FOUND_BODY/unauthorized/logInvalidCredential`(~35 行)
@@ -42,11 +52,12 @@
 ## 破线测试文件(>200 行,实测)拆分原则
 turnstile.test 331 / entry.test 263 / containerEnv.test 257 / turnstileArm.test 229 / anonymous.test 207 / byok.test 205(tiles.test 198 贴线)。原则:**按被测行为域切,不对半切** —— turnstile.test → 验证协议(verify/siteverify 契约)与 gate 状态机(pass-window/re-challenge)两文件;entry.test → container 组装(RuntimeContainer/outboundByHost)与路由行为两文件;containerEnv.test → env 构建与 denylist 两文件;anonymous/byok 各按"闸门"(限流/预算/降级)切。共享 fixture 提到 `test-helpers.ts`(mock env/guard 构造器),消灭复制粘贴的 stub。
 
-## 测试策略
-- 拆分前后 `pnpm run test:worker` 全绿是唯一门禁;先 mv、跑绿、再拆、再跑绿(两个可独立 revert 的 commit)。
+## 测试策略(门禁按性质分类,不再混称"唯一门禁")
+- **合并门(每个 commit/PR 必过)**:`pnpm run test:worker` 全绿。先 mv、跑绿、再拆、再跑绿(两个可独立 revert 的 commit)。
 - 新增一条组装回归测试:断言 `/v1/users/*` 不经过 authenticate(现有 authFallthrough.test 已覆盖部分,补 registration-order 断言)。
-- v2 新增:`trust-chain.test.ts` 顺序守卫(数组序列断言 + 变异验证换序必红);`Admitted` 类型锁的负向验证用 `@ts-expect-error` type-test(裸 identity 传 forwardV1 必须编译失败)。
-- 迁移后 `verify:dependabot` + `wrangler deploy --dry-run` 验 `main` 路径(记忆:root Worker 曾因两份 wrangler 配置从未部署成功——迁移时顺手核对唯一 config)。
+- v2 新增:`trust-chain.test.ts` 顺序守卫(stage `id` 序列断言 + 变异验证换序必红);`Admitted` 类型锁的负向验证用 `@ts-expect-error` type-test(裸 identity 传 forwardV1 必须编译失败);gate 生命周期测试——同一 app 实例连发两次匿名请求,断言复用**同一个** turnstileGate(pass-window 跨请求共享)。
+- **迁移后一次性核对(仅本次迁移 PR)**:`verify:dependabot` + `wrangler deploy --dry-run` 验 `main` 路径(记忆:root Worker 曾因两份 wrangler 配置从未部署成功——迁移时顺手核对唯一 config)。
+- **部署门(不变)**:staging = merge 到 main 后 CI 自动;prod 走既有 production approval——本卡不新增部署门。
 
 ## 风险与回滚
 - 最大风险:漏改 5 处路径触点之一(尤其 ci.yml path-filter → CI 静默不跑 = 假绿)。对策:PR 内 `grep -rn "worker/" .github wrangler.toml package.json` 清零核对。

--- a/docs/iterations/iter6/design-C2-app-ts-split.md
+++ b/docs/iterations/iter6/design-C2-app-ts-split.md
@@ -1,0 +1,54 @@
+# C2 — worker/app.ts 拆分 + worker/ → workers/edge/ 迁移(#652)【v2 定稿】
+
+**结论:按"信任域"拆模块 + 单一组装点,叠加两道顺序保险(owner 2026-08-03 批准):**
+1. **显式信任链管道**:`/v1` 匿名路径的闸门序列做成一个 `as const` 数组值
+   `V1_TRUST_CHAIN = [resolveIdentity, challengeAnonymous, enforceRateLimit, enforceBudget]`,
+   每个 stage 为纯函数 `(ctx) => Continue | ShortCircuit(Response)`;组装层只做 reduce。
+2. **顺序守卫测试**:断言 `V1_TRUST_CHAIN.map(s => s.name)` 等于期望序列,**变异验证**(换序/删项必红)。
+3. **`Admitted` 类型锁(半剂量 type-state)**:`forwardV1`/`anonymousForward` 的签名改为只接受
+   branded 类型 `Admitted`(唯一产源 = 信任链走完的出口);跳过闸门直接转发 = 编译不过。
+   仅锁"最后一道门",不给每个 stage 做全量 type-state(单人仓仪式成本不摊)。
+
+迁移与拆分同一 PR 分两个 commit(先 `git mv` 保 blame,再拆);管道化+类型锁为第三个 commit,可独立 revert。
+
+## 现状问题(实测)
+- `worker/app.ts` 433 行(限 300),单文件混五种职责:Env 定义(28-42)、路径分类谓词(46-142)、转发原语 `forwardV1`(77-96)、匿名流(162-242,turnstile+限流+预算三闸)、session-migrate(301-310)、镜像代理(332-354)、Hono 组装(372-433)。
+- 隐性耦合:`registerWorkerRoutes` 里注册**顺序即安全语义**(users bypass → public → auth → anon 降级),注释承载了大量 owner 裁决(#507/#441/#447),拆分必须保注释随代码走。
+- worker/ 不在根 `lint:oxlint` filter 内(`--filter catalog --filter users --filter web`),自身无 oxlint 依赖 → 事实上零 lint(L1 卡一并修)。
+- 迁移触点(全部实测):`wrangler.toml:59 main="worker/entry.ts"`(+注释 6/26/272)、根 package.json `test:worker`(26 个文件逐一列名)、`ci.yml:90/92/99/263` path-filter、`worker/tsconfig.json include:["*.ts"]`、`pnpm-workspace.yaml`("worker" 条目已注明 future workers/edge)。
+
+## 方案对比
+| | A. Hono 惯用分层(routes/ + middleware/) | B. 信任域模块 + 单一组装点(推荐) | C. 只搬目录不拆 |
+|---|---|---|---|
+| 形态 | `routes/v1.ts` `routes/proxy.ts` 各自 `new Hono()` 子 app,`app.route()` 挂载;auth 做成 middleware | app.ts 只剩组装(<100 行);策略/流程各自成模块,仍是纯函数 | `git mv` 完事 |
+| 顺序语义 | 分散到多文件,users-bypass→auth→anon 的注册顺序不再一眼可见,易被后续 PR 破坏 | 组装仍集中一处,顺序即代码即文档 | 不变 |
+| auth 变 middleware | Hono 正统,但本 app 的 auth 不是横切——它是**分叉点**(authed/anon/401 三路),塞进 middleware 要靠 `c.set()` 传状态,反而绕 | 保持显式分支 | — |
+| 测试改动 | 大(测试现在直接 import `createWorkerApp`/`isAuthRateLimited` 等具名导出) | 近零(export 面不变,新模块 re-export 或测试改 import 路径一次) | 零 |
+
+**推荐 B。** 这个 app 只有一个真正的 route surface(`/v1/*` 一个 handler 内三路分叉),Hono 的 routes/middleware 分层是为多资源 CRUD 设计的,套在"网关+信任分叉"上是形式主义。
+
+## 拆出清单(workers/edge/ 下)
+- `env.ts` — `Env`、`WorkerExecutionContext`(~20 行)
+- `routing-policy.ts` — `PUBLIC_V1`/`ANON_V1`/`AUTH_RATE_LIMITED_*` 表 + `isPublicV1/isAnonymousV1/isAuthRateLimited/decodedForRouting/normalizeV1Path`(纯函数,#464 percent-decode 注释随行,~100 行)
+- `forward.ts` — `forwardV1`/`forwardPublicCatalog`/`publicCatalogHeaders`/`catalogOutbound`/`authenticatedForward`(~110 行)
+- `anonymous-flow.ts` — `handleAnonymousV1` + `anonymousForward/guardBudget/withAnonymousCookie/rateLimitedResponse`(~90 行)
+- `trust-chain.ts`(v2 新增)— `V1_TRUST_CHAIN` 数组 + stage 类型 + `Admitted` branded 类型与其唯一构造出口(~40 行)
+- `session-migrate.ts` — `SESSION_MIGRATE_PATH` + `handleSessionMigrate` + #507 裁决注释(~45 行)
+- `image-proxy.ts` — `handleImageProxy`(~30 行)
+- `responses.ts` — `UNAUTHORIZED_BODY/NOT_FOUND_BODY/unauthorized/logInvalidCredential`(~35 行)
+- `app.ts` — 仅 `registerWorkerRoutes`+`createWorkerApp`,顺序注释保留(~90 行)
+- 既有独立模块(auth/tiles/turnstile/rateLimiter/costBreaker/edgeGuard/containerEnv/entry)原样 `git mv`。
+
+## 破线测试文件(>200 行,实测)拆分原则
+turnstile.test 331 / entry.test 263 / containerEnv.test 257 / turnstileArm.test 229 / anonymous.test 207 / byok.test 205(tiles.test 198 贴线)。原则:**按被测行为域切,不对半切** —— turnstile.test → 验证协议(verify/siteverify 契约)与 gate 状态机(pass-window/re-challenge)两文件;entry.test → container 组装(RuntimeContainer/outboundByHost)与路由行为两文件;containerEnv.test → env 构建与 denylist 两文件;anonymous/byok 各按"闸门"(限流/预算/降级)切。共享 fixture 提到 `test-helpers.ts`(mock env/guard 构造器),消灭复制粘贴的 stub。
+
+## 测试策略
+- 拆分前后 `pnpm run test:worker` 全绿是唯一门禁;先 mv、跑绿、再拆、再跑绿(两个可独立 revert 的 commit)。
+- 新增一条组装回归测试:断言 `/v1/users/*` 不经过 authenticate(现有 authFallthrough.test 已覆盖部分,补 registration-order 断言)。
+- v2 新增:`trust-chain.test.ts` 顺序守卫(数组序列断言 + 变异验证换序必红);`Admitted` 类型锁的负向验证用 `@ts-expect-error` type-test(裸 identity 传 forwardV1 必须编译失败)。
+- 迁移后 `verify:dependabot` + `wrangler deploy --dry-run` 验 `main` 路径(记忆:root Worker 曾因两份 wrangler 配置从未部署成功——迁移时顺手核对唯一 config)。
+
+## 风险与回滚
+- 最大风险:漏改 5 处路径触点之一(尤其 ci.yml path-filter → CI 静默不跑 = 假绿)。对策:PR 内 `grep -rn "worker/" .github wrangler.toml package.json` 清零核对。
+- 部署风险:staging merge 后看 healthz/edge 日志;回滚 = revert 两个 commit(mv 与拆分互不纠缠,可单独退)。
+- 不做:不改任何运行时行为、不动 auth.ts 内部、不趁机重命名导出。

--- a/docs/iterations/iter6/design-C4-type-convergence.md
+++ b/docs/iterations/iter6/design-C4-type-convergence.md
@@ -1,0 +1,44 @@
+# C4 v2 — apps/agent 反射 DI 收敛 + SessionEnvelope 类型化(#654,并入 #663 修复)
+
+**结论:删掉 ports.py 的 7 个 getattr 访问器(不设任何 helper 层),按 bounded context 拆 8 个窄 Protocol;调用方函数签名直接收窄 Protocol,组合根(fastapi lifespan)持有具体 `SupabaseClient` 并解构注入。第一批 = #663 生产静默失效修复 + offline Docker 臂真实写入集成测试。**
+
+## 现状(2026-08-03 全部实测,rg 于 apps/agent,非测试代码)
+- `db: object` 28 处:interfaces/infrastructure 21 处(persistence×7、fastapi_service×4、public_api×3、usage_metering×2、session_facade/anon_quota/_deps/memory 各 1)+ ports.py 访问器 7 处。
+- ports.py 现有 6 个 repo Protocol + 7 个反射访问器(`get_session/bangumi/routes/usage/anon_quota_repo` + `has_session/routes_repo`),全走 `getattr + iscoroutinefunction + cast`。现 `DatabasePort` 只聚合 bangumi+points(消费者:animichi_runner:161、runtime_deps:75、eval null_database)。
+- **#663 死路径(确认)**:`persistence.py:158` `getattr(db,"insert_message")`、`public_api.py:698` `getattr(self._db,"insert_request_log")`。生产 db=裸 `SupabaseClient`(`_lifespan_build_runtime`),真实方法在 `db.messages.insert_message`(repositories/messages.py:16)与 `db.feedback.insert_request_log`(repositories/feedback.py:43),client.py 无顶层同名方法/`__getattr__` → 两个 getattr 恒 None → conversation_messages 与 request_log 生产**静默不写**。
+- session 信封:`session_facade.py` 22 处 / `persistence.py` 11 处 `dict[str, object]`,魔法 key("interactions"/"route_history"/"session_state_v2")+ `_list()` 防御散落。
+- 另一表面(本卡不动,记录):`routes/_deps.py:254 _require_supabase` 直接 isinstance 取具体 client,5 个 HTTP route 模块用 `db.messages/.feedback/.bangumi` —— 已是 typed 访问,无反射病;留待后续卡评估是否同样收窄。
+
+## Protocol 清单(按 bounded context;方法签名 = 已实测的实现/调用形状)
+| Protocol(ports.py) | 方法全集 | 消费者(非测试) |
+|---|---|---|
+| `BangumiRepo`(existing) | `find_bangumi_by_title(title)->str\|None` · `find_all_by_title(title)` · `upsert_bangumi_title(title,bangumi_id)` · `upsert_bangumi(bangumi_id,*,title,cover_url,points_count)` · `find_candidate_details_by_titles(titles)` · `filter_existing_ids(bangumi_ids)->list[str]` | agent tools(经 `CatalogLookup.bangumi`)、persistence.py:336 |
+| `PointsRepo`(existing) | `search_points_by_location(lat,lon,radius_m,*,limit=50)` · `get_points_by_ids(point_ids)` · `upsert_points_batch(rows)` | agent tools(经 `CatalogLookup.points`) |
+| `SessionRepo`(existing) | `create_owned_session` · `upsert_session` · `upsert_conversation` · `update_conversation_title` · `check_session_owner` | persistence.py:198/219/235、session_facade.py:300、public_api.py:230 |
+| `RouteArchive`(rename RoutesRepo) | `save_route(session_id,anime_ids,point_ids,data,*,origin_station,origin_lat,origin_lon)->str` | persistence.py:302 |
+| `UsageMeter`(rename UsageRepo) | `accumulate_usage(*,usage_date,scope,requests,input_tokens,output_tokens,cost_usd)` · `total_cost_usd(*,usage_date,scope)->float` | usage_metering.py:111/139 |
+| `AnonQuotaCounter`(rename AnonQuotaRepo) | `increment_and_count(*,usage_date,anon_id)->int` | anon_quota.py:87 |
+| **`ConversationLog`(新)** | `insert_message(session_id,role,content,response_data:dict\|None=None)`(对齐 messages.py:16 真实签名——第 4 参名是 `response_data` 非 v1 的 `data`) | persistence.persist_messages(#663 修复点) |
+| **`RequestAudit`(新)** | `insert_request_log(*,session_id:str\|None,query_text,locale,plan_steps:list[str]\|None,intent:str\|None,status,latency_ms:int\|None)->str`(feedback.py:43) | public_api.RuntimeAPI(#663 修复点) |
+| `CatalogLookup`(rename DatabasePort) | properties `bangumi: BangumiRepo` · `points: PointsRepo` | animichi_runner:161、runtime_deps:75、eval null_database |
+
+无聚合大 Port、无访问器函数:组合根 `_lifespan_build_runtime` 持具体 `SupabaseClient`,按 `client.messages / client.feedback / client.session / ...`(8 个 @property,PEP 544 结构化满足各窄 Protocol)解构注入;`RuntimeAPI.__init__` 与 `handle_public_request` 的 `db: object` 拆为按需的窄参数(如 `sessions: SessionRepo`、`request_audit: RequestAudit | None`)。测试 double 只需实现所用的那个小 Protocol(现 SimpleNamespace/AsyncMock 天然适配,无需 runtime_checkable)。`memory.py`/`_deps.py` 的 `isinstance(SupabaseClient)`(需裸 pool/具体 client)保留在组合根一侧并注释。
+
+## SessionEnvelope(pydantic,方向维持 v1,命名按语义)
+- `SessionEnvelope`:`interactions: list[InteractionRecord]`(≤20)· `route_history: list[JsonDict]`(≤10)· `last_intent/last_status: str|None` · `last_message: str=""` · `summary: str|None` · `updated_at: datetime` · `session_state_v2: dict|None`(**保 raw**——已有 `SessionState.model_validate` + `_parse_forward_compatible` 回滚安全,不双重校验)。
+- `InteractionRecord`(语义命名,替代 v1 泛名 `Interaction`):`text/intent/status/success/created_at/context_delta/new_messages`。
+- `model_config = ConfigDict(extra="allow")`:存量未知 key 必须 round-trip(对齐现 `normalized.update(state)` 语义)。边界:读入 `model_validate`(ValidationError → 空信封 + warning),写出 `model_dump(mode="json")`;`SessionRepo` 签名不动。
+
+## 迁移批次(每批独立绿、独立 revert)
+1. **B1 = #663 修复(第一批,owner 已决)**:ports.py 增 `ConversationLog`/`RequestAudit`;`persist_messages` 改收 `messages: ConversationLog | None`、RuntimeAPI 请求日志改收 `request_audit: RequestAudit | None`,调用点由组合根传 `client.messages` / `client.feedback`——getattr 删除。测试:先加失败测试钉死 no-op(裸 SupabaseClient 下现行为不写),再修;**集成测试走现有 offline Docker 臂**(`make test-integration` 默认臂):经 fastapi app 走一轮请求后 SELECT `conversation_messages`/`request_log` 断言真实行。上线即开始真实写库(这就是修复本身)——PR 描述标注写入量预期。
+2. **B2**:persistence / session_facade / usage_metering / anon_quota 函数签名收窄 Protocol;**删 ports.py 全部 7 个访问器**与这些文件的 `db: object`(去掉 iscoroutinefunction 运行时嗅探——"repo 缺失"由 `| None` 参数显式表达)。
+3. **B3**:`RuntimeAPI.__init__` / `handle_public_request` / fastapi_service 四处 `db: object|None` 拆窄参数注入;删 public_api.py:619 `cast(DatabasePort,...)`;`DatabasePort→CatalogLookup` 改名(runner/runtime_deps/null_database 三点)。
+4. **B4**:SessionEnvelope——先现网样本 JSON fixture + 双向 round-trip 测试,再切 `normalize_session_state` / `build_updated_session_state` / context block 构造。与 B1-3 无耦合,可并行。
+
+## mypy strict 影响 / 测试策略 / 风险
+- **净收紧**:删 cast(ports.py×5 + public_api×1)、getattr×9(7 访问器内 + 2 裸);`db: object` 28→0(组合根 isinstance 特例除外)。窄 Protocol 让 fake 拼错字段名当场报 mypy 错——收益非成本。加一条结构断言测试:`SupabaseClient` 各 property 赋值给对应 Protocol 变量(编译期契约,防实现漂移)。
+- 测试:B1 集成(Docker 臂真实写入)+ no-op 回归;B2/B3 纯签名重构,靠现有单测 + `make check` 前后各跑;B4 round-trip fixture。变异验证:B1 修复测试须在"还原 getattr"变异下变红。
+- 风险:① B1 开始真实写入 conversation_messages/request_log——表结构已存在(repo SQL 即证据),量级=每请求 ≤3 行,可接受但 PR 单独可 revert;② `extra="allow"` 防旧数据,`updated_at` 脏行走容错分支;③ `RequestAudit.insert_request_log` 返回 `str` 而旧调用点忽略返回——Protocol 按实现声明 `->str`,调用点不变。
+
+---
+**v1→v2 变更说明**:① 删除 v1 方案 B 的"访问器/helper 接口隔离层"——接口隔离改由窄 Protocol 直接做函数参数类型实现,7 个 `get_*/has_*` 访问器在 B2 全删,聚合 `DatabasePort` 不再扩为 8-property 大 Port,改为组合根解构注入 + `CatalogLookup` 窄聚合。② Protocol 按 bounded context 细化命名(RouteArchive/UsageMeter/AnonQuotaCounter/ConversationLog/RequestAudit/CatalogLookup;Interaction→InteractionRecord),并逐一列出实测方法全集与消费者;修正 v1 的 `insert_message` 参数名错误(`data`→`response_data`)与 `db: object` 计数(27→28,含 ports.py 访问器)。③ #663 由"疑似 bug 先立案"升为**第一批迁移**:typed repo 调用点 + offline Docker 臂真实写入集成测试,行为修复不再拆单独 PR。

--- a/docs/iterations/iter6/design-C4-type-convergence.md
+++ b/docs/iterations/iter6/design-C4-type-convergence.md
@@ -1,6 +1,6 @@
 # C4 v2 — apps/agent 反射 DI 收敛 + SessionEnvelope 类型化(#654,并入 #663 修复)
 
-**结论:删掉 ports.py 的 7 个 getattr 访问器(不设任何 helper 层),按 bounded context 拆 8 个窄 Protocol;调用方函数签名直接收窄 Protocol,组合根(fastapi lifespan)持有具体 `SupabaseClient` 并解构注入。第一批 = #663 生产静默失效修复 + offline Docker 臂真实写入集成测试。**
+**结论:删掉 ports.py 的 7 个 getattr 访问器(不设任何 helper 层),按 bounded context 拆 9 个窄 Protocol(8 个 repo Protocol + `CatalogLookup` 窄聚合,与下表逐一对应);调用方函数签名直接收窄 Protocol,组合根(fastapi lifespan)持有具体 `SupabaseClient` 并解构注入。第一批 = #663 生产静默失效修复 + offline Docker 臂真实写入集成测试。**
 
 ## 现状(2026-08-03 全部实测,rg 于 apps/agent,非测试代码)
 - `db: object` 28 处:interfaces/infrastructure 21 处(persistence×7、fastapi_service×4、public_api×3、usage_metering×2、session_facade/anon_quota/_deps/memory 各 1)+ ports.py 访问器 7 处。
@@ -10,6 +10,7 @@
 - 另一表面(本卡不动,记录):`routes/_deps.py:254 _require_supabase` 直接 isinstance 取具体 client,5 个 HTTP route 模块用 `db.messages/.feedback/.bangumi` —— 已是 typed 访问,无反射病;留待后续卡评估是否同样收窄。
 
 ## Protocol 清单(按 bounded context;方法签名 = 已实测的实现/调用形状)
+
 | Protocol(ports.py) | 方法全集 | 消费者(非测试) |
 |---|---|---|
 | `BangumiRepo`(existing) | `find_bangumi_by_title(title)->str\|None` · `find_all_by_title(title)` · `upsert_bangumi_title(title,bangumi_id)` · `upsert_bangumi(bangumi_id,*,title,cover_url,points_count)` · `find_candidate_details_by_titles(titles)` · `filter_existing_ids(bangumi_ids)->list[str]` | agent tools(经 `CatalogLookup.bangumi`)、persistence.py:336 |
@@ -18,25 +19,25 @@
 | `RouteArchive`(rename RoutesRepo) | `save_route(session_id,anime_ids,point_ids,data,*,origin_station,origin_lat,origin_lon)->str` | persistence.py:302 |
 | `UsageMeter`(rename UsageRepo) | `accumulate_usage(*,usage_date,scope,requests,input_tokens,output_tokens,cost_usd)` · `total_cost_usd(*,usage_date,scope)->float` | usage_metering.py:111/139 |
 | `AnonQuotaCounter`(rename AnonQuotaRepo) | `increment_and_count(*,usage_date,anon_id)->int` | anon_quota.py:87 |
-| **`ConversationLog`(新)** | `insert_message(session_id,role,content,response_data:dict\|None=None)`(对齐 messages.py:16 真实签名——第 4 参名是 `response_data` 非 v1 的 `data`) | persistence.persist_messages(#663 修复点) |
-| **`RequestAudit`(新)** | `insert_request_log(*,session_id:str\|None,query_text,locale,plan_steps:list[str]\|None,intent:str\|None,status,latency_ms:int\|None)->str`(feedback.py:43) | public_api.RuntimeAPI(#663 修复点) |
+| **`ConversationLog`(新)** | `insert_message(session_id:str, role:str, content:str, response_data:dict[str,object]\|None=None) -> None`(逐参对齐 messages.py:16 真实签名——第 4 参名是 `response_data` 非 v1 的 `data`,JSON 载荷用仓内既有 `dict[str, object]` 形状) | persistence.persist_messages(#663 修复点) |
+| **`RequestAudit`(新)** | `insert_request_log(*, session_id:str\|None, query_text:str, locale:str, plan_steps:list[str]\|None, intent:str\|None, status:str, latency_ms:int\|None) -> str`(逐参对齐 feedback.py:43) | public_api.RuntimeAPI(#663 修复点) |
 | `CatalogLookup`(rename DatabasePort) | properties `bangumi: BangumiRepo` · `points: PointsRepo` | animichi_runner:161、runtime_deps:75、eval null_database |
 
 无聚合大 Port、无访问器函数:组合根 `_lifespan_build_runtime` 持具体 `SupabaseClient`,按 `client.messages / client.feedback / client.session / ...`(8 个 @property,PEP 544 结构化满足各窄 Protocol)解构注入;`RuntimeAPI.__init__` 与 `handle_public_request` 的 `db: object` 拆为按需的窄参数(如 `sessions: SessionRepo`、`request_audit: RequestAudit | None`)。测试 double 只需实现所用的那个小 Protocol(现 SimpleNamespace/AsyncMock 天然适配,无需 runtime_checkable)。`memory.py`/`_deps.py` 的 `isinstance(SupabaseClient)`(需裸 pool/具体 client)保留在组合根一侧并注释。
 
 ## SessionEnvelope(pydantic,方向维持 v1,命名按语义)
-- `SessionEnvelope`:`interactions: list[InteractionRecord]`(≤20)· `route_history: list[JsonDict]`(≤10)· `last_intent/last_status: str|None` · `last_message: str=""` · `summary: str|None` · `updated_at: datetime` · `session_state_v2: dict|None`(**保 raw**——已有 `SessionState.model_validate` + `_parse_forward_compatible` 回滚安全,不双重校验)。
+- `SessionEnvelope`:`interactions: list[InteractionRecord]`(≤20)· `route_history: list[dict[str, object]]`(≤10)· `last_intent/last_status: str|None` · `last_message: str=""` · `summary: str|None` · `updated_at: datetime | None = None`(**可缺省**——缺失/非法时间戳只走归一化/置 None,**不得**触发整封 ValidationError 把有效的 interactions/route_history/session_state_v2 一起清空)· `session_state_v2: dict[str, object]|None`(**保 raw**——已有 `SessionState.model_validate` + `_parse_forward_compatible` 回滚安全,不双重校验)。
 - `InteractionRecord`(语义命名,替代 v1 泛名 `Interaction`):`text/intent/status/success/created_at/context_delta/new_messages`。
 - `model_config = ConfigDict(extra="allow")`:存量未知 key 必须 round-trip(对齐现 `normalized.update(state)` 语义)。边界:读入 `model_validate`(ValidationError → 空信封 + warning),写出 `model_dump(mode="json")`;`SessionRepo` 签名不动。
 
 ## 迁移批次(每批独立绿、独立 revert)
-1. **B1 = #663 修复(第一批,owner 已决)**:ports.py 增 `ConversationLog`/`RequestAudit`;`persist_messages` 改收 `messages: ConversationLog | None`、RuntimeAPI 请求日志改收 `request_audit: RequestAudit | None`,调用点由组合根传 `client.messages` / `client.feedback`——getattr 删除。测试:先加失败测试钉死 no-op(裸 SupabaseClient 下现行为不写),再修;**集成测试走现有 offline Docker 臂**(`make test-integration` 默认臂):经 fastapi app 走一轮请求后 SELECT `conversation_messages`/`request_log` 断言真实行。上线即开始真实写库(这就是修复本身)——PR 描述标注写入量预期。
+1. **B1 = #663 修复(第一批,owner 已决)**:ports.py 增 `ConversationLog`/`RequestAudit`;`persist_messages` 改收 `messages: ConversationLog | None`、RuntimeAPI 请求日志改收 `request_audit: RequestAudit | None`,调用点由组合根传 `client.messages` / `client.feedback`——getattr 删除。**生产组合根(`_lifespan_build_runtime`)恒传非 None**;`| None` 只允许测试/eval double 使用,生产缺 repo = 组装错误(启动即应暴露),不得再成为一条静默不写路径。测试:先加失败测试钉死 no-op(裸 SupabaseClient 下现行为不写),再修;**集成测试走现有 offline Docker 臂**(`make test-integration` 默认臂):经 fastapi app 走一轮请求后 SELECT `conversation_messages`/`request_log` 断言真实行。上线即开始真实写库(这就是修复本身)——PR 描述标注写入量预期。
 2. **B2**:persistence / session_facade / usage_metering / anon_quota 函数签名收窄 Protocol;**删 ports.py 全部 7 个访问器**与这些文件的 `db: object`(去掉 iscoroutinefunction 运行时嗅探——"repo 缺失"由 `| None` 参数显式表达)。
 3. **B3**:`RuntimeAPI.__init__` / `handle_public_request` / fastapi_service 四处 `db: object|None` 拆窄参数注入;删 public_api.py:619 `cast(DatabasePort,...)`;`DatabasePort→CatalogLookup` 改名(runner/runtime_deps/null_database 三点)。
-4. **B4**:SessionEnvelope——先现网样本 JSON fixture + 双向 round-trip 测试,再切 `normalize_session_state` / `build_updated_session_state` / context block 构造。与 B1-3 无耦合,可并行。
+4. **B4**:SessionEnvelope——先现网样本 JSON fixture + 双向 round-trip 测试(fixture 须含**缺失 `updated_at`** 与**非法 `updated_at`** 两例,断言其余字段完整存活),再切 `normalize_session_state` / `build_updated_session_state` / context block 构造。与 B1-3 无耦合,可并行。
 
 ## mypy strict 影响 / 测试策略 / 风险
-- **净收紧**:删 cast(ports.py×5 + public_api×1)、getattr×9(7 访问器内 + 2 裸);`db: object` 28→0(组合根 isinstance 特例除外)。窄 Protocol 让 fake 拼错字段名当场报 mypy 错——收益非成本。加一条结构断言测试:`SupabaseClient` 各 property 赋值给对应 Protocol 变量(编译期契约,防实现漂移)。
+- **净收紧**:删 cast(ports.py×5 + public_api×1)、getattr×9(7 访问器内 + 2 裸);`db: object` 28→0(组合根 isinstance 特例除外)。窄 Protocol 让 fake 拼错字段名当场报 mypy 错——收益非成本。加一条结构断言:`SupabaseClient` 各 property 赋值给对应 Protocol 变量(编译期契约,防实现漂移)——**必须放在 mypy 扫描路径内**(Makefile 的 typecheck 只扫 agents/interfaces/domain/infrastructure/clients/tests-eval,**不含 tests/unit**;放 tests/unit = mypy 永远看不到 = 形同虚设。建议做成 infrastructure/supabase 下的 `_protocol_conformance.py` 编译期模块)。
 - 测试:B1 集成(Docker 臂真实写入)+ no-op 回归;B2/B3 纯签名重构,靠现有单测 + `make check` 前后各跑;B4 round-trip fixture。变异验证:B1 修复测试须在"还原 getattr"变异下变红。
 - 风险:① B1 开始真实写入 conversation_messages/request_log——表结构已存在(repo SQL 即证据),量级=每请求 ≤3 行,可接受但 PR 单独可 revert;② `extra="allow"` 防旧数据,`updated_at` 脏行走容错分支;③ `RequestAudit.insert_request_log` 返回 `str` 而旧调用点忽略返回——Protocol 按实现声明 `->str`,调用点不变。
 

--- a/docs/iterations/iter6/design-C5-clean-arch-both-sides.md
+++ b/docs/iterations/iter6/design-C5-clean-arch-both-sides.md
@@ -1,0 +1,77 @@
+# C5 — 两侧 Clean Architecture 用例层归位(#666,建立在 C4 九张 Protocol 之上)
+
+**结论:Python 侧把 `interfaces/` 里的 6 个应用服务模块 + `RuntimeAPI` 编排整体迁入 `agent/application/`(interfaces 只剩 fastapi/routes/chat_wire 三类 wire 适配),依赖收 C4 窄 Protocol;守护不变量 = "wire 层不含业务决策、application 不 import infrastructure(组合根除外)",用 **import-linter layers+forbidden 契约**钉死(现存违例 6,起步 ignore-ratchet)。TS 侧不造 class 仪式:catalog `api/*` 与 users `api/routes.ts` 的函数模块**已是用例**,只做两件事——users 行映射抽 `lib/rows.ts`(与 B4 协同)+ catalog 封死 `api→ingest 内部件` 深入口;约束用 **oxlint `no-restricted-imports`**(零新依赖,复用 L1 的 --deny-warnings 门)。**
+
+## 1. Python(apps/agent)用例层重建
+
+现状实测:`application/` 只有 errors.py;真正的应用层散在 `interfaces/`(public_api.py 875 行 + persistence 384 + session_facade 338 + usage_metering 149 + anon_quota 99 + response_builder)。agents/domain 零上行 import(已测),病灶只在 interfaces 混层。
+
+**用例清单(现居 public_api.py,行号 2026-08-03 实测)**:
+
+| 用例(→ application/use_cases/) | 入参 → 出参 | C4 Protocol 依赖 | 现居 |
+|---|---|---|---|
+| `HandleChatTurn`(主编排:handle+_prepare/_load_session+_execute_pipeline+_dispatch+_model_request) | `PublicAPIRequest`+identity(user_id/user_type/is_byok)+model override+`OnStep` → `PublicAPIResponse` | SessionRepo·ConversationLog·CatalogLookup(经 runner)·UsageMeter·RequestAudit + SessionStore/MemoryStore 新港口(§下) | 236-335, 363-373, 375-393, 395-532, 534-559, 604-637 |
+| `ExecuteSelectedRoute` | point_ids+`SessionState`+origin+locale → `AgentResult` | CatalogClientProtocol | `_point_selection` 561-574(实体已在 agents/selected_route.py,薄委托即可) |
+| `ExecuteMultiSelection` / `ExecutePlaceSelection` | candidate_ids/candidate_id+state+locale → `AgentResult` | CatalogClientProtocol | `_candidate_selection` 576-602(实体 agents/selection.py) |
+| `MeterTurnUsage`(实测新发现) | `AgentResult`+identity+`UsagePrices` → None | UsageMeter | `_record_usage` 343-361 + `_record_attributed_usage` 836-845 + usage_metering.py:78/102 |
+| `AuditRequest`(实测新发现) | session_id+request+result+latency → None(best-effort) | RequestAudit·ConversationLog | `_log_request` 666-713(:698 getattr 死路径由 C4-B1 先修) |
+| `PersistTurn`(实测新发现) | session_id+request+result+response+delta → (state,persisted,title) | SessionRepo·ConversationLog | persistence.py:57 `persist_result`(:148/:227/:243 同迁) |
+| `ValidateSessionOwner` | session_id+user_id → None/404 语义错误 | SessionRepo | 224-234(HTTPException 换 ApplicationError,wire 层再译 404) |
+| `ApplyTranslationGate`(实测新发现) | `AgentResult`+locale+payer 隔离 → None(原地改 message) | —(模型解析) | 777-827 + 639-664 |
+| `CheckAnonQuota`(实测新发现) | anon_id+date → verdict | AnonQuotaCounter | anon_quota.py:66 |
+
+**新港口(C4 未覆盖,C5 补 2 张)**:`SessionStorePort`、`MemoryStorePort` —— `HandleChatTurn` 现直接 `from agent.infrastructure.{session,memory} import ...`(public_api.py:63/68),是 forbidden 契约的主违例源;Protocol 放 domain/ports.py,实现留 infrastructure。
+
+**mapper 归位**:`agent_result_to_response`(response_builder.py:144)= domain `AgentResult` → 应用 DTO `PublicAPIResponse` 的映射,随 schemas.py(DTO)一起迁 `application/`(mappers.py + dto.py);interfaces 只剩 chat_wire(SSE 帧)与 routes(HTTP 状态码/headers)。`build_response_session`/`extract_plan_steps`(persistence.py:371/381,纯查询)同归 mappers。无兼容 shim(owner 政策:重构期不留 backward compat)。
+
+**import-linter 契约(pyproject.toml,新 dev dep;make lint 加 `uv run lint-imports`)**:
+```toml
+[tool.importlinter]
+root_package = "agent"
+[[tool.importlinter.contracts]]
+name = "layers"; type = "layers"
+layers = ["agent.interfaces", "agent.application", "agent.agents | agent.tools | agent.clients", "agent.domain"]
+[[tool.importlinter.contracts]]
+name = "infra-only-from-composition-root"; type = "forbidden"
+source_modules = ["agent.interfaces", "agent.application", "agent.agents", "agent.domain"]
+forbidden_modules = ["agent.infrastructure"]
+ignore_imports = [  # 组合根 + 明文 sanctioned 横切面(F8 observability、T13 egress 卫兵)
+  "agent.interfaces.fastapi_service -> agent.infrastructure.*",
+  "agent.interfaces.routes._deps -> agent.infrastructure.*",
+  "* -> agent.infrastructure.observability.*", "* -> agent.infrastructure.egress_*",
+]
+```
+**现存违例实测(上述豁免后)= 6**:public_api.py:63(memory)/:68(session)、persistence.py:23(session)、session_facade.py:17(session)——即 SessionStore/MemoryStore 港口化解决 4 处;tools/eval_feedback_miner.py:61 + eval_scorer.py:83(lazy import SupabaseClient,dev 工具,改收窄参数)。layers 契约今天即 0 违例(agents/domain 上行已测为零)。**方案对比**:import-linter vs 自写 AST 检查——选 import-linter:声明式契约 + `ignore_imports` 白名单可逐条销账(与 L1 的 overrides 销账法同构)、社区维护;自写 AST 脚本要自担 300 行维护 + 无 ratchet 语义,唯一优势(检查 getattr 反射)C4 已用窄 Protocol 根治。
+
+## 2. TS 侧同构(函数模块即用例,不造 class)
+
+- **workers/users**:api/routes.ts(147 行)的 `listRoutes/saveRoute/deleteRoute/claimRoutes` 已是显式用例(收 `DbExecutor` 注入,含 `assertOwner` 所有权不变量)。改两处:① 行映射 `toUserRoute/iso/nullableIso/strings/isStatus/ownerFrom`(routes.ts:15-52/77-82)抽 `src/lib/rows.ts` = DB row→contract 的唯一入口(与 B4 卡协同;timestamptz 归一化集中于此,守护不变量="wire 上只出 ISO 字符串与 contract 形状");② 顺手满足 L1 对该文件的 ×5 函数限拆分。router.ts(32 行)与 index.ts(76 行)已是"解析→用例→序列化",不动。
+- **workers/catalog**:ingest→enrich→publish 已是管道;api/* 已是 `(db, input) → contract 输出` 的用例函数,router.ts 的 oRPC handler 已瘦(错误翻译 callSpots/callAnimeOverview 留在 router,正确)。**实测越界 = api→ingest 内部件 8 处/4 文件**:work-points.ts:11-13(含 `JobStore` 深入口)、search.ts:36-37、resolve.ts:5(`enrich/parse` 的 `parseBangumi`)+:12、preview.ts:13。方案:ingest 出一个门面 `ingest/index.ts`(orchestrator 公开面 + `FetchLike` 型别),api 只许进门面——`JobStore`(jobs.ts)与 `enrich/parse` 直捣内脏的 2 处是真违例要改线;其余 6 处改经门面 re-export 即合法(守护不变量="读路径只能经 orchestrator 触发 ingest,永不绕过 singleflight/TTL")。pipeline→api 反向 = 0(实测)。zod 值 import 在 src/ = 0(实测,契约边界纪律已达标)。
+- **约束工具对比**:dependency-cruiser vs oxlint `no-restricted-imports`——选 oxlint:零新依赖、已是 `--deny-warnings` 硬门(L1 卡正在收编全 workspace)、per-override glob 可表达"api/** 禁 `../ingest/(jobs|sources)`、`../enrich/*`;所有文件禁 `../db/schema` 值引"。dep-cruiser 胜在环检测/可视化,但多一条 CI 链路且规则与现有 lint 门分裂;环检测需求出现再引入。配置草案(catalog/.oxlintrc.json overrides 节):
+```jsonc
+{ "files": ["src/api/**"], "rules": { "no-restricted-imports": [2, { "patterns": [
+  { "group": ["../ingest/*", "!../ingest/index"], "message": "api goes through the ingest facade" },
+  { "group": ["../enrich/*", "../publish/*", "../media/*"], "message": "pipeline internals" } ] }] } }
+```
+users 侧对应规则:`src/index.ts`/`src/router.ts` 禁 `./db/*` 值引之外的深依赖(现 0 违例,纯设防)。
+
+## 3. 分批与测试策略(每批独立绿、行为零变化)
+
+- **P0(先行快照,TDD 前置)**:为 `handle()` 六条路径(模型轮/点选/候选选/timeout/provider_error/byok 拒绝)落 characterization test——fake model + C4 窄 Protocol double,断言 `PublicAPIResponse.model_dump()` 全字段快照 + repo 调用记录。迁移期间此套件一行不许改(变异验证:任一用例体注释掉须变红)。
+- **P1**:usage_metering/anon_quota/persistence/session_facade/response_builder/schemas 整文件迁 `application/`,纯 mv+import 改写,`make check` 前后各跑。**与 C4-B2 撞文件(persistence/session_facade),必须排在 C4-B2 之后**。
+- **P2**:public_api.py 拆用例(§1 表),RuntimeAPI 退役为 routes/_deps 组合根装配;SessionStore/MemoryStore 港口化。排 C4-B3 之后(同文件)。
+- **P3**:import-linter 上 CI(P1 后违例即 0-2,ignore 清单只留 eval tools 两条并开 issue 销账)。
+- **T1(TS,与 P* 全程可并行)**:users `lib/rows.ts` 抽取(先给 toUserRoute 快照测试:draft/null saved_at/Date 与 string 双形态)→ catalog ingest 门面 + 2 处真违例改线 → oxlint 规则落 .oxlintrc.json。
+
+## 4. 明确不做(及理由)
+
+- **战术 DDD(聚合根/领域事件/CQRS)**:owner 已裁;单写者、无并发不变量竞争,聚合根守护的不变量(所有权/singleflight)现由 `assertOwner`+DB 唯一约束已守住,仪式无增益。CQS 注释级实践(public_api.py:526-531)保留即可。
+- **edge worker(worker/)不套用例层**:纯转发/鉴权域,无应用状态;其拆分归 C2 卡(app.ts 按信任域)。
+- **frontend apps/web**:TanStack 路由即边界,cutover 期不叠架构改造;rebuild 完成后另立卡。
+- **catalog api/* 改 class 用例、users 引 repository 类**:TS/Hono 惯用函数模块 + 参数注入已满足 DIP,class 仪式违反 1-10-50 的精神。
+
+---
+执行顺序(3 行):
+1. C4-B1(#663 修复)→ C4-B2/B3(窄 Protocol 收签名)先行落地;C5-P0 快照与 T1(TS 侧)同期并行开工。
+2. C4 收尾后 C5-P1(应用层文件迁移)→ P2(public_api 拆用例 + 双港口)。
+3. 最后 P3 import-linter + oxlint 规则双门上 CI(与 L1 卡的 .oxlintrc 收编合并提交,避免两次动同文件)。

--- a/docs/iterations/iter6/design-C5-clean-arch-both-sides.md
+++ b/docs/iterations/iter6/design-C5-clean-arch-both-sides.md
@@ -60,7 +60,7 @@ users 侧对应规则:`src/index.ts`/`src/router.ts` 禁 `./db/*` 值引之外�
 - **P0(先行快照,TDD 前置)**:为 `handle()` 六条路径(模型轮/点选/候选选/timeout/provider_error/byok 拒绝)落 characterization test——fake model + C4 窄 Protocol double,断言 `PublicAPIResponse.model_dump()` 全字段快照 + repo 调用记录。迁移期间此套件一行不许改(变异验证:任一用例体注释掉须变红)。
 - **P1**:usage_metering/anon_quota/persistence/session_facade/response_builder/schemas 整文件迁 `application/`,纯 mv+import 改写,`make check` 前后各跑。**与 C4-B2 撞文件(persistence/session_facade),必须排在 C4-B2 之后**。
 - **P2**:public_api.py 拆用例(§1 表),RuntimeAPI 退役为 routes/_deps 组合根装配;SessionStore/MemoryStore 港口化。排 C4-B3 之后(同文件)。
-- **P3**:import-linter 上 CI(P1 后违例即 0-2,ignore 清单只留 eval tools 两条并开 issue 销账)。
+- **P3**:import-linter 上 CI。ignore 清单分两类,别混:**常设 sanctioned 豁免**(组合根 fastapi_service/routes._deps 两条 + observability/egress 横切面两条,§1 契约里的 4 条——是架构决定,长期保留)与**债务豁免**(eval tools 两条,开 issue 销账,销完清零)。P1 后债务违例即 0-2,P3 完成时 ignore 清单 = 常设 4 条 + 债务 ≤2 条。
 - **T1(TS,与 P* 全程可并行)**:users `lib/rows.ts` 抽取(先给 toUserRoute 快照测试:draft/null saved_at/Date 与 string 双形态)→ catalog ingest 门面 + 2 处真违例改线 → oxlint 规则落 .oxlintrc.json。
 
 ## 4. 明确不做(及理由)

--- a/docs/iterations/iter6/design-L1-lint-enforcement.md
+++ b/docs/iterations/iter6/design-L1-lint-enforcement.md
@@ -1,43 +1,48 @@
 # L1 — 1-10-50 全 workspace oxlint 强制(#655)
 
-**结论:把 10/50 行函数限 + 300/200 行文件限收进根 `.oxlintrc.json`(带 tests override),apps/web 的私有 override 删除;worker/ 与 packages/contract 补 lint 基建(两者今天事实上零 lint);存量 46 个破线文件用 `overrides` 按文件白名单豁免、逐文件销账,不放松规则本身。**
+**结论:把 10/50 行函数限 + 300/200 行文件限收进根 `.oxlintrc.json`(带 tests override),apps/web 的私有 override 删除;worker/ 与 packages/contract 补 lint 基建(两者今天事实上零 lint);存量 46 个破线文件**一次拆完、零豁免**(owner 裁决 2026-08-03:不设任何 override 白名单/exception baseline),规则收编与拆分同一 campaign 落地。**
 
 ## 现状(全部实测,2026-08-03)
+
 - 根 `.oxlintrc.json`:type-aware 严格,已有 `complexity:10`/`max-depth:2`/`max-lines-per-function:50`;**没有** `max-lines`(300 文件限)且函数限是 50 非 10。1-10-50 目前只在 apps/web 达标(它私有 override 到 10/50)。
 - **执法空洞**:根 `lint:oxlint` = `pnpm --filter catalog --filter users --filter web` —— `worker/`(edge-worker,有 lint script 但无 oxlint devDep,`spawn ENOENT`)和 `packages/contract`(无 lint script)完全没人 lint;CI `_ts-ci.yml` 只跑 workers/{component}。
-- 存量破线(方法:oxlint + 根规则改 prod 10/50 + max-lines 300/200-test,非 type-aware 跑 worker/ workers/ packages/):**46 文件**,违规按文件计:
 
-| 文件(实测行数) | 违规 | 拆分思路(职责边界) |
+## 存量破线清单(精确实测,2026-08-03 复测)
+
+**方法**:oxlint 单独跑 `max-lines-per-function:10`(tests override 50)+ `max-lines:300`(tests 200),两条规则均 `skipBlankLines:true, skipComments:true`(与根配置及 apps/web 现行 override 的既有选项**一致**——这是规则真正执法的口径),非 type-aware,范围 = worker/ workers/ packages/ apps/web(即全部 live TS;frontend 冻结包除外)。
+**去重说明**:初稿表格按组相加得 52,与题头 46 矛盾——差异来源是初稿混用了裸 `wc -l` 行数:turnstileArm.test(229)/anonymous.test(207)/byok.test(205)/containerEnv.test(257) 等 4 个测试文件与 worker/users 两个 ×2 组条目在 skip 口径下**不超限**,不是违规文件;复测按执法口径逐文件去重后 = **46 个唯一文件**(生产 39 + 测试 7),清单如下,无重叠、无 shorthand:
+
+**生产代码 39 文件**(违规数,f=函数限 m=文件限):
+
+| 包 | 文件 | 拆分思路(职责边界) |
 |---|---|---|
-| workers/catalog/src/lib/route.ts (295) ×6 | 函数 | TSP 求解/腿构建/格式化三段,按算法阶段抽纯函数 |
-| workers/users/src/api/routes.ts (147) ×5 | 函数 | 每个 oRPC handler 的校验+DB 调用抽 service 函数 |
-| worker/auth.ts (277) ×5 | 函数+文件 | Supabase 验证 / Neon-JWT 验证 / 匿名身份铸造三域分文件 |
-| worker/app.ts (433) ×5 | 函数+文件 | → C2 卡,按信任域拆 |
-| workers/catalog/src/lib/clustering.ts (186) ×3 | 函数 | 距离矩阵/合并循环/输出映射分层 |
-| workers/catalog/src/ingest/orchestrator.ts (161) ×3 | 函数 | 每 pipeline 阶段一函数,主函数只剩编排 |
-| workers/catalog/src/ingest/jobs.ts (144) ×3 | 函数 | job 状态机转移逐 case 抽函数 |
-| workers/catalog/src/enrich/enrich.ts (154) ×3 | 函数 | 抓取/解析/合并三步早返回化 |
-| workers/catalog/src/api/work-points.ts (121) ×3 | 函数 | 查询构建与响应组装分离 |
-| workers/catalog/scripts/build-gazetteer.ts (357) ×3 | 函数+文件 | 下载/解析/emit 三模块(scripts,可考虑放宽而非拆) |
-| worker/turnstile.ts (240) ×3 | 函数 | siteverify 客户端 vs gate 状态机两文件 |
-| worker/tiles.ts (224) ×3 | 函数 | R2 读取/缓存头/路径校验分函数 |
-| ×2 一批(11 文件):users/index.ts、catalog snapshots/img/series/geocode/index/parse/spots/search/resolve.ts (260)、worker/edgeGuard.ts | 函数 | 均为"一个胖 handler"型:抽 request-parse 与 domain 步骤 |
-| ×1 长尾(20 文件,含 rateLimiter/containerEnv/geo/alias/preview/nearby…) | 函数 | 单函数超限,就地 extract-method 即可 |
-| 测试文件 >200 行:worker 6 个(turnstile 331/entry 263/containerEnv 257/turnstileArm 229/anonymous 207/byok 205)+ catalog 3 个(catalog-api.spike 357/search.worker 314/spike-db-global 303) | 文件 | 按行为域切(见 C2);spike-db-global 是 helper,归 override 豁免 |
+| worker/ (7) | app.ts ×5f · auth.ts ×5f · tiles.ts ×3f · turnstile.ts ×3f · edgeGuard.ts ×2f · containerEnv.ts ×1f · rateLimiter.ts ×1f | app.ts → C2 卡按信任域拆;auth.ts 按 Supabase 验证/Neon-JWT 验证/匿名铸造三域分文件;turnstile.ts 分 siteverify 客户端与 gate 状态机;tiles.ts 分 R2 读取/缓存头/路径校验;其余就地 extract-method |
+| workers/catalog/src/lib (9) | route.ts ×6f · clustering.ts ×3f · geocode.ts ×2f · series.ts ×2f · alias.ts ×1f · geo-query.ts ×1f · geo.ts ×1f · transit/etl/build.ts ×1f + transit/etl/n02.ts ×1f | route.ts 按 TSP 求解/腿构建/格式化三段抽纯函数;clustering.ts 距离矩阵/合并循环/输出映射分层;长尾 extract-method |
+| workers/catalog/src/api (9) | work-points.ts ×3f · resolve.ts ×2f · search.ts ×2f · spots.ts ×2f · anime-overview.ts ×1f · geocode.ts ×1f · nearby.ts ×1f · preview.ts ×1f · route.ts ×1f | 均为"一个胖 handler"型:抽 request-parse 与 domain 步骤(与 C5 用例化协同) |
+| workers/catalog/src 其余 (7) | enrich/enrich.ts ×3f · enrich/parse.ts ×2f · ingest/jobs.ts ×3f · ingest/orchestrator.ts ×3f · ingest/raw-store.ts ×1f · index.ts ×2f · media/img.ts ×2f | enrich 抓取/解析/合并三步早返回化;orchestrator 每 pipeline 阶段一函数;jobs 状态机逐 case 抽函数 |
+| workers/catalog 其它 (3) | publish/gc.ts ×1f · publish/snapshots.ts ×2f · scripts/build-gazetteer.ts ×3(f+m) | build-gazetteer **拆分**为下载/解析/emit 三模块(owner 裁决:不放宽,一律拆) |
+| workers/users/src (3) | api/routes.ts ×5f · index.ts ×2f · auth/jwt.ts ×1f | routes.ts 每个 oRPC handler 的校验+DB 调用抽 service 函数(与 C5-T1 行映射抽取同 PR) |
+| packages/contract (1) | scripts/emit-openapi.ts ×1f | extract-method |
+
+**测试文件 7 个**(>200 行或函数 >50 行,执法口径):worker/turnstile.test.ts(m)· worker/entry.test.ts(m)· workers/catalog/test/catalog-api.spike.test.ts(m)· workers/catalog/test/search.worker.test.ts(m)· workers/catalog/test/spike-db-global.ts(m,helper)· packages/contract/test/share-contract.test.ts(f)· apps/web/tests/msw/chat-handlers.ts(m)。拆分原则:**按被测行为域切,不对半切**(细则见 C2 卡"破线测试文件拆分原则");共享 fixture 提到 test-helpers,消灭复制粘贴 stub。
 
 ## 方案对比
-| | A. 规则下沉根配置 + 存量文件白名单豁免(推荐) | B. 每包自带 .oxlintrc 各自为政 | C. 只加新代码门(CI diff-aware) |
+
+| | A. 规则下沉根配置 + 存量一次拆完(推荐,owner 裁决) | B. 每包自带 .oxlintrc 各自为政 | C. 只加新代码门(CI diff-aware) |
 |---|---|---|---|
 | 一致性 | 单一事实源,apps/web 删私有 rules 段只留 react 插件+ignore | 漂移已发生(web=10,其余=50),会继续 | 规则名义全局、实际不可本地复现 |
-| 存量处理 | `overrides:[{files:[46个],rules:{max-lines*:off}}]` 显式清单=技术债台账,删一个文件条目=销一笔账,**只出不进**(棘轮,同 coverage 慣例) | 各包自行放松,不可审计 | 无台账 |
-| 成本 | 一次配置 PR + worker/contract 补 devDep/script/filter | 低 | 需自研 diff 工具 |
-**推荐 A。** 落地顺序:①根配置加 `max-lines-per-function:10`(tests override 50)+ `max-lines:300`(tests 200)+ 46 文件豁免清单;②worker/ 加 `oxlint`+`oxlint-tsgolint` devDep(今天连二进制都解析不到);③packages/contract 加 lint script;④根 filter 改 `pnpm -r --if-present run lint:oxlint`;⑤`_ts-ci.yml`/新增 edge lane 跑 worker lint。scripts/(build-gazetteer 等离线 ETL)建议 override 放宽 max-lines 到 400 而非拆——一次性脚本拆碎是负收益,owner 裁决。
+| 存量处理 | 46 文件在同 campaign 内全部拆完,配置零豁免条目——不留台账、不留 ratchet 债 | 各包自行放松,不可审计 | 无台账 |
+| 成本 | 拆分 PR 若干 + 一次配置 PR + worker/contract 补 devDep/script/filter | 低 | 需自研 diff 工具 |
+
+**推荐 A。** 落地顺序:①worker/ 加 `oxlint`+`oxlint-tsgolint` devDep(今天连二进制都解析不到)、packages/contract 加 lint script;②按包分批拆完 46 个文件(每批该包既有测试全绿);③根配置加 `max-lines-per-function:10`(tests override 50)+ `max-lines:300`(tests 200),**不带任何文件豁免条目**,apps/web 删私有 override;④根 filter 改 `pnpm -r run lint:oxlint`(**不用 `--if-present`**——它会把缺 script 的包静默跳过、fail-open;另加 preflight 断言每个 workspace 包都定义了 `lint:oxlint`,缺失即红);⑤`_ts-ci.yml`/新增 edge lane 跑 worker lint。
 
 ## 测试策略
-- 配置本身:CI 上 `pnpm -r lint:oxlint` 全绿即验收;另加一条 node --test 断言豁免清单文件数只减不增(读 .oxlintrc.json 计数,防偷偷加白)。
-- 每销账一个文件:该包既有单测全绿 + 该文件从豁免清单删除,同 PR 完成。
+
+- 配置本身:CI 上 `pnpm -r run lint:oxlint`(fail-closed,同上)全绿即验收;另加一条 node --test 断言:根与各包 .oxlintrc.json **不含任何 `max-lines*` 的文件级 override/豁免条目**(零豁免是不变量,防事后偷偷加白;比"清单只减不增"的计数 ratchet 更强——集合级断言,不存在换名/换 glob 钻空)。
+- 每个拆分 PR:该包既有单测全绿 + 行为零变化(纯 extract,不改导出语义)。
 
 ## 风险与回滚
-- worker/ 首次接入 type-aware lint 可能爆出与行数无关的存量违规(no-unsafe-* 类)——先跑一次盘点,若>20 条则 worker 的 typescript 规则同样走豁免清单,不 eslint-disable(仓规禁止 suppression)。
-- 豁免清单被滥用:靠棘轮测试 + review 把关。回滚 = revert 配置 PR,零运行时影响。
-- 数字注意:46 文件是"函数/文件行数"维度实测;C2/C4 落地后 worker/ 侧会自然销掉 ~10 个。
+
+- worker/ 首次接入 type-aware lint 可能爆出与行数无关的存量违规(no-unsafe-* 类)——**单独盘点**:按"文件 × 规则"出一份独立于上述 46 行数清单的 no-unsafe-* 违规清单,先修完这批违规再开 type-aware 门;不设豁免清单、不 suppression(仓规禁止),行数豁免绝不可覆盖类型错误。
+- 回滚 = revert 配置 PR,零运行时影响;拆分 commit 各自独立可 revert。
+- 数字注意:46 文件是"函数/文件行数"维度、skip 空行/注释口径实测;C2/C4 落地后 worker/ 侧会自然销掉 ~10 个,拆分排期以 C2/C4 先行为准免得重复劳动。

--- a/docs/iterations/iter6/design-L1-lint-enforcement.md
+++ b/docs/iterations/iter6/design-L1-lint-enforcement.md
@@ -1,0 +1,43 @@
+# L1 — 1-10-50 全 workspace oxlint 强制(#655)
+
+**结论:把 10/50 行函数限 + 300/200 行文件限收进根 `.oxlintrc.json`(带 tests override),apps/web 的私有 override 删除;worker/ 与 packages/contract 补 lint 基建(两者今天事实上零 lint);存量 46 个破线文件用 `overrides` 按文件白名单豁免、逐文件销账,不放松规则本身。**
+
+## 现状(全部实测,2026-08-03)
+- 根 `.oxlintrc.json`:type-aware 严格,已有 `complexity:10`/`max-depth:2`/`max-lines-per-function:50`;**没有** `max-lines`(300 文件限)且函数限是 50 非 10。1-10-50 目前只在 apps/web 达标(它私有 override 到 10/50)。
+- **执法空洞**:根 `lint:oxlint` = `pnpm --filter catalog --filter users --filter web` —— `worker/`(edge-worker,有 lint script 但无 oxlint devDep,`spawn ENOENT`)和 `packages/contract`(无 lint script)完全没人 lint;CI `_ts-ci.yml` 只跑 workers/{component}。
+- 存量破线(方法:oxlint + 根规则改 prod 10/50 + max-lines 300/200-test,非 type-aware 跑 worker/ workers/ packages/):**46 文件**,违规按文件计:
+
+| 文件(实测行数) | 违规 | 拆分思路(职责边界) |
+|---|---|---|
+| workers/catalog/src/lib/route.ts (295) ×6 | 函数 | TSP 求解/腿构建/格式化三段,按算法阶段抽纯函数 |
+| workers/users/src/api/routes.ts (147) ×5 | 函数 | 每个 oRPC handler 的校验+DB 调用抽 service 函数 |
+| worker/auth.ts (277) ×5 | 函数+文件 | Supabase 验证 / Neon-JWT 验证 / 匿名身份铸造三域分文件 |
+| worker/app.ts (433) ×5 | 函数+文件 | → C2 卡,按信任域拆 |
+| workers/catalog/src/lib/clustering.ts (186) ×3 | 函数 | 距离矩阵/合并循环/输出映射分层 |
+| workers/catalog/src/ingest/orchestrator.ts (161) ×3 | 函数 | 每 pipeline 阶段一函数,主函数只剩编排 |
+| workers/catalog/src/ingest/jobs.ts (144) ×3 | 函数 | job 状态机转移逐 case 抽函数 |
+| workers/catalog/src/enrich/enrich.ts (154) ×3 | 函数 | 抓取/解析/合并三步早返回化 |
+| workers/catalog/src/api/work-points.ts (121) ×3 | 函数 | 查询构建与响应组装分离 |
+| workers/catalog/scripts/build-gazetteer.ts (357) ×3 | 函数+文件 | 下载/解析/emit 三模块(scripts,可考虑放宽而非拆) |
+| worker/turnstile.ts (240) ×3 | 函数 | siteverify 客户端 vs gate 状态机两文件 |
+| worker/tiles.ts (224) ×3 | 函数 | R2 读取/缓存头/路径校验分函数 |
+| ×2 一批(11 文件):users/index.ts、catalog snapshots/img/series/geocode/index/parse/spots/search/resolve.ts (260)、worker/edgeGuard.ts | 函数 | 均为"一个胖 handler"型:抽 request-parse 与 domain 步骤 |
+| ×1 长尾(20 文件,含 rateLimiter/containerEnv/geo/alias/preview/nearby…) | 函数 | 单函数超限,就地 extract-method 即可 |
+| 测试文件 >200 行:worker 6 个(turnstile 331/entry 263/containerEnv 257/turnstileArm 229/anonymous 207/byok 205)+ catalog 3 个(catalog-api.spike 357/search.worker 314/spike-db-global 303) | 文件 | 按行为域切(见 C2);spike-db-global 是 helper,归 override 豁免 |
+
+## 方案对比
+| | A. 规则下沉根配置 + 存量文件白名单豁免(推荐) | B. 每包自带 .oxlintrc 各自为政 | C. 只加新代码门(CI diff-aware) |
+|---|---|---|---|
+| 一致性 | 单一事实源,apps/web 删私有 rules 段只留 react 插件+ignore | 漂移已发生(web=10,其余=50),会继续 | 规则名义全局、实际不可本地复现 |
+| 存量处理 | `overrides:[{files:[46个],rules:{max-lines*:off}}]` 显式清单=技术债台账,删一个文件条目=销一笔账,**只出不进**(棘轮,同 coverage 慣例) | 各包自行放松,不可审计 | 无台账 |
+| 成本 | 一次配置 PR + worker/contract 补 devDep/script/filter | 低 | 需自研 diff 工具 |
+**推荐 A。** 落地顺序:①根配置加 `max-lines-per-function:10`(tests override 50)+ `max-lines:300`(tests 200)+ 46 文件豁免清单;②worker/ 加 `oxlint`+`oxlint-tsgolint` devDep(今天连二进制都解析不到);③packages/contract 加 lint script;④根 filter 改 `pnpm -r --if-present run lint:oxlint`;⑤`_ts-ci.yml`/新增 edge lane 跑 worker lint。scripts/(build-gazetteer 等离线 ETL)建议 override 放宽 max-lines 到 400 而非拆——一次性脚本拆碎是负收益,owner 裁决。
+
+## 测试策略
+- 配置本身:CI 上 `pnpm -r lint:oxlint` 全绿即验收;另加一条 node --test 断言豁免清单文件数只减不增(读 .oxlintrc.json 计数,防偷偷加白)。
+- 每销账一个文件:该包既有单测全绿 + 该文件从豁免清单删除,同 PR 完成。
+
+## 风险与回滚
+- worker/ 首次接入 type-aware lint 可能爆出与行数无关的存量违规(no-unsafe-* 类)——先跑一次盘点,若>20 条则 worker 的 typescript 规则同样走豁免清单,不 eslint-disable(仓规禁止 suppression)。
+- 豁免清单被滥用:靠棘轮测试 + review 把关。回滚 = revert 配置 PR,零运行时影响。
+- 数字注意:46 文件是"函数/文件行数"维度实测;C2/C4 落地后 worker/ 侧会自然销掉 ~10 个。


### PR DESCRIPTION
iter6 Wave 3 四份设计稿定稿入库(owner 逐份评审批准,2026-08-03):

- **C2**(#652)信任域拆分 + 显式信任链管道 + 顺序守卫测试(变异验证)+ `Admitted` 类型锁
- **C4**(#654)9 张按 bounded context 命名的窄 Protocol,无 helper 层;第一批迁移 = #663 生产持久化死路径修复
- **C5**(#666)两侧 Clean Architecture 归位:Python 9 用例迁 application + import-linter;TS ingest 门面 + oxlint 依赖红线
- **L1**(#655)1-10-50 全 workspace 强制,46 个存量破线文件一次拆完(每个先出拆分设计),先修 worker/ oxlint ENOENT 与 contract 无 lint 两个执法真空

含 iter6/README.md 索引与方法论授权记录(两侧统一 TDD/DDD战略/SOLID/OOP/CleanArch,战术 DDD 排除,依赖规则机器守卫)。

Docs-only。关联 #652 #654 #655 #663 #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Iteration 6 cleanup campaign overview, including milestones and Wave 3 plans.
  * Documented planned application structure improvements for trust boundaries, dependency injection, session handling, and clean architecture.
  * Added a lint enforcement plan covering file and function size limits, migration exemptions, and expanded validation.
  * Recorded rollout sequencing, testing strategies, risks, and rollback approaches for the planned work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->