### PR TITLE
fix(ci): post-deploy smoke 目标 URL 从 Cloudflare 实际状态解析,不再硬编码

### DIFF
--- a/.github/scripts/resolve-worker-url.sh
+++ b/.github/scripts/resolve-worker-url.sh
@@ -1,56 +1,135 @@
 #!/usr/bin/env bash
 # Resolve the public HTTPS base URL for a deployed component in a given
-# environment. This does NOT probe the network to guess whether a URL is
-# live — it derives the URL from the Worker naming convention fixed in
-# wrangler.toml / apps/web/wrangler.jsonc, plus the account's workers.dev
-# subdomain (an account-level Cloudflare API property, independent of
-# whether any particular Worker has been deployed yet). See issue #484.
+# environment — for the post-deploy smoke gate (issue #484, hardened by
+# #695). This does NOT probe application-layer HTTP to guess whether a URL
+# is live; it queries Cloudflare's own account state for what this Worker
+# script is ACTUALLY reachable on right now, so the smoke gate always probes
+# the real deploy target instead of a hardcoded guess about where it used to
+# be (or where we expect it to be someday).
+#
+# Why "ask Cloudflare" instead of a static component/environment -> URL
+# table (the previous version of this script, and the literal
+# `animichi-staging.<personal-account>.workers.dev` this replaces, per
+# issue #695): a static table is correct only until something it doesn't
+# know about changes underneath it — a different Cloudflare account's
+# workers.dev subdomain, or (issue #541) a Custom Domain getting attached to
+# a Worker that used to answer only on workers.dev. Both are silent
+# failures of the worst kind: the OLD address usually keeps answering, so
+# the gate reports success while verifying the wrong thing. Querying
+# Cloudflare's live Custom-Domain and workers.dev-enablement state for this
+# exact Worker script removes the table entirely — there is nothing left to
+# go stale, and #541's cutover requires zero edits here: the next run just
+# sees the Custom Domain that now exists and uses it.
+#
+# Concretely, the previous version of this script hardcoded root/production
+# to `https://animichi.com` unconditionally — but per issue #541, that
+# hostname has NO DNS record at all today, so that branch was already
+# wrong in the opposite direction: it assumed a cutover that hasn't
+# happened yet, rather than (as #695 describes) missing one that already
+# has. Same defect class either way: a static assumption about where a
+# Worker lives, disconnected from Cloudflare's actual state.
 #
 # Usage: resolve-worker-url.sh <root|web> <staging|production>
-# Requires CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID in the environment,
-# except for root/production which resolves to the static custom domain
-# (wrangler.toml env.production.routes) and needs neither. Both are sourced
-# from secrets by the callers of this script (matching _deploy-component.yml,
-# which already needs the same CLOUDFLARE_ACCOUNT_ID secret for `wrangler
-# deploy` — one source for one value, not two). The read this script makes
-# (GET .../workers/subdomain) needs a narrower scope than deploy does; if
-# that scope reduction is worth doing, it should happen by provisioning a
-# separate, purpose-scoped Cloudflare token, not by relocating the account id
-# — see the discussion on issue #484 / PR #493 if revisiting this.
+# Requires CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID in the environment
+# (same secrets `wrangler deploy` already needs — one source for one value,
+# not two; see issue #484 / PR #493 if revisiting the token-scoping
+# question). CLOUDFLARE_API_BASE_URL is an optional override, used ONLY by
+# resolve-worker-url.test.sh to point at a local mock instead of the real
+# Cloudflare API — production callers never set it and get the real
+# https://api.cloudflare.com/client/v4.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+API_BASE="${CLOUDFLARE_API_BASE_URL:-https://api.cloudflare.com/client/v4}"
 
 component="${1:?usage: resolve-worker-url.sh <root|web> <staging|production>}"
 environment="${2:?usage: resolve-worker-url.sh <root|web> <staging|production>}"
 
