### PR TITLE
docs(iter6): decision register 2026-08-03 + governance spec + CF-native audit

### DIFF
--- a/docs/iterations/iter6/README.md
+++ b/docs/iterations/iter6/README.md
@@ -14,3 +14,9 @@ Milestone:iter6 — cleanup campaign(#635-#655 + #665 + #666)
 
 方法论授权(owner):两侧统一 TDD / DDD(战略层)/ SOLID / OOP / Clean Architecture;
 战术 DDD 不在授权内;依赖规则一律机器守卫。
+
+## 决议与调研档案
+
+- [decisions-2026-08-03.md](./decisions-2026-08-03.md) — 全域决议册(方法论/secrets/DB/CI-CD/网络/CF-native)
+- [spec-infra-governance.md](./spec-infra-governance.md) — infra 治理 spec(#674,8 卡)
+- [audit-cf-native-v2.md](./audit-cf-native-v2.md) — CF 全目录对照审计

--- a/docs/iterations/iter6/audit-cf-native-v2.md
+++ b/docs/iterations/iter6/audit-cf-native-v2.md
@@ -5,11 +5,11 @@
 
 ## 第一步:CF 产品目录枚举(dashboard 可见开发者面全集)
 
-**Developer platform**: Workers(GA)· Pages(GA,维护模式,官方推 Workers)· Durable Objects(GA)· Containers(GA 2025-06)· Queues(GA,$0.40/M ops)· KV(GA)· D1(GA,serverless SQLite)· Workflows(GA)· **Pipelines(open beta**,流式摄取→SQL 变换→R2 Iceberg/Parquet;定价已公布未开始计费)· **Secrets Store(仍 beta**,账户级 secrets,100/账户)· **Workers VPC(beta**,2025-09 公告 VPC Services、2026-04 VPC Networks public beta;beta 期免费)· Workers for Platforms · Sandbox SDK · Artifacts
-**AI**: Workers AI(GA,按 token 计费)· AI Gateway(GA,LLM 代理/缓存/BYOK)· AI Search/AutoRAG · Vectorize(GA,仅 paid)· **Browser Run(原 Browser Rendering;REST API GA 2025-04,Playwright GA 2025-09**,免费档 10min/天,$0.09/browser-hr)· Agents SDK · AI Crawl Control
-**存储/数据库**: R2(GA,零 egress)· R2 Data Catalog/R2 SQL(open beta)· Hyperdrive(GA,TCP 连接池+查询缓存)· **托管 Postgres/MySQL = PlanetScale 合作(2026 新**:dashboard 内建库、CF 账单代收、经 Hyperdrive 接入 — 非 CF 自营数据库)
-**媒体/实时**: Stream(GA,视频托管)· Images(GA;Free 档 5k unique transformations/月,可变换 R2 内图)· **Realtime 系列(RealtimeKit SDK / Realtime SFU / TURN**,WebRTC 音视频,GA)· MoQ
-**Email**: **Email Service = Email Routing(GA,收)+ Email Sending(public beta 2026-04-16**,`env.EMAIL.send()`,Workers Paid;2026-06 加 SMTP submission beta)
+**Developer platform**: Workers(GA)· Pages(GA,维护模式,官方推 Workers)· Durable Objects(GA)· Containers(GA 2025-06)· Queues(GA,$0.40/M ops)· KV(GA)· D1(GA,serverless SQLite)· Workflows(GA)· **Pipelines**(open beta,流式摄取→SQL 变换→R2 Iceberg/Parquet;定价已公布未开始计费)· **Secrets Store**(仍 beta,账户级 secrets,100/账户)· **Workers VPC**(beta,2025-09 公告 VPC Services、2026-04 VPC Networks public beta;beta 期免费)· Workers for Platforms · Sandbox SDK · Artifacts
+**AI**: Workers AI(GA,按 token 计费)· AI Gateway(GA,LLM 代理/缓存/BYOK)· AI Search/AutoRAG · Vectorize(GA,仅 paid)· **Browser Run**(原 Browser Rendering;REST API GA 2025-04,Playwright GA 2025-09,免费档 10min/天,$0.09/browser-hr)· Agents SDK · AI Crawl Control
+**存储/数据库**: R2(GA,零 egress)· R2 Data Catalog/R2 SQL(open beta)· Hyperdrive(GA,TCP 连接池+查询缓存)· **托管 Postgres/MySQL = PlanetScale 合作**(2026 新:dashboard 内建库、CF 账单代收、经 Hyperdrive 接入 — 非 CF 自营数据库)
+**媒体/实时**: Stream(GA,视频托管)· Images(GA;Free 档 5k unique transformations/月,可变换 R2 内图)· **Realtime 系列**(RealtimeKit SDK / Realtime SFU / TURN,WebRTC 音视频,GA)· MoQ
+**Email**: **Email Service** = Email Routing(GA,收)+ Email Sending(public beta 2026-04-16,`env.EMAIL.send()`,Workers Paid;2026-06 加 SMTP submission beta)
 **安全/边缘**: Turnstile(GA)· WAF/DDoS/Bots/Rate Limiting/API Shield · Access/Zero Trust 全家桶 · Page Shield/Client-side Security · Snippets(GA)
 **网络**: Tunnel · Cloudflare Mesh/WAN · Magic Transit · Spectrum · Load Balancing/Health Checks · Argo · Internal DNS
 **其他**: Zaraz · Waiting Room · Cache/Cache Reserve · Web Analytics · Logpush/Log Explorer · Registrar/DNS · Terraform/Pulumi provider
@@ -29,7 +29,7 @@
 ### B. 该用而未用(逐项评估)
 | 产品 | 现状 | 成熟度 | 定价 | 迁移成本 | 判定 |
 |---|---|---|---|---|---|
-| **Images** | 手写 `/img/*` 代理 `worker/app.ts:331,383` + lazy-R2 原图直出 `media/img.ts`(无缩放/格式协商) | GA | Free 5k unique 变换/月;超出 $0.50/1k;可直接变换 R2 图 | 低:R2 已是源,加 transformations 或 binding 即可,现有 URL 结构可保留 | **该用**。photo-search/点位卡片全是原图字节直出,AVIF/宽度裁剪是白捡的带宽与 LCP;free 档大概率够 |
+| **Images** | 手写 `/img/*` 代理 `worker/app.ts:331,383` + lazy-R2 原图直出 `media/img.ts`(无缩放/格式协商) | GA | Free:5k unique 变换/月,**超出后新变换直接失败(错误 9422),不是付费溢出**;Paid:前 5k 含,之后 $0.50/1k;可直接变换 R2 图 | 低:R2 已是源,加 transformations 或 binding 即可,现有 URL 结构可保留 | **该用**。photo-search/点位卡片全是原图字节直出,AVIF/宽度裁剪是白捡的带宽与 LCP;free 档大概率够 |
 | **Email Sending** | 无发件能力;Neon Auth 走 Neon 共享发件域(不可品牌化、限流共享) | public beta(2026-04);Routing GA | Workers Paid 含;发到已验证地址免费 | 中:需 animichi.com DNS 先上线(目前零记录),Better Auth `sendMagicLink` 换成 `env.EMAIL.send()` 一个函数 | **该用**(排在 SD-31 auth 割接 + 域名上线之后)。beta 风险可接受:magic-link 丢失可重试 |
 | **AI Gateway** | agent 直连 MiMo/Gemini;#284 BYOK 刚做了逐请求注入 | GA | 免费(缓存/日志/限流);付费加高级功能 | 低:改 base_url 即可,容器内 Python 也能走 | **该用-轻量**。给 MiMo/Gemini/BYOK 统一加缓存、审计与故障转移面板,与 Logfire 互补不冲突 |
 | **Workers AI(vision,番剧识别)** | photo-search 走 MiMo/Gemini vision(`worker/photoSearch.test.ts`、#479 vision/probe) | GA;llama-3.2-11b-vision $0.049/M in;kimi-k2.6 带 vision $0.95/M in | 按 token | 低(仅 Workers 侧可用 binding;容器内走 REST) | **观望→spike**。通用开源 vision 模型认「圣地实拍照→具体番剧」能力存疑,Gemini 仍是上限;价值是廉价预筛/降级层。先拿 eval 集对 llama-3.2-11b-vision 跑一轮再定 |
@@ -64,7 +64,7 @@
 4. **Browser Rendering 已更名 Browser Run**,REST API 自 2025-04 起 GA 且有免费档 —— v1 若按「beta/仅付费」评估需更新。
 
 ## 行动清单(按收益/成本比排序)
-1. **Images transformations 接管 photo 出图**(该用,~半天):`/img/*` 与 media/img.ts 出口加 `/cdn-cgi/image/` 或 binding,AVIF+宽度裁剪,free 档起步。移动端 LCP 直接受益。
+1. **Images transformations 接管 photo 出图**(该用,~半天):`/img/*` 与 media/img.ts 出口加 `/cdn-cgi/image/` 或 binding,AVIF+宽度裁剪,free 档起步(Free 超限=新变换失败 9422 而非计费,需加用量监控,逼近 5k/月即升 Paid)。移动端 LCP 直接受益。
 2. **AI Gateway 前置 MiMo/Gemini/BYOK**(该用-轻量,~半天):统一缓存/限流/故障转移,顺手给 #284 BYOK 加审计面。
 3. **Email Sending 接 Better Auth magic-link**(该用,依赖域名上线 + SD-31 割接,~1 天):摆脱 Neon 共享发件域;顺带把 animichi.com DNS 债一起清。
 4. **Workers AI vision spike**(观望→spike,~半天):用现有 photo-search eval 集测 llama-3.2-11b-vision 当廉价预筛层,数据说话。

--- a/docs/iterations/iter6/audit-cf-native-v2.md
+++ b/docs/iterations/iter6/audit-cf-native-v2.md
@@ -1,0 +1,72 @@
+# Cloudflare 全产品目录对照审计 v2 — animichi (2026-08-03)
+
+方法:先枚举 developers.cloudflare.com/products/ 全目录 + cloudflare-docs MCC 逐项核状态,再对照仓库。
+所有 GA/beta 判断以 docs/changelog 引文为准,非训练记忆。
+
+## 第一步:CF 产品目录枚举(dashboard 可见开发者面全集)
+
+**Developer platform**: Workers(GA)· Pages(GA,维护模式,官方推 Workers)· Durable Objects(GA)· Containers(GA 2025-06)· Queues(GA,$0.40/M ops)· KV(GA)· D1(GA,serverless SQLite)· Workflows(GA)· **Pipelines(open beta**,流式摄取→SQL 变换→R2 Iceberg/Parquet;定价已公布未开始计费)· **Secrets Store(仍 beta**,账户级 secrets,100/账户)· **Workers VPC(beta**,2025-09 公告 VPC Services、2026-04 VPC Networks public beta;beta 期免费)· Workers for Platforms · Sandbox SDK · Artifacts
+**AI**: Workers AI(GA,按 token 计费)· AI Gateway(GA,LLM 代理/缓存/BYOK)· AI Search/AutoRAG · Vectorize(GA,仅 paid)· **Browser Run(原 Browser Rendering;REST API GA 2025-04,Playwright GA 2025-09**,免费档 10min/天,$0.09/browser-hr)· Agents SDK · AI Crawl Control
+**存储/数据库**: R2(GA,零 egress)· R2 Data Catalog/R2 SQL(open beta)· Hyperdrive(GA,TCP 连接池+查询缓存)· **托管 Postgres/MySQL = PlanetScale 合作(2026 新**:dashboard 内建库、CF 账单代收、经 Hyperdrive 接入 — 非 CF 自营数据库)
+**媒体/实时**: Stream(GA,视频托管)· Images(GA;Free 档 5k unique transformations/月,可变换 R2 内图)· **Realtime 系列(RealtimeKit SDK / Realtime SFU / TURN**,WebRTC 音视频,GA)· MoQ
+**Email**: **Email Service = Email Routing(GA,收)+ Email Sending(public beta 2026-04-16**,`env.EMAIL.send()`,Workers Paid;2026-06 加 SMTP submission beta)
+**安全/边缘**: Turnstile(GA)· WAF/DDoS/Bots/Rate Limiting/API Shield · Access/Zero Trust 全家桶 · Page Shield/Client-side Security · Snippets(GA)
+**网络**: Tunnel · Cloudflare Mesh/WAN · Magic Transit · Spectrum · Load Balancing/Health Checks · Argo · Internal DNS
+**其他**: Zaraz · Waiting Room · Cache/Cache Reserve · Web Analytics · Logpush/Log Explorer · Registrar/DNS · Terraform/Pulumi provider
+
+## 第二步:四栏判定
+
+### A. 已在用
+| 产品 | 现状 |
+|---|---|
+| Workers | edge `worker/`(wrangler.toml)、`workers/catalog`、`workers/users`、apps/web OpenNext |
+| Containers + DO | agent 容器 `wrangler.toml:125`(RuntimeContainer DO `:127`)、EdgeGuard DO `:141` |
+| Service bindings | CATALOG/USERS 内网直连 `wrangler.toml:107-113`(`catalog.internal` outboundByHost `:102`) |
+| R2 | MAP_TILES `wrangler.toml:121`、catalog 媒体桶 `workers/catalog/wrangler.toml:48`;lazy-R2 照片 `workers/catalog/src/media/img.ts` |
+| Turnstile | `worker/turnstile.ts`(+replay/arm 测试) |
+| Pulumi provider | `infra/index.ts` |
+
+### B. 该用而未用(逐项评估)
+| 产品 | 现状 | 成熟度 | 定价 | 迁移成本 | 判定 |
+|---|---|---|---|---|---|
+| **Images** | 手写 `/img/*` 代理 `worker/app.ts:331,383` + lazy-R2 原图直出 `media/img.ts`(无缩放/格式协商) | GA | Free 5k unique 变换/月;超出 $0.50/1k;可直接变换 R2 图 | 低:R2 已是源,加 transformations 或 binding 即可,现有 URL 结构可保留 | **该用**。photo-search/点位卡片全是原图字节直出,AVIF/宽度裁剪是白捡的带宽与 LCP;free 档大概率够 |
+| **Email Sending** | 无发件能力;Neon Auth 走 Neon 共享发件域(不可品牌化、限流共享) | public beta(2026-04);Routing GA | Workers Paid 含;发到已验证地址免费 | 中:需 animichi.com DNS 先上线(目前零记录),Better Auth `sendMagicLink` 换成 `env.EMAIL.send()` 一个函数 | **该用**(排在 SD-31 auth 割接 + 域名上线之后)。beta 风险可接受:magic-link 丢失可重试 |
+| **AI Gateway** | agent 直连 MiMo/Gemini;#284 BYOK 刚做了逐请求注入 | GA | 免费(缓存/日志/限流);付费加高级功能 | 低:改 base_url 即可,容器内 Python 也能走 | **该用-轻量**。给 MiMo/Gemini/BYOK 统一加缓存、审计与故障转移面板,与 Logfire 互补不冲突 |
+| **Workers AI(vision,番剧识别)** | photo-search 走 MiMo/Gemini vision(`worker/photoSearch.test.ts`、#479 vision/probe) | GA;llama-3.2-11b-vision $0.049/M in;kimi-k2.6 带 vision $0.95/M in | 按 token | 低(仅 Workers 侧可用 binding;容器内走 REST) | **观望→spike**。通用开源 vision 模型认「圣地实拍照→具体番剧」能力存疑,Gemini 仍是上限;价值是廉价预筛/降级层。先拿 eval 集对 llama-3.2-11b-vision 跑一轮再定 |
+| **Vectorize** | S4.8 以图搜图尚无 embedding 底座 | GA | paid:50M queried dims/月含,$0.01/M 超出 | 中:新增索引服务;但数据平面在 Neon | **观望**。先在 Neon 上试 pgvector(单库可与 PostGIS/works 表 join,零新组件);触发条件:pgvector 在目标量级(>1M 向量或 p95 超标)顶不住时切 Vectorize |
+| **Workers VPC** | 服务间隔离用 service binding + `catalog.internal` 主张(wrangler.toml:65,102) | **beta**(Services 2025-09、Networks 2026-04);beta 期免费 | beta 免费,GA 定价未出 | 高且无对象:它解决「Workers→Tunnel 后面的私网(AWS/GCP/本地)」 | **无场景**(修正项,见第三步)。我们没有私网;Neon 是公网 SaaS,不在 Tunnel 后。service binding 的隔离主张不被 VPC 替代——两者解决不同问题 |
+| **托管 Postgres(PlanetScale via CF)** | 数据面 = Neon(branching/Neon Local/MCP/Atlas 全链路已建) | 合作层新;PlanetScale 本体成熟 | PlanetScale 标价经 CF 账单 | **高**:迁库 + 重建 branch-per-PR/test-infra/Auth(Neon Auth 刚定案 SD-31),还要 Hyperdrive 层 | **观望**。收益(同账单、Hyperdrive 加速)远小于重迁成本;触发条件:Neon 定价/冷启动/耐久性出实际事故 |
+| **Hyperdrive** | 显式不用:`workers/catalog/AGENTS.md:16`「no Hyperdrive」;`workers/catalog/wrangler.toml:32-40` 留有注释掉的配置 | GA | Workers Paid 含 | 低 | **无场景(维持,理由核实)**:catalog 用 @neondatabase/serverless neon-http(无状态 HTTP fetch,无 TCP 连接可池化),Hyperdrive 的连接池/缓存收益为零。若未来换 TCP 驱动(postgres.js/pg)则必须重评 |
+| **Queues** | ingest 单飞用 `ingest_jobs` 表(`workers/catalog/src/ingest/jobs.ts:1-10`,INSERT..ON CONFLICT 原子夺锁+负缓存) | GA | $0.40/M ops | 中 | **观望**。现设计的核心是**去重/单飞**,DB 行锁比队列语义更贴;Queues 的价值在「请求生命周期外的重试/扇出」。触发条件:enrich 阶段要拆成多步异步重试,或出现批量回填任务 |
+| **Pipelines** | catalog ingest 是事务型逐 work 拉取,非流式事件 | open beta(计费未开) | ingress 免费;transforms $0.04/GB | 高 | **无场景**(对 ingest);**观望**(对产品分析事件流:搜索词/巡礼行为→Iceberg,做检索质量标尺时再评) |
+| **Browser Run** | e2e 用本地 Playwright(`e2e/`);OG 图为静态 | REST GA、Playwright GA、Stagehand beta | 免费 10min/天;$0.09/hr | 低(REST /screenshot 一个调用) | **观望**。CI e2e 留本地(免费+快);触发条件:要做动态 OG 卡片(每番剧分享图)时用 REST screenshot,免费档够 |
+| **Workflows** | ingest 编排在 `workers/catalog/src/ingest/orchestrator.ts` 请求内完成 | GA | Workers Paid 含 | 中 | **观望**。触发条件同 Queues:出现跨分钟级多步 durable 任务(如全量 enrich 回填) |
+
+### C. 观望(其余)
+- **Secrets Store**:仍 **beta**(docs 2025-04 起未宣 GA)。现状 wrangler per-Worker secrets ×3 env 触点(已知痛点)。账户级共享能消重,但 beta + 迁移动作多;触发条件:GA 或 secrets 数量再翻倍。
+- **KV**:无缓存层诉求(Cache API + R2 覆盖);触发条件:出现高读低写配置面(如 feature flags)。
+- **AI Search (AutoRAG)**:检索质量标尺立项后作为对照组候选。
+- **Snippets / Load Balancing / Waiting Room / Zaraz / Cache Reserve**:单 Worker 架构下均无当前诉求;流量上量后再看。
+
+### D. 无场景(一句话)
+- **D1**:数据面定案 Neon(PostGIS 硬依赖,D1 是 SQLite)。
+- **Realtime 全家桶(SFU/RealtimeKit/TURN/MoQ)**:是 WebRTC 音视频,不是消息推送;聊天 SSE(`apps/agent/agent/interfaces/routes/chat.py:347`)完全够,无音视频功能规划。
+- **Stream**:无视频内容。
+- **Pages**:官方自己在推 Workers,apps/web 已是 Workers 部署。
+- **Access/Zero Trust/Tunnel/Mesh/WAN/Magic Transit/Spectrum**:无企业内网、无自有机房、无非 HTTP 协议面。
+- **Workers for Platforms / Sandbox SDK / R2 SQL**:无多租户代码托管、无沙箱执行、无 lakehouse 查询需求。
+- **Email Routing(收件向)**:无收件产品面(support@ 未来可白捡,随 Email Sending 一起开)。
+
+## 第三步:v1 结论修正
+1. **「CF 无 VPC」不成立(v1 结论修正)**:Workers VPC 真实存在 —— VPC Services beta(changelog 2025-09-25 发布、2025-11-05 上线),VPC Networks + Mesh public beta(changelog 2026-04-14),2026-05-21 起可达 WAN on-ramp。但它是「Workers 访问 Tunnel 后私网」,**不是** service-to-service 私网隔离;我们的 service-binding 隔离主张仍然成立且不被其替代。判定从「产品不存在」改为「产品存在、无适用场景」。
+2. **Secrets Store 状态(v1 复核)**:截至今日 docs/changelog 仍标 **beta**(2025-04-09 入 beta,后续仅扩容到 100 secrets/账户,无 GA 公告)。v1 若写「GA」为误;若写「beta」维持。
+3. **「托管 Postgres/MySQL(新)」定性**:owner 在 dashboard 看到的是 **PlanetScale 合作**(经 Hyperdrive,CF 账单代收,docs hyperdrive/planetscale/ 2026-07-14 更新)——不是 CF 自营数据库,「CF 原生 Postgres」的说法不准确;对 Neon 的替代评估见 B 表(观望)。
+4. **Browser Rendering 已更名 Browser Run**,REST API 自 2025-04 起 GA 且有免费档 —— v1 若按「beta/仅付费」评估需更新。
+
+## 行动清单(按收益/成本比排序)
+1. **Images transformations 接管 photo 出图**(该用,~半天):`/img/*` 与 media/img.ts 出口加 `/cdn-cgi/image/` 或 binding,AVIF+宽度裁剪,free 档起步。移动端 LCP 直接受益。
+2. **AI Gateway 前置 MiMo/Gemini/BYOK**(该用-轻量,~半天):统一缓存/限流/故障转移,顺手给 #284 BYOK 加审计面。
+3. **Email Sending 接 Better Auth magic-link**(该用,依赖域名上线 + SD-31 割接,~1 天):摆脱 Neon 共享发件域;顺带把 animichi.com DNS 债一起清。
+4. **Workers AI vision spike**(观望→spike,~半天):用现有 photo-search eval 集测 llama-3.2-11b-vision 当廉价预筛层,数据说话。
+5. **S4.8 前置决策**:先 pgvector-on-Neon PoC,Vectorize 仅作规模逃生门(写进 S4.8 spec 的 OQ)。
+6. **文档修正**:把 v1 审计中「CF 无 VPC」「Secrets Store GA」两处结论按本文第三步更正;`workers/catalog/AGENTS.md:16` 的 no-Hyperdrive 旁注补理由「neon-http 无 TCP 可池化」。

--- a/docs/iterations/iter6/decisions-2026-08-03.md
+++ b/docs/iterations/iter6/decisions-2026-08-03.md
@@ -1,0 +1,63 @@
+# 决议册 — 2026-08-03(owner 逐项签核)
+
+一天内的全部架构/流程决议,按域归档。执行载体:iter6 milestone + #674 系 + S 线卡。
+
+## 方法论(长期有效)
+
+- **两侧(Python/TS)统一 follow TDD、DDD(战略层)、SOLID、OOP、Clean Architecture**;战术 DDD(聚合根/领域事件/CQRS)不在授权内——模式必须报得出守护的不变量。
+- 依赖规则一律**机器守卫**(import-linter / oxlint 约束),不靠纪律。
+- PR 合并前必须处理**全部** robot 评论线程(读内容、判定、修或有据拒)与失败 CI。
+- 平台能力调研必须**先枚举厂商完整目录**再对照;"平台没有 X"类断言必须当场 docs 核查。
+
+## Secrets / 凭证
+
+| 决议 | 备注 |
+|---|---|
+| **Pulumi ESC = 唯一账本**(方案 A:GH OIDC + `esc run`) | GH 只留 PULUMI_ACCESS_TOKEN bootstrap;#674 C2/C3 |
+| **Pulumi state 留 R2**(owner 否决同迁) | passphrase 保管 + #521 快照 lifecycle 为固有成本,单独记卡 |
+| **CF Secrets Store 立即试点**(不等 GA) | 仅 Worker 侧密钥(binding.get() 可达);容器转发链密钥待适配。角色=递送端,非账本 |
+| **模型密钥收敛 MiMo-only**(#684) | DeepSeek/OpenAI-compat 立删;Maps 验证后删;Gemini 随 #656——#656 升关键路径 |
+| Token 最小权限矩阵 | Pulumi 专用 token 已接线(#675);Neon project-scoped、R2 bucket-scoped 待做 |
+| Secret 语义化改名(SUPABASE_DB_URL→AGENT_DATABASE_URL 等) | 随 ESC 迁移批同车,#312 联动 |
+
+## 数据库
+
+- **staging agent DSN 已切 Neon**(2026-08-03 执行完毕);production 随 #312 数据迁移。
+- **角色矩阵**(#685):migration_admin / agent_rw / catalog_rw / users_rw / readonly / developer。现状实测:svc 组角色 NOLOGIN、GRANT 从未生效、人人 neondb_owner。起点=wip/catalog-db-roles-salvage。
+- **Neon 留任**;CF 托管 PG(PlanetScale 合作款)S1 复评(#681)。
+- 迁移权威:Atlas(db/migrations)唯一;supabase/migrations 仅 auth/legacy,**不收新表**(#672 因此撤案)。
+
+## CI/CD
+
+- **per-package pipelines**(pipeline-agent/catalog/users/web/edge/infra.yml)+ **`reusable-*` 命名模板**;全留 monorepo(GH 约束:reusable 必须平铺 .github/workflows/);弃 `_` 前缀。底稿=cicd-rebuild-spec pipeline 章节(#679)。
+- **Artifact promotion = git-SHA 不可变 tag**(build-once,staging→prod 同 tag 提升;digest 引用卡内 spike)。
+- **告警全套**(#678):GHA 失败通知 + Logfire alert 规则 + CF 健康检查(随 C6 生效)。
+- **回滚 = 分层手册**(#680):Worker 平台秒回滚止血,容器 tag 重部,迁移走 revert 链;不建自动化。
+- Workers Builds 不替代 GHA(无审批门/编排);merge queue 评估在 #671。
+
+## 网络 / 隔离
+
+- **Service bindings 为平台内隔离正解**。Workers VPC 经 docs 定谳:是 Workers→外部私网的出口桥(需 Tunnel/Mesh/WAN),不提供 worker↔worker 隔离;我们无外部私网,无场景(触发条件:未来有自托管资源时复评)。
+- **私网收口顺序**:N1 ingest WorkerEntrypoint(#540,独立先行,防注入收益最大)→ N2 hostname cutover(#541,staging 验通后立即,不等产品 launch)→ N3 staging WAF → N4 关 staging workers_dev。
+- #529 staging CORS wildcard 保留至 C6,cutover 时收紧。
+
+## CF-native 采纳清单(全目录审计 v2 定谳)
+
+| 采 | 内容 |
+|---|---|
+| ✅ | purge crons → **Workers Cron Triggers**(=#661 修复形态:消灭 GHA cron) |
+| ✅ | `/img/*` → **CF Images** transformations(#682) |
+| ✅ | 手写 DO 限流 → 原生 **ratelimit binding**(#680;EdgeGuard 保留预算闩/turnstile) |
+| ✅ | **AI Gateway** 前置模型调用(#683;BYOK SSRF 语义须设计期核对) |
+| ✅ | **Workers AI** llama-vision 进 #656 eval 候选(预筛层,不预设结论) |
+| 观望 | Email Sending(依赖 C6 域名)、Workflows(等 S2 异步批量)、Browser Run(E2E/OG 备选)|
+| 不采 | Hyperdrive(neon-http 无 TCP 可池化)、Queues/Pipelines(ingest=同步单飞)、Realtime(WebRTC≠SSE)、AE 做执法(采样≠强一致)、Access 替 WAF |
+
+## 产品分析 / 开关(待落卡,owner 已认可方向)
+
+- **Analytics Engine 做产品埋点** + CF Web Analytics 做 RUM(S 线;现状=零产品分析)。
+- **KV 动态开关**替 env-var 重部署翻转 + Workers 灰度部署做 canary;第三方 flag 平台暂不上。
+
+## iter6 执行序(更新)
+
+Wave 2 进行中(B2 #676 / B4 #677 在 PR;B1/B3/D3/E1/E2/R1✅);Wave 3 = C1→C4(含#663)→C5→C2→C3→L1(设计全部已批);#674 系 C0-C7 与 CF-native 卡并行穿插;#656 vision 升关键路径。

--- a/docs/iterations/iter6/decisions-2026-08-03.md
+++ b/docs/iterations/iter6/decisions-2026-08-03.md
@@ -30,7 +30,7 @@
 ## CI/CD
 
 - **per-package pipelines**(pipeline-agent/catalog/users/web/edge/infra.yml)+ **`reusable-*` 命名模板**;全留 monorepo(GH 约束:reusable 必须平铺 .github/workflows/);弃 `_` 前缀。底稿=cicd-rebuild-spec pipeline 章节(#679)。
-- **Artifact promotion = git-SHA 不可变 tag**(build-once,staging→prod 同 tag 提升;digest 引用卡内 spike)。
+- **Artifact promotion = git-SHA 不可变 tag**(build-once,staging→prod 同 tag 提升;digest 引用卡内 spike;兜底双重建仅 spike 失败期间临时用,digest mismatch **阻断** prod 非告警)。
 - **告警全套**(#678):GHA 失败通知 + Logfire alert 规则 + CF 健康检查(随 C6 生效)。
 - **回滚 = 分层手册**(#680):Worker 平台秒回滚止血,容器 tag 重部,迁移走 revert 链;不建自动化。
 - Workers Builds 不替代 GHA(无审批门/编排);merge queue 评估在 #671。

--- a/docs/iterations/iter6/spec-infra-governance.md
+++ b/docs/iterations/iter6/spec-infra-governance.md
@@ -7,16 +7,18 @@
 **现状实测**:三分体系共 **51 个名字**——GH repo secrets **27**(其中 ≥7 个 dead:GCP_SA_KEY/GCP_PROJECT_ID/CLAUDE_CODE_OAUTH_TOKEN/ANTHROPIC_API_KEY/ANTHROPIC_BASE_URL/NEXT_PUBLIC_MAPBOX_TOKEN/ZETA_API_KEY)+ staging env **10** + production env **10** + GH vars repo 4 / staging 2 / prod 0 + Pulumi passphrase config(prod 1 secret `catalogDatabaseUrl`+salt;staging 无 secret)。同名双写(repo+env)8 组,repo 层副本全部 unreachable(env 覆盖规则,docs/ops/secrets.md 已证)。**注意**:issue 里说的 `CLOUDFLARE_PULUMI_API_TOKEN` 已在 `_deploy-component.yml:449/502` 接线,但 `gh secret list` 三个 scope 均**未见此名** → 本地 commit 2e3a9c12 未推或 secret 未 provision,当前 Pulumi 步骤实际拿到空 token(`required: false` 静默)。**这是 P0 修复项,先于 ESC。**
 
 **目标态**:ESC 为唯一真源,GH env 只留 bootstrap 凭证。结构(层叠继承,官方 best practice"base → provider → stack"):
-```
+
+```text
 animichi/base            # 非密 config + 共享名(ANITABI_API_URL 等)
 animichi/cloudflare      # CF 三 token(§2)+ ACCOUNT_ID
 animichi/staging         # imports: base, cloudflare; env 专值+secret
-animichi/prod            # 同上; PULUMI_CONFIG_PASSPHRASE 淘汰(见下)
+animichi/prod            # 同上; PULUMI_CONFIG_PASSPHRASE 保留(state 留 R2,见下勘误)
 ```
-**接线方案对比**:(A) GH Actions OIDC → Pulumi Cloud(ESC 官方 OIDC issuer 信任 GH),job 内 `esc run animichi/<env> -- <deploy>` 注入 env;(B) 保持 GH secrets 为镜像、ESC 只作登记。**推荐 A**:零长期静态凭证进 GH,轮换只改 ESC 一处;B 不解决三分散,只加第四份。wrangler 喂法不变:`esc run` 导出的 env 直接被 wrangler-action `secrets:` / `wrangler secret put` 消费,`_deploy-component.yml` 的 `${{ secrets.X }}` 改为 step env 读取。**留在 GH 的**:`GITHUB_TOKEN`(内建)、Codecov OIDC(已无 token)、`PULUMI_ACCESS_TOKEN`(ESC 的 bootstrap 凭证,鸡生蛋,必须留 GH env)、`GITLEAKS_LICENSE`(未 set,维持)。**顺带收益**:ESC 用 Pulumi Cloud 托管加密 → `PULUMI_CONFIG_PASSPHRASE`+R2 state 的"丢 passphrase 即丢 state"风险面消失(state 后端是否同迁 Pulumi Cloud 是独立决策,可不迁)。
+
+**接线方案对比**:(A) GH Actions OIDC → Pulumi Cloud(ESC 官方 OIDC issuer 信任 GH),job 内 `esc run animichi/<env> -- <deploy>` 注入 env;(B) 保持 GH secrets 为镜像、ESC 只作登记。**推荐 A**:零长期静态凭证进 GH,轮换只改 ESC 一处;B 不解决三分散,只加第四份。wrangler 喂法不变:`esc run` 导出的 env 直接被 wrangler-action `secrets:` / `wrangler secret put` 消费,`_deploy-component.yml` 的 `${{ secrets.X }}` 改为 step env 读取。**留在 GH 的**:`GITHUB_TOKEN`(内建)、Codecov OIDC(已无 token)、`PULUMI_ACCESS_TOKEN`(ESC 的 bootstrap 凭证,鸡生蛋,必须留 GH env)、`GITLEAKS_LICENSE`(未 set,维持)。**顺带收益(限 ESC 面,勘误)**:ESC 内 secrets 由 Pulumi Cloud 托管加密;但 stack state 已定**留 R2**(决议册 2026-08-03),`PULUMI_CONFIG_PASSPHRASE` 的"丢 passphrase 即丢 state"风险面**仍在**——passphrase 保管 + #521 快照 lifecycle 是留 R2 的固有成本,单独记卡。
 
 **迁移批次(每批独立可回滚 = 保留旧 GH secret 直到批验证过,回滚仅改 workflow 一行)**:
-B0 修 `CLOUDFLARE_PULUMI_API_TOKEN` 断线(推 2e3a9c12 + provision)。B1 清 7 个 dead secrets(按 secrets.md 逐行动作,GCP_SA_KEY 先撤销)。B2 建 ESC env + OIDC 信任,仅迁 **Pulumi 自身消费**的 5 个(PULUMI_*、R2_*、CLOUDFLARE_PULUMI_API_TOKEN)。B3 迁 catalog/users 面(NEON_DATABASE_URL、NEON_API_KEY)。B4 迁 root 容器面(11 个 container-chain secrets)。B5 删 GH 侧已迁副本 + 更新 secrets.md 为"ESC 指针文档"。
+B0 修 `CLOUDFLARE_PULUMI_API_TOKEN` 断线(推 2e3a9c12 + provision)。B1 清 7 个 dead secrets(按 secrets.md 逐行动作;**例外:撤销/删除类动作不可回滚**,一行 workflow 回滚承诺不适用——GCP_SA_KEY 先做零引用核查(workflow grep + GCP 侧 last-used 审计)确认无消费者再撤销)。B2 建 ESC env + OIDC 信任,仅迁 **Pulumi 自身消费**的 5 个(PULUMI_*、R2_*、CLOUDFLARE_PULUMI_API_TOKEN)。B3 迁 catalog/users 面(NEON_DATABASE_URL、NEON_API_KEY)。B4 迁 root 容器面(11 个 container-chain secrets)。B5 删 GH 侧已迁副本 + 更新 secrets.md 为"ESC 指针文档"。
 
 **守卫**:扩展 `test_secrets_docs_consistency.py`——A 集合加入"ESC env yaml 中声明的名字"(esc env 定义可 export 成 JSON 进 repo fixture);CI 加 `esc env get --format json | jq` 断言每环境必需 key 非空(名字级,不碰值)。
 
@@ -35,7 +37,7 @@ B0 修 `CLOUDFLARE_PULUMI_API_TOKEN` 断线(推 2e3a9c12 + provision)。B1 清 7
 
 **现状**:`wrangler.toml` 三处 `image = "./Dockerfile"` → staging 与 prod 各自现场重建,prod 跑的 digest ≠ staging 验过的。
 **平台事实(CF docs 实测)**:Containers 支持预构建镜像 `image = "registry.cloudflare.com/<account>/<img>:<tag>"`(也支持 Docker Hub/ECR/GAR);CI 路径官方支持 `wrangler containers build -p -t <tag>` / `containers push`。文档只示例 **tag 引用,`@sha256:` digest 引用未见文档确认** → 按 digest 部署标记为**待 spike 验证**。
-**推荐方案**:build-once-promote 可行——CI 在 staging deploy 前 `wrangler containers build -p -t <git-sha>`(immutable tag,等效 digest 固定),`image` 字段改为 registry 引用;deploy 步骤用同一 `<git-sha>` tag 先 staging 后 prod(prod 不再 build)。wrangler config 不支持 image 字段插值 → CI 以 `sed`/生成片段写入 tag,或 spike `WRANGLER_` env 替代。**兜底**(若 registry 引用在 container+DO 组合下有坑):保留双重建,但两次 build 后 `docker inspect` 记录 digest,post-deploy 步骤比对 staging/prod digest 一致才放行 prod(弱保证:需 BuildKit 可重现层,不达标就告警不阻断)。
+**推荐方案**:build-once-promote 可行——CI 在 staging deploy 前 `wrangler containers build -p -t <git-sha>`(immutable tag,等效 digest 固定),`image` 字段改为 registry 引用;deploy 步骤用同一 `<git-sha>` tag 先 staging 后 prod(prod 不再 build)。wrangler config 不支持 image 字段插值 → CI 以 `sed`/生成片段写入 tag,或 spike `WRANGLER_` env 替代。**兜底**(仅当 registry 引用在 container+DO 组合下 spike 失败时临时使用):保留双重建,但两次 build 后 `docker inspect` 记录 digest,post-deploy 步骤比对 staging/prod digest,**不一致即阻断 prod**(非告警放行;豁免只走显式 `workflow_dispatch` 手动批准)。注意兜底依赖 BuildKit 层可重现,预期不稳,不满足 immutable-artifact 目标——registry-tag 路径是唯一正解,兜底转正需 owner 重新决策。
 **守卫**:CI 断言 prod deploy job 无 docker build 步骤(或 digest 比对必须绿);`wrangler.toml` 测试断言 `image` 是 registry 引用非 Dockerfile 路径。
 
 ## 4. Private network 补全
@@ -49,7 +51,7 @@ B0 修 `CLOUDFLARE_PULUMI_API_TOKEN` 断线(推 2e3a9c12 + provision)。B1 清 7
 ## 5. 命名与守卫
 
 **改名批次**(配合 #312 Supabase 退役;借 ESC 迁移批同车,一次名字只改一处真源):R1 `SUPABASE_DB_URL`→`AGENT_DATABASE_URL`(触点:GH/ESC + `_deploy-component.yml` + `deploy.yml` + `CONTAINER_ENV_KEYS` + `CONTAINER_REQUIRED_KEYS` + settings.py + secrets.md,env 三触点教训);R2 `NEON_DATABASE_URL`→`CATALOG_DATABASE_URL`;R3 `MIMO_API_KEY` 等模型 key 维持(名已语义)。每批新旧名并读一个 release(settings 层 alias)再删旧名。
-**配置守卫扩展**(`worker/authConfig.test.ts` 模式 → 新 `worker/secretsWiring.test.ts` + `.github/` contract test):可写断言——(a) `worker_secrets`/`post_deploy_secrets` 列表 ⊆ `_deploy-component.yml` `secrets:` 声明 ∩ env map(三处一致);(b) `CONTAINER_ENV_KEYS` 中 credential 形名字必在某 workflow env map 出现(ZETA/OPENAI_COMPAT 断链即红);(c) wrangler.toml 各 env `image`/`workers_dev`/services 形状钉死;(d) Pulumi 步骤 env 必用 `CLOUDFLARE_PULUMI_API_TOKEN` 而非 wrangler token(防回退)。
+**配置守卫扩展**(`worker/authConfig.test.ts` 模式 → 新 `worker/secretsWiring.test.ts` + `.github/` contract test):可写断言——(a) `worker_secrets`/`post_deploy_secrets` 列表 ⊆ `_deploy-component.yml` `secrets:` 声明 ∩ env map(三处一致);(b) `CONTAINER_ENV_KEYS` 中 credential 形名字必在某 workflow env map 出现(ZETA/OPENAI_COMPAT 断链即红);(c) wrangler.toml 各 env `image`/`workers_dev`/services 形状钉死;(d) Pulumi 步骤 env 必用 `CLOUDFLARE_PULUMI_API_TOKEN` 而非 wrangler token(防回退)。**来源与名字分开校验**:(a)/(b) 断言的是 GH 递送链现状;B2-B5 后已迁 ESC 的名字改为对照 ESC env JSON export(§1 守卫),GH 侧断言只保留未迁/bootstrap 名——否则守卫会为了通过而倒逼保留 GH 重复副本,或误杀合法的 `esc run` 注入。
 
 ## 分卡建议(执行顺序)
 
@@ -62,4 +64,6 @@ B0 修 `CLOUDFLARE_PULUMI_API_TOKEN` 断线(推 2e3a9c12 + provision)。B1 清 7
 7. **C6** Hostname cutover + staging WAF + workers_dev 收口(N2-N4,依赖 owner 定 #541/#529)
 8. **C7** Secret 语义化改名 R1/R2(依赖 C3 的单一真源,#312 同车)
 
-**Owner 决策点**:① ESC 方案 A(OIDC+esc run)是否接受引入 Pulumi Cloud 依赖;② state 后端留 R2 还是同迁;③ promotion 采 registry-tag 方案还是 digest 比对兜底;④ #529 staging CORS 决策;⑤ C6 与产品 launch(#541 即上线)耦合,时点归 owner。
+**Owner 决策点(签核状态见决议册)**:① ESC 方案 A —— **已定:采 A**;② state 后端 —— **已定:留 R2**(passphrase/快照为固有成本);③ promotion —— **已定:registry git-SHA tag**(digest 引用卡内 spike,兜底仅阻断式临时用);④ #529 staging CORS —— **已定:保留 wildcard 至 C6**,cutover 时收紧;⑤ C6 与产品 launch(#541 即上线)时点 —— **待定,归 owner**。
+
+> **执行状态与顺序的权威 = `decisions-2026-08-03.md`**(iter6 执行序:Wave 3 = C1→C4→C5→C2→C3→L1,与 #674 系 C0-C7 并行穿插)。本节分卡序为 spec 起草时的原始建议,不再单独维护。

--- a/docs/iterations/iter6/spec-infra-governance.md
+++ b/docs/iterations/iter6/spec-infra-governance.md
@@ -1,0 +1,65 @@
+# Infra 治理 spec 草案(epic #674)— owner grill 版
+
+日期 2026-08-03 · 分支 feat/frontend-rebuild · 全部数字为本机实测(gh secret/variable list、源码 grep、CF docs 检索)。
+
+## 1. Secrets 中央化(Pulumi ESC)
+
+**现状实测**:三分体系共 **51 个名字**——GH repo secrets **27**(其中 ≥7 个 dead:GCP_SA_KEY/GCP_PROJECT_ID/CLAUDE_CODE_OAUTH_TOKEN/ANTHROPIC_API_KEY/ANTHROPIC_BASE_URL/NEXT_PUBLIC_MAPBOX_TOKEN/ZETA_API_KEY)+ staging env **10** + production env **10** + GH vars repo 4 / staging 2 / prod 0 + Pulumi passphrase config(prod 1 secret `catalogDatabaseUrl`+salt;staging 无 secret)。同名双写(repo+env)8 组,repo 层副本全部 unreachable(env 覆盖规则,docs/ops/secrets.md 已证)。**注意**:issue 里说的 `CLOUDFLARE_PULUMI_API_TOKEN` 已在 `_deploy-component.yml:449/502` 接线,但 `gh secret list` 三个 scope 均**未见此名** → 本地 commit 2e3a9c12 未推或 secret 未 provision,当前 Pulumi 步骤实际拿到空 token(`required: false` 静默)。**这是 P0 修复项,先于 ESC。**
+
+**目标态**:ESC 为唯一真源,GH env 只留 bootstrap 凭证。结构(层叠继承,官方 best practice"base → provider → stack"):
+```
+animichi/base            # 非密 config + 共享名(ANITABI_API_URL 等)
+animichi/cloudflare      # CF 三 token(§2)+ ACCOUNT_ID
+animichi/staging         # imports: base, cloudflare; env 专值+secret
+animichi/prod            # 同上; PULUMI_CONFIG_PASSPHRASE 淘汰(见下)
+```
+**接线方案对比**:(A) GH Actions OIDC → Pulumi Cloud(ESC 官方 OIDC issuer 信任 GH),job 内 `esc run animichi/<env> -- <deploy>` 注入 env;(B) 保持 GH secrets 为镜像、ESC 只作登记。**推荐 A**:零长期静态凭证进 GH,轮换只改 ESC 一处;B 不解决三分散,只加第四份。wrangler 喂法不变:`esc run` 导出的 env 直接被 wrangler-action `secrets:` / `wrangler secret put` 消费,`_deploy-component.yml` 的 `${{ secrets.X }}` 改为 step env 读取。**留在 GH 的**:`GITHUB_TOKEN`(内建)、Codecov OIDC(已无 token)、`PULUMI_ACCESS_TOKEN`(ESC 的 bootstrap 凭证,鸡生蛋,必须留 GH env)、`GITLEAKS_LICENSE`(未 set,维持)。**顺带收益**:ESC 用 Pulumi Cloud 托管加密 → `PULUMI_CONFIG_PASSPHRASE`+R2 state 的"丢 passphrase 即丢 state"风险面消失(state 后端是否同迁 Pulumi Cloud 是独立决策,可不迁)。
+
+**迁移批次(每批独立可回滚 = 保留旧 GH secret 直到批验证过,回滚仅改 workflow 一行)**:
+B0 修 `CLOUDFLARE_PULUMI_API_TOKEN` 断线(推 2e3a9c12 + provision)。B1 清 7 个 dead secrets(按 secrets.md 逐行动作,GCP_SA_KEY 先撤销)。B2 建 ESC env + OIDC 信任,仅迁 **Pulumi 自身消费**的 5 个(PULUMI_*、R2_*、CLOUDFLARE_PULUMI_API_TOKEN)。B3 迁 catalog/users 面(NEON_DATABASE_URL、NEON_API_KEY)。B4 迁 root 容器面(11 个 container-chain secrets)。B5 删 GH 侧已迁副本 + 更新 secrets.md 为"ESC 指针文档"。
+
+**守卫**:扩展 `test_secrets_docs_consistency.py`——A 集合加入"ESC env yaml 中声明的名字"(esc env 定义可 export 成 JSON 进 repo fixture);CI 加 `esc env get --format json | jq` 断言每环境必需 key 非空(名字级,不碰值)。
+
+## 2. 最小权限 token 矩阵
+
+| 消费者 | 现状 | 目标 scope | 轮换 |
+|---|---|---|---|
+| wrangler deploy(4 Workers+container) | `CLOUDFLARE_API_TOKEN` 全权,repo+双 env 三份同名 | Workers Scripts:Edit + Containers(registry push)+ Workers R2:仅当 wrangler 绑定校验需要;**staging/prod 各一枚** | ESC 单点;新旧并行→切→撤销 |
+| Pulumi(R2/DNS/Routes/Ruleset/CustomDomain) | 专用 token 已接线但**未 provision**(见 §1 P0) | R2:Edit + Zone DNS:Edit + Zone Rulesets:Edit + Workers Routes:Edit,zone 限 animichi.com | 同上 |
+| Neon(CI branch 管理) | `NEON_API_KEY` 全账号 | Neon 支持 project-scoped API key → 限 `billowing-fire-22850320` | 同上 |
+| Turnstile siteverify | `TURNSTILE_SECRET`(仅是 widget secret,无 API token 面) | 维持;preflight 已有 siteverify 探针 | 换 widget 对 |
+| Logfire | 双 env 各自 write token(已最小) | 维持 | 已有流程 |
+| R2 state 读写 | R2_* 账号级 S3 key | 限 bucket 的 R2 API token(CF 支持 bucket-scoped) | ESC 单点 |
+
+## 3. Artifact promotion(容器镜像 build-once-promote)
+
+**现状**:`wrangler.toml` 三处 `image = "./Dockerfile"` → staging 与 prod 各自现场重建,prod 跑的 digest ≠ staging 验过的。
+**平台事实(CF docs 实测)**:Containers 支持预构建镜像 `image = "registry.cloudflare.com/<account>/<img>:<tag>"`(也支持 Docker Hub/ECR/GAR);CI 路径官方支持 `wrangler containers build -p -t <tag>` / `containers push`。文档只示例 **tag 引用,`@sha256:` digest 引用未见文档确认** → 按 digest 部署标记为**待 spike 验证**。
+**推荐方案**:build-once-promote 可行——CI 在 staging deploy 前 `wrangler containers build -p -t <git-sha>`(immutable tag,等效 digest 固定),`image` 字段改为 registry 引用;deploy 步骤用同一 `<git-sha>` tag 先 staging 后 prod(prod 不再 build)。wrangler config 不支持 image 字段插值 → CI 以 `sed`/生成片段写入 tag,或 spike `WRANGLER_` env 替代。**兜底**(若 registry 引用在 container+DO 组合下有坑):保留双重建,但两次 build 后 `docker inspect` 记录 digest,post-deploy 步骤比对 staging/prod digest 一致才放行 prod(弱保证:需 BuildKit 可重现层,不达标就告警不阻断)。
+**守卫**:CI 断言 prod deploy job 无 docker build 步骤(或 digest 比对必须绿);`wrangler.toml` 测试断言 `image` 是 registry 引用非 Dockerfile 路径。
+
+## 4. Private network 补全
+
+**已做**:catalog/users 全环境 `workers_dev=false`(catalog 3 处+users 3 处,实测);catalog/users 无公共路由(smoke 步骤明示 by design);`catalog.internal` outboundByHost→service binding(容器→catalog 不出公网);root `workers_dev=false`(#539,staging 例外:显式 `workers_dev=true`,是 promotion gate 契约)。
+**半做**:staging WAF gate(#529/#559)代码已在 `infra/index.ts:186-221`,`stagingGateEnabled=false` 且依赖 #541 hostname cutover(workers.dev 域名绕过 zone WAF——staging 现恰恰只有 workers.dev 入口,**gate 今天开了也没用**)。
+**缺失**:ingest 内部化(#540/#555)——`/catalog/ingest` 仍是 fetch handler 路径靠共享 secret,应改 named `WorkerEntrypoint` + binding-only(注入的 agent 也无法伪造 binding 调用);#529 决策(staging CORS wildcard)未定。
+**收口顺序**:N1 ingest WorkerEntrypoint(#540,独立可做,防注入面最大)→ N2 hostname cutover(#541,前置)→ N3 staging WAF gate 开启(#529/#559,依赖 N2)→ N4 staging `workers_dev` 关闭改走 staging.animichi.com(重写 promotion gate 断言)。
+**守卫**:`infra/topology-*.test.ts` 已有,扩展断言"staging gate enabled 时 stagingDomain 必在 zone 上";wrangler 配置测试断言 catalog/users 永无 routes/workers_dev。
+
+## 5. 命名与守卫
+
+**改名批次**(配合 #312 Supabase 退役;借 ESC 迁移批同车,一次名字只改一处真源):R1 `SUPABASE_DB_URL`→`AGENT_DATABASE_URL`(触点:GH/ESC + `_deploy-component.yml` + `deploy.yml` + `CONTAINER_ENV_KEYS` + `CONTAINER_REQUIRED_KEYS` + settings.py + secrets.md,env 三触点教训);R2 `NEON_DATABASE_URL`→`CATALOG_DATABASE_URL`;R3 `MIMO_API_KEY` 等模型 key 维持(名已语义)。每批新旧名并读一个 release(settings 层 alias)再删旧名。
+**配置守卫扩展**(`worker/authConfig.test.ts` 模式 → 新 `worker/secretsWiring.test.ts` + `.github/` contract test):可写断言——(a) `worker_secrets`/`post_deploy_secrets` 列表 ⊆ `_deploy-component.yml` `secrets:` 声明 ∩ env map(三处一致);(b) `CONTAINER_ENV_KEYS` 中 credential 形名字必在某 workflow env map 出现(ZETA/OPENAI_COMPAT 断链即红);(c) wrangler.toml 各 env `image`/`workers_dev`/services 形状钉死;(d) Pulumi 步骤 env 必用 `CLOUDFLARE_PULUMI_API_TOKEN` 而非 wrangler token(防回退)。
+
+## 分卡建议(执行顺序)
+
+1. **C0** P0:推/provision `CLOUDFLARE_PULUMI_API_TOKEN` + dead secrets 清理(B0+B1)— 半天
+2. **C1** Token 矩阵落地:三枚 CF token + Neon project-scoped key + R2 bucket-scoped(§2)
+3. **C2** ESC bootstrap:env 结构 + GH OIDC + 迁 Pulumi 面 5 secrets(B2)
+4. **C3** ESC 全量:B3+B4+B5 + secrets.md 改指针 + 守卫测试扩展(§1 守卫)
+5. **C4** Ingest WorkerEntrypoint 内部化(#540/#555,N1)— 与 C2 并行无依赖
+6. **C5** Artifact promotion spike + 落地(§3,含 digest 引用验证)
+7. **C6** Hostname cutover + staging WAF + workers_dev 收口(N2-N4,依赖 owner 定 #541/#529)
+8. **C7** Secret 语义化改名 R1/R2(依赖 C3 的单一真源,#312 同车)
+
+**Owner 决策点**:① ESC 方案 A(OIDC+esc run)是否接受引入 Pulumi Cloud 依赖;② state 后端留 R2 还是同迁;③ promotion 采 registry-tag 方案还是 digest 比对兜底;④ #529 staging CORS 决策;⑤ C6 与产品 launch(#541 即上线)耦合,时点归 owner。


### PR DESCRIPTION
今日全域决议存档:方法论授权、secrets/ESC/Store、DB 角色与 Neon 留任、per-package CI、promotion、网络隔离定谳、CF-native 采纳清单、执行序更新。含 #674 spec 与 CF 全目录审计 v2 入库。Docs-only。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a decisions archive covering architecture, credentials, databases, CI/CD, networking, Cloudflare capabilities, analytics, and execution status.
  * Added an infrastructure governance draft detailing secrets management, access controls, deployment promotion, private networking, database configuration, and rollout sequencing.
  * Added a Cloudflare product catalog audit documenting current usage, adoption considerations, pricing, migration effort, and follow-up actions.
  * Added links to the new decision and infrastructure governance resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->