### PR TITLE
ci: parallel per-stage web pipeline + the measurement that justifies it (CI-1 step 3)

### DIFF
--- a/.github/workflows/pipeline-web.yml
+++ b/.github/workflows/pipeline-web.yml
@@ -1,0 +1,138 @@
+name: pipeline-web
+
+on:
+  pull_request:
+  merge_group:
+    branches: [main]
+  push:
+    branches: [main]
+    paths:
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/workflows/pipeline-web.yml"
+      - ".oxlintrc.json"
+      - "apps/web/**"
+      - "e2e/**"
+      - "package.json"
+      - "packages/contract/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.merge_group.head_ref || github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    name: Web / lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Type check (tsc)
+        run: pnpm --filter web typecheck
+      - name: Oxlint (type-aware, strict)
+        run: pnpm --filter web run lint:oxlint
+
+  test:
+    name: Web / test
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Unit tests (vitest, coverage gate)
+        run: pnpm --filter web test
+      - name: Upload coverage
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: apps/web/coverage/lcov.info
+          flags: web
+          fail_ci_if_error: true
+          use_oidc: true
+
+  build:
+    name: Web / build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      WEB_ARTIFACT_NAME: bundle-web-${{ github.sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Build + output-layout integration test
+        run: pnpm --filter web test:integration
+      - name: Package build artifact
+        run: |
+          ARTIFACT_DIR="$RUNNER_TEMP/bundle-web"
+          mkdir -p "$ARTIFACT_DIR"
+          tar -C apps/web -czf "$ARTIFACT_DIR/web-output.tar.gz" .output
+          ARTIFACT_SHA256="$(sha256sum "$ARTIFACT_DIR/web-output.tar.gz" | cut -d ' ' -f1)"
+          printf '{"commit_sha":"%s","sha256":"%s"}\n' "$GITHUB_SHA" "$ARTIFACT_SHA256" \
+            > "$ARTIFACT_DIR/.artifact-meta.json"
+      - name: Upload build artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.WEB_ARTIFACT_NAME }}
+          path: |
+            ${{ runner.temp }}/bundle-web/web-output.tar.gz
+            ${{ runner.temp }}/bundle-web/.artifact-meta.json
+          if-no-files-found: error
+          include-hidden-files: true
+      - name: Isolate original build output
+        run: mv apps/web/.output "$RUNNER_TEMP/original-web-output"
+      - name: Download build artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ env.WEB_ARTIFACT_NAME }}
+          path: ${{ runner.temp }}/downloaded-web-artifact
+      - name: Verify and restore build artifact
+        run: |
+          META_PATH="$RUNNER_TEMP/downloaded-web-artifact/.artifact-meta.json"
+          BUNDLE_PATH="$RUNNER_TEMP/downloaded-web-artifact/web-output.tar.gz"
+          META_COMMIT_SHA="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["commit_sha"])' "$META_PATH")"
+          META_SHA256="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["sha256"])' "$META_PATH")"
+          test "$META_COMMIT_SHA" = "$GITHUB_SHA"
+          printf '%s  %s\n' "$META_SHA256" "$BUNDLE_PATH" | sha256sum --check --strict
+          tar -C apps/web -xzf "$BUNDLE_PATH"
+
+      # PR and merge-queue runs may only restore this release-reachable cache.
+      # The trusted push-to-main run is the sole writer.
+      - name: Resolve Playwright version
+        run: |
+          PLAYWRIGHT_VERSION="$(pnpm --dir e2e exec playwright --version)"
+          echo "PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION#Version }" >> "$GITHUB_ENV"
+        shell: bash
+      - name: Restore Playwright browser cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ env.PLAYWRIGHT_VERSION }}-chromium
+      - name: Install Playwright browser
+        run: pnpm --dir e2e exec playwright install --with-deps chromium
+      - name: Save Playwright browser cache
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ env.PLAYWRIGHT_VERSION }}-chromium
+      - name: Browser test (branded 404 on downloaded worker)
+        run: |
+          pnpm --filter web exec wrangler dev --port 8799 &
+          WRANGLER_PID=$!
+          for _ in $(seq 1 60); do curl -sf -o /dev/null http://localhost:8799/ && break; sleep 1; done
+          E2E_WEB_BASE_URL=http://localhost:8799 pnpm --dir e2e exec playwright test web-404.spec.ts web-maplibre-canary.spec.ts
+          kill "$WRANGLER_PID"

