### PR TITLE
refactor(iter6 B1): quota rejection parsing via @animichi/contract (#641)

### DIFF
--- a/apps/web/src/features/chat/use-chat-session.ts
+++ b/apps/web/src/features/chat/use-chat-session.ts
@@ -1,11 +1,12 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import type { UseChatHelpers } from "@ai-sdk/react";
-import { ChatResponseDataPart } from "@animichi/contract";
+import { AnonLimitErrorEnvelope, ChatResponseDataPart, readQuotaResetsAt } from "@animichi/contract";
 import type { ChatDataPart } from "@animichi/contract";
 import { DefaultChatTransport, generateId } from "ai";
 import type { UIMessage } from "ai";
 import { useCallback, useRef } from "react";
 import type { RefObject } from "react";
+import { z } from "zod";
 import type { SelectedPointsBody } from "../../lib/chat/selectedPointsBypass";
 import { sessionHeaders } from "./session-headers";
 
@@ -88,38 +89,21 @@ interface RejectionDetail {
 
 const NO_REJECTION: RejectionDetail = { code: undefined, quotaResetsAt: undefined };
 
-function errorObjectOf(body: unknown): Record<string, unknown> | undefined {
-  if (typeof body !== "object" || body === null) return undefined;
-  const error: unknown = (body as { error?: unknown }).error;
-  if (typeof error !== "object" || error === null) return undefined;
-  return error as Record<string, unknown>;
-}
-
-function stringField(source: Record<string, unknown> | undefined, key: string): string | undefined {
-  const value: unknown = source?.[key];
-  return typeof value === "string" ? value : undefined;
-}
-
-function rejectionOf(body: unknown): RejectionDetail {
-  const error = errorObjectOf(body);
-  if (error === undefined) return NO_REJECTION;
-  const data = errorObjectOf({ error: error.data }) ?? error;
-  return { code: stringField(error, "code"), quotaResetsAt: stringField(data, "quota_resets_at") };
-}
+const RejectionCodeEnvelope = z.object({ error: z.object({ code: z.string() }) });
 
 /**
  * Read the rejection's error code — which separates D8 (401/403 expiry) from
  * D11 (`anon_budget_exhausted`) and D12 (`anon_quota_exhausted`) — plus D12's
- * `quota_resets_at`, read from `error.data` or flat on `error`. Only failures
- * are parsed; a streaming 2xx body is never touched, let alone buffered.
+ * `quota_resets_at`, read through the shared contract. Only failures are
+ * parsed; a streaming 2xx body is never touched, let alone buffered.
  */
 async function readRejection(response: Response): Promise<RejectionDetail> {
   if (response.ok) return NO_REJECTION;
-  const body: unknown = await response
-    .clone()
-    .json()
-    .catch(() => undefined);
-  return rejectionOf(body);
+  const body: unknown = await response.clone().json().catch(() => undefined);
+  const limit = AnonLimitErrorEnvelope.safeParse(body);
+  const rejection = RejectionCodeEnvelope.safeParse(body);
+  const code = limit.success ? limit.data.error.code : rejection.data?.error.code;
+  return { code, quotaResetsAt: readQuotaResetsAt(body) };
 }
 
 function clearRejection(ref: SessionRef): void {

--- a/apps/web/tests/msw/chat-handlers.ts
+++ b/apps/web/tests/msw/chat-handlers.ts
@@ -149,14 +149,18 @@ export function armedChatHandler(
 
 /** The anonymous daily-budget breaker's rejection (issue #274 S1.8 X4 → D11). */
 export function chatBudgetExhaustedHandler(): HttpHandler {
-  const body = { error: { code: "anon_budget_exhausted", action: "login" } };
+  const body = {
+    error: { code: "anon_budget_exhausted", message: "Anonymous budget exhausted.", action: "login" },
+  };
   return http.post(CHAT_URL, () => HttpResponse.json(body, { status: 403 }));
 }
 
 /** #282 S1.10: this identity's own daily message quota, not the shared budget. */
 export function chatQuotaExhaustedHandler(resetsAt?: string): HttpHandler {
   const data = resetsAt === undefined ? undefined : { quota_resets_at: resetsAt };
-  const body = { error: { code: "anon_quota_exhausted", action: "login", data } };
+  const body = {
+    error: { code: "anon_quota_exhausted", message: "Anonymous quota exhausted.", action: "login", data },
+  };
   return http.post(CHAT_URL, () => HttpResponse.json(body, { status: 403 }));
 }
 

--- a/apps/web/tests/unit/chat/quota-rejection-envelope.test.tsx
+++ b/apps/web/tests/unit/chat/quota-rejection-envelope.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useChatSession } from "../../../src/features/chat/use-chat-session";
+import {
+  CHAT_URL,
+  chatQuotaExhaustedHandler,
+  chatTurnstileRequiredHandler,
+} from "../../msw/chat-handlers";
+import { server } from "../../msw/node";
+
+const { authHeaders } = vi.hoisted(() => ({ authHeaders: vi.fn().mockResolvedValue({}) }));
+vi.mock("../../../src/lib/auth/authSession", () => ({ authHeaders }));
+
+afterEach(() => {
+  authHeaders.mockReset().mockResolvedValue({});
+});
+
+function renderSession() {
+  return renderHook(() => useChatSession(CHAT_URL, "anon-1"));
+}
+
+async function sendRejected(view: ReturnType<typeof renderSession>) {
+  await act(async () => view.result.current.sendMessage({ text: "ユーフォ" }));
+  await waitFor(() => {
+    expect(view.result.current.error).toBeTruthy();
+  });
+}
+
+describe("quota rejection envelope", () => {
+  it("passes quota_resets_at through to the banner-facing session state", async () => {
+    const resetsAt = "2099-01-01T00:00:00Z";
+    server.use(chatQuotaExhaustedHandler(resetsAt));
+    const view = renderSession();
+    await sendRejected(view);
+    expect(view.result.current.lastErrorCode()).toBe("anon_quota_exhausted");
+    expect(view.result.current.lastQuotaResetsAt()).toBe(resetsAt);
+  });
+
+  it("does not misclassify a non-quota rejection as quota exhaustion", async () => {
+    server.use(chatTurnstileRequiredHandler());
+    const view = renderSession();
+    await sendRejected(view);
+    expect(view.result.current.lastErrorCode()).toBe("turnstile_required");
+    expect(view.result.current.lastQuotaResetsAt()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
iter6 W2-B1。use-chat-session 手写信封解析(errorObjectOf/stringField/rejectionOf)删除,改 AnonLimitErrorEnvelope.safeParse + readQuotaResetsAt——error-registry 的'唯一祝福提取点'注释从此成真。

双形态兼容裁决:平铺形态**零生产发射者**(chat.py:222 只发嵌套),按契约收紧删除容忍,特征化测试先行钉死行为。主线独立验收:web 1606 测试全绿,覆盖率 98%+。Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)