### PR TITLE
fix(ci): staging deploys were silently skipped by GitHub's skip propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,7 +579,13 @@ jobs:
   deploy-staging:
     name: Deploy staging
     needs: [agent-ci-gate, backend-ci-gate, web-ci-gate, infra-db-ci-gate, cross-stack-e2e-gate, repository-quality-gate, codecov-patch-gate]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    # `!failure() && !cancelled()` closes the implicit `success()` that GitHub
+    # otherwise prepends: a *skipped* upstream (agent-eval-smoke skips on pushes
+    # that do not touch agent_behavior paths) propagates through the always()
+    # gates and would silently skip every deploy — the bug that kept staging
+    # undeployed for three runs. Gate failures still block: they surface as
+    # failure(), not skipped.
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/_deploy-component.yml
     with:
       component: catalog
@@ -601,7 +607,13 @@ jobs:
   deploy-web-staging:
     name: Deploy web staging
     needs: [agent-ci-gate, backend-ci-gate, web-ci-gate, infra-db-ci-gate, cross-stack-e2e-gate, repository-quality-gate, codecov-patch-gate]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    # `!failure() && !cancelled()` closes the implicit `success()` that GitHub
+    # otherwise prepends: a *skipped* upstream (agent-eval-smoke skips on pushes
+    # that do not touch agent_behavior paths) propagates through the always()
+    # gates and would silently skip every deploy — the bug that kept staging
+    # undeployed for three runs. Gate failures still block: they surface as
+    # failure(), not skipped.
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/_deploy-component.yml
     with:
       component: web
@@ -619,7 +631,13 @@ jobs:
   deploy-users-staging:
     name: Deploy users staging
     needs: [deploy-staging]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    # `!failure() && !cancelled()` closes the implicit `success()` that GitHub
+    # otherwise prepends: a *skipped* upstream (agent-eval-smoke skips on pushes
+    # that do not touch agent_behavior paths) propagates through the always()
+    # gates and would silently skip every deploy — the bug that kept staging
+    # undeployed for three runs. Gate failures still block: they surface as
+    # failure(), not skipped.
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/_deploy-component.yml
     with:
       component: users
@@ -641,7 +659,13 @@ jobs:
   deploy-root-staging:
     name: Deploy root staging
     needs: [deploy-staging, deploy-users-staging]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    # `!failure() && !cancelled()` closes the implicit `success()` that GitHub
+    # otherwise prepends: a *skipped* upstream (agent-eval-smoke skips on pushes
+    # that do not touch agent_behavior paths) propagates through the always()
+    # gates and would silently skip every deploy — the bug that kept staging
+    # undeployed for three runs. Gate failures still block: they surface as
+    # failure(), not skipped.
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/_deploy-component.yml
     with:
       component: root


### PR DESCRIPTION
**根因**(对照实验证据):GitHub 的 skipped 状态沿 needs 链传递,穿透 `always()` 的 gate 层;下游 job 的 `if` 若不含 status-check 函数会继承隐式 `success()`,于是一并被 skip。`agent-eval-smoke` 在未触及 agent_behavior 路径的 push 上 skip → **普通 push 到 main 从不部署**,三个连绿 run 什么都没发。

8/2 决定性对照:run 30735916158(eval-smoke skipped → Deploy skipped)vs 30737053650(eval-smoke ran → Deploy 真跑),两者 workflow 在 gate/deploy 段零差异。

**修复**:四个 staging deploy job 的 if 前置 `!failure() && !cancelled()`。gate 失败仍拦截(失败呈现为 failure 而非 skipped);prod 段经 post-staging 的 needs 链继承。actionlint 干净,257→258 worker 测试绿。

这是今天 staging 迟迟未验通的最后一环。

🤖 Generated with [Claude Code](https://claude.com/claude-code)