### PR TITLE
test(iter6 E2): map browser specs — first-tile budget, empty tiles, R2 fallback (#650)

### DIFF
--- a/e2e/fixtures/map-spike.ts
+++ b/e2e/fixtures/map-spike.ts
@@ -24,13 +24,20 @@ const fulfillSpritePng = (route: Route) => route.fulfill({
   status: 200,
 });
 
-const fulfillEmptyGlyphs = (route: Route) => route.fulfill({ body: Buffer.alloc(0), status: 204 });
+const fulfillEmptyAsset = (route: Route) => route.fulfill({ status: 204 });
 
 export const routeRenderedMap = async (page: Page): Promise<void> => {
   await page.route("**/tiles/**/*.mvt", fulfillEarthTile);
   await page.route("**/tiles/sprites/v4/light*.json", fulfillSpriteJson);
   await page.route("**/tiles/sprites/v4/light*.png", fulfillSpritePng);
-  await page.route("**/tiles/fonts/**/*.pbf", fulfillEmptyGlyphs);
+  await page.route("**/tiles/fonts/**/*.pbf", fulfillEmptyAsset);
+};
+
+export const routeEmptyMap = async (page: Page): Promise<void> => {
+  await page.route("**/tiles/**/*.mvt", fulfillEmptyAsset);
+  await page.route("**/tiles/sprites/v4/light*.json", fulfillSpriteJson);
+  await page.route("**/tiles/sprites/v4/light*.png", fulfillSpritePng);
+  await page.route("**/tiles/fonts/**/*.pbf", fulfillEmptyAsset);
 };
 
 export interface MapFrame {

--- a/e2e/fixtures/map-spike.ts
+++ b/e2e/fixtures/map-spike.ts
@@ -1,0 +1,78 @@
+import type { Page, Route } from "@playwright/test";
+
+const EARTH_VECTOR_TILE = Buffer.from("GiB4AgoFZWFydGgSEhgDIg4JAAAagEAAAIBA/z8ADyiAIA==", "base64");
+const EMPTY_SPRITE_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+
+const fulfillEarthTile = (route: Route) => route.fulfill({
+  body: EARTH_VECTOR_TILE,
+  contentType: "application/vnd.mapbox-vector-tile",
+  status: 200,
+});
+
+const fulfillSpriteJson = (route: Route) => route.fulfill({
+  body: "{}",
+  contentType: "application/json",
+  status: 200,
+});
+
+const fulfillSpritePng = (route: Route) => route.fulfill({
+  body: EMPTY_SPRITE_PNG,
+  contentType: "image/png",
+  status: 200,
+});
+
+const fulfillEmptyGlyphs = (route: Route) => route.fulfill({ body: Buffer.alloc(0), status: 204 });
+
+export const routeRenderedMap = async (page: Page): Promise<void> => {
+  await page.route("**/tiles/**/*.mvt", fulfillEarthTile);
+  await page.route("**/tiles/sprites/v4/light*.json", fulfillSpriteJson);
+  await page.route("**/tiles/sprites/v4/light*.png", fulfillSpritePng);
+  await page.route("**/tiles/fonts/**/*.pbf", fulfillEmptyGlyphs);
+};
+
+export interface MapFrame {
+  readonly backgroundPixels: number;
+  readonly earthPixels: number;
+  readonly renderer: string;
+  readonly sampledPixels: number;
+}
+
+const captureMapColors = async (page: Page): Promise<number[][]> => {
+  const screenshot = await page.locator(".map-spike__gl").screenshot();
+  return page.evaluate(async (encoded) => {
+    const image = new Image();
+    image.src = `data:image/png;base64,${encoded}`;
+    await image.decode();
+    const surface = document.createElement("canvas");
+    [surface.width, surface.height] = [image.width, image.height];
+    const context = surface.getContext("2d");
+    if (context === null) return [];
+    context.drawImage(image, 0, 0);
+    return [0.2, 0.5, 0.8].flatMap((x) => [0.2, 0.5, 0.8].map((y) => [...context.getImageData(Math.floor(image.width * x), Math.floor(image.height * y), 1, 1).data]));
+  }, screenshot.toString("base64"));
+};
+
+const readRenderer = (page: Page): Promise<string> => page.evaluate(() => {
+  const canvas = document.querySelector<HTMLCanvasElement>(".maplibregl-canvas");
+  const gl = canvas?.getContext("webgl2") ?? canvas?.getContext("webgl");
+  if (gl === null || gl === undefined) return "";
+  const rendererInfo = gl.getExtension("WEBGL_debug_renderer_info");
+  return rendererInfo === null ? String(gl.getParameter(gl.RENDERER)) : String(gl.getParameter(rendererInfo.UNMASKED_RENDERER_WEBGL));
+});
+
+const countColor = (colors: readonly number[][], target: readonly number[]): number => {
+  return colors.filter((color) => color.every((value, index) => Math.abs(value - (target.at(index) ?? Number.NaN)) <= 1)).length;
+};
+
+export const readMapFrame = async (page: Page): Promise<MapFrame> => {
+  const colors = await captureMapColors(page);
+  return {
+    backgroundPixels: countColor(colors, [248, 248, 240, 255]),
+    earthPixels: countColor(colors, [226, 223, 218, 255]),
+    renderer: await readRenderer(page),
+    sampledPixels: colors.length,
+  };
+};

--- a/e2e/fixtures/map-spike.ts
+++ b/e2e/fixtures/map-spike.ts
@@ -40,6 +40,10 @@ export const routeEmptyMap = async (page: Page): Promise<void> => {
   await page.route("**/tiles/fonts/**/*.pbf", fulfillEmptyAsset);
 };
 
+export const routeTileOutage = async (page: Page, status: 404 | 500): Promise<void> => {
+  await page.route("**/tiles/**", (route) => route.fulfill({ body: "tile outage", status }));
+};
+
 export interface MapFrame {
   readonly backgroundPixels: number;
   readonly earthPixels: number;

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,7 @@
     "test": "playwright test",
     "test:headed": "playwright test --headed",
     "test:web": "playwright test web-404.spec.ts web-chat-error-states.spec.ts web-chat-anonymous.spec.ts web-chat-save-login-wall.spec.ts web-splash.spec.ts",
-    "test:perf-mobile-cold": "playwright test web-splash.spec.ts"
+    "test:perf-mobile-cold": "playwright test web-splash.spec.ts web-map-spike.spec.ts --grep @perf-mobile-cold"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1"

--- a/e2e/web-map-spike.spec.ts
+++ b/e2e/web-map-spike.spec.ts
@@ -28,7 +28,7 @@ async function applyPerfMobileCold(page: Page): Promise<void> {
   await client.send("Emulation.setCPUThrottlingRate", { rate: 4 });
 }
 
-test("first real map tile paints within 3s under perf-mobile-cold", async ({ page }) => {
+test("first real map tile paints within 3s under perf-mobile-cold", { tag: "@perf-mobile-cold" }, async ({ page }) => {
   await routeRenderedMap(page);
   await applyPerfMobileCold(page);
   const startedAt = performance.now();

--- a/e2e/web-map-spike.spec.ts
+++ b/e2e/web-map-spike.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { readMapFrame, routeEmptyMap, routeRenderedMap } from "./fixtures/map-spike";
+import { readMapFrame, routeEmptyMap, routeRenderedMap, routeTileOutage } from "./fixtures/map-spike";
 
 const FIRST_TILE_BUDGET_MS = 3_000;
 const PROFILE = {
@@ -59,4 +59,33 @@ test("out-of-bounds 204 tiles paint only the plain background", async ({ page })
   expect(frame.backgroundPixels).toBe(frame.sampledPixels);
   expect(frame.earthPixels).toBe(0);
   console.info(`[map-spike] out-of-bounds-background elapsed_ms=${elapsedMs.toFixed(1)}`);
+});
+
+async function expectIllustrationFallback(page: Page, status: 404 | 500): Promise<void> {
+  await routeTileOutage(page, status);
+  const failedAsset = page.waitForResponse((response) => response.url().includes("/tiles/"));
+  const startedAt = performance.now();
+  await page.goto("/map-spike?source=worker", { waitUntil: "commit" });
+  const response = await failedAsset;
+  const stage = page.locator(".map-spike__stage");
+  await expect(stage).toHaveAttribute("data-status", "fallback");
+  const elapsedMs = performance.now() - startedAt;
+  const illustration = stage.getByRole("img", { name: "宇治エリアの巡礼ルート図" });
+  await expect(illustration).toBeVisible();
+  await expect(illustration.locator("polyline")).toHaveCount(1);
+  await expect(illustration.locator("circle")).toHaveCount(5);
+  await expect(stage.locator(".maplibregl-canvas")).toHaveCount(0);
+  const box = await illustration.boundingBox();
+  expect(box?.width ?? 0).toBeGreaterThan(300);
+  expect(box?.height ?? 0).toBeGreaterThan(200);
+  expect(response.status()).toBe(status);
+  console.info(`[map-spike] tile-outage-${status.toString()} elapsed_ms=${elapsedMs.toFixed(1)}`);
+}
+
+test("404 tile outage visibly renders IllustrationBasemap", async ({ page }) => {
+  await expectIllustrationFallback(page, 404);
+});
+
+test("500 tile outage visibly renders IllustrationBasemap", async ({ page }) => {
+  await expectIllustrationFallback(page, 500);
 });

--- a/e2e/web-map-spike.spec.ts
+++ b/e2e/web-map-spike.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { readMapFrame, routeRenderedMap } from "./fixtures/map-spike";
+import { readMapFrame, routeEmptyMap, routeRenderedMap } from "./fixtures/map-spike";
 
 const FIRST_TILE_BUDGET_MS = 3_000;
 const PROFILE = {
@@ -42,4 +42,21 @@ test("first real map tile paints within 3s under perf-mobile-cold", async ({ pag
   expect(frame.renderer).toContain("SwiftShader");
   expect(elapsedMs).toBeLessThanOrEqual(FIRST_TILE_BUDGET_MS);
   console.info(`[map-spike] first-tile elapsed_ms=${elapsedMs.toFixed(1)}`);
+});
+
+test("out-of-bounds 204 tiles paint only the plain background", async ({ page }) => {
+  await routeEmptyMap(page);
+  const emptyTile = page.waitForResponse((response) => response.url().endsWith(".mvt"));
+  const startedAt = performance.now();
+  await page.goto("/map-spike?source=worker", { waitUntil: "commit" });
+  const response = await emptyTile;
+  await expect(page.locator(".map-spike__stage")).toHaveAttribute("data-status", "ready");
+  const elapsedMs = performance.now() - startedAt;
+  await expect(page.locator(".map-spike__gl")).toHaveCSS("opacity", "1");
+  const frame = await readMapFrame(page);
+  expect(response.status()).toBe(204);
+  expect(frame.sampledPixels).toBeGreaterThan(0);
+  expect(frame.backgroundPixels).toBe(frame.sampledPixels);
+  expect(frame.earthPixels).toBe(0);
+  console.info(`[map-spike] out-of-bounds-background elapsed_ms=${elapsedMs.toFixed(1)}`);
 });

--- a/e2e/web-map-spike.spec.ts
+++ b/e2e/web-map-spike.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test, type Page } from "@playwright/test";
+import { readMapFrame, routeRenderedMap } from "./fixtures/map-spike";
+
+const FIRST_TILE_BUDGET_MS = 3_000;
+const PROFILE = {
+  downloadThroughput: 200_000,
+  uploadThroughput: 93_750,
+  latency: 150,
+};
+
+test.use({
+  baseURL: process.env.E2E_WEB_BASE_URL ?? "http://localhost:3000",
+  colorScheme: "light",
+  deviceScaleFactor: 2,
+  launchOptions: {
+    args: ["--enable-unsafe-swiftshader", "--use-angle=swiftshader", "--use-gl=angle"],
+  },
+  serviceWorkers: "block",
+  viewport: { width: 390, height: 844 },
+});
+
+async function applyPerfMobileCold(page: Page): Promise<void> {
+  const client = await page.context().newCDPSession(page);
+  await client.send("Network.enable");
+  await client.send("Network.clearBrowserCache");
+  await client.send("Network.setCacheDisabled", { cacheDisabled: true });
+  await client.send("Network.emulateNetworkConditions", { offline: false, ...PROFILE, connectionType: "cellular3g" });
+  await client.send("Emulation.setCPUThrottlingRate", { rate: 4 });
+}
+
+test("first real map tile paints within 3s under perf-mobile-cold", async ({ page }) => {
+  await routeRenderedMap(page);
+  await applyPerfMobileCold(page);
+  const startedAt = performance.now();
+  await page.goto("/map-spike?source=worker", { waitUntil: "commit" });
+  const stage = page.locator(".map-spike__stage");
+  await expect(stage).toHaveAttribute("data-status", "ready", { timeout: FIRST_TILE_BUDGET_MS });
+  const elapsedMs = performance.now() - startedAt;
+  await expect(page.locator(".map-spike__gl")).toHaveCSS("opacity", "1");
+  const frame = await readMapFrame(page);
+  expect(frame.earthPixels).toBeGreaterThan(0);
+  expect(frame.renderer).toContain("SwiftShader");
+  expect(elapsedMs).toBeLessThanOrEqual(FIRST_TILE_BUDGET_MS);
+  console.info(`[map-spike] first-tile elapsed_ms=${elapsedMs.toFixed(1)}`);
+});

--- a/e2e/web-splash.spec.ts
+++ b/e2e/web-splash.spec.ts
@@ -31,7 +31,7 @@ async function expectSplashWithinBudget(page: Page): Promise<void> {
   await expect(page.locator("main").first()).toBeVisible();
 }
 
-test("light system mode renders the day splash and clears it within 800ms", async ({ page }) => {
+test("light system mode renders the day splash and clears it within 800ms", { tag: "@perf-mobile-cold" }, async ({ page }) => {
   await applyPerfMobileCold(page);
   await expectSplashWithinBudget(page);
   await expect(page.locator(".app-splash__frame.day")).toHaveCSS("display", "flex");
@@ -40,7 +40,7 @@ test("light system mode renders the day splash and clears it within 800ms", asyn
 test.describe("dark system mode", () => {
   test.use({ colorScheme: "dark" });
 
-  test("renders the night splash and clears it within 800ms", async ({ page }) => {
+  test("renders the night splash and clears it within 800ms", { tag: "@perf-mobile-cold" }, async ({ page }) => {
     await applyPerfMobileCold(page);
     await expectSplashWithinBudget(page);
     await expect(page.locator(".app-splash__frame.night")).toHaveCSS("display", "flex");


### PR DESCRIPTION
iter6 E2,回填 S0.4(#237)三条 browser AC 的 e2e 缺口——此前仓库里**没有任何 map-spike spec**,3s 首瓦片测量根本不存在。

- **首瓦片 ≤3s**:perf-mobile-cold profile(CDP 3G + 4× CPU 节流 + 清缓存),按 ADR 风险表配 SwiftShader(`--enable-unsafe-swiftshader --use-angle=swiftshader`)。**防空图**:除耗时外还断言 `frame.earthPixels > 0` 与 renderer 确实是 SwiftShader——无 GPU headless 静默出空图是 ADR 点名的陷阱,只测时间会假绿。
- **越界瓦片 204 → 纯背景**:断言只有背景色,无错误态。
- **R2 故障 → 插画降级**:故障注入 /tiles/* 失败,断言 IllustrationBasemap 可见且 GL canvas 计数为 0(真实语义,不是泛化的 "Status: fallback")。
- **修 `test:perf-mobile-cold` 命名误导**:选择扩组(方案 a),让脚本名与实际覆盖一致,而非拆成两个易漂移的 profile。

完成后可连带关闭 #237。

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)