### PR TITLE
deps: logfire 4.39 (agent) + @types/node 26 (infra)

### DIFF
--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "uvicorn[standard]>=0.51.0",
     "ddgs>=9.14.1",
     # Private BaseScrubber.SAFE_KEYS coupling: unverified upgrades can silently leak.
-    "logfire[asyncpg,fastapi,httpx,variables]>=4.38.0,<4.39",
+    "logfire[asyncpg,fastapi,httpx,variables]>=4.39.0,<4.40",
     "pydantic-ai-harness[codemode]>=0.10.0",
     # Harness 0.10 CodeMode imports MontyRepl; Monty 0.0.19 removed it.
     "pydantic-monty>=0.0.16,<0.0.19",

--- a/apps/agent/uv.lock
+++ b/apps/agent/uv.lock
@@ -90,7 +90,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=2.14.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "idna", specifier = ">=3.15" },
-    { name = "logfire", extras = ["asyncpg", "fastapi", "httpx", "variables"], specifier = ">=4.38.0,<4.39" },
+    { name = "logfire", extras = ["asyncpg", "fastapi", "httpx", "variables"], specifier = ">=4.39.0,<4.40" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.1" },
@@ -1558,7 +1558,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.38.0"
+version = "4.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "executing" },
@@ -1569,9 +1569,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/b7/2b9670e893b5c662c23252bc52cafa2664b7c582b8c36b280693b2beaaa0/logfire-4.38.0.tar.gz", hash = "sha256:da62f7616f3411098cf5fb087f9ff24f54886a9087a238fe0e5fae8bbd609717", size = 1237040, upload-time = "2026-07-20T12:15:33.488Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/7d/9d04b6c716c7963cc0176b0aafee1b7becd0d3c3b2febe704dc9ae5a4318/logfire-4.39.0.tar.gz", hash = "sha256:7291ae695a145c21b4fa9baea2ffaf42b23c79a08e1f3edcef5a4cad41867a0d", size = 1242395, upload-time = "2026-07-24T18:31:34.698Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/84/7593993a474fdea837577303840177864aaa2883859874d5fa6d037af03f/logfire-4.38.0-py3-none-any.whl", hash = "sha256:da4bffd43190930d0b889e06c596c0a7fce1c485a51de862ad9ff0d5033ecfb9", size = 403289, upload-time = "2026-07-20T12:15:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/57/b40307cdfd81d07433ad5ae38de70fe6e543f3fb7e764bdf6944695a386b/logfire-4.39.0-py3-none-any.whl", hash = "sha256:e6046e03ce45098c15a9dbf42ced8b95dfcb60cc1f3600a6250c8f515755be5f", size = 405126, upload-time = "2026-07-24T18:31:30.844Z" },
 ]
 
 [package.optional-dependencies]

--- a/infra/package.json
+++ b/infra/package.json
@@ -11,7 +11,7 @@
     "@pulumi/cloudflare": "^6.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^26.1.1",
     "typescript": "^5.0.0"
   }
 }

--- a/infra/pnpm-lock.yaml
+++ b/infra/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         version: 3.255.0(typescript@5.9.3)
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.20.1
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -306,8 +306,8 @@ packages:
   '@types/google-protobuf@3.15.12':
     resolution: {integrity: sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==}
 
-  '@types/node@22.20.1':
-    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -813,8 +813,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
@@ -1255,9 +1255,9 @@ snapshots:
 
   '@types/google-protobuf@3.15.12': {}
 
-  '@types/node@22.20.1':
+  '@types/node@26.1.1':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 8.3.0
 
   '@types/semver@7.7.1': {}
 
@@ -1658,7 +1658,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2
-      '@types/node': 22.20.1
+      '@types/node': 26.1.1
       long: 5.3.2
 
   read-cmd-shim@6.0.0: {}
@@ -1782,7 +1782,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@6.21.0: {}
+  undici-types@8.3.0: {}
 
   undici@6.28.0: {}
 


### PR DESCRIPTION
重放今天历史重写前 Codex 已验证的 Dependabot 批次 —— 机器人自己的 PR 在基底 commit 消失后被关掉了,内容本身是好的。

| 包 | 从 | 到 |
|---|---|---|
| `logfire[asyncpg,fastapi,httpx,variables]` (agent) | 4.38.0 | 4.39.0 |
| `@types/node` (infra) | ^22.0.0 | ^26.1.1 |

## 关于 @types/node 跨两个大版本

用 CI 的**确切**命令链验的,不是 `pnpm --dir infra install`。`infra/` 在 pnpm workspace 之外、有自己的 lockfile;不加 `--ignore-workspace` 的话它声明的 TypeScript 5 根本不会安装,`pnpm exec tsc` 穿透到根的 7.0.2,后者拒绝 tsconfig 里的 `moduleResolution=node10` 并报 TS5108。那是调法错误造出来的假警报,不是缺陷 —— 加上 `--ignore-workspace` 后 tsc 是 5.9.3,两个 tsconfig project 都干净。

## 门禁

infra install + lockfile 一致性 + typecheck 三道全过;agent 1724 个单测全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)