### PR TITLE
ci: zizmor cache + CI-1 v3 design + hardening step 1 (timeouts / permissions / concurrency)

### DIFF
--- a/.github/workflows/_cross-stack-e2e.yml
+++ b/.github/workflows/_cross-stack-e2e.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   cross-stack-e2e:
+    timeout-minutes: 30
     name: Cross-stack E2E runner
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -65,6 +65,7 @@ on:
         required: false
 jobs:
   deploy:
+    timeout-minutes: 30
     name: Deploy
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}

--- a/.github/workflows/_post-deploy-test.yml
+++ b/.github/workflows/_post-deploy-test.yml
@@ -75,6 +75,7 @@ permissions:
 
 jobs:
   post-deploy-test:
+    timeout-minutes: 30
     name: Post-deploy ${{ inputs.suite }} (${{ inputs.environment }})
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}

--- a/.github/workflows/_python-ci.yml
+++ b/.github/workflows/_python-ci.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   python-ci:
+    timeout-minutes: 20
     name: Python CI
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -22,6 +22,7 @@ jobs:
   # ── Secret scanning ──────────────────────────────────────────
 
   gitleaks:
+    timeout-minutes: 15
     name: gitleaks (secret scan)
     runs-on: ubuntu-latest
     steps:
@@ -37,6 +38,7 @@ jobs:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   trufflehog:
+    timeout-minutes: 15
     name: TruffleHog (verified secrets)
     runs-on: ubuntu-latest
     steps:
@@ -51,6 +53,7 @@ jobs:
   # ── Dependency / lockfile CVE scanning ───────────────────────
 
   osv-scanner:
+    timeout-minutes: 15
     name: osv-scanner (lockfile CVE)
     runs-on: ubuntu-latest
     steps:
@@ -64,6 +67,7 @@ jobs:
             ./
 
   dependabot-config:
+    timeout-minutes: 15
     name: Dependabot pnpm coverage
     runs-on: ubuntu-latest
     steps:
@@ -76,6 +80,7 @@ jobs:
   # ── GitHub Actions security ──────────────────────────────────
 
   zizmor:
+    timeout-minutes: 15
     name: zizmor (GHA security)
     runs-on: ubuntu-latest
     # advanced-security: false (below) → no SARIF upload → security-events not
@@ -131,6 +136,7 @@ jobs:
           key: zizmor-${{ runner.os }}-${{ hashFiles('.github/workflows/*.yml', '.github/actions/**') }}
 
   actionlint:
+    timeout-minutes: 15
     name: actionlint (GHA semantics)
     runs-on: ubuntu-latest
     steps:
@@ -152,6 +158,7 @@ jobs:
   # ── Static analysis (SAST) ───────────────────────────────────
 
   semgrep:
+    timeout-minutes: 15
     name: Semgrep (SAST)
     runs-on: ubuntu-latest
     steps:
@@ -171,6 +178,7 @@ jobs:
   # ── SQL migration lint ───────────────────────────────────────
 
   sqlfluff:
+    timeout-minutes: 15
     name: sqlfluff (SQL lint)
     runs-on: ubuntu-latest
     defaults:
@@ -191,6 +199,7 @@ jobs:
   # ── Deploy-gate script tests ─────────────────────────────────
 
   post-deploy-assert-test:
+    timeout-minutes: 30
     name: post-deploy-assert.sh (shellcheck + behavior)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -109,6 +109,11 @@ jobs:
           restore-keys: zizmor-${{ runner.os }}-
       - name: Install zizmor
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v7.1.1
+        with:
+          # setup-uv's own cache defaults to auto-on and is read-write, which
+          # zizmor's cache-poisoning audit rejects in this workflow. zizmor is a
+          # single small download; the uv cache buys nothing here.
+          enable-cache: false
       - name: Audit workflows
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -97,8 +97,12 @@ jobs:
       # version-pinned CLI directly is the only way to get a warm cache.
       # Cache key is content-based:
       # any workflow edit re-audits, an unchanged tree reuses yesterday's answers.
+      # restore-only (never save): zizmor's own cache-poisoning audit flags a
+      # read-write actions/cache in any workflow whose artifacts can reach a
+      # release path. Restore-only keeps the speed-up while leaving the cache
+      # writable solely by the trusted main-branch run below.
       - name: Restore zizmor audit cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/zizmor
           key: zizmor-${{ runner.os }}-${{ hashFiles('.github/workflows/*.yml', '.github/actions/**') }}
@@ -109,6 +113,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: uvx zizmor@1.5.2 --cache-dir ~/.cache/zizmor .
+      # Only main-branch runs may write the shared cache — a PR (including a
+      # fork PR) can read it but never poison it.
+      - name: Save zizmor audit cache
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/zizmor
+          key: zizmor-${{ runner.os }}-${{ hashFiles('.github/workflows/*.yml', '.github/actions/**') }}
 
   actionlint:
     name: actionlint (GHA semantics)

--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -108,12 +108,15 @@ jobs:
           key: zizmor-${{ runner.os }}-${{ hashFiles('.github/workflows/*.yml', '.github/actions/**') }}
           restore-keys: zizmor-${{ runner.os }}-
       - name: Install zizmor
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v7.1.1
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           # setup-uv's own cache defaults to auto-on and is read-write, which
           # zizmor's cache-poisoning audit rejects in this workflow. zizmor is a
           # single small download; the uv cache buys nothing here.
           enable-cache: false
+          # Required by .github/scripts/test_dependabot_config.py for every
+          # setup-uv call site (kept consistent even with the cache disabled).
+          prune-cache: true
       - name: Audit workflows
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -83,6 +83,12 @@ jobs:
     timeout-minutes: 15
     name: zizmor (GHA security)
     runs-on: ubuntu-latest
+    env:
+      # One pin, three uses: cache key, restore-keys prefix, and the CLI call.
+      # Keeping the version inside the key namespace means a zizmor upgrade
+      # starts from a cold cache instead of restoring another version's
+      # response format through the broad restore-keys prefix.
+      ZIZMOR_VERSION: 1.5.2
     # advanced-security: false (below) → no SARIF upload → security-events not
     # needed. Requesting it caused startup_failure: a reusable job cannot request
     # more than the caller (ci.yml) grants (contents: read → security-events: none).
@@ -110,8 +116,8 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/zizmor
-          key: zizmor-${{ runner.os }}-${{ hashFiles('.github/workflows/*.yml', '.github/actions/**') }}
-          restore-keys: zizmor-${{ runner.os }}-
+          key: zizmor-${{ runner.os }}-${{ env.ZIZMOR_VERSION }}-${{ hashFiles('.github/workflows/*.yml', '.github/actions/**') }}
+          restore-keys: zizmor-${{ runner.os }}-${{ env.ZIZMOR_VERSION }}-
       - name: Install zizmor
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
@@ -125,7 +131,7 @@ jobs:
       - name: Audit workflows
         env:
           GH_TOKEN: ${{ github.token }}
-        run: uvx zizmor@1.5.2 --cache-dir ~/.cache/zizmor .
+        run: uvx zizmor@"$ZIZMOR_VERSION" --cache-dir ~/.cache/zizmor .
       # Only main-branch runs may write the shared cache — a PR (including a
       # fork PR) can read it but never poison it.
       - name: Save zizmor audit cache
