### PR TITLE
feat(iter6): Wave 2 tail (B5/B6/B9) + CI hardening step 2

### DIFF
--- a/.github/workflows/_cross-stack-e2e.yml
+++ b/.github/workflows/_cross-stack-e2e.yml
@@ -24,10 +24,29 @@ jobs:
       - name: Build emitted web Worker
         run: pnpm --filter web test:integration
 
+      - name: Resolve Playwright version
+        run: |
+          PLAYWRIGHT_VERSION="$(pnpm --dir e2e exec playwright --version)"
+          echo "PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION#Version }" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Restore Playwright browser cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ env.PLAYWRIGHT_VERSION }}-chromium
+
       - name: Install Playwright browser
         run: |
           test -x node_modules/.bin/playwright
           node_modules/.bin/playwright install --with-deps chromium
+
+      - name: Save Playwright browser cache
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ env.PLAYWRIGHT_VERSION }}-chromium
 
       - name: Exercise emitted Worker routes
         shell: bash

--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -152,9 +152,14 @@ jobs:
       - name: Download actionlint
         run: |
           ACTIONLINT_VERSION="1.7.7"
-          ACTIONLINT_URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          curl -sSfL -o actionlint.tar.gz "${ACTIONLINT_URL}"
-          tar -xzf actionlint.tar.gz actionlint
+          ACTIONLINT_ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          ACTIONLINT_CHECKSUMS="actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          ACTIONLINT_BASE_URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+          curl -sSfL -o "${ACTIONLINT_ARCHIVE}" "${ACTIONLINT_BASE_URL}/${ACTIONLINT_ARCHIVE}"
+          curl -sSfL -o "${ACTIONLINT_CHECKSUMS}" "${ACTIONLINT_BASE_URL}/${ACTIONLINT_CHECKSUMS}"
+          grep -F "  ${ACTIONLINT_ARCHIVE}" "${ACTIONLINT_CHECKSUMS}" > actionlint.sha256
+          sha256sum -c actionlint.sha256
+          tar -xzf "${ACTIONLINT_ARCHIVE}" actionlint
           chmod +x actionlint
         shell: bash
       - name: Run actionlint

--- a/.github/workflows/_webapp-ci.yml
+++ b/.github/workflows/_webapp-ci.yml
@@ -43,8 +43,27 @@ jobs:
           use_oidc: true
 
       # Runs the browser AC (branded 404) against the same artifact the integration step built.
+      - name: Resolve Playwright version
+        run: |
+          PLAYWRIGHT_VERSION="$(pnpm --dir e2e exec playwright --version)"
+          echo "PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION#Version }" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Restore Playwright browser cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ env.PLAYWRIGHT_VERSION }}-chromium
+
       - name: Install Playwright browser
         run: pnpm --dir e2e exec playwright install --with-deps chromium
+
+      - name: Save Playwright browser cache
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ env.PLAYWRIGHT_VERSION }}-chromium
 
       - name: Browser test (branded 404 on built worker)
         run: |

--- a/apps/web/src/features/maplibre/maplibreAdapter.ts
+++ b/apps/web/src/features/maplibre/maplibreAdapter.ts
@@ -25,13 +25,22 @@ export type MapLibreHandle = Readonly<{
   map: MapLibreMap;
 }>;
 
-let pmtilesRegistered = false;
+let pmtilesRegistration: Promise<void> | undefined;
 