--- a/docs/iterations/iter6/measurement-CI-1-web-pipeline-split.md
+++ b/docs/iterations/iter6/measurement-CI-1-web-pipeline-split.md
@@ -1,0 +1,79 @@
+# 实测 — CI-1 第 3 步:web pipeline 阶段拆分
+
+立于 2026-08-03。这份文件回答设计稿 `design-CI-1-pipeline-refactor.md` 留下的实证问题:
+**把单个 Web CI job 拆成多个阶段,到底快不快?**
+
+数据源:`main` 上一次成功的 `ci.yml` run(`30808763707`)的 step 级时间戳,
+经 `actions/runs/<id>/jobs` 取得,非本地估算。
+
+## 基线:现在的单 job(`_webapp-ci.yml`)
+
+`Web component CI / Web app CI`,11:22:23 → 11:26:04,**总计 221s**。
+
+| step | 耗时 |
+|---|---|
+| Set up job + checkout | 4s |
+| `./.github/actions/setup` | 17s |
+| Build + output-layout integration test | 34s |
+| Type check (tsc) | 3s |
+| Oxlint(type-aware) | 5s |
+| **Unit tests(vitest + coverage)** | **118s** |
+| Upload coverage | 5s |
+| Install Playwright browser | 23s |
+| Browser test(branded 404) | 8s |
+| Post steps | 2s |
+
+两个事实决定了后面的结论:
+
+1. **单 step 主导**:vitest 一个 step 占 118s,是整个 job 的 53%。任何不动它的拆分都只能在剩下 47% 里腾挪。
+2. **固定开销 ≈23s/job**:Set up job + checkout + setup + post。每多一个 job 就多付一次。
+
+## 三个阶段互相独立(实测,非推断)
+
+拆分的前提是阶段之间没有隐藏依赖。`apps/web/src/routeTree.gen.ts` 是 gitignored 的生成物,
+`_webapp-ci.yml` 的注释因此声明"build 必须先跑"。实测下来这个约束**不成立**:
+
+- `pnpm --filter web typecheck` 本身就是 `pnpm run routes:generate && tsc --noEmit`,自己生成路由树。
+  删掉生成物后从零跑,typecheck 与 oxlint 均 exit 0。
+- `pnpm --filter web test` 在没有 `.output`、没有 `routeTree.gen.ts` 的状态下,
+  215 个测试文件 / 1608 个测试全过,exit 0。
+
+所以 lint / test / build 三者可以任意并发。
+
+## 结论:串行拆分更慢,并行拆分才快
+
+| 方案 | 墙钟 | 相对基线 | runner 分钟 |
+|---|---|---|---|
+| 基线(单 job) | 221s | — | 1.0× |
+| **串行拆分**(`needs` 链) | **≈302s** | **慢 37%** | 1.3× |
+| **并行拆分**(无 `needs`) | **≈146s** | **快 34%** | 1.4× |
+
+串行方案(spike 最初的写法,lint → test → build 用 `needs` 串起来)之所以更慢,
+是因为它把本来就串行的东西又串了一遍,同时多付两次 23s 固定开销、并新增一趟
+artifact 往返(打包 + 上传 + 下载 + 校验),却完全没有碰 118s 的 vitest。
+
+并行方案的墙钟由最慢的那个 job 决定:
+
+- lint = 23(开销)+ 3(tsc)+ 5(oxlint) ≈ **31s**
+- **test = 23 + 118(vitest)+ 5(coverage) ≈ 146s ← 关键路径**
+- build = 23 + 34(build)+ ~15(artifact 往返)+ 23(playwright)+ 8(browser) ≈ **103s**
+
+代价是 runner 分钟约 1.4×。快 34% 换多花 40% 机器时间,在这个规模上值得:
+Web 是耗时最长的组件,PR 上的等待直接体现为人的等待。
+
+## 下一步不该做的事
+
+**不要指望继续拆能继续快。** 关键路径现在是 vitest 那 118s,再拆阶段无法触及它。
+真要往下压,唯一有意义的方向是把 vitest 本身分片(`--shard`)并发,
+那是独立的一张卡,收益与 runner 成本要重新测,不在本卡范围内。
+
+## 落地方式
+
+按设计稿的并存流程,不做原地替换:
+
+1. **本 PR**:`pipeline-web.yml` 与现有的 `_webapp-ci.yml` **同时运行**,PR 上会看到两套 Web 检查。
+2. 观察若干次 run,确认新 pipeline 的三个 job 稳定绿、耗时符合上表。
+3. ruleset 用并集法改必需检查:先加 `Web / lint`、`Web / test`、`Web / build` 三个新名字,
+   验证通过后再移除 `Web component CI / Web app CI` —— 绝不先删后加,
+   因为 `bypass_actors: []` 会让 Pending 永久卡住。
+4. 最后从 `ci.yml` 摘掉对 `_webapp-ci.yml` 的调用并删除该文件。


### PR DESCRIPTION
CI-1 第 3 步。**主产物是数据**,workflow 文件是数据得出的结论。
完整实测见 `docs/iterations/iter6/measurement-CI-1-web-pipeline-split.md`。

## 结论

| 方案 | 墙钟 | 相对基线 |
|---|---|---|
| 基线(单 job) | 221s | — |
| 串行拆分(`needs` 链) | ≈302s | **慢 37%** |
| 并行拆分(本 PR) | ≈146s | **快 34%** |

spike 最初把 lint → test → build 用 `needs` 串起来 —— 那是唯一不可能赢的写法:
它把本来就串行的东西又串一遍,多付两次 ~23s 固定开销,新增一趟 artifact 往返,
却完全没碰占整个 job 53% 的 118s vitest step。

## 三阶段独立性是实测的,不是假设

`_webapp-ci.yml` 的注释声明"build 必须先跑,因为 `routeTree.gen.ts` 是生成物"。实测不成立:

- `typecheck` 脚本本身是 `pnpm run routes:generate && tsc --noEmit`,自己生成路由树;删掉生成物后从零跑,typecheck 与 oxlint 均 exit 0
- `pnpm --filter web test` 在无 `.output`、无 `routeTree.gen.ts` 的状态下,215 文件 / 1608 测试全过

## 代价与落地

runner 分钟 ≈1.4×。Web 是耗时最长的组件,PR 上的等待就是人的等待,这笔换得值。

本 PR **故意**与 `_webapp-ci.yml` 并存,PR 上会看到两套 Web 检查。ruleset 翻转走并集法(先加三个新名字 → 验证 → 再移除旧名字),绝不先删后加 —— `bypass_actors: []` 会让 Pending 永久卡住。

## 下一步不该做的

关键路径已是 vitest 的 118s,再拆阶段碰不到它。唯一有意义的方向是 `vitest --shard` 分片,那是独立的一张卡。

🤖 Generated with [Claude Code](https://claude.com/claude-code)