### PR TITLE
iter6 W2-B9: 跨端魔法常量入契约包 — EdDSA/Turnstile 守卫

### DIFF
--- a/.github/scripts/test_config_read_sets.py
+++ b/.github/scripts/test_config_read_sets.py
@@ -24,6 +24,8 @@ CHECK_PATHS = (
     "apps/agent/agent/tests/unit/test_documentation_guardrails.py",
     "apps/agent/agent/tests/unit/test_secrets_docs_consistency.py",
     "workers/maintenance/test/config.worker.test.ts",
+    "workers/users/test/eddsa-shared-primitive.worker.test.ts",
+    "apps/web/tests/unit/chat/turnstile-constants-guard.test.ts",
 )
 TS_READS = re.compile(
     r"export\s+const\s+READS\s*=\s*(\[[^]]*])\s+as\s+const\s*;", re.DOTALL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,11 @@ jobs:
           filters: |
             contract: ['packages/contract/**']
             catalog: ['workers/catalog/**', 'packages/contract/**']
-            users: ['workers/users/**', 'packages/contract/**']
+            # workers/users/test/eddsa-shared-primitive.worker.test.ts asserts worker/auth.ts
+            # (the edge /v1 EdDSA consumer) still delegates to the shared contract verifier —
+            # scoping this filter to workers/users/** + packages/contract/** alone would let a
+            # regression land in worker/auth.ts while ci-users skips (issue #647).
+            users: ['workers/users/**', 'packages/contract/**', 'worker/auth.ts']
             # workers/maintenance/test/config.worker.test.ts asserts against the deploy
             # wiring itself — ci.yml, deploy.yml, _deploy-component.yml, both deprecated
             # fallback workflows and docs/ops/secrets.md are read verbatim by that test.
@@ -106,7 +110,12 @@ jobs:
             # while this filter excluded tests/eval/**, so the smoke job SKIPPED
             # on the very PR that changed it — a gate that cannot test itself.
             agent_behavior: ['apps/agent/agent/agents/**', 'apps/agent/agent/config/model_aliases.py', 'apps/agent/agent/config/settings.py', 'apps/agent/agent/tests/eval/**']
-            web: ['apps/web/**']
+            # apps/web/tests/unit/chat/turnstile-constants-guard.test.ts reads
+            # worker/turnstile.ts + packages/contract/src/constants.ts to assert the
+            # edge worker and this app still share the Turnstile header/TTL constants
+            # (issue #647); without these two entries a regression in either file
+            # would land while ci-web skips.
+            web: ['apps/web/**', 'worker/turnstile.ts', 'packages/contract/**']
             worker: ['worker/**']
             infra: ['infra/**']
             migrations: ['supabase/migrations/**', 'db/**', 'docs/ops/migrations.md', 'docs/ops/deployment.md', 'README*', 'Makefile', 'worker/migrationBoundary.test.ts', '.github/workflows/ci.yml', '.github/workflows/deploy.yml']

--- a/apps/web/tests/unit/chat/turnstile-constants-guard.test.ts
+++ b/apps/web/tests/unit/chat/turnstile-constants-guard.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "vitest";
 import constantsSource from "../../../../../packages/contract/src/constants.ts?raw";
 import edgeTurnstileSource from "../../../../../worker/turnstile.ts?raw";
-import { describe, expect, it } from "vitest";
 import tokenStoreSource from "../../../src/lib/turnstile/tokenStore.ts?raw";
 
 /**
@@ -9,9 +9,28 @@ import tokenStoreSource from "../../../src/lib/turnstile/tokenStore.ts?raw";
  * sync only by a comment cross-reference. Both now import
  * `TURNSTILE_HEADER` / `TURNSTILE_WINDOW_MS` / `TURNSTILE_TOKEN_TTL_MS` from
  * `@animichi/contract/constants` (fix(auth): share edge security primitives,
- * 1edb45a5) — this iter6 B9 (issue #647) guard fails the moment either side
- * reverts to a hand-typed literal instead of the shared import, which is
- * exactly how the two would silently drift again.
+ * 1edb45a5). This iter6 B9 (issue #647) guard fails the moment either side
+ * reverts to a hand-typed literal instead of the shared import.
+ *
+ * Second review pass on this guard flagged that a plain "does the file
+ * contain this substring" check has real holes: it only checked ONE of the
+ * three constants, and a `"..."`-only literal ban is dodged by switching
+ * quotes. Judged semantically instead, on comment-stripped source (a doc
+ * comment mentioning a constant's name in prose must not count as "using"
+ * it — this file's own comments do exactly that, which is why stripping
+ * matters and not just an abstract concern):
+ *   - each constant is checked individually — imported from the contract
+ *     module AND referenced again beyond that import line, in actual code;
+ *   - literal bans match any quote style (`'`, `"`, or a template literal).
+ *
+ * `typescript@7` (this repo's pin) restructured the package around the new
+ * native compiler and dropped the classic `ts.createSourceFile` tree-walking
+ * API; the surviving fallback (`typescript/unstable/ast`'s scanner) OOMs the
+ * `vitest-pool-workers` isolate used by the sibling EdDSA guard in
+ * `workers/users` (verified: `JavaScript heap out of memory`). To keep both
+ * guards on one technique, this file uses the same regex-based semantic
+ * checks rather than a real parser — see that guard's block comment for the
+ * full rationale.
  */
 export const READS = [
   "packages/contract/src/constants.ts",
@@ -19,32 +38,91 @@ export const READS = [
   "apps/web/src/lib/turnstile/tokenStore.ts",
 ] as const;
 
-const IMPORTS_SHARED_CONSTANTS =
-  /import\s*\{[^}]*\bTURNSTILE_HEADER\b[^}]*\}\s*from\s*["']@animichi\/contract\/constants["']/;
+const MODULE = "@animichi/contract/constants";
+const QUOTED = (literal: string): RegExp => new RegExp(`['"\`]${literal}['"\`]`);
+
+/**
+ * Comments removed, string/template literals left intact. A naive
+ * line-comment regex would truncate a `"https://..."` literal at its `//`,
+ * so string/template literals are matched as whole alternatives *before*
+ * the comment alternatives — the regex engine consumes an entire literal in
+ * one match, so a `//` or `/*` inside it is never seen as its own token.
+ */
+const LITERAL_OR_COMMENT =
+  /'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`|\/\/[^\n]*|\/\*[\s\S]*?\*\//g;
+
+function stripComments(source: string): string {
+  return source.replace(LITERAL_OR_COMMENT, (match) =>
+    match.startsWith("//") || match.startsWith("/*") ? "" : match,
+  );
+}
+
+function importsNamedFrom(code: string, moduleSpecifier: string, name: string): boolean {
+  const escapedModule = moduleSpecifier.replaceAll("/", String.raw`\/`);
+  const re = new RegExp(String.raw`import\s*\{([^}]*)\}\s*from\s*['"]${escapedModule}['"]`, "g");
+  for (const match of code.matchAll(re)) {
+    const names = (match[1] ?? "").split(",").map((entry) => entry.trim());
+    if (names.includes(name)) return true;
+  }
+  return false;
+}
+
+/** How many times `name` appears as a standalone word in comment-free `code`. */
+function occurrenceCount(code: string, name: string): number {
+  return [...code.matchAll(new RegExp(String.raw`\b${name}\b`, "g"))].length;
+}
+
+/**
+ * `code` with every `import { ... } from "..."` and `export { ... }` line
+ * removed — a bare re-export (this file has one) mentions the name without
+ * ever *using* it, so it must not count toward "genuinely referenced".
+ */
+function withoutImportExportLines(code: string): string {
+  return code
+    .replaceAll(/import\s*\{[^}]*\}\s*from\s*['"][^'"]*['"];?/g, "")
+    .replaceAll(/export\s*\{[^}]*\};?/g, "");
+}
+
+/** `name` is imported from the module AND referenced in code beyond that. */
+function isRealConsumer(code: string, name: string): boolean {
+  return importsNamedFrom(code, MODULE, name) && occurrenceCount(withoutImportExportLines(code), name) > 0;
+}
+
+/** Every quoted-literal value (single/double/template, no interpolation) in `code`. */
+function stringLiteralValues(code: string): Set<string> {
+  const re = /'((?:[^'\\]|\\.)*)'|"((?:[^"\\]|\\.)*)"|`((?:[^`\\$]|\\.)*)`/g;
+  const values = new Set<string>();
+  for (const match of code.matchAll(re)) values.add(match[1] ?? match[2] ?? match[3] ?? "");
+  return values;
+}
+
+const edgeCode = stripComments(edgeTurnstileSource);
+const tokenStoreCode = stripComments(tokenStoreSource);
+const constantsCode = stripComments(constantsSource);
 
 describe("Turnstile constants stay in the shared contract package (issue #647)", () => {
-  it("the edge worker imports the shared header + window constants", () => {
-    expect(edgeTurnstileSource).toMatch(IMPORTS_SHARED_CONSTANTS);
-    expect(edgeTurnstileSource).toMatch(/\bTURNSTILE_WINDOW_MS\b/);
+  it("the edge worker imports and genuinely uses TURNSTILE_HEADER and TURNSTILE_WINDOW_MS", () => {
+    expect(isRealConsumer(edgeCode, "TURNSTILE_HEADER")).toBe(true);
+    expect(isRealConsumer(edgeCode, "TURNSTILE_WINDOW_MS")).toBe(true);
   });
 
-  it("the web token store imports the shared header + TTL constants", () => {
-    expect(tokenStoreSource).toMatch(IMPORTS_SHARED_CONSTANTS);
-    expect(tokenStoreSource).toMatch(/\bTURNSTILE_TOKEN_TTL_MS\b/);
+  it("the web token store imports and genuinely uses TURNSTILE_HEADER and TURNSTILE_TOKEN_TTL_MS", () => {
+    expect(isRealConsumer(tokenStoreCode, "TURNSTILE_HEADER")).toBe(true);
+    expect(isRealConsumer(tokenStoreCode, "TURNSTILE_TOKEN_TTL_MS")).toBe(true);
   });
 
-  it("neither consumer hand-rolls the wire header name as a literal", () => {
-    expect(edgeTurnstileSource).not.toContain('"cf-turnstile-response"');
-    expect(tokenStoreSource).not.toContain('"cf-turnstile-response"');
+  it("neither consumer hand-rolls the wire header name as a literal (any quote style)", () => {
+    expect(QUOTED("cf-turnstile-response").test(edgeCode)).toBe(false);
+    expect(QUOTED("cf-turnstile-response").test(tokenStoreCode)).toBe(false);
   });
 
   it("the shared constant is still the one place the header literal lives", () => {
-    expect(constantsSource).toContain('TURNSTILE_HEADER = "cf-turnstile-response"');
+    expect(stringLiteralValues(constantsCode)).toContain("cf-turnstile-response");
   });
 
   it("the token TTL is still derived from the window, not a second literal", () => {
-    expect(constantsSource).toMatch(
-      /TURNSTILE_TOKEN_TTL_MS\s*=\s*TURNSTILE_WINDOW_MS\s*-\s*60_000/,
-    );
+    // TURNSTILE_WINDOW_MS must appear at least twice in constants.ts: once for
+    // its own declaration and once as the right-hand side TTL derives from.
+    expect(occurrenceCount(constantsCode, "TURNSTILE_WINDOW_MS")).toBeGreaterThan(1);
   });
 });

--- a/apps/web/tests/unit/chat/turnstile-constants-guard.test.ts
+++ b/apps/web/tests/unit/chat/turnstile-constants-guard.test.ts
@@ -1,0 +1,50 @@
+import constantsSource from "../../../../../packages/contract/src/constants.ts?raw";
+import edgeTurnstileSource from "../../../../../worker/turnstile.ts?raw";
+import { describe, expect, it } from "vitest";
+import tokenStoreSource from "../../../src/lib/turnstile/tokenStore.ts?raw";
+
+/**
+ * The Turnstile header name and TTL/window relationship lived once in the edge
+ * worker (`worker/turnstile.ts`) and once in this app's token store, kept in
+ * sync only by a comment cross-reference. Both now import
+ * `TURNSTILE_HEADER` / `TURNSTILE_WINDOW_MS` / `TURNSTILE_TOKEN_TTL_MS` from
+ * `@animichi/contract/constants` (fix(auth): share edge security primitives,
+ * 1edb45a5) — this iter6 B9 (issue #647) guard fails the moment either side
+ * reverts to a hand-typed literal instead of the shared import, which is
+ * exactly how the two would silently drift again.
+ */
+export const READS = [
+  "packages/contract/src/constants.ts",
+  "worker/turnstile.ts",
+  "apps/web/src/lib/turnstile/tokenStore.ts",
+] as const;
+
+const IMPORTS_SHARED_CONSTANTS =
+  /import\s*\{[^}]*\bTURNSTILE_HEADER\b[^}]*\}\s*from\s*["']@animichi\/contract\/constants["']/;
+
+describe("Turnstile constants stay in the shared contract package (issue #647)", () => {
+  it("the edge worker imports the shared header + window constants", () => {
+    expect(edgeTurnstileSource).toMatch(IMPORTS_SHARED_CONSTANTS);
+    expect(edgeTurnstileSource).toMatch(/\bTURNSTILE_WINDOW_MS\b/);
+  });
+
+  it("the web token store imports the shared header + TTL constants", () => {
+    expect(tokenStoreSource).toMatch(IMPORTS_SHARED_CONSTANTS);
+    expect(tokenStoreSource).toMatch(/\bTURNSTILE_TOKEN_TTL_MS\b/);
+  });
+
+  it("neither consumer hand-rolls the wire header name as a literal", () => {
+    expect(edgeTurnstileSource).not.toContain('"cf-turnstile-response"');
+    expect(tokenStoreSource).not.toContain('"cf-turnstile-response"');
+  });
+
+  it("the shared constant is still the one place the header literal lives", () => {
+    expect(constantsSource).toContain('TURNSTILE_HEADER = "cf-turnstile-response"');
+  });
+
+  it("the token TTL is still derived from the window, not a second literal", () => {
+    expect(constantsSource).toMatch(
+      /TURNSTILE_TOKEN_TTL_MS\s*=\s*TURNSTILE_WINDOW_MS\s*-\s*60_000/,
+    );
+  });
+});

--- a/workers/users/test/eddsa-shared-primitive.worker.test.ts
+++ b/workers/users/test/eddsa-shared-primitive.worker.test.ts
@@ -1,0 +1,49 @@
+import contractJwtSource from "../../../packages/contract/src/jwt.ts?raw";
+import edgeAuthSource from "../../../worker/auth.ts?raw";
+import { describe, expect, it } from "vitest";
+import usersJwtSource from "../src/auth/jwt.ts?raw";
+
+/**
+ * Neon Auth EdDSA verification lived twice — `worker/auth.ts` (edge `/v1`) and
+ * `workers/users/src/auth/jwt.ts` (this service's own JWKS check) each called
+ * `jose.jwtVerify` with a hand-typed `algorithms: ["EdDSA"]` restriction. Two
+ * engineers keeping the same cryptographic policy in sync by memory is exactly
+ * the failure mode iter6 B9 (issue #647) exists to close: both now delegate to
+ * `verifyEdDsaJwt` in `@animichi/contract/jwt` (fix(auth): share edge security
+ * primitives, 1edb45a5). This guard fails the moment either consumer drifts
+ * back to its own inline `algorithms: ["EdDSA"]`, since a re-inlined check is
+ * a policy fork nothing else here would notice.
+ */
+export const READS = [
+  "packages/contract/src/jwt.ts",
+  "worker/auth.ts",
+  "workers/users/src/auth/jwt.ts",
+] as const;
+
+const IMPORTS_SHARED_VERIFIER =
+  /import\s*\{[^}]*\bverifyEdDsaJwt\b[^}]*\}\s*from\s*["']@animichi\/contract\/jwt["']/;
+
+describe("EdDSA verification stays a single shared primitive (issue #647)", () => {
+  it("the edge worker (/v1) delegates to the shared verifier", () => {
+    expect(edgeAuthSource).toMatch(IMPORTS_SHARED_VERIFIER);
+  });
+
+  it("the users worker delegates to the shared verifier", () => {
+    expect(usersJwtSource).toMatch(IMPORTS_SHARED_VERIFIER);
+  });
+
+  it("neither consumer hand-rolls its own EdDSA algorithm restriction", () => {
+    // `worker/auth.ts` legitimately reads a JWT header's `alg` field to decide
+    // *whether* to route to the Neon verifier — that is routing logic, not a
+    // second implementation of the crypto policy. What must never reappear in
+    // either consumer is an inline `jwtVerify(..., { algorithms: ["EdDSA"] })`
+    // — that is the literal duplication `verifyEdDsaJwt` replaced.
+    const inlineAlgorithmRestriction = /algorithms:\s*\[\s*["']EdDSA["']\s*\]/;
+    expect(edgeAuthSource).not.toMatch(inlineAlgorithmRestriction);
+    expect(usersJwtSource).not.toMatch(inlineAlgorithmRestriction);
+  });
+
+  it("the shared primitive is still the one place EdDSA is pinned", () => {
+    expect(contractJwtSource).toMatch(/algorithms:\s*\["EdDSA"\]/);
+  });
+});

--- a/workers/users/test/eddsa-shared-primitive.worker.test.ts
+++ b/workers/users/test/eddsa-shared-primitive.worker.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "vitest";
 import contractJwtSource from "../../../packages/contract/src/jwt.ts?raw";
 import edgeAuthSource from "../../../worker/auth.ts?raw";
-import { describe, expect, it } from "vitest";
 import usersJwtSource from "../src/auth/jwt.ts?raw";
 
 /**
@@ -11,8 +11,30 @@ import usersJwtSource from "../src/auth/jwt.ts?raw";
  * the failure mode iter6 B9 (issue #647) exists to close: both now delegate to
  * `verifyEdDsaJwt` in `@animichi/contract/jwt` (fix(auth): share edge security
  * primitives, 1edb45a5). This guard fails the moment either consumer drifts
- * back to its own inline `algorithms: ["EdDSA"]`, since a re-inlined check is
- * a policy fork nothing else here would notice.
+ * back to its own inline `algorithms: ["EdDSA"]` — or keeps the import but
+ * stops actually calling it, which an import-only check would miss.
+ *
+ * Second review pass on this guard flagged two holes in the original regex
+ * version: it asserted the import existed but never that the imported
+ * function was actually *called* (an unused import next to a re-inlined
+ * verification would have passed), and its literal ban only matched
+ * double-quoted `"EdDSA"`. Both are closed below by checking semantics —
+ * import presence, an actual call site, and a quote-agnostic literal scan —
+ * on comment-stripped source, so a doc comment merely *mentioning* a name
+ * or a literal (like this one) can never masquerade as real usage.
+ *
+ * A real parser would make this more precise still, but `typescript@7`
+ * (this repo's pin) restructured the package around the new native compiler
+ * and no longer ships the classic `ts.createSourceFile` API. The surviving
+ * fallback, `typescript/unstable/ast`'s tokenizer, was tried here first and
+ * reliably OOMs this file's `vitest-pool-workers` isolate:
+ *
+ *   V8 fatal error; message = : allocation failed: JavaScript heap out of memory
+ *
+ * (reproduced 2026-08-04, loading `typescript/unstable/ast` inside this same
+ * `test/*.worker.test.ts` file — its generated AST/factory modules are too
+ * large for the Worker isolate's heap). Falling back to regex checks that are
+ * provably quote-agnostic and assert actual usage, not just import shape.
  */
 export const READS = [
   "packages/contract/src/jwt.ts",
@@ -20,30 +42,74 @@ export const READS = [
   "workers/users/src/auth/jwt.ts",
 ] as const;
 
-const IMPORTS_SHARED_VERIFIER =
-  /import\s*\{[^}]*\bverifyEdDsaJwt\b[^}]*\}\s*from\s*["']@animichi\/contract\/jwt["']/;
+const MODULE = "@animichi/contract/jwt";
+
+/**
+ * Comments removed, string/template literals left intact. A naive
+ * line-comment regex would truncate a `"https://..."` literal at its `//`,
+ * so string/template literals are matched as whole alternatives *before*
+ * the comment alternatives — the regex engine consumes an entire literal in
+ * one match, so a `//` or `/*` inside it is never seen as its own token.
+ */
+const LITERAL_OR_COMMENT =
+  /'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`|\/\/[^\n]*|\/\*[\s\S]*?\*\//g;
+
+function stripComments(source: string): string {
+  return source.replace(LITERAL_OR_COMMENT, (match) =>
+    match.startsWith("//") || match.startsWith("/*") ? "" : match,
+  );
+}
+
+function importsNamedFrom(code: string, moduleSpecifier: string, name: string): boolean {
+  const escapedModule = moduleSpecifier.replaceAll("/", String.raw`\/`);
+  const re = new RegExp(String.raw`import\s*\{([^}]*)\}\s*from\s*['"]${escapedModule}['"]`, "g");
+  for (const match of code.matchAll(re)) {
+    const names = (match[1] ?? "").split(",").map((entry) => entry.trim());
+    if (names.includes(name)) return true;
+  }
+  return false;
+}
+
+/** `name` is called as a function — an identifier immediately followed by `(`. */
+function isCalled(code: string, name: string): boolean {
+  return new RegExp(String.raw`\b${name}\s*\(`).test(code);
+}
+
+/** An `algorithms: [...]` object-literal property whose array contains "EdDSA". */
+function hasInlineEdDsaAlgorithms(code: string): boolean {
+  const arrays = code.matchAll(/algorithms\s*:\s*\[([^\]]*)\]/g);
+  for (const match of arrays) {
+    if (/['"`]EdDSA['"`]/.test(match[1] ?? "")) return true;
+  }
+  return false;
+}
+
+const edgeCode = stripComments(edgeAuthSource);
+const usersCode = stripComments(usersJwtSource);
+const contractCode = stripComments(contractJwtSource);
 
 describe("EdDSA verification stays a single shared primitive (issue #647)", () => {
-  it("the edge worker (/v1) delegates to the shared verifier", () => {
-    expect(edgeAuthSource).toMatch(IMPORTS_SHARED_VERIFIER);
+  it("the edge worker (/v1) imports and calls the shared verifier", () => {
+    expect(importsNamedFrom(edgeCode, MODULE, "verifyEdDsaJwt")).toBe(true);
+    expect(isCalled(edgeCode, "verifyEdDsaJwt")).toBe(true);
   });
 
-  it("the users worker delegates to the shared verifier", () => {
-    expect(usersJwtSource).toMatch(IMPORTS_SHARED_VERIFIER);
+  it("the users worker imports and calls the shared verifier", () => {
+    expect(importsNamedFrom(usersCode, MODULE, "verifyEdDsaJwt")).toBe(true);
+    expect(isCalled(usersCode, "verifyEdDsaJwt")).toBe(true);
   });
 
-  it("neither consumer hand-rolls its own EdDSA algorithm restriction", () => {
+  it("neither consumer hand-rolls its own EdDSA algorithm restriction (any quote style)", () => {
     // `worker/auth.ts` legitimately reads a JWT header's `alg` field to decide
     // *whether* to route to the Neon verifier — that is routing logic, not a
-    // second implementation of the crypto policy. What must never reappear in
-    // either consumer is an inline `jwtVerify(..., { algorithms: ["EdDSA"] })`
-    // — that is the literal duplication `verifyEdDsaJwt` replaced.
-    const inlineAlgorithmRestriction = /algorithms:\s*\[\s*["']EdDSA["']\s*\]/;
-    expect(edgeAuthSource).not.toMatch(inlineAlgorithmRestriction);
-    expect(usersJwtSource).not.toMatch(inlineAlgorithmRestriction);
+    // second implementation of the crypto policy. What must never reappear is
+    // an inline `algorithms: [...]` array containing "EdDSA", the literal
+    // duplication `verifyEdDsaJwt` replaced.
+    expect(hasInlineEdDsaAlgorithms(edgeCode)).toBe(false);
+    expect(hasInlineEdDsaAlgorithms(usersCode)).toBe(false);
   });
 
   it("the shared primitive is still the one place EdDSA is pinned", () => {
-    expect(contractJwtSource).toMatch(/algorithms:\s*\["EdDSA"\]/);
+    expect(hasInlineEdDsaAlgorithms(contractCode)).toBe(true);
   });
 });

--- a/workers/users/tsconfig.json
+++ b/workers/users/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers/types"],
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers/types", "vite/client"],
     "strict": true,
     "noImplicitAny": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
Closes #647

## 背景核验(先证有没有真重复,再动手)

对卡片指名的两处逐一核验,发现**两处的实际收敛工作已在昨天的 `1edb45a5`(fix(auth): share edge security primitives)完成**,先于本卡分配:

| 候选 | 两侧现在一致吗? | 是跨端契约还是实现细节? | Python 侧消费? |
|---|---|---|---|
| Turnstile header 名 + TTL/窗口关系 | **一致**——`worker/turnstile.ts` 与 `apps/web/src/lib/turnstile/tokenStore.ts` 都从 `@animichi/contract/constants` 导入 `TURNSTILE_HEADER` / `TURNSTILE_WINDOW_MS` / `TURNSTILE_TOKEN_TTL_MS`,已是单一真源,无漂移 | 纯 TS 跨包契约(worker/ + apps/web/) | 不涉及——Turnstile 只在边缘/浏览器两端 |
| Neon Auth EdDSA 校验 | **一致**——`worker/auth.ts` 与 `workers/users/src/auth/jwt.ts` 都委托给 `packages/contract/src/jwt.ts` 的 `verifyEdDsaJwt` | 纯 TS 跨包契约(worker/ + workers/users/) | 不涉及——EdDSA 校验只发生在两个 TS Worker |

两处都不涉及 Python,不适用"给 Python 侧加断言两边一致"的兜底方案。本 PR 的价值在于补上此前缺失的**回归守卫**。

## 守卫第一版的问题(qodo 二审 + owner 复核判定成立)

第一版守卫用字符串/正则做浅层匹配,有真实假阴性漏洞:

1. Turnstile 守卫只查了 `TURNSTILE_HEADER` 一个常量,`TURNSTILE_WINDOW_MS` / `TURNSTILE_TOKEN_TTL_MS` 可以被重新写成本地常量而守卫照样绿。
2. 字面量禁令只匹配双引号,单引号能绕过。
3. EdDSA 守卫只断言消费方 **import 了** `verifyEdDsaJwt`,没断言它**真的调用**——保留一个未使用的 import、旁边重新内联 `jwtVerify(..., { algorithms: ["EdDSA"] })`,守卫照样通过。

## 这一版:按语义判定,不按字面形状

先试过真正的 TypeScript AST(`ts.createSourceFile`),但发现本仓 pin 的 `typescript@7.0.2` 是围绕新原生编译器重构的版本,**已经不再导出经典的 `createSourceFile`/`forEachChild` 解析 API**(`package.json` 的 `exports` 只剩 `./unstable/ast` 等子路径,且不含完整解析树)。退而使用 `typescript/unstable/ast` 的 `createScanner`(真正的分词器)在 `workers/users` 的 `vitest-pool-workers` isolate 里加载时**实测 OOM 崩溃**:

```
V8 fatal error; message = : allocation failed: JavaScript heap out of memory
```

于是两个守卫改为**语义化的正则检查**(而非字面形状匹配),两边保持同一套技术以便审查:

- 每个常量/函数**逐个**校验:必须从契约包 `import`,并且在 import 行之外的代码里**真的被引用**(`isRealConsumer` / `isCalled`)——只导入不使用不算数。
- 所有字面量判定对引号风格无关(`'`/`"`/模板字符串三选一都能命中)。
- 判定前先**剥离注释**(`stripComments`,用字符串/模板字面量优先匹配的正则,不会被字面量内的 `//`/`/*` 误伤,如 `"https://..."`)——这是编写第一版语义检查时自己发现的真坑:两个源文件的文档注释里恰好都写了目标常量名/字面量,不剥离注释会让"用注释掩盖真删除"这条路径悄悄放行。
- EdDSA 守卫额外要求**真实调用点**(标识符紧跟 `(`),而不只是 import 出现。

## 变异验证(硬要求,6 次,真实输出)

### 1. `TURNSTILE_HEADER` →本地字面量(双引号)
`worker/turnstile.ts`: `request.headers.get(TURNSTILE_HEADER)` → `request.headers.get("cf-turnstile-response")`
```
FAIL ... the edge worker imports and genuinely uses TURNSTILE_HEADER and TURNSTILE_WINDOW_MS
FAIL ... neither consumer hand-rolls the wire header name as a literal (any quote style)
Tests  2 failed | 3 passed (5)
```

### 2. `TURNSTILE_HEADER` →本地字面量(单引号)
同上,换成 `'cf-turnstile-response'`:
```
FAIL ... the edge worker imports and genuinely uses TURNSTILE_HEADER and TURNSTILE_WINDOW_MS
FAIL ... neither consumer hand-rolls the wire header name as a literal (any quote style)
Tests  2 failed | 3 passed (5)
```
(单引号版本证明第一版"只匹配双引号"的漏洞已修复)

### 3. `TURNSTILE_WINDOW_MS` →本地数值常量
`worker/turnstile.ts`: `options.windowMs ?? TURNSTILE_WINDOW_MS` → `options.windowMs ?? 5 * 60_000`(import 仍在,只是不再引用)
```
FAIL ... the edge worker imports and genuinely uses TURNSTILE_HEADER and TURNSTILE_WINDOW_MS
Tests  1 failed | 4 passed (5)
```

### 4. `TURNSTILE_TOKEN_TTL_MS` →本地数值常量
`apps/web/src/lib/turnstile/tokenStore.ts`: `now + TURNSTILE_TOKEN_TTL_MS` → `now + (5 * 60_000 - 60_000)`
```
FAIL ... the web token store imports and genuinely uses TURNSTILE_HEADER and TURNSTILE_TOKEN_TTL_MS
Tests  1 failed | 4 passed (5)
```

### 5. EdDSA 守卫的关键绕过路径:保留 import,重新内联验证逻辑
`worker/auth.ts`:`import { verifyEdDsaJwt } from "@animichi/contract/jwt";` **保留不动**,但 `verifyNeon` 的实现改回 `jwtVerify(token, jwks, { algorithms: ["EdDSA"], issuer, audience: issuer })`,不再调用 `verifyEdDsaJwt`:
```
FAIL ... the edge worker (/v1) imports and calls the shared verifier
FAIL ... neither consumer hand-rolls its own EdDSA algorithm restriction (any quote style)
Tests  2 failed | 2 passed (4)
```
这正是 qodo 指出的具体绕过路径——两条断言（"真的调用了"+"没有内联 algorithms"）分别单独就能抓住它。

### 6. 反向验证:无害格式化改动必须保持绿
同时对三个文件做纯格式改动(import 引号 `"`→`'`、`worker/turnstile.ts` 的 import 拆成多行、`packages/contract/src/jwt.ts` 的 `algorithms: ["EdDSA"]` 改成 `algorithms: [ 'EdDSA' ]` 并断行),不改变任何语义:
```
apps/web:        Test Files  1 passed (1) / Tests  5 passed (5)
workers/users:   Test Files  1 passed (1) / Tests  4 passed (4)
```
全部保持绿,证明守卫对格式/引号风格确实无关。

每次变异后都 `git checkout --` 或手工还原到干净基线,并重跑确认恢复绿。

## 配套改动(与上一版一致,未变)

- `workers/users/tsconfig.json` 补 `"vite/client"`(为 `?raw` 源码导入提供类型)。
- `.github/workflows/ci.yml`:`users` filter 追加 `worker/auth.ts`,`web` filter 追加 `worker/turnstile.ts` + `packages/contract/**`。
- `.github/scripts/test_config_read_sets.py`:两条新测试的 `READS` 注册进 `CHECK_PATHS`(跑通:`OK: 5 config check read sets are covered for push and pull_request`)。

## 验证

- `workers/users`: `pnpm run typecheck` 通过 · `pnpm run lint:oxlint` 通过(含新增的复杂度/嵌套深度整改)· `pnpm test` 5 files / 42 tests passed
- `apps/web`: `pnpm run typecheck` 通过 · `pnpm run lint:oxlint` 通过 · `pnpm test` 216 files / 1612 tests passed,coverage 98.42/95.34/98.57/99.44(高于门槛)
- `.github/scripts/test_config_read_sets.py` 通过
- `make lint typecheck test`(Python + 全仓)全绿
- `make test-integration` 本地因 `atlas` 全局版本 `v1.2.4` vs 仓库固定 `0.30.0` 报错——与本 PR 无关(未触碰任何 Python/DB 代码),沙箱既有问题
- 分支已 rebase 到最新 `main`(经历了上游的 CI 元检查修复 + 若干无关提交),rebase 后重新跑通全部上述验证

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
