### PR TITLE
fix(ci): 修复 SonarCloud S6506/S8541 安全告警

### DIFF
--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Audit workflows
         env:
           GH_TOKEN: ${{ github.token }}
-        run: uvx zizmor@"$ZIZMOR_VERSION" --cache-dir ~/.cache/zizmor .
+        run: uvx --no-build zizmor@"$ZIZMOR_VERSION" --cache-dir ~/.cache/zizmor .
       # Only main-branch runs may write the shared cache — a PR (including a
       # fork PR) can read it but never poison it.
       - name: Save zizmor audit cache
@@ -172,8 +172,8 @@ jobs:
           ACTIONLINT_ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           ACTIONLINT_CHECKSUMS="actionlint_${ACTIONLINT_VERSION}_checksums.txt"
           ACTIONLINT_BASE_URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
-          curl -sSfL -o "${ACTIONLINT_ARCHIVE}" "${ACTIONLINT_BASE_URL}/${ACTIONLINT_ARCHIVE}"
-          curl -sSfL -o "${ACTIONLINT_CHECKSUMS}" "${ACTIONLINT_BASE_URL}/${ACTIONLINT_CHECKSUMS}"
+          curl -sSfL --proto '=https' --proto-redir '=https' -o "${ACTIONLINT_ARCHIVE}" "${ACTIONLINT_BASE_URL}/${ACTIONLINT_ARCHIVE}"
+          curl -sSfL --proto '=https' --proto-redir '=https' -o "${ACTIONLINT_CHECKSUMS}" "${ACTIONLINT_BASE_URL}/${ACTIONLINT_CHECKSUMS}"
           grep -F "  ${ACTIONLINT_ARCHIVE}" "${ACTIONLINT_CHECKSUMS}" > actionlint.sha256
           sha256sum -c actionlint.sha256
           tar -xzf "${ACTIONLINT_ARCHIVE}" actionlint


### PR DESCRIPTION
## 背景

`.github/workflows/_security.yml` 上有两条 SonarCloud 一直报 ERROR 的真实告警——都是在已合并 PR 上冒出来、但没人处理，导致 main 的 Quality Gate 一直是 ERROR。

## 修复内容

### 1. `githubactions:S6506` ×2（第 175-176 行）

`actionlint` 归档 + 校验和文件的下载 curl 都没有强制 HTTPS，重定向可被降级到 http。更严重的是：**校验和文件本身也走同一条不安全连接下载**，如果攻击者能劫持重定向，就可以同时替换归档和校验和——`sha256sum -c` 会验证一个被攻击者一并替换掉的"正确答案"，形同虚设。

修法：两条 curl 都加 `--proto '=https' --proto-redir '=https'`，禁止初始请求或重定向降级到明文协议。

### 2. `githubactions:S8541`（第 151 行）

`uvx zizmor@"$ZIZMOR_VERSION" --cache-dir ~/.cache/zizmor .` 没有禁止 sdist 构建，如果 zizmor 解析到源码分发包，会执行其 build/setup 脚本。

修法：加 `--no-build`（这是 `uvx`/`uv` 的标志，不是 zizmor CLI 的标志，所以放在 `uvx --no-build zizmor@...` 而不是 `zizmor@... --no-build`——zizmor 自己没有这个参数，传给它会直接报错），与仓库里 `.github/scripts/test_config_read_sets.py` 已经用的 `uv run --script --locked --no-build` 是同一族修复。

## 实测验证

- `actionlint .github/workflows/_security.yml` → exit 0，无告警。
- `GH_TOKEN=$(gh auth token) uvx --no-build zizmor@1.5.2 --cache-dir /tmp/zzr .` → 对整个 workflow 集合跑通，输出 `No findings to report. Good job! (5 suppressed)`。确认了 zizmor 1.5.2 确实发布了 wheel，加 `--no-build` 不会导致审计失败。
- 单独跑了改动后的两条 curl 命令（真实 GitHub releases URL：actionlint v1.7.7 归档 + 校验和文件），确认下载都成功，且 `sha256sum -c` 加了 `--proto` 参数后依然显示 `OK`。

## 约束

无任何 suppression（无 NOSONAR / eslint-disable / continue-on-error / skip），纯粹修代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved workflow security auditing and validation.
  * Enforced HTTPS for actionlint archive downloads and redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->