### PR TITLE
fix(iter6 R1): land the three stranded rebuild-tail fixes (#531 test, #517/#556 vision metering, #526 session listing)

### DIFF
--- a/apps/agent/agent/agents/photo_search.py
+++ b/apps/agent/agent/agents/photo_search.py
@@ -11,11 +11,12 @@ contract shapes so rendering shares the text-search path.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 from pydantic import BaseModel
 
+from agent.agents.agent_result import AttributedUsage
 from agent.agents.catalog_failures import CATALOG_FAILURES
 from agent.agents.vision_supply_router import VisionRecognitionFailed, VisionSupply
 from agent.clients.catalog_client import (
@@ -95,6 +96,7 @@ class PhotoSearchResponse(BaseModel):
 class PhotoSearchOutcome:
     response: PhotoSearchResponse
     signals: PhotoSearchSignals
+    usage: AttributedUsage | None = None
 
 
 def _point(row: PilgrimagePoint) -> PhotoPoint:
@@ -266,8 +268,11 @@ async def run_photo_search(
     except VisionRecognitionFailed:
         return await _vision_unavailable_outcome(catalog, gps)
     titles = call.recognition.candidate_titles
+    usage = AttributedUsage(
+        call.usage, "byok" if call.provider_kind == "byok" else "platform"
+    )
     if titles:
         outcome = await _layer_one(catalog, titles, gps)
         if outcome is not None:
-            return outcome
-    return await _degrade(catalog, titles, gps)
+            return replace(outcome, usage=usage)
+    return replace(await _degrade(catalog, titles, gps), usage=usage)

--- a/apps/agent/agent/agents/vision_supply_router.py
+++ b/apps/agent/agent/agents/vision_supply_router.py
@@ -16,6 +16,7 @@ from typing import Literal, NewType, Protocol
 import httpx
 import structlog
 from pydantic import BaseModel, Field
+from pydantic_ai.usage import RunUsage
 
 logger = structlog.get_logger(__name__)
 
@@ -89,6 +90,7 @@ class VisionRecognition(BaseModel):
 
     reported_image_count: int
     candidate_titles: list[str] = Field(default_factory=list)
+    usage: RunUsage | None = None
 
 
 class VisionProvider(Protocol):
@@ -146,6 +148,7 @@ class VisionCallResult:
     recognition: VisionRecognition
     provider_kind: VisionProviderKind
     fell_back_to_platform: bool
+    usage: RunUsage
 
 
 @dataclass
@@ -160,6 +163,10 @@ class VisionSupply:
     def route(self, authenticated: bool) -> VisionRoute:
         return choose_vision_route(self.byok_endpoint, self.registry, authenticated)
 
+    @staticmethod
+    def _usage(recognition: VisionRecognition) -> RunUsage:
+        return recognition.usage or RunUsage(requests=1)
+
     async def recognize(
         self, images: list[bytes], locale: str, authenticated: bool
     ) -> VisionCallResult:
@@ -169,7 +176,12 @@ class VisionSupply:
             if result is not None:
                 return result
         recognition = await self._recognize_platform(images, locale)
-        return VisionCallResult(recognition, "platform", route.provider_kind == "byok")
+        return VisionCallResult(
+            recognition,
+            "platform",
+            route.provider_kind == "byok",
+            self._usage(recognition),
+        )
 
     async def _recognize_platform(
         self, images: list[bytes], locale: str
@@ -197,7 +209,9 @@ class VisionSupply:
         if recognition is None:
             return None
         if recognition.reported_image_count == len(images):
-            return VisionCallResult(recognition, "byok", False)
+            return VisionCallResult(
+                recognition, "byok", False, self._usage(recognition)
+            )
         self.registry.mark(endpoint, False)
         return None
 

--- a/apps/agent/agent/clients/gemini_vision.py
+++ b/apps/agent/agent/clients/gemini_vision.py
@@ -12,6 +12,7 @@ import base64
 import json
 
 import httpx
+from pydantic_ai.usage import RunUsage
 
 from agent.agents.vision_supply_router import (
     VisionProviderMisconfigured,
@@ -96,6 +97,23 @@ def _parse_recognition(text: str) -> VisionRecognition:
     )
 
 
+def _parse_usage(body: object) -> RunUsage | None:
+    if not isinstance(body, dict):
+        return None
+    metadata = body.get("usageMetadata")
+    if not isinstance(metadata, dict):
+        return None
+    return RunUsage(
+        requests=1,
+        input_tokens=_token_count(metadata.get("promptTokenCount")),
+        output_tokens=_token_count(metadata.get("candidatesTokenCount")),
+    )
+
+
+def _token_count(value: object) -> int:
+    return value if isinstance(value, int) and value >= 0 else 0
+
+
 def _string_list(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
@@ -137,7 +155,10 @@ class GeminiVisionProvider:
             json=_payload(images, locale),
         )
         response.raise_for_status()
-        return _parse_recognition(_response_text(response.json()))
+        body = response.json()
+        recognition = _parse_recognition(_response_text(body))
+        recognition.usage = _parse_usage(body)
+        return recognition
 
     async def aclose(self) -> None:
         if self._owns_client and self._client is not None:

--- a/apps/agent/agent/interfaces/public_api.py
+++ b/apps/agent/agent/interfaces/public_api.py
@@ -845,6 +845,16 @@ async def _record_attributed_usage(
     await record_turn_usage(db, usage=item.usage, scope=scope, prices=prices)
 
 
+async def record_attributed_usage(
+    db: object,
+    item: AttributedUsage,
+    user_id: str | None,
+    user_type: str | None,
+    platform_prices: UsagePrices,
+) -> None:
+    await _record_attributed_usage(db, item, user_id, user_type, platform_prices)
+
+
 def _set_span_request_attrs(
     span: object,
     session_id: str | None,

--- a/apps/agent/agent/interfaces/routes/photo_search.py
+++ b/apps/agent/agent/interfaces/routes/photo_search.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from agent.interfaces.routes.chat import BUDGET_EXHAUSTED_MESSAGE
 from agent.agents.photo_search import (
     GpsPoint,
     PhotoSearchResponse,
@@ -251,7 +252,13 @@ async def _budget_rejection(
         return None
     return JSONResponse(
         status_code=403,
-        content={"error": {"code": ANON_BUDGET_EXHAUSTED_CODE, "action": "login"}},
+        content={
+            "error": {
+                "code": ANON_BUDGET_EXHAUSTED_CODE,
+                "message": BUDGET_EXHAUSTED_MESSAGE,
+                "action": "login",
+            }
+        },
     )
 
 

--- a/apps/agent/agent/interfaces/routes/photo_search.py
+++ b/apps/agent/agent/interfaces/routes/photo_search.py
@@ -43,13 +43,20 @@ from agent.infrastructure.observability.photo_search import (
     QuotaKey,
     record_photo_search,
 )
+from agent.interfaces.public_api import record_attributed_usage
 from agent.interfaces.routes._deps import (
     TrustedAuthContext,
     _error_response,
     _get_settings_from_request,
     _get_trusted_auth_context,
 )
-from agent.interfaces.usage_metering import is_anonymous_identity
+from agent.interfaces.usage_metering import (
+    ANON_BUDGET_EXHAUSTED_CODE,
+    ANONYMOUS_USER_TYPE,
+    UsagePrices,
+    anonymous_budget_verdict,
+    is_anonymous_identity,
+)
 
 router = APIRouter(prefix="/v1", tags=["photo-search"])
 
@@ -221,6 +228,45 @@ def _check_quota(
     )
 
 
+async def _budget_rejection(
+    request: Request, auth: TrustedAuthContext
+) -> JSONResponse | None:
+    # Route through the canonical predicate rather than testing `user_type`
+    # directly: a request carrying `X-User-Id` but no `X-User-Type` is an
+    # identified caller, and a looser check here metered them into the anonymous
+    # scope and could refuse them once the anon budget ran out. The edge sets
+    # both headers together (`worker/app.ts`), so this is defence in depth
+    # rather than a reachable path — but the same concept having two different
+    # answers in the codebase is how it stops being one.
+    if auth.user_id is not None and not is_anonymous_identity(
+        auth.user_id, auth.user_type
+    ):
+        return None
+    settings = _get_settings_from_request(request)
+    verdict = await anonymous_budget_verdict(
+        request.app.state.db_client,
+        budget_usd=settings.anon_daily_cost_budget_usd,
+    )
+    if not verdict.exhausted:
+        return None
+    return JSONResponse(
+        status_code=403,
+        content={"error": {"code": ANON_BUDGET_EXHAUSTED_CODE, "action": "login"}},
+    )
+
+
+def _scope_user_type(auth: TrustedAuthContext) -> str | None:
+    """Two different absences that a blanket `or "anonymous"` conflated.
+
+    No `X-User-Id` means no identity was asserted at all — the anonymous tier.
+    An `X-User-Id` with no `X-User-Type` is an identified caller whose type
+    header went missing; `scope_for_identity` resolves that against the user-id
+    convention, so it must be passed through rather than coerced, or their
+    spend lands in the anon scope.
+    """
+    return auth.user_type if auth.user_id is not None else ANONYMOUS_USER_TYPE
+
+
 def _supply(runtime: PhotoSearchRuntime, byok: EndpointId | None) -> VisionSupply:
     provider = runtime.byok_providers.get(byok) if byok is not None else None
     return VisionSupply(
@@ -254,6 +300,15 @@ async def handle_photo_search(
     authenticated = auth.user_id is not None and not is_anonymous_identity(
         auth.user_id, auth.user_type
     )
+    # The budget check runs before the image is decoded. It needs only `auth`,
+    # and a breaker that fires after the work it is meant to prevent is most of
+    # a breaker that does not work. The visible consequence: a caller who is both
+    # over budget and sending a malformed image now gets 403 rather than 400 —
+    # the correct precedence, since being over budget is the reason we are not
+    # looking at their image at all.
+    budget_rejection = await _budget_rejection(request, auth)
+    if budget_rejection is not None:
+        return budget_rejection
     try:
         image = _decode_image(body)
         tier = quota_tier_for(authenticated)
@@ -261,7 +316,7 @@ async def handle_photo_search(
         _check_quota(runtime, settings, tier, _quota_key(auth, request), byok)
     except PhotoSearchRejection as rejection:
         return _rejection_response(rejection)
-    return await _run_pipeline(runtime, byok, image, body, request, authenticated)
+    return await _run_pipeline(runtime, byok, image, body, request, auth, authenticated)
 
 
 async def _run_pipeline(
@@ -270,6 +325,7 @@ async def _run_pipeline(
     image: bytes,
     body: PhotoSearchBody,
     request: Request,
+    auth: TrustedAuthContext,
     authenticated: bool,
 ) -> JSONResponse:
     outcome = await run_photo_search(
@@ -281,6 +337,18 @@ async def _run_pipeline(
         authenticated,
     )
     record_photo_search(outcome.signals)
+    if outcome.usage is not None:
+        settings = _get_settings_from_request(request)
+        await record_attributed_usage(
+            request.app.state.db_client,
+            outcome.usage,
+            auth.user_id,
+            _scope_user_type(auth),
+            UsagePrices(
+                input_usd_per_mtok=settings.model_input_cost_per_mtok_usd,
+                output_usd_per_mtok=settings.model_output_cost_per_mtok_usd,
+            ),
+        )
     return JSONResponse(outcome.response.model_dump(exclude_none=True))
 
 

--- a/apps/agent/agent/interfaces/routes/photo_search.py
+++ b/apps/agent/agent/interfaces/routes/photo_search.py
@@ -17,7 +17,6 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from agent.interfaces.routes.chat import BUDGET_EXHAUSTED_MESSAGE
 from agent.agents.photo_search import (
     GpsPoint,
     PhotoSearchResponse,
@@ -51,6 +50,7 @@ from agent.interfaces.routes._deps import (
     _get_settings_from_request,
     _get_trusted_auth_context,
 )
+from agent.interfaces.routes.chat import BUDGET_EXHAUSTED_MESSAGE
 from agent.interfaces.usage_metering import (
     ANON_BUDGET_EXHAUSTED_CODE,
     ANONYMOUS_USER_TYPE,

--- a/apps/agent/agent/tests/unit/test_gemini_vision.py
+++ b/apps/agent/agent/tests/unit/test_gemini_vision.py
@@ -78,6 +78,7 @@ class _StubAsyncClient:
     ) -> httpx.Response:
         text = {"image_count": 1, "candidate_titles": ["リズと青い鳥"]}
         body = {
+            "usageMetadata": {"promptTokenCount": 12, "candidatesTokenCount": 7},
             "candidates": [
                 {
                     "content": {
@@ -86,7 +87,7 @@ class _StubAsyncClient:
                         ]
                     }
                 }
-            ]
+            ],
         }
         request = httpx.Request("POST", url)
         return httpx.Response(200, json=body, request=request)
@@ -98,6 +99,9 @@ async def test_recognize_posts_and_parses(monkeypatch: pytest.MonkeyPatch) -> No
     recognition = await provider.recognize([b"\xff\xd8\xff"], "ja")
     assert recognition.reported_image_count == 1
     assert recognition.candidate_titles == ["リズと青い鳥"]
+    assert recognition.usage is not None
+    assert recognition.usage.input_tokens == 12
+    assert recognition.usage.output_tokens == 7
 
 
 async def test_recognize_with_empty_key_fails_fast_without_a_network_call(

--- a/apps/agent/agent/tests/unit/test_photo_search_route.py
+++ b/apps/agent/agent/tests/unit/test_photo_search_route.py
@@ -16,6 +16,7 @@ from agent.config.settings import Settings
 from agent.infrastructure.observability import photo_search as telemetry
 from agent.infrastructure.observability.photo_search import PhotoSearchQuota
 from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.routes.chat import BUDGET_EXHAUSTED_MESSAGE
 from agent.interfaces.routes.photo_search import (
     MAX_IMAGE_BASE64_CHARS,
     PhotoSearchRuntime,
@@ -153,6 +154,8 @@ async def test_exhausted_anonymous_budget_rejects_before_vision() -> None:
         response = await client.post("/v1/photo-search", json=_body())
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "anon_budget_exhausted"
+    assert response.json()["error"]["message"] == BUDGET_EXHAUSTED_MESSAGE
+    assert response.json()["error"]["action"] == "login"
     assert app.state.photo_search.platform_provider.calls == 0
 
 

--- a/apps/agent/agent/tests/unit/test_photo_search_route.py
+++ b/apps/agent/agent/tests/unit/test_photo_search_route.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import base64
-from datetime import UTC, datetime
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
 from fastapi import FastAPI
 
-from agent.agents.vision_supply_router import VisionRecognition
+from agent.agents.vision_supply_router import EndpointId, VisionRecognition
 from agent.config.settings import Settings
 from agent.infrastructure.observability import photo_search as telemetry
 from agent.infrastructure.observability.photo_search import PhotoSearchQuota
@@ -82,6 +83,54 @@ def _outage_app() -> FastAPI:
     return app
 
 
+@dataclass(frozen=True)
+class _UsageCall:
+    """One `accumulate_usage` invocation, mirroring the port signature exactly.
+
+    Typed rather than a `dict[str, object]` bag so the fake enforces the port
+    contract: `**kwargs: object` would swallow a misspelled or dropped keyword
+    argument and the test would still pass.
+    """
+
+    usage_date: date
+    scope: str
+    requests: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+
+
+class _UsageRepo:
+    def __init__(self, spent: float = 0.0) -> None:
+        self.spent = spent
+        self.calls: list[_UsageCall] = []
+
+    async def accumulate_usage(
+        self,
+        *,
+        usage_date: date,
+        scope: str,
+        requests: int,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+    ) -> None:
+        self.calls.append(
+            _UsageCall(
+                usage_date=usage_date,
+                scope=scope,
+                requests=requests,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=cost_usd,
+            )
+        )
+
+    async def total_cost_usd(self, *, usage_date: date, scope: str) -> float:
+        del usage_date, scope
+        return self.spent
+
+
 def _assert_clarify_response(response: httpx.Response) -> None:
     assert response.status_code == 200
     payload = response.json()
@@ -94,6 +143,45 @@ async def test_platform_vision_outage_degrades_to_clarify_not_500() -> None:
     async with async_client(_outage_app()) as client:
         response = await client.post("/v1/photo-search", json=_body())
     _assert_clarify_response(response)
+
+
+async def test_exhausted_anonymous_budget_rejects_before_vision() -> None:
+    app = _app(settings=Settings(anon_daily_cost_budget_usd=5.0))
+    repo = _UsageRepo(spent=5.0)
+    app.state.db_client.usage = repo
+    async with async_client(app) as client:
+        response = await client.post("/v1/photo-search", json=_body())
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "anon_budget_exhausted"
+    assert app.state.photo_search.platform_provider.calls == 0
+
+
+async def test_platform_vision_is_recorded_in_the_anonymous_scope() -> None:
+    app = _app(settings=Settings(model_input_cost_per_mtok_usd=2.0))
+    repo = _UsageRepo()
+    app.state.db_client.usage = repo
+    async with async_client(app) as client:
+        response = await client.post("/v1/photo-search", json=_body())
+    assert response.status_code == 200
+    assert [(call.scope, call.requests) for call in repo.calls] == [("anon", 1)]
+
+
+async def test_byok_fallback_is_recorded_as_platform_user_usage() -> None:
+    app = _app(settings=Settings(model_input_cost_per_mtok_usd=2.0))
+    repo = _UsageRepo()
+    app.state.db_client.usage = repo
+    endpoint = EndpointId("ep-1")
+    app.state.photo_search.registry.mark(endpoint, True)
+    app.state.photo_search.byok_providers[endpoint] = _DownVisionProvider()
+    headers = {
+        "X-User-Id": "user-1",
+        "X-User-Type": "human",
+        "x-byok-endpoint": "ep-1",
+    }
+    async with async_client(app) as client:
+        response = await client.post("/v1/photo-search", json=_body(), headers=headers)
+    assert response.status_code == 200
+    assert [call.scope for call in repo.calls] == ["user"]
 
 
 async def test_unsupported_mime_type_is_a_clear_415() -> None:
@@ -210,3 +298,24 @@ async def test_confirm_rejects_the_vision_unavailable_alert_signal() -> None:
     async with async_client(_app()) as client:
         response = await client.post("/v1/photo-search/confirm", json=body)
     assert response.status_code == 422
+
+
+async def test_identified_caller_without_user_type_is_not_metered_as_anonymous() -> (
+    None
+):
+    """`X-User-Id` with no `X-User-Type` is identified, not anonymous.
+
+    The edge sets both headers together, so this is defence in depth. It is
+    pinned because the failure is silent: the caller's spend lands in the anon
+    scope and, once the anon budget is exhausted, they are refused with a
+    login prompt they cannot act on.
+    """
+    app = _app(settings=Settings(anon_daily_cost_budget_usd=5.0))
+    repo = _UsageRepo(spent=5.0)
+    app.state.db_client.usage = repo
+    async with async_client(app) as client:
+        response = await client.post(
+            "/v1/photo-search", json=_body(), headers={"X-User-Id": "user-1"}
+        )
+    assert response.status_code == 200
+    assert [call.scope for call in repo.calls] == ["user"]

--- a/packages/contract/src/users-contract.ts
+++ b/packages/contract/src/users-contract.ts
@@ -107,8 +107,44 @@ export const ListRoutesResult = z.object({ routes: z.array(UserRoute) });
 /** Inferred list-routes result. */
 export type ListRoutesResult = z.infer<typeof ListRoutesResult>;
 
+/** Bounded page controls for listing the caller's sessions. */
+export const ListSessionsInput = z.strictObject({
+  limit: z.coerce.number().int().min(1).max(50).default(30),
+  offset: z.coerce.number().int().nonnegative().max(1_000).default(0),
+});
+/** Inferred session-list page controls. */
+export type ListSessionsInput = z.infer<typeof ListSessionsInput>;
+
+/** Conversation summary for one authenticated session. */
+export const UserSession = z.strictObject({
+  session_id: z.string().min(1),
+  title: z.string().nullable(),
+  first_query: z.string(),
+  created_at: z.iso.datetime({ offset: true }),
+  updated_at: z.iso.datetime({ offset: true }),
+});
+/** Inferred authenticated session summary. */
+export type UserSession = z.infer<typeof UserSession>;
+
+/** One bounded page of the caller's sessions. */
+export const ListSessionsResult = z.strictObject({
+  sessions: z.array(UserSession).max(50),
+  next_offset: z.number().int().nonnegative().nullable(),
+});
+/** Inferred session-list result. */
+export type ListSessionsResult = z.infer<typeof ListSessionsResult>;
+
 /** oRPC contract for authenticated user-route operations. */
 export const usersContract = {
+  listSessions: oc
+    .route({
+      method: "GET",
+      path: "/v1/users/sessions",
+      summary: "List the caller's sessions",
+      spec: requireBearer,
+    })
+    .input(ListSessionsInput)
+    .output(ListSessionsResult),
   listRoutes: oc
     .route({
       method: "GET",

--- a/packages/contract/test/users-openapi.test.ts
+++ b/packages/contract/test/users-openapi.test.ts
@@ -1,3 +1,4 @@
+import { ListSessionsInput } from "../src/users-contract.js";
 import { describe, expect, it } from "vitest";
 import usersOpenApi from "../users-openapi.json";
 
@@ -8,6 +9,10 @@ const resolveSchema = usersOpenApi.paths["/v1/users/shares/resolve/{token}"]
 const itinerary = resolveSchema.properties.itinerary.properties;
 
 describe("users OpenAPI security", () => {
+  it("rejects session offsets beyond the resource-safety limit", () => {
+    expect(ListSessionsInput.safeParse({ offset: 1_001 }).success).toBe(false);
+  });
+
   it("defines HTTP bearer JWT authentication", () => {
     expect(usersOpenApi.components.securitySchemes).toEqual({
       bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
@@ -16,6 +21,7 @@ describe("users OpenAPI security", () => {
 
   it("requires bearer authentication for users, check-in, and share mutations", () => {
     expect(usersOpenApi.paths["/v1/users/routes"].get.security).toEqual(BEARER_SECURITY);
+    expect(usersOpenApi.paths["/v1/users/sessions"].get.security).toEqual(BEARER_SECURITY);
     expect(usersOpenApi.paths["/v1/users/routes"].post.security).toEqual(BEARER_SECURITY);
     expect(usersOpenApi.paths["/v1/users/routes/{id}"].delete.security).toEqual(BEARER_SECURITY);
     expect(usersOpenApi.paths["/v1/users/routes/claim"].post.security).toEqual(BEARER_SECURITY);

--- a/packages/contract/users-openapi.json
+++ b/packages/contract/users-openapi.json
@@ -15,6 +15,116 @@
   },
   "openapi": "3.1.1",
   "paths": {
+    "/v1/users/sessions": {
+      "get": {
+        "operationId": "listSessions",
+        "summary": "List the caller's sessions",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 30
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1000,
+              "default": 0
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sessions": {
+                      "type": "array",
+                      "maxItems": 50,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "session_id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "title": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "first_query": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        },
+                        "required": [
+                          "session_id",
+                          "title",
+                          "first_query",
+                          "created_at",
+                          "updated_at"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "next_offset": {
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "sessions",
+                    "next_offset"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
     "/v1/users/routes": {
       "get": {
         "operationId": "listRoutes",

--- a/worker/containerEnv.ts
+++ b/worker/containerEnv.ts
@@ -27,7 +27,7 @@ export const CONTAINER_ENV_KEYS = [
   "ANON_DAILY_COST_BUDGET_USD", "MODEL_INPUT_COST_PER_MTOK_USD", "MODEL_OUTPUT_COST_PER_MTOK_USD",
   // Per-identity anonymous daily message quota (issue #282, S1.10): same
   // container-ingress-authoritative reasoning as the budget breaker above.
-  "ANON_DAILY_MESSAGE_QUOTA",
+  "ANON_DAILY_MESSAGE_QUOTA", "PHOTO_SEARCH_QUOTA_ANON", "PHOTO_SEARCH_QUOTA_MEMBER",
 ];
 
 // APP_ENV joined this list in issue #498: it used to be seeded with a

--- a/worker/entry.test.ts
+++ b/worker/entry.test.ts
@@ -249,6 +249,16 @@ void test("an unset ANON_DAILY_MESSAGE_QUOTA is simply absent, not forwarded as 
   assert.equal("ANON_DAILY_MESSAGE_QUOTA" in envVars, false);
 });
 
+void test("photo-search quota settings reach the container", () => {
+  const envVars = buildContainerEnvVars({
+    ...requiredEnv(),
+    PHOTO_SEARCH_QUOTA_ANON: "3",
+    PHOTO_SEARCH_QUOTA_MEMBER: "8",
+  });
+  assert.equal(envVars.PHOTO_SEARCH_QUOTA_ANON, "3");
+  assert.equal(envVars.PHOTO_SEARCH_QUOTA_MEMBER, "8");
+});
+
 // #284 Task 7 (PR #478 review): `entry.ts` imports `Container` from
 // `@cloudflare/containers`, whose ESM build only resolves under workerd's
 // module loader (see `containerEnv.ts`'s header comment) — so this cannot be a

--- a/workers/users/src/api/routes.ts
+++ b/workers/users/src/api/routes.ts
@@ -15,6 +15,9 @@ import { sql } from "drizzle-orm";
 import type { DbExecutor } from "../db/client";
 import { routeNotFound, routeNotOwned } from "../lib/errors";
 
+/** ListSessionsInput caps offset at 1000 (packages/contract users-contract.ts). */
+const MAX_LIST_OFFSET = 1_000;
+
 type RecordRow = Record<string, unknown>;
 
 function toSession(value: unknown): UserSession {
@@ -86,7 +89,11 @@ export async function listSessions(
     LIMIT ${input.limit + 1} OFFSET ${input.offset}
   `);
   const rows = result.rows.slice(0, input.limit).map(toSession);
-  return { sessions: rows, next_offset: result.rows.length > input.limit ? input.offset + input.limit : null };
+  const next = input.offset + input.limit;
+  // Must stay within ListSessionsInput's offset cap (packages/contract users-contract.ts): a
+  // next_offset the contract would reject is worse than ending pagination early.
+  const hasMore = result.rows.length > input.limit && next <= MAX_LIST_OFFSET;
+  return { sessions: rows, next_offset: hasMore ? next : null };
 }
 
 async function createRoute(

--- a/workers/users/src/api/routes.ts
+++ b/workers/users/src/api/routes.ts
@@ -3,16 +3,31 @@ import type {
   ClaimRoutesResult,
   DeleteRouteInput,
   DeleteRouteResult,
+  ListSessionsInput,
+  ListSessionsResult,
   ListRoutesResult,
   RouteStatus,
   SaveRouteInput,
   UserRoute,
+  UserSession,
 } from "@animichi/contract";
 import { sql } from "drizzle-orm";
 import type { DbExecutor } from "../db/client";
 import { routeNotFound, routeNotOwned } from "../lib/errors";
 
 type RecordRow = Record<string, unknown>;
+
+function toSession(value: unknown): UserSession {
+  if (!isRecord(value)) throw new Error("invalid session row");
+  const { session_id, first_query, title } = value;
+  if (typeof session_id !== "string" || typeof first_query !== "string") {
+    throw new Error("invalid session row");
+  }
+  return {
+    session_id, title: typeof title === "string" ? title : null,
+    first_query, created_at: iso(value.created_at), updated_at: iso(value.updated_at),
+  };
+}
 
 function isRecord(value: unknown): value is RecordRow {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -58,6 +73,20 @@ export async function listRoutes(db: DbExecutor, userId: string): Promise<ListRo
     FROM routes WHERE user_id = ${userId} ORDER BY updated_at DESC
   `);
   return { routes: result.rows.map(toUserRoute) };
+}
+
+/** List conversation-backed sessions owned by a user, newest first. */
+export async function listSessions(
+  db: DbExecutor, userId: string, input: ListSessionsInput,
+): Promise<ListSessionsResult> {
+  const result = await db.execute(sql`
+    SELECT session_id, title, first_query, created_at, updated_at
+    FROM conversations WHERE user_id = ${userId}
+    ORDER BY updated_at DESC, session_id DESC
+    LIMIT ${input.limit + 1} OFFSET ${input.offset}
+  `);
+  const rows = result.rows.slice(0, input.limit).map(toSession);
+  return { sessions: rows, next_offset: result.rows.length > input.limit ? input.offset + input.limit : null };
 }
 
 async function createRoute(

--- a/workers/users/src/router.ts
+++ b/workers/users/src/router.ts
@@ -4,6 +4,7 @@ import {
   claimRoutes as claimHandler,
   deleteRoute as deleteHandler,
   listRoutes as listHandler,
+  listSessions as listSessionsHandler,
   saveRoute as saveHandler,
 } from "./api/routes";
 import type { DbExecutor } from "./db/client";
@@ -16,6 +17,9 @@ const os = implement(usersContract).$context<UsersContext>();
 const listRoutes = os.listRoutes.handler(async ({ context }) =>
   listHandler(context.db, context.userId),
 );
+const listSessions = os.listSessions.handler(async ({ input, context }) =>
+  listSessionsHandler(context.db, context.userId, input),
+);
 const saveRoute = os.saveRoute.handler(async ({ input, context }) =>
   saveHandler(context.db, context.userId, input),
 );
@@ -27,6 +31,6 @@ const claimRoutes = os.claimRoutes.handler(async ({ input, context }) =>
 );
 
 /** Users service oRPC implementation. */
-export const usersRouter = { listRoutes, saveRoute, deleteRoute, claimRoutes };
+export const usersRouter = { listSessions, listRoutes, saveRoute, deleteRoute, claimRoutes };
 /** Users router type. */
 export type UsersRouter = typeof usersRouter;

--- a/workers/users/test/helpers.ts
+++ b/workers/users/test/helpers.ts
@@ -57,11 +57,12 @@ export interface FakeRouteRow {
   id: string;
   session_id: string | null;
   user_id: string | null;
-  title: string;
+  title: string | null;
   point_ids: string[];
   status: RouteStatus;
   saved_at: string | null;
   updated_at: string;
+  first_query?: string;
 }
 
 const NOW = "2026-07-13T04:00:00.000Z";
@@ -88,6 +89,7 @@ function insertRow(values: unknown[]): FakeRouteRow {
     status,
     saved_at: status === "draft" ? null : NOW,
     updated_at: NOW,
+    first_query: "",
   };
 }
 
@@ -136,6 +138,22 @@ export function fakeDb(seed: FakeRouteRow[] = []): { db: DbExecutor; rows: FakeR
     }
     if (text.includes("set user_id")) {
       return Promise.resolve({ rows: claimRows(rows, values) });
+    }
+    if (text.includes("from conversations")) {
+      const userId = values[0];
+      const matches = rows.filter((item) => item.user_id === userId);
+      matches.sort((a, b) => b.updated_at.localeCompare(a.updated_at) ||
+        (b.id.localeCompare(a.id)));
+      const limit = Number(values[1]);
+      const offset = Number(values[2]);
+      const page = matches.slice(offset, offset + limit).map((item) => ({
+        session_id: item.id,
+        title: item.title,
+        first_query: item.first_query ?? "",
+        created_at: item.updated_at,
+        updated_at: item.updated_at,
+      }));
+      return Promise.resolve({ rows: page });
     }
     if (text.includes("update routes")) {
       const [id, userId] = values.slice(-2);

--- a/workers/users/test/routes-api.worker.test.ts
+++ b/workers/users/test/routes-api.worker.test.ts
@@ -83,7 +83,7 @@ describe("user session handlers", () => {
   });
 
   it("caps next_offset at the contract offset ceiling", async () => {
-    const rows = Array.from({ length: 1050 }, (_, i) => row({ session_id: `s-${i}` }));
+    const rows = Array.from({ length: 1050 }, (_, i) => row({ session_id: `s-${String(i)}` }));
     const result = await listSessions(fakeDb(rows).db, "user-a", { limit: 30, offset: 980 });
     expect(result.next_offset).toBeNull();
   });

--- a/workers/users/test/routes-api.worker.test.ts
+++ b/workers/users/test/routes-api.worker.test.ts
@@ -82,6 +82,12 @@ describe("user session handlers", () => {
     expect(result.next_offset).toBe(1);
   });
 
+  it("caps next_offset at the contract offset ceiling", async () => {
+    const rows = Array.from({ length: 1050 }, (_, i) => row({ session_id: `s-${i}` }));
+    const result = await listSessions(fakeDb(rows).db, "user-a", { limit: 30, offset: 980 });
+    expect(result.next_offset).toBeNull();
+  });
+
   it("returns the final page without a next offset", async () => {
     const result = await listSessions(fakeDb([row()]).db, "user-a", { limit: 2, offset: 0 });
     expect(result.next_offset).toBeNull();

--- a/workers/users/test/routes-api.worker.test.ts
+++ b/workers/users/test/routes-api.worker.test.ts
@@ -4,6 +4,7 @@ import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 import { listRoutes, saveRoute } from "../src/api/routes";
+import { listSessions } from "../src/api/routes";
 import type { DbExecutor } from "../src/db/client";
 import { fakeDb, type FakeRouteRow } from "./helpers";
 
@@ -16,7 +17,7 @@ const UPDATE_INPUT: SaveRouteInput = {
 function row(overrides: Partial<FakeRouteRow> = {}): FakeRouteRow {
   return {
     id: ID, session_id: null, user_id: "user-a", title: "Tokyo", point_ids: ["p1"],
-    status: "saved", saved_at: RAW, updated_at: RAW, ...overrides,
+    status: "saved", saved_at: RAW, updated_at: RAW, first_query: "Find Tokyo", ...overrides,
   };
 }
 
@@ -68,6 +69,23 @@ describe("user routes handlers", () => {
     const result = await listRoutes(fakeDb([row()]).db, "user-a");
     expect(result.routes[0]?.saved_at).toBe("2026-07-13T12:34:56.000Z");
     expect(result.routes[0]?.updated_at).toBe("2026-07-13T12:34:56.000Z");
+  });
+});
+
+describe("user session handlers", () => {
+  it("lists only owned sessions in stable newest-first pages", async () => {
+    const older = row({ id: "00000000-0000-4000-8000-000000000001", first_query: "older", updated_at: "2026-07-12T00:00:00Z" });
+    const newer = row({ id: "00000000-0000-4000-8000-000000000002", first_query: "newer", updated_at: "2026-07-13T00:00:00Z" });
+    const other = row({ id: "00000000-0000-4000-8000-000000000003", user_id: "user-b" });
+    const result = await listSessions(fakeDb([older, newer, other]).db, "user-a", { limit: 1, offset: 0 });
+    expect(result.sessions.map((session) => session.first_query)).toEqual(["newer"]);
+    expect(result.next_offset).toBe(1);
+  });
+
+  it("returns the final page without a next offset", async () => {
+    const result = await listSessions(fakeDb([row()]).db, "user-a", { limit: 2, offset: 0 });
+    expect(result.next_offset).toBeNull();
+    expect(result.sessions[0]).toMatchObject({ session_id: ID, title: "Tokyo" });
   });
 });
 

--- a/workers/users/test/worker.worker.test.ts
+++ b/workers/users/test/worker.worker.test.ts
@@ -28,6 +28,13 @@ describe("Users Worker routes wire", () => {
     expect(await listed.json()).toMatchObject({ routes: [{ title: "Tokyo" }] });
   });
 
+  it("lists sessions through the authenticated users endpoint", async () => {
+    const { app, headers } = await setup();
+    const response = await app.request("/v1/users/sessions?limit=1", { headers }, TEST_ENV);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ sessions: [], next_offset: null });
+  });
+
   it.each([
     [{ point_ids: [] }, "missing title"],
     [{ title: "", point_ids: [] }, "empty title"],


### PR DESCRIPTION
iter6 R1(#665)。rebuild 尾部三个从未到达 main 的修复,从原始作者提交剥离 sync 噪音后逐 patch 移植,三个 commit:

- test(#531) BYOK probe timeout 按 transport state 断言
- fix(#517/#556) 匿名 vision 计量 + budget breaker —— 两张开放安全 issue 的修复本体
- feat(#526) users Worker 认证态 session listing(含契约变更,openapi 已再生成)

验收:agent 单测/lint/typecheck 绿(Codex + 主线);users worker 运行时套件 37/37(主线在非沙箱环境补跑,Codex 沙箱 EPERM 无法 bind loopback);origin/main blob 核实无重复实现。

Closes #665;修复 #517 #556,推进 #526 #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)