### PR TITLE
fix(db): grant DELETE on anon_daily_message_count to agent_svc (#661)

### DIFF
--- a/apps/agent/agent/tests/integration/test_anon_quota_repo_contract.py
+++ b/apps/agent/agent/tests/integration/test_anon_quota_repo_contract.py
@@ -39,36 +39,36 @@ async def _cleanup(pool: asyncpg.Pool, anon_ids: list[str]) -> None:
     )
 
 
-async def test_agent_svc_holds_the_grants_the_repo_needs(db_pool: asyncpg.Pool) -> None:
-    """The migration's GRANT actually took — `has_table_privilege` probes the
-    grant layer directly (same pattern as `test_service_roles.py`), catching
-    a typo'd role name or a forgotten GRANT that a mocked unit test can't.
+# The repo's four operations against this table (issue #661): the UPSERT
+# (`increment_and_count`) needs SELECT/INSERT/UPDATE; the retention purge
+# (`purge_older_than`) needs DELETE. One parametrize case per privilege keeps
+# each test body under the 1-10-50 function-length limit *and* makes a
+# missing grant self-diagnosing — a failure names the exact privilege that's
+# missing (`test_agent_svc_holds_the_grant[DELETE]`) instead of a single
+# bundled assertion that only says "grants are wrong".
+_REPO_PRIVILEGES = ("SELECT", "INSERT", "UPDATE", "DELETE")
 
-    DELETE is asserted here (issue #661) because the sibling
+
+@pytest.mark.parametrize("privilege", _REPO_PRIVILEGES)
+async def test_agent_svc_holds_the_grant(db_pool: asyncpg.Pool, privilege: str) -> None:
+    """The migration's GRANT actually took — `has_table_privilege` probes the
+    grant layer directly (same pattern as `test_service_roles.py`), catching a
+    typo'd role name or a forgotten GRANT that a mocked unit test can't.
+
+    DELETE is covered here because the sibling
     `test_purge_older_than_removes_stale_rows_and_keeps_recent_ones` below
     calls `repo.purge_older_than()` through the unscoped `db_pool` fixture,
     not as `agent_svc` — so it stayed green through 20260729000001 shipping
     without a DELETE grant, and only the real retention cron (running as
     `agent_svc`) ever hit "permission denied for table
-    anon_daily_message_count". This probe is the one that would have caught it.
+    anon_daily_message_count". This is the probe that would have caught it.
     """
     async with db_pool.acquire() as conn:
-        select = await conn.fetchval(
-            "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', 'SELECT')"
+        held = await conn.fetchval(
+            "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', $1)",
+            privilege,
         )
-        insert = await conn.fetchval(
-            "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', 'INSERT')"
-        )
-        update = await conn.fetchval(
-            "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', 'UPDATE')"
-        )
-        delete = await conn.fetchval(
-            "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', 'DELETE')"
-        )
-    assert select is True
-    assert insert is True
-    assert update is True
-    assert delete is True
+    assert held is True
 
 
 async def test_the_same_key_increments_across_calls(db_pool: asyncpg.Pool) -> None:

--- a/apps/agent/agent/tests/integration/test_anon_quota_repo_contract.py
+++ b/apps/agent/agent/tests/integration/test_anon_quota_repo_contract.py
@@ -42,7 +42,16 @@ async def _cleanup(pool: asyncpg.Pool, anon_ids: list[str]) -> None:
 async def test_agent_svc_holds_the_grants_the_repo_needs(db_pool: asyncpg.Pool) -> None:
     """The migration's GRANT actually took — `has_table_privilege` probes the
     grant layer directly (same pattern as `test_service_roles.py`), catching
