### PR TITLE
feat(auth): staging Neon Auth cutover + agent DSN groundwork (#312 slice 1)

### DIFF
--- a/worker/authConfig.test.ts
+++ b/worker/authConfig.test.ts
@@ -22,8 +22,12 @@ function blockFor(header: string): string {
   return WRANGLER.slice(start, next === -1 ? undefined : next);
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function hasAssignment(block: string, key: string, value: string): boolean {
-  return new RegExp(`^${key}\\s*=\\s*"${value}"$`, "m").test(block);
+  return new RegExp(`^${key}\\s*=\\s*"${escapeRegExp(value)}"$`, "m").test(block);
 }
 
 function countMatches(source: string, pattern: RegExp): number {
@@ -41,15 +45,18 @@ function parsedWorkerName(environment: string): string {
 const STAGING_NEON_ISSUER =
   "https://ep-broad-frost-aopp3uqq.neonauth.c-2.ap-southeast-1.aws.neon.tech/neondb/auth";
 
-void test("Neon Auth vars stay on their intended Wrangler paths", () => {
-  // SD-31 staging cutover (owner-approved 2026-08-03, #312 slice 1): staging
-  // verifies Neon Auth; root defaults and production stay off until their own
-  // cutover is approved.
+// SD-31 staging cutover (owner-approved 2026-08-03, #312 slice 1): staging
+// verifies Neon Auth; root defaults and production stay off until their own
+// cutover is approved.
+void test("root and production keep Neon Auth off until their cutover", () => {
   for (const header of ["[vars]", "[env.production.vars]"]) {
     const block = blockFor(header);
     assert.equal(hasAssignment(block, "NEON_AUTH_ENABLED", "false"), true, `${header} must keep Neon Auth off`);
     assert.equal(hasAssignment(block, "NEON_AUTH_ISSUER", ""), true, `${header} must declare the public issuer slot`);
   }
+});
+
+void test("staging pins the approved Neon Auth issuer and JWKS", () => {
   const staging = blockFor("[env.staging.vars]");
   assert.equal(hasAssignment(staging, "NEON_AUTH_ENABLED", "true"), true, "staging cutover must stay on");
   assert.equal(hasAssignment(staging, "NEON_AUTH_ISSUER", STAGING_NEON_ISSUER), true, "staging must pin the Neon issuer");

--- a/worker/authConfig.test.ts
+++ b/worker/authConfig.test.ts
@@ -38,12 +38,26 @@ function parsedWorkerName(environment: string): string {
   );
 }
 
+const STAGING_NEON_ISSUER =
+  "https://ep-broad-frost-aopp3uqq.neonauth.c-2.ap-southeast-1.aws.neon.tech/neondb/auth";
+
 void test("Neon Auth vars stay on their intended Wrangler paths", () => {
-  for (const header of ENV_BLOCKS) {
+  // SD-31 staging cutover (owner-approved 2026-08-03, #312 slice 1): staging
+  // verifies Neon Auth; root defaults and production stay off until their own
+  // cutover is approved.
+  for (const header of ["[vars]", "[env.production.vars]"]) {
     const block = blockFor(header);
     assert.equal(hasAssignment(block, "NEON_AUTH_ENABLED", "false"), true, `${header} must keep Neon Auth off`);
     assert.equal(hasAssignment(block, "NEON_AUTH_ISSUER", ""), true, `${header} must declare the public issuer slot`);
   }
+  const staging = blockFor("[env.staging.vars]");
+  assert.equal(hasAssignment(staging, "NEON_AUTH_ENABLED", "true"), true, "staging cutover must stay on");
+  assert.equal(hasAssignment(staging, "NEON_AUTH_ISSUER", STAGING_NEON_ISSUER), true, "staging must pin the Neon issuer");
+  assert.equal(
+    hasAssignment(staging, "NEON_AUTH_JWKS_URL", `${STAGING_NEON_ISSUER}/.well-known/jwks.json`),
+    true,
+    "staging must pin the JWKS endpoint derived from the issuer",
+  );
 });
 
 void test("bare Wrangler deploy has no target, while named environments keep theirs", () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -293,8 +293,13 @@ CATALOG_API_URL = "http://catalog.internal"
 # conflict with.
 CORS_ALLOWED_ORIGIN = "https://animichi-web-staging.zhenjiazhou0127.workers.dev"
 ANON_ACCESS_ENABLED = "true"
-NEON_AUTH_ENABLED = "false"
-NEON_AUTH_ISSUER = ""
+# SD-31 staging cutover (owner-approved 2026-08-03, #312 slice 1): edge verifies
+# Neon Auth (Better Auth) tokens against the staging branch's JWKS. Migrated
+# users only — legacy Supabase tokens still verify via the dual-issuer
+# fallback in worker/auth.ts (non-EdDSA + non-Neon issuer → verifySupabase).
+NEON_AUTH_ENABLED = "true"
+NEON_AUTH_ISSUER = "https://ep-broad-frost-aopp3uqq.neonauth.c-2.ap-southeast-1.aws.neon.tech/neondb/auth"
+NEON_AUTH_JWKS_URL = "https://ep-broad-frost-aopp3uqq.neonauth.c-2.ap-southeast-1.aws.neon.tech/neondb/auth/.well-known/jwks.json"
 # Per-identity burst limit (abuse control). The per-identity DAILY message
 # quota is issue #282 and is configured separately.
 ANON_RATE_LIMIT = "20"


### PR DESCRIPTION
SD-31/#312 第一切片(owner 授权一条龙):

- staging `NEON_AUTH_ENABLED=true` + issuer/JWKS 钉死(staging Neon 分支的 Neon Auth 实例)
- authConfig 守卫测试改为编码新批准状态(staging 开、root/prod 关)
- 257/257 worker 测试绿

配套(不在本 diff):VITE_NEON_AUTH_BASE_URL staging 变量已写;SUPABASE_DB_URL→Neon 连接串与 VITE_TURNSTILE_SITE_KEY 待 operator(命令已备);trusted_origins 已加 staging 源。

Refs #312 #661 #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Neon Auth for the staging environment.
  * Configured staging authentication with its issuer and JWKS endpoint.

* **Tests**
  * Updated configuration checks to verify staging authentication settings and preserve disabled settings for other environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->