@@ -133,7 +139,7 @@ jobs:
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/zizmor
-          key: zizmor-${{ runner.os }}-${{ hashFiles('.github/workflows/*.yml', '.github/actions/**') }}
+          key: zizmor-${{ runner.os }}-${{ env.ZIZMOR_VERSION }}-${{ hashFiles('.github/workflows/*.yml', '.github/actions/**') }}
 
   actionlint:
     timeout-minutes: 15

--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -87,10 +87,28 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+      # zizmor's online audits (impostor-commit) resolve every third-party action
+      # ref against the GitHub API, which makes our CI availability a function of
+      # theirs — four red runs on 2026-08-03 were all upstream 502s, none of them
+      # our code. zizmor >=0.10 caches those lookups persistently, but the
+      # official zizmor-action runs zizmor inside a Docker container whose HOME
+      # is unrelated to the runner's, so a host-side actions/cache mount is
+      # invisible to it — and it exposes no --cache-dir passthrough. Calling the
+      # version-pinned CLI directly is the only way to get a warm cache.
+      # Cache key is content-based:
+      # any workflow edit re-audits, an unchanged tree reuses yesterday's answers.
+      - name: Restore zizmor audit cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          # Lint the whole workflow tree; do not upload SARIF (no code scanning).
-          advanced-security: false
+          path: ~/.cache/zizmor
+          key: zizmor-${{ runner.os }}-${{ hashFiles('.github/workflows/*.yml', '.github/actions/**') }}
+          restore-keys: zizmor-${{ runner.os }}-
+      - name: Install zizmor
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v7.1.1
+      - name: Audit workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uvx zizmor@1.5.2 --cache-dir ~/.cache/zizmor .
 
   actionlint:
     name: actionlint (GHA semantics)

--- a/.github/workflows/_ts-ci.yml
+++ b/.github/workflows/_ts-ci.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   ts-ci:
+    timeout-minutes: 20
     name: TS CI
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/_webapp-ci.yml
+++ b/.github/workflows/_webapp-ci.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   webapp-ci:
+    timeout-minutes: 20
     name: Web app CI
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/agent-eval-nightly.yml
+++ b/.github/workflows/agent-eval-nightly.yml
@@ -31,6 +31,7 @@ env:
 
 jobs:
   agent-eval-full:
+    timeout-minutes: 45
     name: Agent Eval (L1 full, uncapped)
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
   # ── Affected detection ────────────────────────────────────────
 
   changes:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     # dorny/paths-filter resolves a pull_request's changed files through the
     # GitHub API (listFiles), which needs `pull-requests: read`. The workflow-level
@@ -155,6 +156,7 @@ jobs:
       component: maintenance
 
   contract-openapi-drift:
+    timeout-minutes: 20
     name: Contract OpenAPI drift
     runs-on: ubuntu-latest
     needs: changes
@@ -182,6 +184,7 @@ jobs:
     uses: ./.github/workflows/_webapp-ci.yml
 
   ci-worker:
+    timeout-minutes: 20
     name: Edge worker component CI
     runs-on: ubuntu-latest
     needs: changes
@@ -194,6 +197,7 @@ jobs:
       - run: pnpm run test:worker
 
   ci-infra:
+    timeout-minutes: 20
     name: Infra component CI
     runs-on: ubuntu-latest
     needs: changes
@@ -235,6 +239,7 @@ jobs:
   # deploy `needs:` chain so it never gates a release. Promote to blocking once proven.
 
   agnix:
+    timeout-minutes: 15
     name: Agent config lint (agnix, warn-only)
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -251,6 +256,7 @@ jobs:
   # ── DB migrations (Atlas validation + optional Neon dry-run) ──
 
   db-validate:
+    timeout-minutes: 20
     name: DB Migrations (Atlas)
     runs-on: ubuntu-latest
     needs: changes
@@ -317,6 +323,7 @@ jobs:
   # runs nightly instead of on every PR — see agent-eval-nightly.yml.
 
   agent-eval-smoke:
+    timeout-minutes: 45
     name: Agent Eval (L0 smoke, ~80 cases)
     runs-on: ubuntu-latest
     needs: changes
@@ -350,6 +357,7 @@ jobs:
   # ── Neon test infrastructure (non-gating during calibration) ──
 
   python-integration:
+    timeout-minutes: 30
     name: Python integration (Neon)
     runs-on: ubuntu-latest
     permissions:
@@ -409,6 +417,7 @@ jobs:
         run: uv run pytest agent/tests/integration -q --no-cov
 
   catalog-spikes:
+    timeout-minutes: 30
     name: Catalog spikes (Neon)
     runs-on: ubuntu-latest
     permissions:
@@ -451,6 +460,7 @@ jobs:
   # A failed or cancelled component still fails its lane and blocks promotion.
 
   web-ci-gate:
+    timeout-minutes: 5
     name: Web CI
     needs: [changes, ci-web]
     if: ${{ always() }}
@@ -466,6 +476,7 @@ jobs:
         run: bash .github/scripts/assert-ci-needs.sh "Web CI" "$CHANGES_STATUS $STATUSES"
 
   backend-ci-gate:
+    timeout-minutes: 5
     name: Backend CI
     needs: [changes, ci-catalog, ci-users, ci-maintenance, contract-openapi-drift, ci-worker]
     if: ${{ always() }}
@@ -486,6 +497,7 @@ jobs:
         run: bash .github/scripts/assert-ci-needs.sh "Backend CI" "$STATUSES"
 
   agent-ci-gate:
+    timeout-minutes: 5
     name: Agent CI
     needs: [changes, ci-agent, agent-eval-smoke]
     if: ${{ always() }}
@@ -503,6 +515,7 @@ jobs:
         run: bash .github/scripts/assert-ci-needs.sh "Agent CI" "$STATUSES"
 
   infra-db-ci-gate:
+    timeout-minutes: 5
     name: Infra & DB CI
     needs: [changes, ci-infra, db-validate]
     if: ${{ always() }}
@@ -529,6 +542,7 @@ jobs:
     uses: ./.github/workflows/_cross-stack-e2e.yml
 
   cross-stack-e2e-gate:
+    timeout-minutes: 5
     name: Cross-stack E2E
     needs: [changes, ci-cross-stack-e2e]
     if: ${{ always() }}
@@ -545,6 +559,7 @@ jobs:
         run: bash .github/scripts/assert-ci-needs.sh "Cross-stack E2E" "$STATUSES"
 
   repository-quality-gate:
+    timeout-minutes: 5
     name: Repository Quality
     needs: [changes, security, agnix]
     if: ${{ always() }}
@@ -566,6 +581,7 @@ jobs:
         run: bash .github/scripts/assert-ci-needs.test.sh
 
   codecov-patch-gate:
+    timeout-minutes: 5
     name: Codecov Patch
     needs: [changes, ci-agent, ci-catalog, ci-users, ci-maintenance, ci-web, ci-worker]
     if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ env:
   NODE_VERSION: "24"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# One in-flight run per ref: a new push to a PR cancels the previous