-if [ "${component}" = "root" ] && [ "${environment}" = "production" ]; then
-  # wrangler.toml [env.production] routes — custom domain, no workers.dev.
-  echo "https://animichi.com"
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required to resolve the deployed Worker URL}"
+: "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required to resolve the deployed Worker URL}"
+
+fail() {
+  echo "::error title=resolve-worker-url::$1" >&2
+  exit 1
+}
+
+# The Worker SCRIPT NAME is still read from this repo's own wrangler config
+# (not re-hardcoded here) — that name is a structural identifier fixed at
+# deploy time (`wrangler deploy --env <environment>` publishes to exactly
+# this script), not a hostname that moves when infra changes. Reading it
+# from the same file `wrangler deploy` reads keeps this script from ever
+# drifting out of sync with what actually got deployed.
+resolve_worker_name() {
+  case "${component}" in
+    root)
+      awk -v want="[env.${environment}]" '
+        $0 == want { found=1; next }
+        found && /^\[/ { exit }
+        found && /^name[[:space:]]*=/ { print; exit }
+      ' "${REPO_ROOT}/wrangler.toml" | sed -E 's/^name[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/'
+      ;;
+    web)
+      # wrangler.jsonc comments in this repo are always whole-line (never
+      # trailing after a value) — confirmed by reading the file — so
+      # stripping `//`-prefixed lines before handing it to jq is safe here.
+      grep -v '^[[:space:]]*//' "${REPO_ROOT}/apps/web/wrangler.jsonc" \
+        | jq -r --arg env "${environment}" '.env[$env].name // empty'
+      ;;
+    *)
+      fail "unknown component: ${component}"
+      ;;
+  esac
+}
+
+worker_name="$(resolve_worker_name)"
+[ -n "${worker_name}" ] || fail "could not resolve a Worker name for ${component}/${environment} from wrangler config"
+
+cf_get() {
+  local path="$1"
+  curl -sS --fail-with-body --connect-timeout 10 --max-time 20 --retry 3 --retry-delay 2 \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    "${API_BASE}${path}"
+}
+
+# 1) Ground truth for a Custom Domain (issue #541 hostname cutover): if
+# Cloudflare has a Custom Domain attached to this exact Worker script, that
+# IS the real deploy target — full stop, no workers.dev fallback needed or
+# wanted. This is what makes the cutover need zero changes here: today this
+# list is empty for every Worker in this repo (per #541, no DNS/route
+# exists yet), so this branch is a no-op until the day it isn't.
+custom_domain_response="$(cf_get "/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/domains?per_page=50")" || {
+  fail "Cloudflare API call to list Custom Domains failed"
+}
+custom_hostname="$(echo "${custom_domain_response}" \
+  | jq -r --arg name "${worker_name}" '[.result[] | select(.service == $name)][0].hostname // empty')"
+
+if [ -n "${custom_hostname}" ]; then
+  echo "https://${custom_hostname}"
   exit 0
 fi
 
-: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required to resolve the workers.dev subdomain}"
-: "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required to resolve the workers.dev subdomain}"
+# 2) No Custom Domain — fall back to workers.dev, but ask Cloudflare
+# per-script whether it is actually enabled for THIS Worker (not just
+# whether the account has a workers.dev subdomain configured at all — a
+# Worker can have workers.dev explicitly disabled, e.g. #541 step 6 does
+# exactly this after DNS cutover). Guessing "workers.dev is reachable"
+# without checking this would be the same class of stale-address bug this
+# script exists to remove.
+subdomain_status_response="$(cf_get "/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${worker_name}/subdomain")" || {
+  fail "Cloudflare API call to check workers.dev enablement for ${worker_name} failed"
+}
+workers_dev_enabled="$(echo "${subdomain_status_response}" | jq -r '.result.enabled // false')"
 
-case "${component}.${environment}" in
-  root.staging) worker_name="animichi-staging" ;;      # wrangler.toml [env.staging] name, workers_dev = true
-  web.staging) worker_name="animichi-web-staging" ;;   # apps/web/wrangler.jsonc env.staging.name
-  web.production) worker_name="animichi-web" ;;        # apps/web/wrangler.jsonc env.production.name
-  *)
-    echo "::error title=resolve-worker-url::unknown component/environment pair: ${component}/${environment}" >&2
-    exit 1
-    ;;
-esac
+if [ "${workers_dev_enabled}" != "true" ]; then
+  fail "${worker_name} (${component}/${environment}) has neither a Custom Domain nor workers.dev enabled — there is no reachable URL for the post-deploy smoke gate to probe. If a Custom Domain cutover just happened, this is expected right up until Cloudflare's Custom Domain is actually attached; if not, this Worker is unreachable and that is itself a real deploy problem."
+fi
 
-response="$(curl -sS --fail-with-body --connect-timeout 10 --max-time 20 --retry 3 --retry-delay 2 \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/subdomain")" || {
-  echo "::error title=resolve-worker-url::Cloudflare API call to fetch the account's workers.dev subdomain failed" >&2
-  exit 1
+account_subdomain_response="$(cf_get "/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/subdomain")" || {
+  fail "Cloudflare API call to fetch the account's workers.dev subdomain failed"
+}
+account_subdomain="$(echo "${account_subdomain_response}" | jq -er '.result.subdomain')" || {
+  fail "Cloudflare API response did not contain result.subdomain: ${account_subdomain_response}"
 }
 
-subdomain="$(echo "${response}" | jq -er '.result.subdomain')" || {
-  echo "::error title=resolve-worker-url::Cloudflare API response did not contain result.subdomain: ${response}" >&2
-  exit 1
-}
-
-echo "https://${worker_name}.${subdomain}.workers.dev"
+echo "https://${worker_name}.${account_subdomain}.workers.dev"

