### PR TITLE
ci(sonar): exclude static design-mockup exports from analysis (#725)

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -4,3 +4,11 @@
 # supabase migration to ship a near-identical auth-stripped atlas twin —
 # duplication across the two migration trees is structural, not accidental.
 sonar.cpd.exclusions=supabase/migrations/**,db/migrations/**
+
+# #725: these two trees are static design-mockup exports (HTML/JS/JSX/CSS +
+# their own spec markdown) — never built, bundled, or deployed, and they never
+# execute against production data. Scanning them as production code produced
+# ~18 false-positive VULNERABILITY findings (e.g. Math.random() in a static
+# splash-screen mockup flagged as weak crypto). Keep this list narrow: only
+# directories verified to contain nothing that ships or runs in a request path.
+sonar.exclusions=docs/design/2026-07-06-design-sync/**,docs/mockups/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,3 +2,11 @@
 # are frozen auth/legacy compatibility history, not a second data-plane source.
 # Keep both migration trees excluded from copy-paste detection for that boundary.
 sonar.cpd.exclusions=supabase/migrations/**,db/migrations/**
+
+# #725: these two trees are static design-mockup exports (HTML/JS/JSX/CSS +
+# their own spec markdown) — never built, bundled, or deployed, and they never
+# execute against production data. Scanning them as production code produced
+# ~18 false-positive VULNERABILITY findings (e.g. Math.random() in a static
+# splash-screen mockup flagged as weak crypto). Keep this list narrow: only
+# directories verified to contain nothing that ships or runs in a request path.
+sonar.exclusions=docs/design/2026-07-06-design-sync/**,docs/mockups/**


### PR DESCRIPTION
## 一句话

`sonar-project.properties` / `.sonarcloud.properties` 只有 `sonar.cpd.exclusions`,没有 `sonar.exclusions`,导致 SonarCloud 把 `docs/design/2026-07-06-design-sync/` 下的静态设计稿导出物当生产代码扫。**这是扫描范围配错,不是代码问题**——本 PR 只改两份 properties,不删任何文件,不加 `NOSONAR`。

Closes #725

## 权威清单核对(改动前,main 上实测数据)

用 `https://sonarcloud.io/api/issues/search?componentKeys=lifeodyssey_Seichijunrei-agent&branch=main&resolved=false` 取的实测数字(不是凭 issue 正文里的旧快照猜的——issue 里提到的 `docs/.../seed-local-r2.sh` 那条 `shell:S6505`,核实后**该文件在当前 main 上已经不存在**,对应告警已经是陈旧数据,本 PR 不需要为它排除任何路径)。

`directories` facet 精确核对后,main 上**唯一**有活跃告警的 `docs/` 子树是 `docs/design/2026-07-06-design-sync/`(含全部子目录):

| 类型 | 该子树告警数 |
|---|---|
| VULNERABILITY | 18 |
| BUG | 235 |
| CODE_SMELL | 580 |
| **合计** | **833** |

`docs/mockups/**` 当前实测 **0** 条告警(可能是文件类型/大小导致扫描器目前没触发规则)——仍然一并加入 exclusions,因为它和 `docs/design/...` 同属"静态设计稿导出物,不构建、不部署、不处理生产数据",owner 已明确两者都要留在 repo,不排除的话未来任何一次分析规则更新都可能重新触发误报。

生产代码侧(排除范围之外的一切)当前 VULNERABILITY = **15 条**,全部在 `.github/workflows/*.yml` 与 `Dockerfile`(githubactions:S8541/S8544/S6505、docker:S8541),与本次改动的路径**零重叠**:

| 文件 | 规则 | 条数 |
|---|---|---|
| `.github/workflows/_python-ci.yml` | S8541 | 4 |
| `.github/workflows/_security.yml` | S8541/S8544 | 3 |
| `.github/workflows/ci.yml` | S8541 | 3 |
| `.github/workflows/_webapp-ci.yml` | S6505 | 1 |
| `.github/workflows/agent-eval-nightly.yml` | S8541 | 1 |
| `.github/workflows/pipeline-web.yml` | S6505 | 1 |
| `.github/workflows/purge-anonymous-sessions.yml` | S8541 | 1 |
| `Dockerfile` | S8541 | 1 |

## 排除清单逐条理由

| Pattern | 涵盖内容 | 理由 |
|---|---|---|
| `docs/design/2026-07-06-design-sync/**` | 设计同步导出的整棵目录:顶层 HTML mockup(Splash/Chat/Landing 等)、`_ds/.../_ds_bundle.js`(vendored 设计系统 bundle)、`tweaks-panel.jsx`、`support.js`、`scene-cut.js`、`image-slot.js`、`styles.css`,以及内嵌的 `docs/`(spec markdown)、`src/components/{Tag,Modal,Button,Tabs}` | 已用文件系统核对:整棵子树只有 html/js/jsx/css/md/图片,没有 `package.json`/构建配置/部署清单——不会被任何构建流程打包,不出现在任何请求路径上。造成本 issue 里举例的全部误报(`Math.random()`、`postMessage` 未校验 origin 等)都在这棵子树内 |
| `docs/mockups/**` | 早期 wave 的静态 HTML mockup(`variant-A-editorial.html`、`unified-mockup.html` 等)+ 截图 jpg | 同属"设计稿导出物",owner 明确要求留在 repo 不删;当前 0 条活跃告警,提前排除是防御性的,不影响本次验收数字 |

**没有排除**、也确认不该排除的:
- `docs/superpowers/**`(specs/plans/进度文档)—— issue 提到的 `seed-local-r2.sh` 已经不存在,该子树目前 0 活跃告警,不动
- `db/migrations/**`、`supabase/migrations/**` —— 已有 `sonar.cpd.exclusions` 覆盖重复检测,不属于本卡范围,未新增 `sonar.exclusions`(它们是真实迁移历史,不是设计稿)
- `.github/workflows/**`、`Dockerfile` —— 生产 CI/CD 配置,15 条 VULNERABILITY 原样保留,这是本 PR 的对照组

## 验收对照(改动前 → 预期改动后)

| 范围 | 改动前(main 实测) | 预期改动后 |
|---|---|---|
| `docs/design/2026-07-06-design-sync/**` 全部告警 | 833(18 VULN + 235 BUG + 580 CODE_SMELL) | 0 |
| `docs/mockups/**` 全部告警 | 0 | 0(不变) |
| 生产代码 VULNERABILITY(`.github/workflows` + `Dockerfile`) | 15 | 15(不变,零误伤) |

**重要区分**:SonarCloud 对 PR 分支用的是 PR 自己的 `sonar.exclusions` 配置,所以这个 PR 的 SonarCloud 检查会直接反映排除生效——但 **main 分支上的计数要等 main 合并后的下一次分析才会更新**。上表"预期改动后"的数字是本 PR 分支分析结果的预期值,不代表 main 已经修好;merge 后请等下一次 main 分析确认。

## 约束遵守

- 未删除任何文件
- 未使用 `# NOSONAR`
- 未在 SonarCloud UI 标记 False Positive
- 只改了 `sonar-project.properties` 与 `.sonarcloud.properties` 两个文件