-const registerPmtilesProtocol = async (gl: MapLibreModule): Promise<void> => {
-  if (pmtilesRegistered) return;
-  pmtilesRegistered = true;
-  const { Protocol } = await import("pmtiles");
-  gl.addProtocol("pmtiles", new Protocol({ metadata: true }).tile);
+// Cache the in-flight promise, not a boolean: a flag set before the dynamic
+// import resolves lets a concurrent mount build a map while the protocol is
+// still missing, and a flag left true after a failed import would skip
+// registration for the rest of the session. Awaiting the shared promise
+// serialises callers; clearing it on failure keeps the next mount retryable.
+const registerPmtilesProtocol = (gl: MapLibreModule): Promise<void> => {
+  pmtilesRegistration ??= (async () => {
+    const { Protocol } = await import("pmtiles");
+    gl.addProtocol("pmtiles", new Protocol({ metadata: true }).tile);
+  })().catch((error: unknown) => {
+    pmtilesRegistration = undefined;
+    throw error;
+  });
+  return pmtilesRegistration;
 };
 
 const mapOptions = (options: MapLibreMountOptions): MapOptions => ({

--- a/apps/web/src/features/maplibre/maplibreAdapter.ts
+++ b/apps/web/src/features/maplibre/maplibreAdapter.ts
@@ -25,84 +25,13 @@ export type MapLibreHandle = Readonly<{
   map: MapLibreMap;
 }>;
 
-interface ProtocolRegistration {
-  gl: MapLibreModule;
-  removed: boolean;
-  users: number;
-}
+let pmtilesRegistered = false;
 
-let protocolRegistration: ProtocolRegistration | null = null;
-let protocolRegistrationPromise: Promise<ProtocolRegistration> | null = null;
-
-const releaseProtocol = (registration: ProtocolRegistration): void => {
-  if (registration.users > 0) registration.users -= 1;
-  if (registration.users !== 0 || protocolRegistration !== registration) return;
-  try {
-    if (typeof registration.gl.removeProtocol === "function") registration.gl.removeProtocol("pmtiles");
-  } finally {
-    registration.removed = true;
-    protocolRegistration = null;
-  }
-};
-
-const leaseProtocol = (registration: ProtocolRegistration): () => void => {
-  registration.users += 1;
-  let released = false;
-  return () => {
-    if (released) return;
-    released = true;
-    releaseProtocol(registration);
-  };
-};
-
-const createProtocolRegistration = async (gl: MapLibreModule): Promise<ProtocolRegistration> => {
+const registerPmtilesProtocol = async (gl: MapLibreModule): Promise<void> => {
+  if (pmtilesRegistered) return;
+  pmtilesRegistered = true;
   const { Protocol } = await import("pmtiles");
   gl.addProtocol("pmtiles", new Protocol({ metadata: true }).tile);
-  return { gl, removed: false, users: 0 };
-};
-
-const pendingProtocolRegistration = (gl: MapLibreModule): Promise<ProtocolRegistration> => {
-  return protocolRegistrationPromise ?? (protocolRegistrationPromise = createProtocolRegistration(gl));
-};
-
-const clearPendingRegistration = (pending: Promise<ProtocolRegistration>): void => {
-  if (protocolRegistrationPromise === pending) protocolRegistrationPromise = null;
-};
-
-const validateRegistration = (registration: ProtocolRegistration, gl: MapLibreModule): ProtocolRegistration => {
-  if (registration.gl !== gl) throw new Error("MapLibre module changed while PMTiles was registering");
-  return registration;
-};
-
-const usableRegistration = (gl: MapLibreModule): ProtocolRegistration | null => {
-  const registration = protocolRegistration;
-  if (registration === null) return null;
-  const validated = validateRegistration(registration, gl);
-  if (!validated.removed) return validated;
-  protocolRegistration = null;
-  return null;
-};
-
-const awaitProtocolRegistration = async (gl: MapLibreModule): Promise<ProtocolRegistration> => {
-  const pending = pendingProtocolRegistration(gl);
-  return pending.then((registration) => {
-    clearPendingRegistration(pending);
-    return validateRegistration(registration, gl);
-  }, (error: unknown) => {
-    clearPendingRegistration(pending);
-    throw error;
-  });
-};
-
-const registerPmtilesProtocol = async (gl: MapLibreModule): Promise<ProtocolRegistration> => {
-  const current = usableRegistration(gl);
-  if (current !== null) return current;
-  const registration = await awaitProtocolRegistration(gl);
-  if (registration.removed) return registerPmtilesProtocol(gl);
-  const live = usableRegistration(gl);
-  if (live !== null) return live;
-  protocolRegistration = registration;
-  return registration;
 };
 
 const mapOptions = (options: MapLibreMountOptions): MapOptions => ({
@@ -236,21 +165,16 @@ class MapLifecycle implements MapLibreHandle {
   };
 }
 
-const createMap = (gl: MapLibreModule, options: MapLibreMountOptions, release: () => void): MapLibreMap => {
-  try {
-    return new gl.Map(mapOptions(options));
-  } catch (error) {
-    release();
-    throw error;
-  }
+const createMap = (gl: MapLibreModule, options: MapLibreMountOptions): MapLibreMap => {
+  return new gl.Map(mapOptions(options));
 };
 
 export const mountMapLibre = async (options: MapLibreMountOptions): Promise<MapLibreHandle> => {
   browserOnly();
   const gl = await import("maplibre-gl");
-  const release = options.registerPmtiles ? leaseProtocol(await registerPmtilesProtocol(gl)) : () => undefined;
-  const map = createMap(gl, options, release);
-  return new MapLifecycle({ ...options, gl, map, releaseProtocolLease: release });
+  if (options.registerPmtiles) await registerPmtilesProtocol(gl);
+  const map = createMap(gl, options);
+  return new MapLifecycle({ ...options, gl, map });
 };
 
 interface Attachment {

--- a/apps/web/src/lib/auth/authSession.ts
+++ b/apps/web/src/lib/auth/authSession.ts
@@ -3,9 +3,9 @@ import { fetchAuthToken } from "./neonAuth";
 /**
  * In-memory Neon Auth JWT cache.
  *
- * `fetchAuthToken` exchanges the Better Auth session cookie for a fresh
- * 15-minute EdDSA JWT; caching it here avoids a network round trip to the
- * Neon Auth origin on every outgoing chat/history/users request. Module
+ * `fetchAuthToken` exchanges the Better Auth session cookie for an EdDSA JWT;
+ * caching it until shortly before its own `exp` avoids a network round trip to
+ * the Neon Auth origin on every outgoing chat/history/users request. Module
  * state only (no storage) — a page reload re-derives it from the cookie.
  */
 interface CachedToken {
@@ -14,7 +14,6 @@ interface CachedToken {
 }
 
 const REFRESH_MARGIN_MS = 60_000;
-const TOKEN_TTL_MS = 15 * 60_000 - REFRESH_MARGIN_MS;
 
 let cached: CachedToken | undefined;
 
@@ -22,16 +21,40 @@ function isFresh(entry: CachedToken | undefined, now: number): entry is CachedTo
   return entry !== undefined && entry.expiresAt > now;
 }
 
-async function refreshToken(now: number): Promise<string | undefined> {
+function decodePayload(segment: string): unknown {
+  const base64 = segment.replaceAll("-", "+").replaceAll("_", "/");
+  const binary = atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "="));
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+}
+
+function expiryClaim(payload: unknown): number | undefined {
+  if (typeof payload !== "object" || payload === null || !("exp" in payload)) return undefined;
+  return typeof payload.exp === "number" && Number.isFinite(payload.exp) ? payload.exp : undefined;
+}
+
+function expiresAt(token: string): number | undefined {
+  const segment = token.split(".")[1];
+  if (!segment) return undefined;
+  try {
+    const expiry = expiryClaim(decodePayload(segment));
+    return expiry === undefined ? undefined : expiry * 1_000 - REFRESH_MARGIN_MS;
+  } catch {
+    return undefined;
+  }
+}
+
+async function refreshToken(): Promise<string | undefined> {
   const token = await fetchAuthToken();
-  cached = token ? { token, expiresAt: now + TOKEN_TTL_MS } : undefined;
+  const expiry = token === undefined ? undefined : expiresAt(token);
+  cached = token !== undefined && expiry !== undefined ? { token, expiresAt: expiry } : undefined;
   return token;
 }
 
 /** The current session's bearer token, refetched once the cache goes stale. */
 export async function getAuthToken(now: number = Date.now()): Promise<string | undefined> {
   if (isFresh(cached, now)) return cached.token;
-  return refreshToken(now);
+  return refreshToken();
 }
 
 /** Drop the cached token, forcing the next call to re-derive it from the cookie. */

--- a/apps/web/src/lib/auth/neonAuth.ts
+++ b/apps/web/src/lib/auth/neonAuth.ts
@@ -1,6 +1,5 @@
 import { createAuthClient } from "better-auth/client";
-import { magicLinkClient } from "better-auth/client/plugins";
-import { z } from "zod";
+import { jwtClient, magicLinkClient } from "better-auth/client/plugins";
 
 /**
  * Neon Auth (Better Auth base) magic-link client.
@@ -29,7 +28,11 @@ export function isNeonAuthConfigured(): boolean {
 }
 
 function neonAuthClient(baseURL: string) {
-  return createAuthClient({ baseURL, plugins: [magicLinkClient()] });
+  return createAuthClient({
+    baseURL,
+    fetchOptions: { credentials: "include" },
+    plugins: [magicLinkClient(), jwtClient()],
+  });
 }
 
 export async function sendMagicLink(request: MagicLinkRequest): Promise<MagicLinkResult> {
@@ -43,26 +46,17 @@ export async function sendMagicLink(request: MagicLinkRequest): Promise<MagicLin
   }
 }
 
-const TokenPayload = z.object({ token: z.string().min(1) });
-
-async function parseTokenResponse(response: Response): Promise<string | undefined> {
-  if (!response.ok) return undefined;
-  const parsed = TokenPayload.safeParse(await response.json());
-  return parsed.success ? parsed.data.token : undefined;
-}
-
 /**
  * Exchanges the Better Auth session cookie (set by the magic-link callback
- * on the Neon Auth origin) for a short-lived EdDSA JWT via the `jwt` plugin's
- * `/token` endpoint. The edge worker (`worker/auth.ts`) already verifies this
- * exact token shape against the same JWKS, so this is the one bridge the
- * cross-origin cookie needs to become a bearer credential for `/v1/*`.
+ * on the Neon Auth origin) for an EdDSA JWT via Better Auth's `jwtClient`.
+ * The edge worker (`worker/auth.ts`) verifies this token against the same JWKS.
  */
 export async function fetchAuthToken(): Promise<string | undefined> {
   const base = baseUrl();
   if (!base) return undefined;
   try {
-    return await parseTokenResponse(await fetch(`${base}/token`, { credentials: "include" }));
+    const { data, error } = await neonAuthClient(base).token();
+    return error ? undefined : data.token;
   } catch {
     return undefined;
   }

--- a/apps/web/src/lib/auth/neonAuth.ts
+++ b/apps/web/src/lib/auth/neonAuth.ts
@@ -56,6 +56,10 @@ export async function fetchAuthToken(): Promise<string | undefined> {
   if (!base) return undefined;
   try {
     const { data, error } = await neonAuthClient(base).token();
+    // No null-guard on `data`: better-auth types the success branch as
+    // non-nullable with a required `token`, and type-aware oxlint rejects the
+    // check as provably dead (`no-unnecessary-condition`). A review bot asked
+    // for one; the type system says the shape it fears cannot occur here.
     return error ? undefined : data.token;
   } catch {
     return undefined;

--- a/apps/web/src/lib/turnstile/tokenStore.ts
+++ b/apps/web/src/lib/turnstile/tokenStore.ts
@@ -1,18 +1,17 @@
+import {
+  TURNSTILE_HEADER,
+  TURNSTILE_TOKEN_TTL_MS,
+} from "@animichi/contract/constants";
+
+export { TURNSTILE_HEADER, TURNSTILE_TOKEN_TTL_MS };
+
 /**
  * In-memory holder for the current Turnstile token (S1.9 / issue #281).
  *
- * Mirrors the edge's short-lived window (`worker/turnstile.ts`
- * TURNSTILE_WINDOW_MS): one solved challenge covers every message sent inside
- * it, so an anonymous user is not re-challenged per message. Module state
- * only — a reload re-renders the widget and mints a fresh token.
+ * One solved challenge covers every message inside the shared contract's
+ * short-lived window, so an anonymous user is not re-challenged per message.
+ * Module state only — a reload re-renders the widget and mints a fresh token.
  */
-
-/** Kept a touch under the edge window so the client stops offering a token
- * slightly before the Worker would stop honouring it. */
-export const TURNSTILE_TOKEN_TTL_MS = 4 * 60_000;
-
-/** Request header carrying the token — must match `TURNSTILE_HEADER`. */
-export const TURNSTILE_HEADER = "cf-turnstile-response";
 
 interface StoredToken {
   readonly token: string;

--- a/apps/web/tests/unit/auth-session.test.ts
+++ b/apps/web/tests/unit/auth-session.test.ts
@@ -6,13 +6,25 @@ vi.mock("../../src/lib/auth/neonAuth", () => ({ fetchAuthToken }));
 
 import { authHeaders, clearAuthToken, getAuthToken } from "../../src/lib/auth/authSession";
 
+const NOW = 2_000_000_000_000;
+const REFRESH_MARGIN_MS = 60_000;
+
+function jwt(expiryMs: number): string {
+  const payload = btoa(JSON.stringify({ exp: expiryMs / 1_000 }))
+    .replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+  return `header.${payload}.signature`;
+}
+
 beforeEach(() => {
   clearAuthToken();
   vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
 });
 
 afterEach(() => {
   clearAuthToken();
+  vi.useRealTimers();
 });
 
 describe("getAuthToken", () => {
@@ -23,34 +35,61 @@ describe("getAuthToken", () => {
   });
 
   it("returns the fetched token and injects it as a Bearer header", async () => {
-    fetchAuthToken.mockResolvedValue("jwt-abc");
-    expect(await getAuthToken()).toBe("jwt-abc");
-    expect(await authHeaders()).toEqual({ Authorization: "Bearer jwt-abc" });
-  });
-
-  it("caches the token across calls within the TTL window", async () => {
-    fetchAuthToken.mockResolvedValue("jwt-cached");
-    const now = 1_000_000;
-    await getAuthToken(now);
-    await getAuthToken(now + 1_000);
-    expect(fetchAuthToken).toHaveBeenCalledTimes(1);
-  });
-
-  it("refetches once the cached token expires", async () => {
-    fetchAuthToken.mockResolvedValue("jwt-1");
-    const now = 1_000_000;
-    await getAuthToken(now);
-    fetchAuthToken.mockResolvedValue("jwt-2");
-    const later = now + 15 * 60 * 1000;
-    expect(await getAuthToken(later)).toBe("jwt-2");
-    expect(fetchAuthToken).toHaveBeenCalledTimes(2);
+    const token = jwt(NOW + 5 * 60_000);
+    fetchAuthToken.mockResolvedValue(token);
+    expect(await getAuthToken()).toBe(token);
+    expect(await authHeaders()).toEqual({ Authorization: `Bearer ${token}` });
   });
 
   it("clearAuthToken forces a refetch on the next call", async () => {
-    fetchAuthToken.mockResolvedValue("jwt-1");
+    fetchAuthToken.mockResolvedValue(jwt(NOW + 5 * 60_000));
     await getAuthToken();
     clearAuthToken();
-    fetchAuthToken.mockResolvedValue("jwt-2");
-    expect(await getAuthToken()).toBe("jwt-2");
+    const second = jwt(NOW + 10 * 60_000);
+    fetchAuthToken.mockResolvedValue(second);
+    expect(await getAuthToken()).toBe(second);
+  });
+});
+
+describe("getAuthToken cache expiry", () => {
+  it("refreshes a short token at its exp boundary minus the safety margin", async () => {
+    const expiry = NOW + 5 * 60_000;
+    const first = jwt(expiry);
+    const second = jwt(expiry + 10 * 60_000);
+    fetchAuthToken.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    expect(await getAuthToken()).toBe(first);
+    vi.setSystemTime(expiry - REFRESH_MARGIN_MS - 1);
+    expect(await getAuthToken()).toBe(first);
+    expect(fetchAuthToken).toHaveBeenCalledTimes(1);
+    vi.setSystemTime(expiry - REFRESH_MARGIN_MS);
+    expect(await getAuthToken()).toBe(second);
+  });
+
+  it("keeps a long token beyond the old fixed TTL and refreshes at its own boundary", async () => {
+    const expiry = NOW + 30 * 60_000;
+    const first = jwt(expiry);
+    const second = jwt(expiry + 30 * 60_000);
+    fetchAuthToken.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    expect(await getAuthToken()).toBe(first);
+    vi.setSystemTime(NOW + 20 * 60_000);
+    expect(await getAuthToken()).toBe(first);
+    vi.setSystemTime(expiry - REFRESH_MARGIN_MS);
+    expect(await getAuthToken()).toBe(second);
+    expect(fetchAuthToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a token whose payload cannot be decoded", async () => {
+    fetchAuthToken.mockResolvedValue("not-a-jwt");
+    expect(await getAuthToken()).toBe("not-a-jwt");
+    expect(await getAuthToken()).toBe("not-a-jwt");
+    expect(fetchAuthToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a token without a numeric exp claim", async () => {
+    const payload = btoa(JSON.stringify({ exp: "later" }));
+    fetchAuthToken.mockResolvedValue(`header.${payload}.signature`);
+    await getAuthToken();
+    await getAuthToken();
+    expect(fetchAuthToken).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/tests/unit/chat/turnstile-token-store.test.ts
+++ b/apps/web/tests/unit/chat/turnstile-token-store.test.ts
@@ -70,10 +70,7 @@ describe("default clock argument", () => {
   });
 });
 
-// The worker defines its own TURNSTILE_HEADER constant, and every other test on
-// both sides imports the constant it is testing — so renaming one side alone
-// leaves both suites green while anonymous turns silently arrive tokenless and
-// 403 forever. Pin the wire name as a literal on each side independently.
+// Pin the shared contract value to Cloudflare's canonical wire name.
 describe("the cf-turnstile-response wire name", () => {
   it("is literally cf-turnstile-response, matching the worker's constant", () => {
     expect(TURNSTILE_HEADER).toBe("cf-turnstile-response");

--- a/apps/web/tests/unit/maplibre-adapter.test.ts
+++ b/apps/web/tests/unit/maplibre-adapter.test.ts
@@ -84,7 +84,6 @@ beforeEach(() => {
   mapState.state.instances.length = 0;
   mapState.state.throwOnConstruct = false;
   mapState.state.throwOnRemove = false;
-  mapState.addProtocol.mockClear();
   mapState.removeProtocol.mockClear();
 });
 
@@ -105,7 +104,6 @@ describe("MapLibre v5 adapter lifecycle", () => {
     expect(cleanup).toHaveBeenCalledOnce();
     expect(map.offCalls).toBe(2);
     expect(map.removeCalls).toBe(1);
-    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
   });
 
   it("turns an error into one fallback and never reports ready after failure", async () => {
@@ -121,7 +119,6 @@ describe("MapLibre v5 adapter lifecycle", () => {
     expect(onError).toHaveBeenCalledOnce();
     expect(onReady).not.toHaveBeenCalled();
     expect(map.removeCalls).toBe(1);
-    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
     handle.destroy();
   });
 
@@ -138,18 +135,16 @@ describe("MapLibre v5 adapter lifecycle", () => {
     expect(onError).toHaveBeenCalledOnce();
     expect(cleanup).toHaveBeenCalledOnce();
     expect(map.removeCalls).toBe(1);
-    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
     handle.destroy();
   });
 });
 
 describe("MapLibre v5 teardown", () => {
-  it("contains teardown failures while releasing the protocol lease", async () => {
+  it("contains map teardown failures", async () => {
     mapState.state.throwOnRemove = true;
     const handle = await mountMapLibre(options(vi.fn(), vi.fn()));
 
     expect(() => { handle.destroy(); }).not.toThrow();
-    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
   });
 });
 
@@ -165,19 +160,6 @@ it("handles duplicate load events once", async () => {
   handle.destroy();
 });
 
-describe("MapLibre v5 protocol lease", () => {
-  it("keeps the shared PMTiles protocol until every map releases its lease", async () => {
-    const first = await mountMapLibre(options(vi.fn(), vi.fn()));
-    const second = await mountMapLibre(options(vi.fn(), vi.fn()));
-
-    expect(mapState.addProtocol).toHaveBeenCalledOnce();
-    first.destroy();
-    expect(mapState.removeProtocol).not.toHaveBeenCalled();
-    second.destroy();
-    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
-  });
-});
-
 describe("MapLibre v5 adapter failure handling", () => {
   it("reports constructor failure through the attachment fallback path", async () => {
     mapState.state.throwOnConstruct = true;
@@ -186,7 +168,6 @@ describe("MapLibre v5 adapter failure handling", () => {
 
     await vi.waitFor(() => { expect(onError).toHaveBeenCalledOnce(); });
     detach();
-    expect(mapState.removeProtocol).toHaveBeenCalledOnce();
   });
 
   it("destroys a handle that resolves after React already detached", async () => {

--- a/apps/web/tests/unit/maplibre-registration.test.ts
+++ b/apps/web/tests/unit/maplibre-registration.test.ts
@@ -1,0 +1,39 @@
+/** @vitest-environment jsdom */
+
+import { expect, it, vi } from "vitest";
+import type { StyleSpecification } from "maplibre-gl";
+
+const maplibre = vi.hoisted(() => {
+  class FakeMap {
+    on(): this { return this; }
+    off(): this { return this; }
+    remove(): void { this.off(); }
+  }
+  return { addProtocol: vi.fn(), FakeMap, removeProtocol: vi.fn() };
+});
+
+vi.mock("maplibre-gl", () => ({
+  Map: maplibre.FakeMap,
+  addProtocol: maplibre.addProtocol,
+  removeProtocol: maplibre.removeProtocol,
+}));
+
+vi.mock("pmtiles", () => ({
+  Protocol: class {
+    readonly tile = () => ({ data: new ArrayBuffer(0) });
+  },
+}));
+
+import { mountMapLibre } from "../../src/features/maplibre/maplibreAdapter";
+
+const STYLE = { version: 8, sources: {}, layers: [] } satisfies StyleSpecification;
+
+it("registers the shared PMTiles protocol only once across repeated mounts", async () => {
+  const options = { container: document.createElement("div"), onError: vi.fn(), registerPmtiles: true, style: STYLE };
+  const first = await mountMapLibre(options);
+  const second = await mountMapLibre(options);
+  expect(maplibre.addProtocol).toHaveBeenCalledOnce();
+  first.destroy();
+  second.destroy();
+  expect(maplibre.removeProtocol).not.toHaveBeenCalled();
+});

--- a/apps/web/tests/unit/neon-auth.test.ts
+++ b/apps/web/tests/unit/neon-auth.test.ts
@@ -1,13 +1,16 @@
-import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { server } from "../msw/node";
 
-const { magicLink } = vi.hoisted(() => ({ magicLink: vi.fn() }));
+const { createAuthClient, jwtClient, magicLink, token } = vi.hoisted(() => ({
+  createAuthClient: vi.fn(),
+  jwtClient: vi.fn(() => ({ id: "jwt" })),
+  magicLink: vi.fn(),
+  token: vi.fn(),
+}));
 
 vi.mock("better-auth/client", () => ({
-  createAuthClient: () => ({ signIn: { magicLink } }),
+  createAuthClient,
 }));
-vi.mock("better-auth/client/plugins", () => ({ magicLinkClient: () => ({}) }));
+vi.mock("better-auth/client/plugins", () => ({ jwtClient, magicLinkClient: () => ({}) }));
 
 import { fetchAuthToken, isNeonAuthConfigured, sendMagicLink } from "../../src/lib/auth/neonAuth";
 
@@ -18,6 +21,7 @@ beforeEach(() => {
   // machine's apps/web/.env.local) so "unset" cases don't false-red. Passing
   // undefined deletes the key from import.meta.env (vitest vi.stubEnv contract).
   vi.stubEnv("VITE_NEON_AUTH_BASE_URL", undefined);
+  createAuthClient.mockReturnValue({ signIn: { magicLink }, token });
 });
 
 afterEach(() => {
@@ -68,45 +72,36 @@ describe("fetchAuthToken", () => {
 
   it("returns the JWT from a signed-in session's /token response", async () => {
     configure();
-    server.use(
-      http.get("https://auth.test/neondb/auth/token", () => HttpResponse.json({ token: "jwt-xyz" })),
-    );
+    token.mockResolvedValue({ data: { token: "jwt-xyz" }, error: null });
     expect(await fetchAuthToken()).toBe("jwt-xyz");
   });
 
-  it("sends the request with credentials included, so the auth cookie rides along", async () => {
+  it("uses jwtClient with cross-origin credentials included", async () => {
     configure();
-    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ token: "jwt-xyz" }), { status: 200 }),
-    );
+    token.mockResolvedValue({ data: { token: "jwt-xyz" }, error: null });
     await fetchAuthToken();
-    expect(spy).toHaveBeenCalledWith(
-      "https://auth.test/neondb/auth/token",
-      expect.objectContaining({ credentials: "include" }),
-    );
+    expect(jwtClient).toHaveBeenCalledTimes(1);
+    expect(createAuthClient).toHaveBeenCalledWith(expect.objectContaining({
+      baseURL: "https://auth.test/neondb/auth",
+      fetchOptions: { credentials: "include" },
+    }));
   });
 
-  it("returns undefined when there is no session (401)", async () => {
+  it("returns undefined when jwtClient reports no session", async () => {
     configure();
-    server.use(
-      http.get("https://auth.test/neondb/auth/token", () => new HttpResponse(null, { status: 401 })),
-    );
+    token.mockResolvedValue({ data: null, error: { status: 401 } });
     expect(await fetchAuthToken()).toBeUndefined();
   });
 
-  it("returns undefined when the response body doesn't match the expected shape", async () => {
+  it("returns undefined when jwtClient returns no token data", async () => {
     configure();
-    server.use(
-      http.get("https://auth.test/neondb/auth/token", () => HttpResponse.json({ nope: true })),
-    );
+    token.mockResolvedValue({ data: null, error: null });
     expect(await fetchAuthToken()).toBeUndefined();
   });
 
-  it("returns undefined when the fetch throws", async () => {
+  it("returns undefined when jwtClient throws", async () => {
     configure();
-    server.use(
-      http.get("https://auth.test/neondb/auth/token", () => HttpResponse.error()),
-    );
+    token.mockRejectedValue(new Error("network"));
     expect(await fetchAuthToken()).toBeUndefined();
   });
 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "verify:dependabot": "pnpm run lint:oxlint && pnpm run test:worker && pnpm -r --if-present typecheck && pnpm --filter web build"
   },
   "dependencies": {
+    "@animichi/contract": "workspace:*",
     "@cloudflare/containers": "^0.3.7",
     "hono": "^4.12.31",
     "jose": "^6.2.4"

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -10,7 +10,8 @@
     ".": "./src/index.ts",
     "./models": "./src/models.ts",
     "./contract": "./src/contract.ts",
-    "./constants": "./src/constants.ts"
+    "./constants": "./src/constants.ts",
+    "./jwt": "./src/jwt.ts"
   },
   "scripts": {
     "emit:openapi": "node --import tsx scripts/emit-openapi.ts",
@@ -21,6 +22,7 @@
     "@orpc/contract": "1.14.8",
     "@orpc/openapi": "1.14.8",
     "@orpc/zod": "1.14.8",
+    "jose": "^6.2.4",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/packages/contract/src/constants.ts
+++ b/packages/contract/src/constants.ts
@@ -1,2 +1,11 @@
 /** Owner-sign-off cap for deterministic anime-resolution candidates. */
 export const MAX_CANDIDATES = 6;
+
+/** Header carrying a browser-solved Turnstile token to the edge gate. */
+export const TURNSTILE_HEADER = "cf-turnstile-response";
+
+/** How long the edge reuses a successful Turnstile verification. */
+export const TURNSTILE_WINDOW_MS = 5 * 60_000;
+
+/** Stop offering a token one minute before the edge pass window closes. */
+export const TURNSTILE_TOKEN_TTL_MS = TURNSTILE_WINDOW_MS - 60_000;

--- a/packages/contract/src/jwt.ts
+++ b/packages/contract/src/jwt.ts
@@ -1,0 +1,16 @@
+import { jwtVerify, type JWTPayload, type JWTVerifyGetKey } from "jose";
+
+export interface EdDsaJwtVerification {
+  readonly audience: string;
+  readonly issuer: string;
+  readonly key: JWTVerifyGetKey;
+  readonly token: string;
+}
+
+/** Verify the shared EdDSA cryptographic envelope; callers own trust policy. */
+export async function verifyEdDsaJwt(options: EdDsaJwtVerification): Promise<JWTPayload> {
+  const { payload } = await jwtVerify(options.token, options.key, {
+    algorithms: ["EdDSA"], audience: options.audience, issuer: options.issuer,
+  });
+  return payload;
+}

--- a/packages/contract/test/jwt.test.ts
+++ b/packages/contract/test/jwt.test.ts
@@ -1,0 +1,27 @@
+import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT } from "jose";
+import { describe, expect, it } from "vitest";
+import { verifyEdDsaJwt } from "../src/jwt";
+
+const ISSUER = "https://auth.animichi.test";
+
+async function signedToken(algorithm: "EdDSA" | "ES256") {
+  const { privateKey, publicKey } = await generateKeyPair(algorithm);
+  const jwk = { ...await exportJWK(publicKey), kid: "test-key" };
+  const token = await new SignJWT({}).setProtectedHeader({ alg: algorithm, kid: jwk.kid })
+    .setSubject("user-a").setIssuer(ISSUER).setAudience(ISSUER).setExpirationTime("5m").sign(privateKey);
+  return { key: createLocalJWKSet({ keys: [jwk] }), token };
+}
+
+describe("verifyEdDsaJwt", () => {
+  it("returns the verified EdDSA payload", async () => {
+    const signed = await signedToken("EdDSA");
+    const payload = await verifyEdDsaJwt({ ...signed, issuer: ISSUER, audience: ISSUER });
+    expect(payload.sub).toBe("user-a");
+  });
+
+  it("rejects a valid token signed with another algorithm", async () => {
+    const signed = await signedToken("ES256");
+    const verification = verifyEdDsaJwt({ ...signed, issuer: ISSUER, audience: ISSUER });
+    await expect(verification).rejects.toThrow();
+  });
+});

--- a/packages/contract/test/jwt.test.ts
+++ b/packages/contract/test/jwt.test.ts
@@ -1,14 +1,26 @@
 import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT } from "jose";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { verifyEdDsaJwt } from "../src/jwt";
 
 const ISSUER = "https://auth.animichi.test";
+const OTHER = "https://other.animichi.test";
+// jose resolves `.setExpirationTime("5m")` against the wall clock, so pin the
+// fixture to a fixed instant instead of to whenever the suite happens to run.
+const FIXED_NOW = new Date("2026-01-01T00:00:00.000Z");
 
-async function signedToken(algorithm: "EdDSA" | "ES256") {
+beforeAll(() => {
+  vi.useFakeTimers({ now: FIXED_NOW, shouldAdvanceTime: true });
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+async function signedToken(algorithm: "EdDSA" | "ES256", issuer = ISSUER, audience = ISSUER) {
   const { privateKey, publicKey } = await generateKeyPair(algorithm);
   const jwk = { ...await exportJWK(publicKey), kid: "test-key" };
   const token = await new SignJWT({}).setProtectedHeader({ alg: algorithm, kid: jwk.kid })
-    .setSubject("user-a").setIssuer(ISSUER).setAudience(ISSUER).setExpirationTime("5m").sign(privateKey);
+    .setSubject("user-a").setIssuer(issuer).setAudience(audience).setExpirationTime("5m").sign(privateKey);
   return { key: createLocalJWKSet({ keys: [jwk] }), token };
 }
 
@@ -21,6 +33,18 @@ describe("verifyEdDsaJwt", () => {
 
   it("rejects a valid token signed with another algorithm", async () => {
     const signed = await signedToken("ES256");
+    const verification = verifyEdDsaJwt({ ...signed, issuer: ISSUER, audience: ISSUER });
+    await expect(verification).rejects.toThrow();
+  });
+
+  it("rejects a valid EdDSA token minted by another issuer", async () => {
+    const signed = await signedToken("EdDSA", OTHER, ISSUER);
+    const verification = verifyEdDsaJwt({ ...signed, issuer: ISSUER, audience: ISSUER });
+    await expect(verification).rejects.toThrow();
+  });
+
+  it("rejects a valid EdDSA token minted for another audience", async () => {
+    const signed = await signedToken("EdDSA", ISSUER, OTHER);
     const verification = verifyEdDsaJwt({ ...signed, issuer: ISSUER, audience: ISSUER });
     await expect(verification).rejects.toThrow();
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
 
   .:
     dependencies:
+      '@animichi/contract':
+        specifier: workspace:*
+        version: link:packages/contract
       '@cloudflare/containers':
         specifier: ^0.3.7
         version: 0.3.7
@@ -194,6 +197,9 @@ importers:
       '@orpc/zod':
         specifier: 1.14.8
         version: 1.14.8(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.8(@opentelemetry/api@1.9.1))(@orpc/server@1.14.8(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.1))(crossws@0.3.5)(ws@8.21.1)(zod@4.4.3)
+      jose:
+        specifier: ^6.2.4
+        version: 6.2.4
       zod:
         specifier: 4.4.3
         version: 4.4.3

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -1,5 +1,6 @@
 /// <reference types="@cloudflare/workers-types" />
 
+import { verifyEdDsaJwt } from "@animichi/contract/jwt";
 import { createRemoteJWKSet, customFetch, decodeJwt, decodeProtectedHeader, jwtVerify } from "jose";
 
 /**
@@ -86,7 +87,7 @@ async function verifyNeon(token: string, env: AuthEnv, f: typeof fetch): Promise
   try {
     const issuer = env.NEON_AUTH_ISSUER ?? "";
     const jwks = remoteJwks(env.NEON_AUTH_JWKS_URL ?? "", f);
-    const { payload } = await jwtVerify(token, jwks, { issuer, audience: issuer, algorithms: ["EdDSA"] });
+    const payload = await verifyEdDsaJwt({ token, key: jwks, issuer, audience: issuer });
     return human(payload.sub);
   } catch {
     return INVALID;

--- a/worker/turnstile.test.ts
+++ b/worker/turnstile.test.ts
@@ -253,9 +253,7 @@ void test("a stringly-typed success value fails closed", async () => {
   assert.equal(result.ok, false);
 });
 
-// Pin the wire name as a literal. Both sides define their own TURNSTILE_HEADER
-// constant and every other test imports the constant it is testing, so renaming
-// one side alone stays green while anonymous turns silently arrive tokenless.
+// Pin the shared contract value to Cloudflare's canonical wire name.
 void test("the token header is literally cf-turnstile-response", () => {
   assert.equal(TURNSTILE_HEADER, "cf-turnstile-response");
 });

--- a/worker/turnstile.ts
+++ b/worker/turnstile.ts
@@ -1,5 +1,9 @@
 /// <reference types="@cloudflare/workers-types" />
 
+import { TURNSTILE_HEADER, TURNSTILE_WINDOW_MS } from "@animichi/contract/constants";
+
+export { TURNSTILE_HEADER, TURNSTILE_WINDOW_MS };
+
 /**
  * Cloudflare Turnstile edge gate (S1.9 / issue #281).
  *
@@ -11,9 +15,6 @@
 
 /** Cloudflare's canonical server-side verification endpoint. */
 const SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
-
-/** Request header carrying the widget token (not a form field, not a body key). */
-export const TURNSTILE_HEADER = "cf-turnstile-response";
 
 /**
  * How long one successful verification keeps covering follow-up turns.
@@ -29,8 +30,6 @@ export const TURNSTILE_HEADER = "cf-turnstile-response";
  * Keyed by identity, a cookie-dropper misses the cache, siteverify sees the
  * replay, answers `timeout-or-duplicate`, and the turn is rejected.
  */
-export const TURNSTILE_WINDOW_MS = 5 * 60_000;
-
 export interface TurnstileResult {
   readonly ok: boolean;
   readonly errorCodes: readonly string[];

--- a/workers/users/src/auth/jwt.ts
+++ b/workers/users/src/auth/jwt.ts
@@ -1,6 +1,6 @@
+import { verifyEdDsaJwt } from "@animichi/contract/jwt";
 import {
   createRemoteJWKSet,
-  jwtVerify,
   type JWTVerifyGetKey,
 } from "jose";
 
@@ -36,9 +36,8 @@ export async function verifyBearer(
   if (!token) return null;
   try {
     const base = issuerFromJwksUrl(jwksUrl);
-    const { payload } = await jwtVerify(token, getKey ?? cachedRemote(jwksUrl), {
-      algorithms: ["EdDSA"], issuer: base, audience: base,
-    });
+    const key = getKey ?? cachedRemote(jwksUrl);
+    const payload = await verifyEdDsaJwt({ token, key, issuer: base, audience: base });
     return typeof payload.sub === "string" && payload.sub.length > 0
       ? { userId: payload.sub }
       : null;


### PR DESCRIPTION
Wave 2 收尾三卡 + CI 加固第 2 步,五个独立 commit。

## CI 加固第 2 步(CI-1 落地顺序第 2 行)
- **Playwright 浏览器缓存**:e2e 此前每次重下浏览器。按本仓库已验证的 **restore-only + 仅 main push 时 save** 模式(zizmor 的 cache-poisoning 审计拒绝读写缓存),key 含 Playwright 版本。
- **actionlint 校验和**:此前 curl 下载 tar **无 checksum 校验**,现改为官方 checksums + `sha256sum -c`,失败即红。

## Wave 2 三卡
- **B5(#645)**:`authSession.ts` 的 15 分钟硬编码 TTL 改为从 JWT 的 `exp` claim 解出。原实现假设上游 token 寿命不变,一旦变化就会供出过期 token → 间歇 401。
- **B6(#646)**:`maplibreAdapter.ts` 的引用计数租约系统(~80 行:计数、lease/release、pending-promise 去重、防"模块被换"校验、递归重注册)删除,替换为惰性单次注册。`addProtocol` 幂等且廉价,单 bundle SPA 内不存在它防御的并发场景。
- **B9(#649)**:Turnstile header/窗口常量入契约包(此前两侧各写一份靠注释对齐);Neon Auth EdDSA 校验原语在 root 与 users worker 间共享(只提校验原语,不提策略——两者信任模型不同)。

## 验收
contract 63 测试 + OpenAPI 零漂移、root worker 258、apps/web 1608、**users worker 38(Codex 沙箱 EPERM 跑不了,主线在非沙箱环境补跑)**、actionlint、zizmor 全树零发现、dependabot pin 守卫、全 workspace typecheck。

Closes #645, Closes #646, Closes #649


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication token caching by honoring each token’s actual expiration and refreshing safely before expiry.
  - Improved sign-in token retrieval and credential handling for more reliable authentication.
  - Improved map rendering stability when using PMTiles data.
  - Standardized and strengthened JWT validation across services.

- **Chores**
  - Improved browser test caching and download verification in automated checks.
  - Centralized shared security and Turnstile configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->