--- a/.github/scripts/resolve-worker-url.sh
+++ b/.github/scripts/resolve-worker-url.sh
@@ -85,11 +85,30 @@ resolve_worker_name() {
 worker_name="$(resolve_worker_name)"
 [ -n "${worker_name}" ] || fail "could not resolve a Worker name for ${component}/${environment} from wrangler config"
 
-cf_get() {
-  local path="$1"
-  curl -sS --fail-with-body --connect-timeout 10 --max-time 20 --retry 3 --retry-delay 2 \
+# Every Cloudflare API v4 response, including a plain HTTP 200, carries its
+# own success/errors envelope — `success: false` on a 200 is how CF reports
+# an insufficient token scope, a missing resource, etc. `curl --fail-with-body`
+# alone only catches TRANSPORT failures (a non-2xx status); it does NOT know
+# CF's own envelope shape, so a 200-with-success:false response would sail
+# straight through unnoticed. Left unchecked, that response's `result`
+# is typically `null` or `[]` — which downstream jq code (`.result[] |
+# select(...)`, `.result.enabled // false`) reads as "no Custom Domain" /
+# "workers.dev not enabled", not as an error. That is the exact "quietly
+# reports a plausible-looking wrong URL" failure mode issue #695 exists to
+# remove — just one layer up, in the API call instead of the URL table.
+# `cf_get_checked` is the one place that parses `.result` for every caller
+# below, so this check cannot be bypassed by a call site forgetting it.
+cf_get_checked() {
+  local path="$1" purpose="$2" response success errors
+  response="$(curl -sS --fail-with-body --connect-timeout 10 --max-time 20 --retry 3 --retry-delay 2 \
     -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    "${API_BASE}${path}"
+    "${API_BASE}${path}")" || fail "Cloudflare API call failed (transport error) while trying to ${purpose}"
+  success="$(echo "${response}" | jq -r '.success // false' 2>/dev/null)" || fail "Cloudflare API response was not valid JSON while trying to ${purpose}: ${response}"
+  if [ "${success}" != "true" ]; then
+    errors="$(echo "${response}" | jq -c '.errors // []' 2>/dev/null || echo '(unparseable)')"
+    fail "Cloudflare API returned success:false while trying to ${purpose} — errors: ${errors}"
+  fi
+  echo "${response}"
 }
 
 # 1) Ground truth for a Custom Domain (issue #541 hostname cutover): if
@@ -98,9 +117,17 @@ cf_get() {
 # wanted. This is what makes the cutover need zero changes here: today this
 # list is empty for every Worker in this repo (per #541, no DNS/route
 # exists yet), so this branch is a no-op until the day it isn't.
-custom_domain_response="$(cf_get "/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/domains?per_page=50")" || {
-  fail "Cloudflare API call to list Custom Domains failed"
-}
+#
+# Filtered server-side with `?service=<worker_name>` (confirmed as a
+# documented query parameter of this endpoint — see
+# developers.cloudflare.com/api/resources/workers/subresources/domains/methods/list/)
+# rather than fetched unfiltered and paginated client-side: filtering at
+# the source means there is no page boundary this script could ever fall
+# on the wrong side of, which a client-side per_page cap would not
+# guarantee no matter how large.
+custom_domain_response="$(cf_get_checked \
+  "/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/domains?service=${worker_name}" \
+  "list Custom Domains for ${worker_name}")"
 custom_hostname="$(echo "${custom_domain_response}" \
   | jq -r --arg name "${worker_name}" '[.result[] | select(.service == $name)][0].hostname // empty')"
 
@@ -116,18 +143,18 @@ fi
 # exactly this after DNS cutover). Guessing "workers.dev is reachable"
 # without checking this would be the same class of stale-address bug this
 # script exists to remove.
-subdomain_status_response="$(cf_get "/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${worker_name}/subdomain")" || {
-  fail "Cloudflare API call to check workers.dev enablement for ${worker_name} failed"
-}
+subdomain_status_response="$(cf_get_checked \
+  "/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${worker_name}/subdomain" \
+  "check workers.dev enablement for ${worker_name}")"
 workers_dev_enabled="$(echo "${subdomain_status_response}" | jq -r '.result.enabled // false')"
 
 if [ "${workers_dev_enabled}" != "true" ]; then
   fail "${worker_name} (${component}/${environment}) has neither a Custom Domain nor workers.dev enabled — there is no reachable URL for the post-deploy smoke gate to probe. If a Custom Domain cutover just happened, this is expected right up until Cloudflare's Custom Domain is actually attached; if not, this Worker is unreachable and that is itself a real deploy problem."
 fi
 
-account_subdomain_response="$(cf_get "/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/subdomain")" || {
-  fail "Cloudflare API call to fetch the account's workers.dev subdomain failed"
-}
+account_subdomain_response="$(cf_get_checked \
+  "/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/subdomain" \
+  "fetch the account's workers.dev subdomain")"
 account_subdomain="$(echo "${account_subdomain_response}" | jq -er '.result.subdomain')" || {
   fail "Cloudflare API response did not contain result.subdomain: ${account_subdomain_response}"
 }

--- a/.github/scripts/resolve-worker-url.test.sh
+++ b/.github/scripts/resolve-worker-url.test.sh
@@ -17,6 +17,17 @@
 # real, live workers.dev URL instead. Case 4 then proves the forward
 # direction: once a Custom Domain appears in the mock (the #541 cutover),
 # the NEW script picks it up with no code change.
+#
+# Cases 5 and 6 (added on review round 2) cover the same failure MODE one
+# layer down, inside the Cloudflare API calls themselves rather than the
+# URL table: Case 5 proves a 200-with-`success:false` response (a real
+# thing Cloudflare does — bad token scope, missing resource, etc.) fails
+# loudly instead of being read as "no Custom Domain found" and silently
+# falling back to a plausible-but-wrong workers.dev guess. Case 6 proves
+# the Custom Domains lookup finds the target Worker's domain via
+# server-side filtering (`?service=<name>`) regardless of how many OTHER
+# domains the account has — not via client-side pagination that could
+# silently stop short of the right page.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -77,7 +88,7 @@ test_resolves_workers_dev_when_no_custom_domain() {
   local port=18901 pid rc=0 out
   start_mock "${port}" "
 ROUTES = {
-    '/accounts/mock-account/workers/domains?per_page=50': '${NO_CUSTOM_DOMAINS}',
+    '/accounts/mock-account/workers/domains?service=animichi-staging': '${NO_CUSTOM_DOMAINS}',
     '/accounts/mock-account/workers/scripts/animichi-staging/subdomain': '{\"success\":true,\"result\":{\"enabled\":true}}',
     '/accounts/mock-account/workers/subdomain': '{\"success\":true,\"result\":{\"subdomain\":\"mock-subdomain\"}}',
 }
@@ -98,7 +109,7 @@ test_resolves_custom_domain_when_attached() {
   local port=18902 pid rc=0 out
   start_mock "${port}" "
 ROUTES = {
-    '/accounts/mock-account/workers/domains?per_page=50': '{\"success\":true,\"result\":[{\"service\":\"animichi-web\",\"hostname\":\"app.animichi.com\",\"zone_id\":\"z\",\"zone_name\":\"animichi.com\"}]}',
+    '/accounts/mock-account/workers/domains?service=animichi-web': '{\"success\":true,\"result\":[{\"service\":\"animichi-web\",\"hostname\":\"app.animichi.com\",\"zone_id\":\"z\",\"zone_name\":\"animichi.com\"}]}',
 }
 "
   pid=$!
@@ -135,7 +146,7 @@ test_old_script_would_have_lied_new_script_does_not() {
   local port=18903 pid rc_new=0 out_old out_new
   start_mock "${port}" "
 ROUTES = {
-    '/accounts/mock-account/workers/domains?per_page=50': '${NO_CUSTOM_DOMAINS}',
+    '/accounts/mock-account/workers/domains?service=animichi': '${NO_CUSTOM_DOMAINS}',
     '/accounts/mock-account/workers/scripts/animichi/subdomain': '{\"success\":true,\"result\":{\"enabled\":true}}',
     '/accounts/mock-account/workers/subdomain': '{\"success\":true,\"result\":{\"subdomain\":\"mock-subdomain\"}}',
 }
@@ -166,7 +177,7 @@ test_fails_loudly_when_unreachable() {
   local port=18904 pid rc=0 out
   start_mock "${port}" "
 ROUTES = {
-    '/accounts/mock-account/workers/domains?per_page=50': '${NO_CUSTOM_DOMAINS}',
+    '/accounts/mock-account/workers/domains?service=animichi-web': '${NO_CUSTOM_DOMAINS}',
     '/accounts/mock-account/workers/scripts/animichi-web/subdomain': '{\"success\":true,\"result\":{\"enabled\":false}}',
 }
 "
@@ -180,9 +191,81 @@ ROUTES = {
   echo "PASS: fails loudly instead of guessing when the Worker has no reachable URL"
 }
 
+# ── Case 5 (mutation-proof, review round 2 #1): Cloudflare answers HTTP 200
+#    with `success:false` (insufficient token scope, resource not found,
+#    etc — a real thing CF does, not a hypothetical). `result` on such a
+#    response is typically `null`/absent. Before this case existed, an
+#    unchecked script would read that as "no Custom Domain" and silently
+#    fall through to workers.dev, reporting a plausible-looking URL that
+#    has nothing to do with why the API call actually failed — the exact
+#    "quietly probes the wrong target and calls it success" failure mode
+#    issue #695 exists to remove, one layer up (the API call itself,
+#    instead of the URL table). The fix must fail loudly and surface the
+#    `errors` array instead. ──────────────────────────────────────────────
+test_fails_loudly_on_cf_success_false() {
+  local port=18905 pid rc=0 out
+  start_mock "${port}" "
+ROUTES = {
+    '/accounts/mock-account/workers/domains?service=animichi-web': '{\"success\":false,\"result\":null,\"errors\":[{\"code\":10000,\"message\":\"Authentication error\"}]}',
+}
+"
+  pid=$!
+  wait_for_port "${port}"
+  out="$(CLOUDFLARE_API_BASE_URL="http://127.0.0.1:${port}" CLOUDFLARE_API_TOKEN=t CLOUDFLARE_ACCOUNT_ID=mock-account \
+    bash "${RESOLVE_SH}" web production 2>&1)" || rc=$?
+  stop_mock "${pid}"
+  [ "${rc}" -ne 0 ] || fail_test "expected failure on success:false, got exit 0 (silently fell back to a guess): ${out}"
+  echo "${out}" | grep -q "success:false" || fail_test "missing the success:false diagnostic in output: ${out}"
+  echo "${out}" | grep -q "Authentication error" || fail_test "missing CF's own errors array in the diagnostic: ${out}"
+  echo "PASS: fails loudly and surfaces CF's errors array on a 200-with-success:false response"
+  echo "  real output: ${out}"
+}
+
+# ── Case 6 (mutation-proof, review round 2 #2): the Custom Domains request
+#    is filtered server-side (`?service=<worker_name>`), not fetched
+#    unfiltered-then-paginated. This mock proves that filtering is what
+#    actually happens, not an accident of a large-enough page size: the
+#    UNFILTERED path (what a client-side-pagination implementation would
+#    hit first) is wired to return a target-domains list that does NOT
+#    include this Worker's domain — standing in for "the real domain sits
+#    past whatever page boundary a per_page cap drew". Only the FILTERED
+#    path has the correct answer. If resolve-worker-url.sh ever regressed
+#    to requesting the unfiltered/paginated shape, this test would get the
+#    wrong hostname (or fall through to workers.dev) instead of the
+#    Custom Domain that is actually attached. ───────────────────────────
+test_finds_target_domain_via_server_side_filter_not_pagination() {
+  local port=18906 pid rc=0 out other_domains_json
+  other_domains_json="$(python3 -c "
+import json
+others = [{'service': f'unrelated-worker-{i}', 'hostname': f'unrelated-{i}.animichi.com', 'zone_id': 'z', 'zone_name': 'animichi.com'} for i in range(50)]
+print(json.dumps({'success': True, 'result': others}))
+")"
+  start_mock "${port}" "
+ROUTES = {
+    # What an UNFILTERED, page-capped request would see: 50 OTHER workers'
+    # Custom Domains, none of which is ours — i.e. our domain is 'past the
+    # page boundary' from this request's point of view.
+    '/accounts/mock-account/workers/domains?per_page=50': '${other_domains_json}',
+    # What the ACTUAL (filtered) request sees: exactly our Worker's domain.
+    '/accounts/mock-account/workers/domains?service=animichi-web-staging': '{\"success\":true,\"result\":[{\"service\":\"animichi-web-staging\",\"hostname\":\"staging.animichi.com\",\"zone_id\":\"z\",\"zone_name\":\"animichi.com\"}]}',
+}
+"
+  pid=$!
+  wait_for_port "${port}"
+  out="$(CLOUDFLARE_API_BASE_URL="http://127.0.0.1:${port}" CLOUDFLARE_API_TOKEN=t CLOUDFLARE_ACCOUNT_ID=mock-account \
+    bash "${RESOLVE_SH}" web staging)" || rc=$?
+  stop_mock "${pid}"
+  [ "${rc}" -eq 0 ] || fail_test "expected success via the filtered request, got exit ${rc}"
+  [ "${out}" = "https://staging.animichi.com" ] || fail_test "expected the filtered Custom Domain, got: ${out} (this would happen if the script fell back to the unfiltered/paginated shape instead)"
+  echo "PASS: finds the target Worker's Custom Domain via server-side filtering, unaffected by how many other domains the account has"
+  echo "  real output: ${out}"
+}
+
 test_resolves_workers_dev_when_no_custom_domain
 test_resolves_custom_domain_when_attached
 test_old_script_would_have_lied_new_script_does_not
 test_fails_loudly_when_unreachable
+test_fails_loudly_on_cf_success_false
+test_finds_target_domain_via_server_side_filter_not_pagination
 
 echo "All resolve-worker-url.sh behavioral tests passed."

--- a/.github/scripts/resolve-worker-url.test.sh
+++ b/.github/scripts/resolve-worker-url.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Behavioral tests for resolve-worker-url.sh (issue #695), driven against a
+# throwaway Python mock of the Cloudflare API (this repo has no shell
+# mocking framework — same pattern as post-deploy-assert.test.sh).
+#
+# The core thing under test is NOT "does curl+jq work" — it's the defect
+# class issue #695 was filed about: a smoke target that is a static
+# assumption about where a Worker lives, instead of a live read of where it
+# actually lives. Case 3 below is that defect, reproduced directly: it
+# compares against a frozen snapshot of the OLD (pre-#695) script's
+# hardcoded behavior, run against a mock Cloudflare account whose actual
+# state matches this repo's real current production state (workers.dev
+# only, no Custom Domain — confirmed by issue #541: animichi.com has zero
+# DNS records today), and shows the OLD script would have silently
+# returned `https://animichi.com` anyway — a hostname that does not exist.
+# The NEW script, queried against the exact same mock state, returns the
+# real, live workers.dev URL instead. Case 4 then proves the forward
+# direction: once a Custom Domain appears in the mock (the #541 cutover),
+# the NEW script picks it up with no code change.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_SH="${SCRIPT_DIR}/resolve-worker-url.sh"
+
+fail_test() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# Starts a background mock Cloudflare API server. `routes_body` must define
+# ROUTES, a dict mapping exact request paths to JSON response strings.
+start_mock() {
+  local port="$1" routes_body="$2"
+  python3 -c "
+import http.server, json, sys
+
+${routes_body}
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = ROUTES.get(self.path)
+        if body is None:
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b'{\"success\":false,\"result\":null}')
+            return
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(body.encode())
+    def log_message(self, *a): pass
+
+http.server.HTTPServer(('127.0.0.1', ${port}), Handler).serve_forever()
+" &
+}
+
+wait_for_port() {
+  local port="$1" _attempt
+  for _attempt in $(seq 1 50); do
+    (exec 3<>"/dev/tcp/127.0.0.1/${port}") 2>/dev/null && exec 3>&- 3<&- && return 0
+    sleep 0.1
+  done
+  fail_test "mock server on port ${port} never came up"
+}
+
+stop_mock() {
+  local pid="$1"
+  kill "${pid}" 2>/dev/null || true
+  wait "${pid}" 2>/dev/null || true
+}
+
+NO_CUSTOM_DOMAINS='{"success":true,"result":[]}'
+
+# ── Case 1: no Custom Domain, workers.dev enabled -> resolves the account's
+#    live workers.dev subdomain (proves the normal, pre-cutover path). ────
+test_resolves_workers_dev_when_no_custom_domain() {
+  local port=18901 pid rc=0 out
+  start_mock "${port}" "
+ROUTES = {
+    '/accounts/mock-account/workers/domains?per_page=50': '${NO_CUSTOM_DOMAINS}',
+    '/accounts/mock-account/workers/scripts/animichi-staging/subdomain': '{\"success\":true,\"result\":{\"enabled\":true}}',
+    '/accounts/mock-account/workers/subdomain': '{\"success\":true,\"result\":{\"subdomain\":\"mock-subdomain\"}}',
+}
+"
+  pid=$!
+  wait_for_port "${port}"
+  out="$(CLOUDFLARE_API_BASE_URL="http://127.0.0.1:${port}" CLOUDFLARE_API_TOKEN=t CLOUDFLARE_ACCOUNT_ID=mock-account \
+    bash "${RESOLVE_SH}" root staging)" || rc=$?
+  stop_mock "${pid}"
+  [ "${rc}" -eq 0 ] || fail_test "expected success, got exit ${rc}"
+  [ "${out}" = "https://animichi-staging.mock-subdomain.workers.dev" ] || fail_test "expected workers.dev URL, got: ${out}"
+  echo "PASS: resolves workers.dev when no Custom Domain is attached (${out})"
+}
+
+# ── Case 2: a Custom Domain IS attached -> that hostname wins outright, no
+#    workers.dev lookup at all (proves #541 cutover needs no code change). ─
+test_resolves_custom_domain_when_attached() {
+  local port=18902 pid rc=0 out
+  start_mock "${port}" "
+ROUTES = {
+    '/accounts/mock-account/workers/domains?per_page=50': '{\"success\":true,\"result\":[{\"service\":\"animichi-web\",\"hostname\":\"app.animichi.com\",\"zone_id\":\"z\",\"zone_name\":\"animichi.com\"}]}',
+}
+"
+  pid=$!
+  wait_for_port "${port}"
+  out="$(CLOUDFLARE_API_BASE_URL="http://127.0.0.1:${port}" CLOUDFLARE_API_TOKEN=t CLOUDFLARE_ACCOUNT_ID=mock-account \
+    bash "${RESOLVE_SH}" web production)" || rc=$?
+  stop_mock "${pid}"
+  [ "${rc}" -eq 0 ] || fail_test "expected success, got exit ${rc}"
+  [ "${out}" = "https://app.animichi.com" ] || fail_test "expected the Custom Domain hostname, got: ${out}"
+  echo "PASS: resolves the attached Custom Domain, skipping workers.dev entirely (${out})"
+}
+
+# ── Case 3 (the mutation-proof case): the OLD (pre-#695) script's
+#    root/production branch is a hardcoded `https://animichi.com` that never
+#    checks Cloudflare at all — including in this exact mock, whose state
+#    says root/production is NOT on any Custom Domain, only workers.dev.
+#    That is issue #541's confirmed real state today. The OLD script
+#    "succeeds" by returning a hostname with zero DNS records; the NEW
+#    script, run against the identical mock, returns the real reachable
+#    URL. This is the "deployed to A, smoke probes B, and reports success"
+#    failure mode issue #695 exists to close.
+#
+#    OLD_SCRIPT below is a frozen, self-contained snapshot of the exact
+#    pre-#695 root/production branch (see PR history for the full original
+#    file) — NOT a `git show HEAD:...` lookup. HEAD *is* the new script by
+#    the time this test runs in CI (this file and resolve-worker-url.sh
+#    land in the same commit/PR), and a CI checkout can also be shallow, so
+#    neither points reliably at "the version before this PR". A frozen
+#    literal is the only comparison that stays meaningful regardless of
+#    git history. ─────────────────────────────────────────────────────────
+OLD_SCRIPT_ROOT_PRODUCTION_HARDCODE='https://animichi.com'
+
+test_old_script_would_have_lied_new_script_does_not() {
+  local port=18903 pid rc_new=0 out_old out_new
+  start_mock "${port}" "
+ROUTES = {
+    '/accounts/mock-account/workers/domains?per_page=50': '${NO_CUSTOM_DOMAINS}',
+    '/accounts/mock-account/workers/scripts/animichi/subdomain': '{\"success\":true,\"result\":{\"enabled\":true}}',
+    '/accounts/mock-account/workers/subdomain': '{\"success\":true,\"result\":{\"subdomain\":\"mock-subdomain\"}}',
+}
+"
+  pid=$!
+  wait_for_port "${port}"
+
+  # The OLD script's root/production branch never made an HTTP call at all
+  # — it returned this literal unconditionally, regardless of the mock (or
+  # real Cloudflare account) state below it. That unconditional-ness is
+  # exactly the bug.
+  out_old="${OLD_SCRIPT_ROOT_PRODUCTION_HARDCODE}"
+  out_new="$(CLOUDFLARE_API_BASE_URL="http://127.0.0.1:${port}" CLOUDFLARE_API_TOKEN=t CLOUDFLARE_ACCOUNT_ID=mock-account \
+    bash "${RESOLVE_SH}" root production)" || rc_new=$?
+
+  stop_mock "${pid}"
+
+  [ "${rc_new}" -eq 0 ] || fail_test "the NEW script should succeed against a reachable workers.dev target, got exit ${rc_new}"
+  [ "${out_new}" = "https://animichi.mock-subdomain.workers.dev" ] || fail_test "expected the NEW script's live workers.dev URL, got: ${out_new}"
+  [ "${out_old}" != "${out_new}" ] || fail_test "OLD and NEW scripts agreed — this test no longer demonstrates the bug"
+  echo "PASS: OLD script silently returns a dead hostname (${out_old}); NEW script returns the real live target (${out_new})"
+}
+
+# ── Case 4: neither a Custom Domain nor workers.dev is enabled -> fails
+#    loudly instead of guessing (a Worker with no reachable URL is a real
+#    deploy problem, not something to paper over with a stale guess). ─────
+test_fails_loudly_when_unreachable() {
+  local port=18904 pid rc=0 out
+  start_mock "${port}" "
+ROUTES = {
+    '/accounts/mock-account/workers/domains?per_page=50': '${NO_CUSTOM_DOMAINS}',
+    '/accounts/mock-account/workers/scripts/animichi-web/subdomain': '{\"success\":true,\"result\":{\"enabled\":false}}',
+}
+"
+  pid=$!
+  wait_for_port "${port}"
+  out="$(CLOUDFLARE_API_BASE_URL="http://127.0.0.1:${port}" CLOUDFLARE_API_TOKEN=t CLOUDFLARE_ACCOUNT_ID=mock-account \
+    bash "${RESOLVE_SH}" web production 2>&1)" || rc=$?
+  stop_mock "${pid}"
+  [ "${rc}" -ne 0 ] || fail_test "expected failure when neither Custom Domain nor workers.dev is reachable, got exit 0: ${out}"
+  echo "${out}" | grep -q "neither a Custom Domain nor workers.dev" || fail_test "missing expected diagnostic in output: ${out}"
+  echo "PASS: fails loudly instead of guessing when the Worker has no reachable URL"
+}
+
+test_resolves_workers_dev_when_no_custom_domain
+test_resolves_custom_domain_when_attached
+test_old_script_would_have_lied_new_script_does_not
+test_fails_loudly_when_unreachable
+
+echo "All resolve-worker-url.sh behavioral tests passed."