+# run (wasted work), while pushes to main queue instead of cancelling
+# so a deploy is never killed mid-flight.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   # ── Affected detection ────────────────────────────────────────

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   analyze:
+    timeout-minutes: 20
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,11 @@ on:
   schedule:
     - cron: '37 18 * * 0'
 
+# Least-privilege default for every job in this file (GitHub hardening
+# guide): jobs that need more declare it themselves at job level.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     timeout-minutes: 20

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   # ── Stage 1: Quick verify (no AI cost) ────────────────────
   verify:
+    timeout-minutes: 20
     name: Verify Upgrade
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
@@ -114,6 +115,7 @@ jobs:
 
   # ── Stage 2: Report a verified upgrade for manual review ──
   ready-for-review:
+    timeout-minutes: 20
     name: Ready for Review
     needs: verify
     if: >-
@@ -132,6 +134,7 @@ jobs:
 
   # ── Stage 3: Fail closed and request human intervention ──
   needs-manual-review:
+    timeout-minutes: 20
     name: Needs Manual Review
     needs: verify
     if: >-

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -10,6 +10,11 @@ env:
   NODE_VERSION: "24"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Least-privilege default for every job in this file (GitHub hardening
+# guide): jobs that need more declare it themselves at job level.
+permissions:
+  contents: read
+
 jobs:
   # ── Stage 1: Quick verify (no AI cost) ────────────────────
   verify:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   deploy:
+    timeout-minutes: 30
     name: Deploy to Production
     runs-on: ubuntu-latest
     environment: production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,11 +127,16 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.4.0 # zizmor: ignore[cache-poisoning]
-        # Justification: workflow_dispatch only — no untrusted code can trigger this. cache: "" disables caching.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.4.0
+        # No `cache:` key at all. `cache: ""` still counts as opting in to
+        # setup-node's cache machinery, which zizmor's cache-poisoning audit
+        # flags because this workflow reaches a deploy step; omitting the key
+        # is the only way to be genuinely cache-free. The former
+        # `zizmor: ignore` sat on this line while the finding anchors on the
+        # deploy step below, so it never applied — and suppression is banned
+        # here anyway.
         with:
           node-version: "24"
-          cache: ""
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/neon-test-base.yml
+++ b/.github/workflows/neon-test-base.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   test-base:
+    timeout-minutes: 20
     name: Refresh Neon test-base
     runs-on: ubuntu-latest
     permissions:

--- a/docs/iterations/iter6/GOAL.md
+++ b/docs/iterations/iter6/GOAL.md
@@ -1,0 +1,64 @@
+# GOAL — iter6 清扫战役与 staging 上线
+
+立于 2026-08-03。本文件是本轮工作的验收契约:条件全部满足即 iter6 结束,进入 S2 功能线。
+
+## 一句话
+
+**把 staging 变成一个真实可用、可观测、可回滚的环境,并把支撑它的代码与流水线清理到能长期维护的状态。**
+
+## 完成条件(全部满足才算达成)
+
+### A. staging 真正站起来
+
+- [ ] 四组件全绿部署:catalog+Pulumi ✅ / users ✅ / web ✅ / **root 容器仍失败(#694)**
+- [ ] `/healthz` 返回 200,post-deploy 烟测通过
+- [ ] 匿名聊天走通一次真实对话(Turnstile → 限流 → 配额 → 容器 → Neon)
+- [ ] Neon Auth 登录走通一次(magic link → JWT → edge 验证 → 用户数据)
+- [ ] photo-search 走通一次(含 vision 计量落 daily_usage)
+- [ ] retention cron 在 Workers Cron Triggers 上真跑过一轮(#692 已合,待验证)
+
+### B. 交付链可信
+
+- [ ] 部署不再被静默跳过(#691 已修,须由一次真实部署证实)
+- [ ] 烟测目标 URL 不再硬编码个人子域(#695)
+- [ ] 部署没发生 / cron 失败 / 容器错误率异常 → **有告警**(#678)
+- [ ] 回滚手册可执行(#680),Worker 层秒级止血路径演练过一次
+
+### C. 代码与流水线可维护
+
+- [ ] iter6 Wave 1 全部合并 ✅
+- [ ] Wave 2 十卡合并(B1✅ B2 B3 B4✅ B5 B6 B9 D3 E1 E2)
+- [ ] Wave 3 五卡合并(C1 迁移 / C4 类型收敛含 #663 / C5 Clean Arch / C2 拆分 / C3 docs 瘦身 / L1 lint 全线)
+- [ ] CI-1 per-package pipeline 落地到第 4 步(artifact 契约 + attestation)
+- [ ] 所有 PR 的 robot 线程逐条读判(不是批量 resolve)
+
+### D. 治理落到机器上
+
+- [ ] Pulumi ESC 成为唯一密钥账本(#674 C2/C3)
+- [ ] DB 角色矩阵生效(#685),GRANT 不再是装饰
+- [ ] 依赖规则由 import-linter / oxlint 守卫(#666)
+- [ ] 模型密钥收敛到 MiMo-only(#684,依赖 #656 vision 重设计)
+
+## 不在本轮范围
+
+- production 部署与域名上线(C6:staging 验通后立即做,但属下一轮)
+- S2-S6 功能开发
+- 战术 DDD、turbo、SLSA L3、changesets(均有明确否决理由,见决议册)
+
+## 执行原则
+
+1. **每卡零混入**:纯删除不带重构,重构不带行为变化,迁移不与功能同卡。
+2. **设计先行**:C2/C4/C5/L1/CI-1 已有 owner 批准的设计稿;新的大改同样先出稿再动手。
+3. **机器守卫优于纪律**:任何"以后要记得"的约定,当场变成断言,否则不算完成。
+4. **绿色不等于完成**:部署要看副作用(SHA/端点/日志),不看 run 的颜色。
+5. **PR robot 线程全部处理**:有效则修,无效则记录理由,不留未判定项。
+
+## 当前阻塞
+
+| 阻塞项 | 卡住谁 | 需要谁 |
+|---|---|---|
+| root 容器起不来(#694) | A 全部 | 待诊断(CF Containers 运行时日志) |
+| artifact retention 当前值未知 | CI-1 第 4 步 | **owner** 去 Settings 读一眼 |
+| `sha_pinning_required` 开关 | 安全加固 | **owner** 一次点击 |
+| Pulumi/R2/CF 三组凭证曾贴进对话 | 安全 | **owner** 轮换 |
+| #656 vision 重设计 | #684 密钥收敛 | 设计 + eval |

--- a/docs/iterations/iter6/README.md
+++ b/docs/iterations/iter6/README.md
@@ -20,3 +20,8 @@ Milestone:iter6 — cleanup campaign(#635-#655 + #665 + #666)
 - [decisions-2026-08-03.md](./decisions-2026-08-03.md) — 全域决议册(方法论/secrets/DB/CI-CD/网络/CF-native)
 - [spec-infra-governance.md](./spec-infra-governance.md) — infra 治理 spec(#674,8 卡)
 - [audit-cf-native-v2.md](./audit-cf-native-v2.md) — CF 全目录对照审计
+
+## CI/CD 重构(#679)
+
+- [design-CI-1-pipeline-refactor.md](./design-CI-1-pipeline-refactor.md) — v3 定稿(阶段模型 + 全量 artifact + 依赖图触发)
+- [review-CI-1-fable.md](./review-CI-1-fable.md) — Fable 5 独立评审(7 条必改全部吸收)

--- a/docs/iterations/iter6/design-CI-1-pipeline-refactor.md
+++ b/docs/iterations/iter6/design-CI-1-pipeline-refactor.md
@@ -1,0 +1,175 @@
+# CI-1 — per-package pipeline 重构设计稿 v3 定稿(#679)
+
+底稿:`docs/superpowers/specs/2026-07-29-cicd-rebuild-spec.md` §4/§5/§7;决议册 `docs/iterations/iter6/decisions-2026-08-03.md` §CI/CD。v3 = v2 + Fable 席评审 7 条 [必须修改] 全部落实。本稿数字全部 2026-08-03 实测(分支 `fix/zizmor-cache`,与 `main` 仅差 `_security.yml`)。
+
+## 结论先行
+
+1. **每条 pipeline = stage DAG**:`lint → test → build`(web 加 `e2e-web`;credentialed 另立 `verify`)。stage 间 `needs` 硬边界 + artifact 流动,不在一个 job 里 `&&` 串。
+2. **build-once 是 artifact 契约**,不是约定。deploy 只**消费+校验**,缺失即红、不回落重建。
+3. **artifact 信任根上移到 GitHub 平台**:`actions/attest-build-provenance`(SLSA Build L2)+ 自建 meta.json 并存;镜像**按 digest 部署**,tag 只做人类可读别名。
+4. **依赖图只驱动 push 侧 paths 的 codegen**,不决定"跑不跑";turbo 不引入(量化论证见 §依赖图)。
+5. **merge queue(#671)是本设计的硬前置**,不是并行议题:required context 必须在 `merge_group` 事件下产生,否则启用队列 = 永久阻塞。
+6. **可机检的运维不变量再加三条**:每个 job 必须有 `timeout-minutes`、每个 workflow 必须有顶层 `permissions`、每条 pipeline 必须有 `concurrency` —— 无则 meta-check 红。
+
+## v1/v2 保留项(不重复论证)
+
+gate 层整层删除 · required checks 落在真 job 名上(方案 C)· deploy 独立 workflow 不挂 CI `needs` · `pipeline-quality` 无 filter 做不动点 · `reusable-*`/`pipeline-*`/`deploy-*` 命名 · ruleset 并集法换名零空窗 · #691/#692 的结构解 · hermetic vs credentialed 的 required 边界 · artifact 契约表 7 类产物 · deploy 只认 `push: main` 的 run · turbo 否决的量化论证 · meta-check 不变量族。
+
+## 现状实测(2026-08-03)
+
+| 项 | 实测值 |
+|---|---|
+| workflow 文件 / 带 `runs-on` 的 job | 15 / 40 |
+| 有 `timeout-minutes` 的 job | **2**(仅 `purge-anonymous-sessions.yml`、`purge-anon-quota-counts.yml`)⇒ **38/40 = 95% 无超时** |
+| 有 `concurrency` 的 workflow | 4/15(`ci`、`agent-eval-nightly`、两个 purge) |
+| 有顶层 `permissions` 的 workflow | 13/15,缺 **`codeql.yml`、`dependabot-agent.yml`** |
+| ruleset required contexts | **7 个**(`Web CI`/`Backend CI`/`Agent CI`/`Infra & DB CI`/`Cross-stack E2E`/`Repository Quality`/`Codecov Patch`)—— **v1/v2 写的 "11" 是错的** |
+| ruleset 其它 | `strict_required_status_checks_policy: true`、`allowed_merge_methods: ["rebase"]`、`required_approving_review_count: 0`、`required_linear_history` |
+| merge queue | GraphQL `repository.mergeQueue == null` ⇒ **今天未启用** |
+| `actionlint` | **已存在**(`_security.yml:125`,v1.7.7,curl 下载 tar)—— 评审"缺席"判断有误,改为**归位 + 补 SHA 校验** |
+| `actions/cache` 全仓用量 | **2 处**,均在 `_security.yml:105/120`(zizmor restore + main-only save) |
+| pnpm / uv 缓存 | setup-node `cache: pnpm`(key=`pnpm-lock.yaml`)、setup-uv v9 `prune-cache: true` |
+| Playwright | `@playwright/test ^1.61.1`;`install --with-deps chromium` 在 2 处**每次全量下载,零缓存** |
+| 容器镜像 | `wrangler.toml:128 / 216 / 338`(default/production/staging **三处**)`image = "./Dockerfile"` ⇒ deploy 时构建(v2 写"两处 / :135,:222"已修正) |
+| `CLOUDFLARE_API_TOKEN` | **repo secret 与 staging/production environment secret 同时存在** ⇒ 待办是**删 repo 级**,不是新建 env 级 |
+| artifact retention | `GET /actions/permissions` 只回 `{enabled, allowed_actions, sha_pinning_required:false}`,**无 retention 字段、无 repo 级 REST 端点** ⇒ 只能 owner 去 Settings 看 |
+
+## 阶段模型 · 超时 · concurrency
+
+| stage | 内容 | 目标耗时 | `timeout-minutes` | required |
+|---|---|---|---|---|
+| `lint` | oxlint/ruff + tsc/ty(hermetic) | <90s | **5** | ✅ |
+| `test` | 单测 + hermetic 集成 + coverage | <5min | **12** | ✅ |
+| `build` | 产出可部署 artifact + attest | <4min | **15**(含镜像构建) | ✅ |
+| `e2e-web` | 消费 build artifact 跑浏览器 AC | <6min | **20** | ✅ |
+| `verify` | credentialed(Neon/pulumi/eval-smoke) | — | **30** | ❌ 禁入 |
+| `deploy-*` | 部署 | — | **20** | n/a |
+
+超时取值规则:**目标耗时 ×2,向上取整到 5 的倍数,下限 5**(留 runner 冷启动 + 缓存 miss 的余量;比目标紧会把缓存 miss 误判成故障)。
+
+concurrency group 命名规则(全仓唯一,meta 可派生):
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.merge_group.head_ref || github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+```
+
+- PR 侧 `cancel-in-progress: true`(连推即取消旧 run);`push: main` / `merge_group` / `deploy-*` 一律 **false**(取消队列内 run = 队列卡死;取消部署 = 半部署态)。
+- `github.workflow` 天然按 pipeline 隔离,9 条 pipeline 互不抢占;`merge_group.head_ref` 保证同一 PR 的 PR-run 与队列 run **不同组**(同组会互相取消)。
+
+新增 meta-check(`pipeline-quality / meta`,全部 fail-fast 红):
+
+| 断言 | 规则 |
+|---|---|
+| `assert-every-job-has-timeout` | 解析全部 `.github/workflows/*.yml`,任一含 `runs-on` 的 job 缺 `timeout-minutes` ⇒ 红 |
+| `assert-workflow-default-permissions` | 每个 workflow 必须有顶层 `permissions:` 块(最小 `contents: read`)⇒ 覆盖今天缺的 `codeql.yml`/`dependabot-agent.yml` |
+| `assert-concurrency-present` | 每条 `pipeline-*.yml`/`deploy-*.yml` 必须声明 `concurrency`,且 group 表达式逐字等于上面的模板 |
+| `assert-merge-group-trigger` | 每个产出 required context 的 workflow 必须含 `on: merge_group`(见下节) |
+
+## merge queue(#671)× required check 的事件矩阵
+
+**失效模式**:required context 若不能在 `merge_group` 事件下产生,PR 进队后队列等一个永不出现的 check ⇒ 永久阻塞、需人工解队。26 个 stage 级 context 把这个风险放大 26 倍。
+
+| workflow 类 | `pull_request` | `merge_group` | `push: main` | `schedule` | 说明 |
+|---|---|---|---|---|---|
+| `pipeline-*`(9 条,hermetic) | ✅ 无 paths 过滤 | ✅ **必须**,`branches: [main]` | ✅ 带 codegen paths | — | PR 侧与队列侧行为必须逐字一致 |
+| `pipeline-quality` | ✅ | ✅ | ✅ | — | 不动点,永远无过滤 |
+| `verify`(credentialed) | ❌(fork 无 secret) | ❌ | ✅ | — | 非 required,不入队列语义 |
+| `deploy-*` | ❌ | ❌ | ✅ | — | 队列合并落 main 后由 push 触发 |
+| `agent-eval-nightly` / purge | ❌ | ❌ | ❌ | ✅ | 与 required set 无关 |
+
+**关键平台约束**:`on: merge_group` **只支持 `branches` 过滤,不支持 `paths`**。这与 v1「PR 侧不做 paths 过滤」的决定天然相容 —— 队列侧同样全量跑,PR 绿 = 队列绿,无第二套语义。(此条列入下面的 pre-flight 逐项实测。)
+
+**启用前检查清单(#671 拍板前逐条打勾,任一未过不得开队列)**:
+
+1. `pipeline-*.yml` 9 条全部含 `on: merge_group: branches: [main]`,且 `merge_group` 与 `pull_request` 走同一 `reusable-stage-*.yml`(避免两套逻辑漂移)。
+2. `ruleset-sync.sh --check` 在 merge_group 名义下派生的 context 名与 PR 名义下**逐字相同**(job name 不含事件相关表达式)。
+3. 关闭 `strict_required_status_checks_policy`(现为 `true`):队列本身就在合并结果上跑 check,"require branches up to date" 与队列语义重复且会制造多余 rerun。
+4. `allowed_merge_methods` 现为 `["rebase"]` —— 与 `required_linear_history` 一致,队列 merge method 必须同选 rebase。
+5. **SHA 语义实测**:`merge_group` 下 `github.sha` = 队列临时合并提交,`github.event.merge_group.head_sha` = PR 头。artifact 命名与 deploy 侧 `gh run list --commit` 的绑定 SHA 必须取**最终落 main 的那个**;rebase 队列下二者是否相等**必须实测一次**(不等则 deploy 查不到 artifact run ⇒ 全红)。
+6. 缓存 save 的 `github.event_name == 'push'` 守卫在 merge_group 下自动为假 —— 已是期望行为,无需改,但写进注释防后人"修复"。
+7. 首次开队列先只挂 `pipeline-quality` 一个 context 跑 3 个 PR,确认不卡,再并集法加满 26 个。
+
+## required set:逐 stage 26 个,以及被否决的标准解
+
+**承认标准解存在**:业界主流是「每 pipeline 一个 `if: always()` 汇总 job,显式断言 `needs.*.result == 'success'`」,ruleset 只挂 ~9 个 context,merge-queue 友好,断言写对后对 skip 同样免疫。**这是被否决的标准解,不是不存在的解。**
+
+**否决理由(诚实版)**:不是"业界没有",而是 ①#691 的病因正是"把判定藏进 job 内部表达式" —— 汇总 job 把 26 个 stage 的通过与否压缩成一条手写布尔表达式,漏写一个 `needs` 就静默放行,与 #691 同族;②该表达式无法被外部机检(ruleset 只看 context 名,看不到断言内容),而逐 stage 方案的正确性由 `needs-closure-subset-of-required` **可机检**;③本仓库刚吃过两次"表达式写错 = 静默绿"的亏,信任预算已用尽。代价是 ruleset 条目从 7 涨到 ≈26,由 `ruleset-sync.sh` 机器维护,人不手改。
+
+## 缓存策略(v3 新增整节)
+
+拆 stage 后 install 次数 ×3~4,缓存从优化变成时长预算的前提。
+
+| 缓存 | 键 | 失效边界 | 读写模式 |
+|---|---|---|---|
+| pnpm store | 现有 setup-node `cache: pnpm`,key=`pnpm-lock.yaml` | lockfile 变更 | 读写(见下面安全边界) |
+| uv | setup-uv v9 内建,key=`uv.lock` | lockfile 变更 | 读写 |
+| **Playwright browsers**(新) | `playwright-${{ runner.os }}-1.61.1`(版本从 `e2e/package.json` 读出,不手写) | `@playwright/test` 版本号 | 读写;命中则跳过 `install --with-deps`,miss 才装 |
+| **Docker layer**(新) | `docker/build-push-action` + `cache-from/to: type=gha,mode=max` | `Dockerfile` + `uv.lock` + `apps/agent/**` | **restore-only + main-only save** |
+| zizmor 审计缓存 | 已落地:`zizmor-${{ runner.os }}-${{ hashFiles('.github/workflows/*.yml','.github/actions/**') }}` | 任一 workflow/action 变更 | restore-only + main-only save |
+
+**通用规则(从 `fix/zizmor-cache` 的实测提炼,写进模板注释)**:
+
+> 凡其产物能到达 release/deploy 路径的 workflow,**只允许 `actions/cache/restore`**;`actions/cache/save` 必须带 `if: github.ref == 'refs/heads/main' && github.event_name == 'push'`。理由:zizmor 的 cache-poisoning 审计会拒绝这类 workflow 里的读写 cache —— fork PR 能写共享 cache 就能污染发布物。restore-only 保留全部提速,写权限只留给可信的 main 分支 run。
+
+边界说明:zizmor 的启发式按"是否有 release/tag/publish 触发"判定。`pipeline-*.yml`(`pull_request`/`merge_group`/`push`)今天不触发该审计,故 pnpm/uv 的内建读写缓存可留;**一旦 build stage 挂上 attestation/镜像推送而被判为 release-reach,立刻按上述规则降级**,不得用 `# zizmor: ignore` 抑制(仓库禁 suppression)。`deploy-*.yml` 一律**零 cache**。
+
+lint stage 若要守 90s,评估 `pnpm install --filter <pkg>...` 局部安装(实测项,不达标则放宽 lint 目标到 120s / timeout 5min 不变)。
+
+## artifact 出处证明与镜像 digest
+
+**attestation(新增,SLSA Build L2)**:每个 `build` stage 在上传前加一步 `actions/attest-build-provenance`(bundle 用 `subject-path`,镜像用 `subject-digest`),job 加 `permissions: { id-token: write, attestations: write, contents: read }`;deploy 侧 `gh attestation verify <artifact> --repo <owner>/<repo>` 通过才继续。
+
+**信任根差异(必须写清)**:自建 `.artifact-meta.json` 的签发者是**写它的那个 workflow 自己** —— 能改 workflow 的人就能改 meta,防的是"手滑/漂移",不是"篡改"。attestation 的签发者是 **GitHub 的 OIDC + Sigstore 透明日志**,workflow 作者伪造不了,防的是"产物被替换"。**二者并存**:meta.json 继续承担 commit 绑定与文件级 sha256 的自检(缺失即红,不回落),attestation 承担外部可验证的出处。不上 slsa-github-generator 冲 **L3**:L3 要求隔离的、非作者可控的构建服务,收益是"防仓库管理员本人",本仓单人、无多方信任需求 ⇒ **L2 + digest 是本项目的合理停点(已考虑,主动放弃)**。
+
+**镜像按 digest 部署(单向切换)**:v2 只把 digest 记进 deployment record —— 记录 ≠ 约束,tag 仍可变。v3 改为 `wrangler.toml` 的 `image` 逐字引用 digest,prod/staging 一致性从"事后比对"变成"构造性成立"。
+
+平台事实(Cloudflare 官方文档实测):CF Containers 支持的镜像来源是 **`registry.cloudflare.com`、Docker Hub、Amazon ECR、Google Artifact Registry** —— **GHCR 不在列**,故评审"安全维度倾向 GHCR"对**容器镜像不可行**(GHCR 仍可用于非容器产物)。官方全部示例均为 `<ref>:<TAG>` 形式,**未见 `@sha256:` digest 示例**。
+
+⇒ **spike(阻塞 5.5 步)**:①`image = "registry.cloudflare.com/<acct>/animichi-agent@sha256:<digest>"` 是否被 wrangler 接受并成功拉取;②不接受时的退路 = **不可变 tag 约定**(`sha-<40位>` 永不覆写)+ deploy 前 `wrangler containers images list` 解析 digest 并与 attestation subject 比对,不一致即红(弱一档,但仍构造性阻断)。③`wrangler containers build -p -t sha-<sha>` 在 CI 里推送、`wrangler deploy` 不重建 —— 与 `--no-bundle` spike(5.6)同一个 PR 验。
+
+## 权限与凭证收敛
+
+| 项 | v3 规则 |
+|---|---|
+| workflow 顶层默认 | 每个 workflow 必须写 `permissions: { contents: read }`(或更小),job 级按需加 —— 由 `assert-workflow-default-permissions` 机检,覆盖今天缺的 2 个文件 |
+| `build` stage | `+ id-token: write, attestations: write` |
+| `resolve-artifacts` | `actions: read, contents: read`(跨 run 下载的最小集) |
+| CF token | **删除 repo 级 `CLOUDFLARE_API_TOKEN`**,只保留 staging/production environment secret(两者今天并存;job 已声明 `environment:`,env 级会覆盖,删 repo 级零风险且封死"忘写 environment 就拿到 prod token"的面) |
+| reusable workflow | 显式 `secrets:` 传参,**禁 `secrets: inherit`** |
+| OIDC | **Cloudflare API 不支持 GHA OIDC 联邦(无官方 audience)⇒ 长期 token 是平台约束,不是本设计的缺陷。**能做的收敛只有:environment 作用域 + production 环境的 reviewer 保护 + 定期轮换 |
+| 触发面 | hermetic pipeline 一律 `pull_request`(禁 `pull_request_target`),写成 meta 断言 |
+| 免费加固 | `actions/permissions` 实测 `sha_pinning_required: false`,而仓库已 100% SHA-pin ⇒ **打开该开关零成本**(顺手项) |
+
+**actionlint 归位**:zizmor 管安全不管语法(表达式拼写、shellcheck、`needs` 引用错)。actionlint **已在 `_security.yml:125`**,v3 只做三件事:①随 `_security.yml` 整体迁入 `pipeline-quality / static`,与 zizmor 并列为两个独立 required context;②当前用 curl 下载 tar **未校验 checksum**,改为 pin 版本 + `sha256sum -c`;③新增 26 个 stage job 后,actionlint 是唯一能抓 `needs:` 拼写错的工具 —— 它红 = 阻塞,不得降级为 warning。
+
+**changesets/changelog 明确不做**:持续部署、无版本化发布物、无外部消费者、单人仓 ⇒ changesets 的收益(变更聚合 + 版本协商)在此处无接收方。写在这里以免下轮评审重问。
+
+## 落地顺序(ROI 降序,吸收评审 7 步)
+
+| # | 内容 | 估时 | 备注 |
+|---|---|---|---|
+| 1 | `timeout-minutes` + `concurrency` + 顶层 `permissions` 三件套 + 三条 meta 断言 | 半天 | 模板级,立刻覆盖 38/40 个裸奔 job;**独立于其余全部改动,可先合** |
+| 2 | Playwright browser 缓存 + actionlint 归位/校验和 + 删 repo 级 CF token + 打开 `sha_pinning_required` | 半天 | 每 PR 都省;无架构耦合 |
+| 3 | 阶段拆分 spike(v2 步骤 1.5),同期移除 `ci.yml:67` 的 `dorny/paths-filter` | 2 天 | 先量真实 stage 耗时,校准第 1 步的 timeout |
+| 4 | artifact 契约 + `attest-build-provenance` **同一个 PR 落地** | 2 天 | 分两期会让 meta.json 先固化成事实标准 |
+| 5 | 镜像 digest 化(并入 5.5)+ `--no-bundle` spike(5.6) | 2 天 | 单向切换,先在 staging 真部署一次 |
+| 6 | merge-group 触发 + 启用前 7 项检查清单 | 1 天 | **#671 拍板前必须完成**,阻塞项 |
+| 7 | Docker layer 缓存(restore-only)、SBOM(`buildx --sbom`)、Logfire CI 指标 | 收尾 | flake 判定数据源 = junit retry 记录 |
+
+## 待 owner 裁决
+
+1. required set **7 → ≈26**(机器维护)—— 接受否?退化选项(每 pipeline 只留 `lint` + 终端 stage)会重开"skipped 判过"的缝。
+2. **artifact retention 当前值:REST API 不暴露,需 owner 亲自去 Settings → Actions → Artifact and log retention 读数并回填**。若 <14 天,契约表的保留期不成立。(评审建议 PR 侧 14d→7d 省配额,一并定。)
+3. 容器 registry:GHCR 已被平台事实排除 ⇒ 在 **CF managed registry**(零额外凭证,`wrangler containers push`)与 **GAR/ECR**(多一个凭证面)间选。默认建议 CF managed。
+4. **`image` → digest 是单向切换**:改回 `./Dockerfile` 需重推镜像并重新部署,无平滑回滚。批准单独一个 PR、staging 先跑通再合?
+5. 5.6 `--no-bundle` spike 失败时,是否接受降级到"重建 + bundle sha256 比对"。
+6. #671 merge queue 与本设计**同车**(推荐:第 6 步与 #671 拍板绑定),还是先冻结 required set 再开队列?
+7. v1 遗留 4 条(contract/quality 两条 delta、方案 C、`pipeline-maintenance` 依赖 #692)**未撤销**,仍待签核。
+
+---
+**v2→v3 变更说明**
+① 落实评审 7 条 [必须修改]:新增 merge_group 事件矩阵 + 7 项启用前检查清单、每 stage `timeout-minutes`/`concurrency` 规则 + 三条 meta 断言、`attest-build-provenance`(L2,含与自建 meta.json 的信任根对比)、镜像按 digest 部署 + spike 与退路、**缓存策略整节**(含从 `fix/zizmor-cache` 提炼的 restore-only + main-only save 通用规则)、actionlint 归位、CF token 收敛到 environment secret + 顶层默认 `permissions`。
+② 修正 v2 的三处事实错误:required contexts 是 **7 个非 11**;`wrangler.toml` 的 `image = "./Dockerfile"` 是 **三处(128/216/338)非两处**;actionlint **已存在**(评审"缺席"亦有误)。新增实测:95% 的 job 无超时、CF token repo+env 并存、merge queue 未启用、retention 无 REST 端点、**GHCR 不被 CF Containers 支持**(推翻评审的 GHCR 建议)。
+③ 补齐评审要求的显式表态:承认"汇总 job"是**被否决的标准解**并给出否决理由(#691 同族 + 不可机检);写明 Cloudflare 不支持 GHA OIDC 联邦 ⇒ 长期 token 是平台约束;写明 SLSA L3 与 changesets 在单人仓不适用的理由。

--- a/docs/iterations/iter6/review-CI-1-fable.md
+++ b/docs/iterations/iter6/review-CI-1-fable.md
@@ -1,0 +1,71 @@
+# CI-1 v2 评审 — Fable 席(独立)2026-08-03
+
+依据实测:repo 已有 SHA-pin(全部 `uses:` 带 40 位 SHA+版本注释)、zizmor(`_security.yml:78`)、dependabot.yml、pnpm 缓存(`.github/actions/setup` 经 setup-node `cache: pnpm`)、uv 缓存(setup-uv v9);**全 repo 仅 2 个 cron workflow 有 `timeout-minutes`**,Playwright 每次 `install --with-deps`,actionlint 缺席。
+
+## 1. 阶段模型
+
+- [可接受] `lint→test→build(→e2e-web)` + `needs` 硬边界符合 GHA 成熟范式;`prepare/package` 独立 stage 在 7 包 3 依赖边规模下是过度仪式,不设是对的。`verify` 与 hermetic 的隔离(secrets 禁入 required)做对了,这正是 GitHub fork-PR hardening 的推荐切法。
+- [建议] required 26 个逐 stage vs 业界主流的「每 pipeline 一个 `if: always()` 汇总 job 显式断言 `needs.*.result == 'success'`」:后者 ruleset 只挂 ~9 个 check、merge-queue 友好,且写对断言后对 skip 同样免疫。v2 因 #691 创伤选逐 stage + 脚本同步,soundness 论证成立,可接受;但请在文中承认汇总 job 是**被否决的标准解而非不存在的解**——否决理由应是「不再信任 needs 语义」而非「业界没有」。
+- [必须修改] **merge queue(#671)与 26 个 required check 的交互未提**:一旦启用 merge queue,所有 required context 必须在 `merge_group` 事件上产生,否则队列永久阻塞。9 条 pipeline 都要加 `on: merge_group` 或明确 #671 与本设计互斥先后。这是已知裁决项的硬依赖,不能留白。
+- [必须修改] 9 个新 workflow 各自需要 `concurrency: { group: pipeline-<pkg>-${{ github.ref }}, cancel-in-progress: <PR侧 true> }` 与每 job `timeout-minutes`(现状全仓几乎为零)。stage 表里已写目标耗时,直接落成 timeout(目标×2)。GitHub hardening 指南与 well-architected workflow 基线双双要求。
+- [建议] 9 份 pipeline YAML 会复制同一 stage 骨架 → 用 `reusable-stage-*.yml` 承载 lint/test/build 逻辑、pipeline 文件只留触发+paths+参数,防 9 处漂移(v1 命名已预留 `reusable-*`,用起来)。
+
+## 2. artifact 契约(SLSA 差距)
+
+- [可接受] meta.json + sha256 + commit 绑定 + 缺失即红不回落:自建校验做得扎实,「回落开关会在最需要时失效」的判断正确。
+- [必须修改] **缺 GitHub 原生 attestation**:`actions/attest-build-provenance` 对 bundle/镜像各加 1 step,deploy 侧 `gh attestation verify`,即达 **SLSA Build L2**(hosted runner + 平台签名,底层就是 sigstore)。自建 meta.json 的信任根是「写它的 workflow 自己」,attestation 的信任根是 GitHub 平台——这正是 owner 要的 best practice,且成本≈零。需要 `permissions: id-token: write, attestations: write`。
+- [必须修改] **镜像按 digest 部署,不按 tag**:v2 只「记录」digest 进 deployment record,但 `wrangler.toml` 仍引用 tag——tag 可变,记录≠约束。build 后解析 `sha-<sha>` → digest,deploy 逐字引用 `@sha256:…`。prod/staging digest 一致性检查随之从「事后比对」变「构造性成立」。
+- [建议] SBOM:镜像用 `docker buildx --sbom=true`(或 anchore/sbom-action)、attest 为 SBOM attestation;JS 侧 pnpm lockfile 已是事实 SBOM,不必另造。
+- [可接受] 不上 slsa-github-generator 冲 L3:solo 项目、无多方信任需求,L2+digest 是本项目的合理停点——但把这句判断写进文档,别留「没考虑过」的观感。
+- [建议] 保留期:PR 14d 偏长(排障窗口实际 ≤3d),PR 侧 7d 可省配额;Playwright 7d 合理。
+
+## 3. 依赖图/触发
+
+- [可接受,做对了] 三方案对比诚实;turbo 否决理由(3 条边、6/7 无 build、fork 拿不到远程缓存 token)+ 量化重开条件,是模范级 honest evaluation。dorny/paths-filter 因 #691 否决也成立——注意 **repo 现状 ci.yml:67 还在用它**,迁移步骤里应有「移除 dorny」的显式项。
+- [可接受] codegen paths 提交进仓 + meta 双向断言:业界无此成品工具,但「生成静态配置+CI 断言不漂移」与 GitHub 官方对 `paths` 静态性的约束相容,比运行时 filter 更符合本仓库的失效历史。
+- [建议] `derive-paths.mjs` 的全局项要断言完整:`pnpm-lock.yaml`、`pnpm-workspace.yaml`、`.github/actions/**`、`.github/scripts/**`、各包 `package.json` 必须进每条相关 pipeline 的 paths;extraPaths 表本身要有测试(改表忘 regen 也得红)。
+
+## 4. 缓存策略(v2 整节缺失 → [必须修改])
+
+拆 stage 后 install 次数 ×3~4,缓存从锦上添花变成时长预算的前提。文档必须补一节:
+- pnpm store:已有(setup-node `cache: pnpm`,key=pnpm-lock.yaml)——写明沿用即可;
+- uv:已有(setup-uv 内建,key=uv.lock)——沿用;
+- **Playwright browsers:现状每次全量下载**。`actions/cache` path `~/.cache/ms-playwright`,key=`playwright-${{ runner.os }}-<@playwright/test 版本>`,miss 才 `install --with-deps`(Playwright 官方 CI 文档的标准做法),`e2e-web` 与 quality/e2e 两处受益;
+- **Docker layer**:镜像改在 CI 构建后,`docker/build-push-action` + `cache-from/to: type=gha,mode=max`(或 registry cache)。失效边界=Dockerfile+uv.lock;
+- lint stage 若只跑 oxlint/ruff+tsc,评估 `pnpm install --filter` 局部安装以守 90s 目标。
+
+## 5. 安全与权限
+
+- [可接受,做对了] SHA-pin 全覆盖、per-job permissions、zizmor 在库、`resolve-artifacts` 最小权限、deploy 只认 `push: main` 的 run + commit/repo 绑定——最后一条正好封死 GHSA 反复告警的 artifact-poisoning 面。
+- [可接受] OIDC:Cloudflare API 不支持 GHA OIDC 联邦(无官方 audience),长期 token 是平台约束非设计缺陷——但 [必须修改] token 必须放 **environment secret**(production 环境带 reviewer 保护),不能是 repo secret;文档应写明这条边界与理由。
+- [建议] registry 裁决(待裁决 3)安全维度倾向 **GHCR**:`GITHUB_TOKEN` 的 `packages: write` 即推即拉,零长期凭证;CF managed registry 则多一个 token 面。
+- [建议] reusable workflow 用显式 `secrets:` 传递,禁 `secrets: inherit`(GitHub hardening 指南);hermetic pipeline 全部仅 `on: pull_request`(非 `pull_request_target`)——现状如此,新架构写成 meta 断言。
+- [必须修改] workflow 级默认 `permissions: {}` 或 `contents: read`,job 级按需加——26 个 job 手写易漏,并入 zizmor 已查的项即可,但 pipeline-*.yml 模板要带默认块。
+
+## 6. 可观测性
+
+- [可接受,做对了] junit→job summary、`if: failure()` 传全量 trace、非空 testsuite 断言(直接治「rtk 伪绿」教训)——把今天 zero-artifact 的实测痛点全部覆盖。
+- [建议] CI 指标:repo 已有 Logfire,用 OTel CI 导出(如 `otel-cicd-action`)或每周 scheduled job 拉 `gh api runs` 算时长/失败率/flake 率进 Logfire dashboard——比引入第三方 CI 分析 SaaS 更贴本仓库既有栈。flake 判定数据源=junit 里的 retry 记录,Playwright `retries` 配置需同步声明。
+- [建议] oxlint/ruff 输出接 GitHub problem matcher / SARIF,红时 PR 内联 annotation,省一次点进日志。
+
+## 7. 遗漏项清单
+
+- [必须修改] `actionlint` 缺席:zizmor 管安全不管正确性(表达式拼写、shellcheck、needs 引用错)。加进 `pipeline-quality / static`,与 zizmor 并列。
+- [必须修改] concurrency + timeout-minutes(见 §1)。
+- [可接受] changelog/changesets 不做:持续部署、无版本化发布物、solo 仓,changesets 无消费者——理由成立,建议在文档写一句免得下轮评审再问。
+- [可接受] dependabot 已有;确认 `github-actions` ecosystem 覆盖新增 action(attest/build-push/cache)即可。
+- [建议] matrix:4 条无差别 Worker pipeline(users/edge/maintenance/catalog-hermetic 部分)可在 reusable-stage 内用 matrix 参数化,但 required check 名要稳定(`pipeline-users / build` 形态),msg:matrix 展开名含参数,验证 ruleset-sync 派生逻辑能处理再用。
+- [做对了] meta-check 自覆盖面(ruleset-sync --check、paths-match-dependency-graph、needs-closure-subset-of-required、assert-tests-are-unfiltered)是本稿最强的部分,业界罕见有人把 CI 的不变量写成机检。
+
+## 总评
+
+**若全部采纳**:九条 per-package stage-DAG pipeline(lint/test/build/e2e,reusable-stage 骨架 + codegen paths + 机检不变量),build 产物经 GitHub 原生 attestation 签名、按 digest 单向流入 deploy,凭证收敛到 environment secrets,全链 concurrency/timeout/缓存齐备,指标进 Logfire——SLSA L2、GitHub hardening 清单全绿的单人仓 CI。
+
+**落地顺序(投入产出比降序)**:
+1. timeout-minutes + concurrency + workflow 默认 permissions(半天,模板级);
+2. Playwright browser 缓存 + actionlint(半天,每 PR 都省);
+3. 阶段拆分 spike(v2 步骤 1.5,原案);
+4. artifact 契约 + attest-build-provenance 一起落(增量一个 step,别分两期);
+5. digest 化镜像引用(并入 v2 步骤 5.5,同一个 PR);
+6. merge-group 触发裁决(在 #671 拍板前完成,阻塞项);
+7. Docker layer 缓存、SBOM、Logfire CI 指标(收尾)。


### PR DESCRIPTION
本 PR 含三块,按 owner 指示合并为一个:

## 1. zizmor 联网审计缓存(起因)
今天四次红灯全是 zizmor 的 impostor-commit 审计撞 GitHub API 502——它把我们的 CI 可用性变成了上游 API 的可用性。改为版本钉死的 CLI + 内容键缓存;因官方 action 在 Docker 容器内运行(HOME 与 runner 无关)且不透传 `--cache-dir`,无法只加 actions/cache。
按 zizmor 自己的 cache-poisoning 审计整改了两轮:**restore-only + main-only save**(缓存只有一个可信写入者)、关闭 setup-uv 自带读写缓存。全树扫描零发现。

## 2. CI-1 v3 设计定稿 + Fable 5 评审入库
`docs/iterations/iter6/design-CI-1-pipeline-refactor.md`(v3:阶段模型 lint→test→build、全量 artifact 契约、依赖图驱动触发、merge queue 事件矩阵、attestation/SLSA L2)与 `review-CI-1-fable.md`(7 条必改全部吸收)。
v3 实测推翻五处既有认知:CF Containers 不支持 GHCR、actionlint 早已在库(真缺口是无 sha256 校验)、required contexts 是 7 个不是 11、CF token 已是 environment secret(待办是删 repo 级副本)、`image = "./Dockerfile"` 是三处。

## 3. 评审第一步落地(ROI 最高的两项)
- **timeout-minutes:59 个 job 从 2 个有超时补到 100%**。无超时 = 继承 6 小时默认,卡死时看起来像还在跑。按 job 性质分档(gate 5 / 静态分析 15 / 常规 CI 20 / 部署与 e2e 30 / 模型 eval 45),各留 2-3 倍余量。
- **顶层最小权限 + concurrency**:codeql.yml 与 dependabot-agent.yml 补顶层 `contents: read`(此前只有 job 级,新增 job 会静默继承仓库默认);ci.yml 补顶层 concurrency(PR 取消旧 run、main 排队不取消,部署不被腰斩)。副产品:两处 zizmor suppression 变得不必要(7→5)。
- 顺带修 deploy.yml 的 `cache: ""`——它其实是 opt-in 写法,且原有的 `zizmor: ignore` 挂错了行(发现锚点在部署步骤);本仓库禁 suppression,删掉该 key 才是诚实修法。

验证:actionlint 全绿、zizmor 全树零发现、dependabot pin 守卫 OK、258 worker 测试、11 个 CI 相关 Python 守卫测试全绿。

Refs #679