### PR TITLE
fix(edge): enable_ctx_exports — containers failed to start on staging

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -55,7 +55,14 @@
 #                                pair (site 1x00000000000000000000AA / secret 1x0000000000000000000000000000000AA).
 
 compatibility_date = "2025-03-01"
-compatibility_flags = ["nodejs_compat"]
+# `enable_ctx_exports` is required for the `ctx.exports` loopback-binding API
+# (docs: workers/runtime-apis/context#exports — "you must use the
+# enable_ctx_exports compatibility flag", on by default only in future).
+# @cloudflare/containers reaches ctx.exports.ContainerProxy when starting the
+# RuntimeContainer; without the flag the export exists but the API does not,
+# and every container start fails with "ctx.exports is undefined" — staging
+# /healthz 500 on the first real root deploy (run 30795617682).
+compatibility_flags = ["nodejs_compat", "enable_ctx_exports"]
 main = "worker/entry.ts"
 
 # Plain (non-secret) vars forwarded into the RuntimeContainer (Python agent).


### PR DESCRIPTION
首次真实 root staging 部署(run 30795617682)的失败根因:Worker 部署成功、镜像推送成功(Containers 权限已通),但容器启动即 `ctx.exports is undefined` → /healthz 500。

**根因**:`ContainerProxy` 早已从 worker/entry.ts:12 导出(注释也提过这个坑),缺的是 **compatibility flag**。CF docs 明载 `ctx.exports` loopback-binding API **目前必须显式开 `enable_ctx_exports`**(未来才默认开);@cloudflare/containers 在启动容器时走 `ctx.exports.ContainerProxy`,没有 flag 时导出存在而 API 不存在。

**修复**:root wrangler.toml 的 compatibility_flags 加 `enable_ctx_exports`。258 worker 测试绿(本地 dry-run 需 Docker,CI 侧验证)。

这是 staging 完整站立的最后一环:catalog+Pulumi ✅ users ✅ web ✅ root(部署✅ 容器❌→本 PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)