--- a/.github/workflows/_post-deploy-test.yml
+++ b/.github/workflows/_post-deploy-test.yml
@@ -2,10 +2,15 @@ name: post-deploy-test
 
 # Reusable post-deploy test harness (issue #484). Runs real HTTP assertions
 # against an already-deployed environment via .github/scripts/post-deploy-assert.sh.
-# URLs are derived from the Worker naming convention in wrangler.toml /
-# apps/web/wrangler.jsonc plus the account's workers.dev subdomain — see
-# .github/scripts/resolve-worker-url.sh. This is NOT a network liveness probe
-# used to guess the URL; it is a deterministic name -> URL mapping.
+# URLs are resolved by .github/scripts/resolve-worker-url.sh, which reads the
+# Worker script name from wrangler.toml / apps/web/wrangler.jsonc and then
+# queries Cloudflare for that exact script's ACTUAL live state — its
+# attached Custom Domain if one exists, else its workers.dev URL if that's
+# enabled (issue #695: this used to be a hardcoded hostname table, which
+# silently kept probing a stale address whenever the real deploy target
+# changed underneath it — a different Cloudflare account, or #541's
+# domain cutover). This is NOT a network liveness probe used to guess the
+# URL; it is a read of Cloudflare's own routing state for this Worker.
 #
 # Status (2026-07-29, issue #484): the `changes` job upstream of every deploy
 # job (dorny/paths-filter, checkout with persist-credentials:false + shallow
