### PR TITLE
fix(db): add missing Supabase mirror for anon_daily_message_count (#661)

### DIFF
--- a/supabase/migrations/20260729000001_anon_daily_message_quota.sql
+++ b/supabase/migrations/20260729000001_anon_daily_message_quota.sql
@@ -1,4 +1,3 @@
--- Auth-stripped Atlas twin of supabase/migrations/20260729000001_anon_daily_message_quota.sql.
 -- Per-identity anonymous daily message quota (issue #282, S1.10).
 --
 -- `daily_usage` (20260726000001) meters a *global* dollar ceiling across the


### PR DESCRIPTION
根因见 #661 诊断:PR #472 只写了 Atlas/Neon 腿的 DDL,SUPABASE_DB_URL 库从未建表 → retention cron 自 7/29 零次成功 + 匿名每日配额 fail-open 静默失效。

- 补 `supabase/migrations/20260729000001_anon_daily_message_quota.sql`(daily_usage 双镜像先例,内容与 db/ 版一致)
- db/ 版补标准 twin header

**注意:合并本 PR 不会自动建表**——还需把迁移 apply 到 SUPABASE_DB_URL 指向的库(等 owner 批准后走 supabase MCP `apply_migration`),然后验证 cron 转绿 + Logfire 告警清零。

Refs #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)