-    a typo'd role name or a forgotten GRANT that a mocked unit test can't."""
+    a typo'd role name or a forgotten GRANT that a mocked unit test can't.
+
+    DELETE is asserted here (issue #661) because the sibling
+    `test_purge_older_than_removes_stale_rows_and_keeps_recent_ones` below
+    calls `repo.purge_older_than()` through the unscoped `db_pool` fixture,
+    not as `agent_svc` — so it stayed green through 20260729000001 shipping
+    without a DELETE grant, and only the real retention cron (running as
+    `agent_svc`) ever hit "permission denied for table
+    anon_daily_message_count". This probe is the one that would have caught it.
+    """
     async with db_pool.acquire() as conn:
         select = await conn.fetchval(
             "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', 'SELECT')"
@@ -53,9 +62,13 @@ async def test_agent_svc_holds_the_grants_the_repo_needs(db_pool: asyncpg.Pool) 
         update = await conn.fetchval(
             "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', 'UPDATE')"
         )
+        delete = await conn.fetchval(
+            "SELECT has_table_privilege('agent_svc', 'public.anon_daily_message_count', 'DELETE')"
+        )
     assert select is True
     assert insert is True
     assert update is True
+    assert delete is True
 
 
 async def test_the_same_key_increments_across_calls(db_pool: asyncpg.Pool) -> None:

--- a/db/migrations/20260804000001_anon_daily_message_count_delete_grant.sql
+++ b/db/migrations/20260804000001_anon_daily_message_count_delete_grant.sql
@@ -1,0 +1,14 @@
+-- Fix #661: `anon_daily_message_count` (20260729000001) granted agent_svc only
+-- SELECT/INSERT/UPDATE, never DELETE. The retention purge
+-- (agent/scripts/purge_anon_quota_counts.py -> AnonQuotaRepository.purge_older_than,
+-- and its port in workers/maintenance/src/purge.ts) runs
+-- `DELETE FROM anon_daily_message_count ...` as agent_svc, so every purge attempt
+-- would fail closed with "permission denied for table anon_daily_message_count"
+-- even after the cron's UndefinedTableError (missing DSN cutover) is fixed —
+-- the same gap the daily_usage twin (20260726000001) also has, though nothing
+-- purges that table yet so it is not load-bearing there today.
+--
+-- Append-only per docs/ops/migrations.md: 20260729000001 already reached a
+-- shared environment, so this ships as its own migration instead of editing
+-- the applied file.
+GRANT DELETE ON anon_daily_message_count TO agent_svc;

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:W3IXU2wlInCAxpa0TCyYLWpJjl1LOzMHyZHEZUK9nmk=
+h1:LIWPQmFJWcaxxAWwlDyAiCNJPWjZNw0o+5uw3YL5kzc=
 20260623000001_init.sql h1:j96dtVbOQB/5eNuug4tZpdgURdZ5h0Zh4Vka7/dy1A0=
 20260713000001_user_routes.sql h1:th9ag/cdiRp9plYQraVBGIuRXeH4g5R3XvCuGZeFx8Q=
 20260714000001_catalog_geocoding.sql h1:EwkJGRPfg5camebXRzw+5xRVf6TWu23t3/tnw91uPwY=
@@ -10,3 +10,4 @@ h1:W3IXU2wlInCAxpa0TCyYLWpJjl1LOzMHyZHEZUK9nmk=
 20260726000001_daily_usage.sql h1:sBFx7wFXsR8SKXqny7S87YZiamGNDA0FXMrSV3EXj7c=
 20260728000001_conversations_user_id_pattern_ops.sql h1:7SCuWtKAHlYDv4EINCwR6NYWw/qJ7afcC3+rUoqHuaM=
 20260729000001_anon_daily_message_quota.sql h1:Z6fxATy3/W6M5CKVdC6rwcscKOWbwx88vIyf0bnZDpk=
+20260804000001_anon_daily_message_count_delete_grant.sql h1:5ZEq0LdBIMP08wrpsrtWtdeyWHbbK8w3pr3mqk1gwu4=


### PR DESCRIPTION
## 根因(实测,非卡片猜测)

`Purge anon_daily_message_count (retention)` **从 2026-07-29 创建起零次成功**,不是 2026-08-02 才开始。真实失败日志(`gh run view 30488877636 --log-failed`):

```
asyncpg.exceptions.UndefinedTableError: relation "anon_daily_message_count" does not exist
```

不是凭证/`get_settings`/staging 变量问题——姊妹 cron `Purge Anonymous Sessions` 同一个 `SUPABASE_DB_URL` secret、同一天,持续全绿,是天然对照组,排除了 secret 本身的问题。

根因链(已在合并进 main 的 #672→#692 里诊断并大部分修复,本分支 cut 之前就已落地):
- PR #472 只把 `anon_daily_message_count` 的 DDL 写进了 `db/migrations`(Atlas/Neon 腿),cron 和线上 app 实际连的 `SUPABASE_DB_URL` 库里这张表根本不存在。
- Owner 定的方向修正:不做 Supabase 镜像(违反 #631 的 migrations.md 边界),而是把 agent 运行时 DSN 切到 Neon(表已经在那)。
- 进一步升级为 CF-native:两个 GHA purge cron 被 Workers Cron Triggers(`workers/maintenance`,commit `537e4a76` / PR #692)取代,GHA 的 `schedule:` 触发器已经从 `purge-anon-quota-counts.yml` / `purge-anonymous-sessions.yml` 里删掉了——**这个 workflow 不会再按计划失败**。

## 这条 PR 修的是什么

上面这条链留了一个没排掉的地雷:`db/migrations/20260729000001_anon_daily_message_quota.sql` 只给 `agent_svc` 授了 `SELECT, INSERT, UPDATE`,没有 `DELETE`(`daily_usage`,20260726000001,也有一样的缺口,但目前没有代码路径清理它,不算活风险)。

而真正的清理逻辑——Python 的 `AnonQuotaRepository.purge_older_than` 和它在 `workers/maintenance/src/purge.ts` 里的 TS 移植(`purgeAnonQuotaCounts`)——跑的都是 `DELETE FROM anon_daily_message_count`。等 DSN 切换 / Cron Trigger 真正部署上线,清理会从「表不存在」变成「permission denied for table anon_daily_message_count」——换了个失败姿势,retention 依旧是零效果。

修法:新增一条 append-only 的 Atlas 迁移(`20260729000001` 已经到达共享环境,不能原地改,按 `docs/ops/migrations.md` 的规则新开一个),补上缺的 `GRANT DELETE`。同时给 `test_agent_svc_holds_the_grants_the_repo_needs` 加了 DELETE 断言——现有的 `test_purge_older_than_removes_stale_rows_and_keeps_recent_ones` 是通过未限定角色的 `db_pool` fixture 调 `purge_older_than()`,不是以 `agent_svc` 身份,所以这个缺口第一次就没被测出来,以后回归也不会被测出来。

## 停摆两天的实际后果

- 匿名每日配额(`AnonQuotaRepository.increment_and_count`)的写路径本身不受这个 bug 影响——只是清理没跑,过期行会一直堆积,不是"配额永远不重置"那种用户可感知故障。
- `interfaces/anon_quota.py` 的 `_QUOTA_ERRORS = Exception` + fail-open 意味着哪怕写路径出问题也是静默放行,不是拒绝服务;因为 production 目前没有真实流量,实际暴露面≈零,staging 起量后才是活风险(已有独立 owner 记录,不在本 PR 范围)。
- 结论:是需要修的正确性 bug,不是当前用户可感知的生产故障。

## 范围外(明确不在这条 PR 里做)

- CF Cron Trigger 的首次真实验证 + 之后删除 deprecated 的 GHA fallback workflow——两个文件的 header 注释都明确写了"等 staging 记录一次真实 Cron Trigger 成功事件再删除",本分支不部署,验证不了。
- `daily_usage` 的同款缺口——没有代码路径清理它,暂不算债。
- CI 当前 `Deploy root staging` 因为无关的 zizmor 上游 GitHub API 503(`request error ... 503 Service Unavailable`)+ 一个已存在的 Turnstile/healthz 问题持续红,和这条 PR 无关,不在本卡范围内处理。

## 验证

- `atlas migrate validate --dir file://db/migrations` — 绿(`atlas migrate hash` 后重新生成的 `atlas.sum` 里其余每个文件的哈希逐行比对 `origin/main` 完全未变,只多了新文件一行 + 顶部汇总哈希)。
- `sqlfluff lint --dialect postgres` 新迁移文件 — 绿。
- `actionlint` 对相关 workflow 文件(未改动,回归确认) — 绿。
- 定向 `pytest`(quota repo + purge script 单测)— 33 passed。
- `pnpm --dir workers/maintenance test` — 18/18 passed, 100% coverage。

## 告警建议(不在本卡内加,供 #678 立卡参考)

这个 cron 停摆两天+零次成功没人发现,本身值得一张独立卡:给 `workers/maintenance` 的 Cron Trigger 挂 Cloudflare/Logfire 失败告警(而不是只靠人工翻 GHA run 列表),纳入 #678 告警全套一起做。

Closes #661