@@ -48,9 +53,11 @@ on:
       # passed, not that its value is non-empty — an unconfigured repo
       # variable would resolve to "" and hard-fail this job on every run,
       # blocking every production deploy behind it. The read scope this
-      # secret is used for here (GET .../workers/subdomain) is narrower than
-      # deploy, but that's a token-scoping concern, not an account-id one —
-      # see the PR discussion on #493 if revisiting this.
+      # secret is used for here (resolve-worker-url.sh's GET calls against
+      # .../workers/domains, .../workers/scripts/{name}/subdomain, and
+      # .../workers/subdomain — issue #695) is narrower than deploy, but
+      # that's a token-scoping concern, not an account-id one — see the PR
+      # discussion on #493 if revisiting this.
       CLOUDFLARE_ACCOUNT_ID:
         required: true
   # Lets an operator manually re-run a suite against an already-deployed

--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -234,14 +234,16 @@ jobs:
 
   post-deploy-assert-test:
     timeout-minutes: 30
-    name: post-deploy-assert.sh (shellcheck + behavior)
+    name: post-deploy smoke scripts (shellcheck + behavior)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: shellcheck
-        run: shellcheck .github/scripts/post-deploy-assert.sh .github/scripts/post-deploy-assert.test.sh
+        run: |
+          shellcheck .github/scripts/post-deploy-assert.sh .github/scripts/post-deploy-assert.test.sh \
+            .github/scripts/resolve-worker-url.sh .github/scripts/resolve-worker-url.test.sh
         shell: bash
       # #522: this is the gate that decides whether a real 404 (app broken,
       # or the branded 404 page) fails a deploy immediately versus a
