### PR TITLE
fix: remove false-green neon-auth test + dedupe error-message literal

### DIFF
--- a/apps/agent/agent/agents/error_messages.py
+++ b/apps/agent/agent/agents/error_messages.py
@@ -23,6 +23,13 @@ InputError = Literal["message_too_long", "non_text_message"]
 _DEFAULT_LOCALE = "en"
 CATALOG_ROUTE_UNAVAILABLE_MESSAGE = "Catalog route unavailable"
 INTERNAL_ERROR_DETAIL_MESSAGE = "An internal error occurred. Please try again."
+# `service_unavailable`, `configuration_error`, and `missing_config` are distinct
+# error codes that share one public-facing message: none of them expose actionable
+# detail to the user, so the runtime state behind them is intentionally
+# indistinguishable at the trust boundary (SD-19).
+_SERVICE_UNAVAILABLE_MESSAGE = (
+    "The service is temporarily unavailable. Please try again."
+)
 
 _PUBLIC_ERROR_MESSAGES: dict[str, str] = {
     "invalid_request": "The request is invalid.",
@@ -45,9 +52,9 @@ _PUBLIC_ERROR_MESSAGES: dict[str, str] = {
     "internal_error": "The runtime failed before producing a pipeline result.",
     "unknown_error": "An unknown error occurred. Please try again.",
     "external_service_error": "An external service failed. Please try again.",
-    "service_unavailable": "The service is temporarily unavailable. Please try again.",
-    "configuration_error": "The service is temporarily unavailable. Please try again.",
-    "missing_config": "The service is temporarily unavailable. Please try again.",
+    "service_unavailable": _SERVICE_UNAVAILABLE_MESSAGE,
+    "configuration_error": _SERVICE_UNAVAILABLE_MESSAGE,
+    "missing_config": _SERVICE_UNAVAILABLE_MESSAGE,
     "provider_error": (
         "The AI service is temporarily unavailable. Please try again in a moment."
     ),

--- a/apps/web/tests/unit/neon-auth.test.ts
+++ b/apps/web/tests/unit/neon-auth.test.ts
@@ -93,12 +93,6 @@ describe("fetchAuthToken", () => {
     expect(await fetchAuthToken()).toBeUndefined();
   });
 
-  it("returns undefined when jwtClient returns no token data", async () => {
-    configure();
-    token.mockResolvedValue({ data: null, error: null });
-    expect(await fetchAuthToken()).toBeUndefined();
-  });
-
   it("returns undefined when jwtClient throws", async () => {
     configure();
     token.mockRejectedValue(new Error("network"));


### PR DESCRIPTION
## 概述

- **任务 1（核心）**：删除 `apps/web/tests/unit/neon-auth.test.ts` 中「因错误原因通过」的用例。
- **任务 2（低危）**：`apps/agent/agent/agents/error_messages.py` 抽取重复三次的对外话术字面量为常量（Sonar `python:S1192`）。

## 任务 1 证据

被删用例（原第 96-100 行）用 `token.mockResolvedValue({ data: null, error: null })` 断言 `fetchAuthToken()` 返回 `undefined`。这个输入形状是 better-auth 类型系统禁止的（成功分支 `data` 必为非空、`token` 必填，此前一轮已用 tsc 探针核实生产路径不可能出现该形状）。

**变异测试证据**（先跑基线，再变异，记录前后输出）：

1. 基线：`pnpm exec vitest run tests/unit/neon-auth.test.ts` → 11 个用例全绿。
2. 变异：把 `fetchAuthToken` 的 `catch` 块从 `return undefined` 改成 `return "MUTATED_CATCH_VALUE"`。
3. 结果：「returns undefined when jwtClient returns no token data」（就是那条可疑用例）与「returns undefined when jwtClient throws」**同时、同样地**失败——两者断言完全相同的错误值。这证明可疑用例并没有测试任何独立的业务分支，它只是碰巧靠 `data.token` 在 `data: null` 时抛出 TypeError、被同一个 `catch` 吞掉而"蒙对"了输出，和真实的网络异常路径是同一段代码、零增量覆盖。

处理方式：直接删除该用例（未加生产代码空值守卫——已确认生产路径非空，加守卫是死代码）。

删除后验证：
- `neon-auth.test.ts`：10 个用例全绿。
- `apps/web` 全量：`pnpm run test` → 215 个测试文件、1607 个用例全绿；覆盖率 statements 98.42 / branches 95.34 / functions 98.57 / lines 99.44（地板为 95/94/95/95，见 `vitest.config.ts`），未跌破。

## 任务 2 证据

`_PUBLIC_ERROR_MESSAGES` 中 `service_unavailable`、`configuration_error`、`missing_config` 三个错误码逐字重复同一条话术。抽成模块常量 `_SERVICE_UNAVAILABLE_MESSAGE`，并加注释说明这三个错误码在信任边界（SD-19）上刻意共享同一条不可操作的话术——不是巧合。**未改变任何一条对外话术的实际文本**。

验证：`cd apps/agent && uv run pytest agent/tests/unit/ -q` → 1724 个用例全绿，覆盖率 89.26%（地板 87%），与改动前一致。

## 测试计划

- [x] `pnpm exec vitest run tests/unit/neon-auth.test.ts`（改前 11 绿 / 改后 10 绿）
- [x] `pnpm run test`（apps/web 全量，215 文件 / 1607 用例全绿，覆盖率达标）
- [x] `uv run pytest agent/tests/unit/ -q`（1724 用例全绿，覆盖率达标）

🤖 Generated with [Claude Code](https://claude.com/claude-code)