### PR TITLE
fix(e2e): scope 404 branded-wordmark assertion to the NotFound landmark

### DIFF
--- a/e2e/web-404.spec.ts
+++ b/e2e/web-404.spec.ts
@@ -27,10 +27,21 @@ test("undefined route renders a branded 404", async ({ page }) => {
   const response = await page.goto("/this-route-does-not-exist");
 
   expect(response?.status()).toBe(404);
-  await expect(page.getByRole("heading", { name: "404" })).toBeVisible();
-  await expect(page.getByText("Animichi").first()).toBeVisible();
 
-  const homeLink = page.getByRole("link", { name: "Return home" });
+  // Scope to the 404 <main> landmark: the root document also renders an
+  // aria-hidden splash screen containing its own "ANIMICHI" wordmark before
+  // this page's content in DOM order (see src/routes/__root.tsx), and
+  // getByText() matches case-insensitively, so an unscoped
+  // getByText("Animichi").first() is ambiguous between the two nodes. Which
+  // one .first() resolved to — and whether it was visible — depended on how
+  // far the splash's CSS dismissal animation had progressed when the
+  // assertion polled, making the check a startup-timing race rather than a
+  // check of the 404 page itself.
+  const notFoundRegion = page.getByRole("main", { name: "404" });
+  await expect(notFoundRegion.getByRole("heading", { name: "404" })).toBeVisible();
+  await expect(notFoundRegion.getByText("Animichi")).toBeVisible();
+
+  const homeLink = notFoundRegion.getByRole("link", { name: "Return home" });
   await expect(homeLink).toBeVisible();
   await expect(homeLink).toHaveAttribute("href", "/");
 });


### PR DESCRIPTION
## 问题

`e2e/web-404.spec.ts:31` 的断言 `page.getByText("Animichi").first().toBeVisible()` 是一条模糊断言,阻塞着 CI 必需检查 `Cross-stack E2E`,进而 BLOCK 了 #721/#722/#723/#724 四个 PR。main 上碰巧是绿的——这正是竞速的特征,不是某个 PR 把它弄坏了。

## 根因(竞速链路)

1. `src/routes/__root.tsx` 渲染顺序是 `<body><Splash />{children}<Scripts /></body>`——`Splash` 在被路由的内容(含 404 页)**之前**挂载。
2. `Splash.tsx` 的 `SplashMiddle` 渲染了 `<span class="app-splash__wordmark">ANIMICHI</span>`(day/night 两帧各一个),`aria-hidden="true"`。Playwright 的 `getByText()` 大小写不敏感,于是同时匹配 3 个节点:2 个 splash wordmark span + 404 页自己的 `<p class="eyebrow">Animichi</p>`。`.first()` 取到的**永远**是某个 splash span,从不是 404 页自己的品牌标识。
3. splash 的消失由 CSS 动画驱动:`animation: app-splash-dismiss 1ms step-end 320ms forwards`,在 320ms 时刻把它切到 `display:none`。所以 `.first().toBeVisible()` 的结果纯粹取决于断言轮询发生在 320ms 之前(splash 还可见→碰巧通过)还是之后(splash 已隐藏→失败)——跟 404 页面本身渲染是否正确毫无关系。
4. PR #719 给 CI 的 e2e 构建注入了 `VITE_TURNSTILE_SITE_KEY`(见 `.github/workflows/_cross-stack-e2e.yml`),拉长了应用的启动路径,使更多次运行的断言轮询点被推过 320ms 那条线——这正是为什么问题在该 PR 合并后才开始抖动,以及为什么 main 依然可能是绿的(概率偏移,不是硬性回归)。

## 复现证据

针对真实的 `.output` Worker(`wrangler dev` 加载 `pnpm --filter web test:integration` 产出的构建、`VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA`)跑的独立复现脚本:

```
total matches for getByText('Animichi'): 3
match[0]: <span class="app-splash__wordmark">ANIMICHI</span>
match[1]: <span class="app-splash__wordmark">ANIMICHI</span>
match[2]: <p class="eyebrow">Animichi</p>
first() visible immediately after goto: true
first() visible 500ms after goto (post-dismiss): false
```

再用冻结/推迟 splash 消失动画的方式确认了两种结局都会在真实构建上发生,而新的作用域断言在两种情况下都稳定通过。

## 修法

把断言限定在 404 页自己的 `<main>` landmark 内(`page.getByRole("main", { name: "404" })`),使其**只能**解析到 `NotFound` 组件自己的标记,与 splash 的存在与否/时序完全无关。**没有**加大 timeout、没有加 retry、没有换成 `.nth(1)`、没有等 splash 消失再断言、没有删断言。

## 验证

对着真实产出的 Worker 产物(`pnpm --filter web test:integration` 构建 → `wrangler dev --port 8799`)连续跑 5 次 CI 门禁用的三条 spec(`web-404.spec.ts` `web-maplibre-canary.spec.ts` `web-chat-anonymous.spec.ts`),全部 11/11 通过:

| Run | 结果 |
|---|---|
| 1 | 11 passed (5.0s) |
| 2 | 11 passed (5.1s) |
| 3 | 11 passed (5.0s) |
| 4 | 11 passed (5.1s) |
| 5 | 11 passed (5.1s) |

## 变异验证

临时删掉 `NotFound.tsx` 里的 `<p className="eyebrow">Animichi</p>`,重新构建 + 重启 `wrangler dev`,新断言按预期变红:

```
Error: expect(locator).toBeVisible() failed
Locator: getByRole('main', { name: '404' }).getByText('Animichi')
Expected: visible
Error: element(s) not found
```

验证后已还原 `NotFound.tsx`(工作区无残留改动),重新构建确认 5 次全绿。

## 同族排查

审计了 `e2e/*.spec.ts` 里所有 `getByText(...).first()` 一类的模糊定位。除报错的这一处外,唯一的 `.first()` 用法在 `web-splash.spec.ts:31`(`page.locator("main").first()`),但那个页面(落地页)本身只有一个 `<main>`,不存在跨节点歧义,未改动。

## 约束确认

- 未使用 suppression / skip / 删断言
- 未合并本 PR,留待人工评审

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved 404-page end-to-end test coverage by scoping assertions to the correct page content.
  * Removed ambiguous element matching to make test results more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->