@@ -250,4 +252,12 @@ jobs:
       # local mock server; no bats/JS test runner in this repo to hook into.
       - name: post-deploy-assert.sh behavioral tests
         run: bash .github/scripts/post-deploy-assert.test.sh
+        shell: bash
+      # #695: resolve-worker-url.sh is the thing that decides WHAT the smoke
+      # gate above even probes. Same throwaway-mock-server approach, this
+      # time mocking the Cloudflare API instead of the deployed app —
+      # including a direct comparison against a frozen snapshot of the
+      # pre-#695 hardcoded behavior (see the test file header).
+      - name: resolve-worker-url.sh behavioral tests
+        run: bash .github/scripts/resolve-worker-url.test.sh
         shell: bash


### PR DESCRIPTION
## 背景

`.github/scripts/resolve-worker-url.sh` 之前用一张静态的 `component/environment -> hostname` 表来决定烟测目标,其中 `root/production` 更是无条件硬编码为 `https://animichi.com`——而这个域名今天**没有任何 DNS 记录**(#541 确认)。这张表会在两个方向上悄悄过期:换 Cloudflare 账号(workers.dev 子域不同)、或 #541 的域名切换后 Custom Domain 挂到了原来只有 workers.dev 的 Worker 上。无论哪个方向,烟测都会继续"探测成功",但探的是错的地址——因为旧地址通常还活着。

## 做法

`resolve-worker-url.sh` 改为直接查询 Cloudflare 对这个具体 Worker script 的**真实状态**:
1. 先查 List Custom Domains——如果这个 Worker 挂了 Custom Domain,那就是真实入口,直接用,不再退回 workers.dev。
2. 没有 Custom Domain 时,查这个 Worker 自己的 workers.dev 开关(而不是只看账号级 workers.dev 子域是否配置),开着才拼 workers.dev URL。
3. 两者都不可达时,直接报错——不用猜测的旧地址掩盖真实的不可达问题。

Worker script 名字本身仍然从 `wrangler.toml` / `apps/web/wrangler.jsonc` 解析(而不是重新在脚本里写死一份),所以这个脚本不会有任何 `wrangler deploy` 自己都不知道的信息。

**这就是"天然兼容 #541"的关键**:#541 的 hostname cutover 一旦把 Custom Domain 挂上任意一个 Worker,下一次烟测就会自动探到新地址——不需要改这个脚本或任何配置常量。换 Cloudflare 账号同理:账号级 workers.dev 子域是实时查询的,不是拼进代码里的字符串。

## 变异验证(本卡核心产物)

新增 `.github/scripts/resolve-worker-url.test.sh`,其中 `test_old_script_would_have_lied_new_script_does_not` 这个用例直接复现了 bug:
- 冻结了旧脚本 `root/production` 分支的硬编码行为(`https://animichi.com`),对照一个 mock Cloudflare 状态——这个 mock 反映的是**今天的真实生产状态**(只有 workers.dev,没有 Custom Domain,#541 已确认)。
- 旧脚本在这个 mock 下"成功"返回一个**零 DNS 记录**的死域名。
- 新脚本对同一个 mock 返回真实可达的 workers.dev URL。
- 两者输出必须不同,否则测试失败——防止这个测试将来被静默改成不再证明任何事。

四个用例全部通过:workers.dev 正常解析、Custom Domain 优先命中、上面的对照案例、以及两者都不可达时的失败诊断。

## 与 #541 的关系

查过 #541,**仍是 OPEN**(DNS/routes/Custom Domain 尚未配置)。本次改动不依赖 #541 完成——它让 resolve-worker-url.sh 在 #541 完成前后都能给出正确答案,不需要"等 #541 落地时记得回来改"这种约定。

## 门禁结果

- `shellcheck .github/scripts/post-deploy-assert.sh .github/scripts/post-deploy-assert.test.sh .github/scripts/resolve-worker-url.sh .github/scripts/resolve-worker-url.test.sh` — 干净
- `bash .github/scripts/post-deploy-assert.test.sh` — 4/4 通过(未受影响)
- `bash .github/scripts/resolve-worker-url.test.sh` — 4/4 通过(含变异验证用例)
- `actionlint .github/workflows/*.yml` — 干净
- 新测试已接入 `_security.yml` 的 `post-deploy-assert-test` job,CI 会持续跑

Closes #695