### PR TITLE
fix(dx): 让 make test-integration 自检+自愈 Atlas CLI 版本(#730)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ backend/tests/eval/results/agent_openai-mimo-*
 # apps/web TS source — re-include (root lib/ rule is too broad)
 !apps/web/src/lib/
 !apps/web/src/lib/**
+
+# Pinned Atlas CLI self-heal cache (#730) — downloaded, checksum-verified
+# binary for `make test-integration`; never checked in, never the global install.
+/.cache/atlas/

--- a/apps/agent/agent/tests/atlas_helper.py
+++ b/apps/agent/agent/tests/atlas_helper.py
@@ -7,12 +7,15 @@ import os
 import platform
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from pathlib import Path
 from urllib.parse import urlparse
+
+import httpx
 
 PINNED_ATLAS_VERSION = "0.30.0"
 # Upgrade policy (review by 2027-01): Atlas supports only the newest two minors,
@@ -40,6 +43,15 @@ ATLAS_ARTIFACTS: dict[tuple[str, str], tuple[str, str | None]] = {
 ATLAS_TIMEOUT_SECONDS = 600
 ROOT = Path(__file__).resolve().parents[4]
 MIGRATIONS_DIR = ROOT / "db" / "migrations"
+
+# Self-check + self-heal (#730): a homebrew-global Atlas that doesn't match
+# PINNED_ATLAS_VERSION must never silently weaken this test arm. The cache
+# lives outside .venv/site-packages so a `uv sync` cannot prune it, and it is
+# never written to a location that shadows or replaces the user's global
+# `atlas` install.
+ATLAS_CACHE_DIR = ROOT / ".cache" / "atlas"
+ATLAS_RELEASE_BASE_URL = "https://release.ariga.io/atlas"
+ATLAS_DOWNLOAD_TIMEOUT_SECONDS = 60
 
 
 def parse_atlas_version(output: str) -> str:
@@ -72,16 +84,23 @@ def verify_atlas_checksum(
         )
 
 
-def verify_atlas_pin(environment: Mapping[str, str] = os.environ) -> None:
-    configured = environment.get("ATLAS_VERSION", PINNED_ATLAS_VERSION)
-    if configured != PINNED_ATLAS_VERSION:
-        raise RuntimeError(f"ATLAS_VERSION must equal {PINNED_ATLAS_VERSION}")
+def _cached_atlas_dir(system: str, machine: str) -> Path:
+    return ATLAS_CACHE_DIR / f"{PINNED_ATLAS_VERSION}-{system}-{machine}"
+
+
+def _cached_atlas_binary(system: str, machine: str) -> Path:
+    # Always named literally "atlas": callers prepend this file's directory to
+    # PATH and invoke the literal command name, so subprocess argv never
+    # carries a computed executable path (keeps ruff S603 happy for real,
+    # not via suppression — see apply_migrations).
+    return _cached_atlas_dir(system, machine) / "atlas"
+
+
+def _global_atlas_matching_pin() -> Path | None:
+    """The global `atlas` on PATH, if it already satisfies the pin, else None."""
     executable = shutil.which("atlas")
     if executable is None:
-        raise RuntimeError(
-            "Atlas 0.30.0 was not found; its pinned release may have been removed "
-            "(404), so review the pin and checksums"
-        )
+        return None
     try:
         result = subprocess.run(
             ["atlas", "version"],
@@ -90,16 +109,93 @@ def verify_atlas_pin(environment: Mapping[str, str] = os.environ) -> None:
             timeout=10,
             check=False,
         )
-    except (OSError, subprocess.TimeoutExpired) as error:
-        raise RuntimeError("unable to execute atlas version") from error
+    except (OSError, subprocess.TimeoutExpired):
+        return None
     if result.returncode != 0:
-        raise RuntimeError("unable to execute atlas version")
-    installed = parse_atlas_version(result.stdout + result.stderr)
-    if installed != PINNED_ATLAS_VERSION:
+        return None
+    try:
+        installed = parse_atlas_version(result.stdout + result.stderr)
+    except RuntimeError:
+        return None
+    return Path(executable) if installed == PINNED_ATLAS_VERSION else None
+
+
+def _download_pinned_atlas(system: str, machine: str) -> Path:
+    """Fetch, checksum-verify, and cache the pinned Atlas binary.
+
+    The sha256 compared here is the digest already committed in this file
+    (recorded once from the official release and human-reviewed) — never a
+    checksums file fetched over the same channel as the binary, which would
+    only prove transport integrity, not artifact identity (#723).
+    """
+    artifact = ATLAS_ARTIFACTS.get((system, machine))
+    if artifact is None:
         raise RuntimeError(
-            f"installed Atlas is {installed}; expected {PINNED_ATLAS_VERSION}"
+            "integration test arm did NOT run: no pinned Atlas artifact is "
+            f"recorded for {system}/{machine}; install Atlas {PINNED_ATLAS_VERSION} "
+            "yourself and put it on PATH, or extend ATLAS_ARTIFACTS"
         )
-    verify_atlas_checksum(Path(executable))
+    artifact_name, _ = artifact
+    destination = _cached_atlas_binary(system, machine)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    tmp_destination = destination.with_suffix(".download")
+    url = f"{ATLAS_RELEASE_BASE_URL}/{artifact_name}"
+    try:
+        response = httpx.get(url, timeout=ATLAS_DOWNLOAD_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        tmp_destination.write_bytes(response.content)
+    except (httpx.HTTPError, OSError) as error:
+        tmp_destination.unlink(missing_ok=True)
+        raise RuntimeError(
+            "integration test arm did NOT run: could not download the pinned "
+            f"Atlas {PINNED_ATLAS_VERSION} binary from {url} ({error}) — this is "
+            "not an unrelated environment blip, the integration arm has not "
+            "executed; check network access and retry, or install Atlas "
+            f"{PINNED_ATLAS_VERSION} manually and put it on PATH"
+        ) from error
+    try:
+        verify_atlas_checksum(tmp_destination, system, machine)
+    except RuntimeError as error:
+        tmp_destination.unlink(missing_ok=True)
+        raise RuntimeError(f"integration test arm did NOT run: {error}") from error
+    tmp_destination.chmod(
+        tmp_destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+    tmp_destination.replace(destination)
+    return destination
+
+
+def ensure_pinned_atlas() -> Path | None:
+    """Resolve the pinned Atlas 0.30.0 and report a PATH prefix, if any.
+
+    This never touches the user's global Atlas install. Resolution order:
+    (1) a global `atlas` on PATH that already matches the pin is used as-is —
+    returns None, no PATH change needed; (2) otherwise a cached,
+    sha256-verified binary under ATLAS_CACHE_DIR is reused or freshly
+    downloaded, keyed by (system, machine) so darwin-arm64 and linux-amd64
+    caches never collide, and its directory is returned for the caller to
+    prepend to PATH for the test command only. Any failure path raises with
+    "integration test arm did NOT run" so a mismatch never reads as an
+    unrelated environment blip.
+    """
+    configured = os.environ.get("ATLAS_VERSION", PINNED_ATLAS_VERSION)
+    if configured != PINNED_ATLAS_VERSION:
+        raise RuntimeError(
+            "integration test arm did NOT run: ATLAS_VERSION must equal "
+            f"{PINNED_ATLAS_VERSION}"
+        )
+    if _global_atlas_matching_pin() is not None:
+        return None
+    system, machine = platform.system(), platform.machine()
+    cached = _cached_atlas_binary(system, machine)
+    if cached.exists():
+        try:
+            verify_atlas_checksum(cached, system, machine)
+        except RuntimeError:
+            cached.unlink(missing_ok=True)
+        else:
+            return cached.parent
+    return _download_pinned_atlas(system, machine).parent
 
 
 def atlas_apply_command() -> tuple[str, ...]:
@@ -121,8 +217,13 @@ def _sanitize_atlas_output(text: str) -> str:
 
 
 def apply_migrations(dsn: str) -> float:
-    verify_atlas_pin()
+    atlas_path_prefix = ensure_pinned_atlas()
     environment = {**os.environ, "DATABASE_URL": dsn}
+    if atlas_path_prefix is not None:
+        # Prepend only for this subprocess call — never mutate the caller's
+        # own PATH or the global `atlas` install (#730).
+        existing_path = environment.get("PATH", "")
+        environment["PATH"] = f"{atlas_path_prefix}{os.pathsep}{existing_path}"
     started = time.monotonic()
     try:
         result = subprocess.run(

--- a/apps/agent/agent/tests/atlas_helper.py
+++ b/apps/agent/agent/tests/atlas_helper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import os
 import platform
@@ -120,13 +121,35 @@ def _global_atlas_matching_pin() -> Path | None:
     return Path(executable) if installed == PINNED_ATLAS_VERSION else None
 
 
+def _fetch_atlas_artifact(url: str) -> bytes:
+    response = httpx.get(
+        url, timeout=ATLAS_DOWNLOAD_TIMEOUT_SECONDS, follow_redirects=True
+    )
+    response.raise_for_status()
+    return response.content
+
+
+def _write_verified_binary(
+    tmp_destination: Path, destination: Path, payload: bytes, system: str, machine: str
+) -> None:
+    tmp_destination.write_bytes(payload)
+    verify_atlas_checksum(tmp_destination, system, machine)
+    executable_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    tmp_destination.chmod(tmp_destination.stat().st_mode | executable_bits)
+    tmp_destination.replace(destination)
+
+
 def _download_pinned_atlas(system: str, machine: str) -> Path:
     """Fetch, checksum-verify, and cache the pinned Atlas binary.
 
     The sha256 compared here is the digest already committed in this file
     (recorded once from the official release and human-reviewed) — never a
     checksums file fetched over the same channel as the binary, which would
-    only prove transport integrity, not artifact identity (#723).
+    only prove transport integrity, not artifact identity (#723). Every step
+    from "decided to download" to "binary is executable" — the HTTP fetch,
+    `mkdir`, the write, the checksum, `chmod`, and the atomic `replace` — is
+    inside one failure boundary: any of them raising must read as "the
+    integration arm did NOT run", never as an unrelated filesystem error.
     """
     artifact = ATLAS_ARTIFACTS.get((system, machine))
     if artifact is None:
@@ -137,31 +160,21 @@ def _download_pinned_atlas(system: str, machine: str) -> Path:
         )
     artifact_name, _ = artifact
     destination = _cached_atlas_binary(system, machine)
-    destination.parent.mkdir(parents=True, exist_ok=True)
     tmp_destination = destination.with_suffix(".download")
     url = f"{ATLAS_RELEASE_BASE_URL}/{artifact_name}"
     try:
-        response = httpx.get(url, timeout=ATLAS_DOWNLOAD_TIMEOUT_SECONDS)
-        response.raise_for_status()
-        tmp_destination.write_bytes(response.content)
-    except (httpx.HTTPError, OSError) as error:
-        tmp_destination.unlink(missing_ok=True)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        payload = _fetch_atlas_artifact(url)
+        _write_verified_binary(tmp_destination, destination, payload, system, machine)
+    except (httpx.HTTPError, OSError, RuntimeError) as error:
+        with contextlib.suppress(OSError):
+            tmp_destination.unlink(missing_ok=True)
         raise RuntimeError(
-            "integration test arm did NOT run: could not download the pinned "
-            f"Atlas {PINNED_ATLAS_VERSION} binary from {url} ({error}) — this is "
-            "not an unrelated environment blip, the integration arm has not "
-            "executed; check network access and retry, or install Atlas "
-            f"{PINNED_ATLAS_VERSION} manually and put it on PATH"
+            "integration test arm did NOT run: could not prepare the pinned "
+            f"Atlas {PINNED_ATLAS_VERSION} binary ({error}); check network access, "
+            f"disk space, and write permissions under {ATLAS_CACHE_DIR}, or install "
+            f"Atlas {PINNED_ATLAS_VERSION} manually and put it on PATH"
         ) from error
-    try:
-        verify_atlas_checksum(tmp_destination, system, machine)
-    except RuntimeError as error:
-        tmp_destination.unlink(missing_ok=True)
-        raise RuntimeError(f"integration test arm did NOT run: {error}") from error
-    tmp_destination.chmod(
-        tmp_destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-    )
-    tmp_destination.replace(destination)
     return destination
 
 
@@ -192,7 +205,13 @@ def ensure_pinned_atlas() -> Path | None:
         try:
             verify_atlas_checksum(cached, system, machine)
         except RuntimeError:
-            cached.unlink(missing_ok=True)
+            with contextlib.suppress(OSError):
+                cached.unlink(missing_ok=True)
+        except OSError as error:
+            raise RuntimeError(
+                "integration test arm did NOT run: could not read the cached "
+                f"Atlas binary at {cached} to verify it ({error})"
+            ) from error
         else:
             return cached.parent
     return _download_pinned_atlas(system, machine).parent

--- a/apps/agent/agent/tests/unit/test_atlas_apply_migrations_path.py
+++ b/apps/agent/agent/tests/unit/test_atlas_apply_migrations_path.py
@@ -1,0 +1,63 @@
+"""PATH contract for apply_migrations() (#730, #737 review item 5).
+
+The behavior this card actually promises — apply_migrations() only prepends
+the resolved Atlas cache directory to PATH for its own subprocess call, and
+never touches the caller's own PATH — had no direct test before this file;
+ensure_pinned_atlas() alone doesn't exercise it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent.tests import atlas_helper
+from agent.tests.atlas_helper import apply_migrations
+
+
+def _capture_run(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def _fake_run(
+        argv: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        captured["argv"] = argv
+        captured["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(atlas_helper.subprocess, "run", _fake_run)
+    return captured
+
+
+def test_apply_migrations_prepends_only_the_resolved_atlas_directory_to_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        atlas_helper, "ensure_pinned_atlas", lambda: Path("/fake/atlas/bin")
+    )
+    captured = _capture_run(monkeypatch)
+    original_path = os.environ.get("PATH", "")
+
+    apply_migrations("postgresql://example/test")
+
+    assert captured["argv"] == list(atlas_helper.atlas_apply_command())
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["PATH"] == f"/fake/atlas/bin{os.pathsep}{original_path}"
+    assert os.environ.get("PATH") == original_path  # caller's own PATH untouched
+
+
+def test_apply_migrations_leaves_path_untouched_when_global_atlas_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(atlas_helper, "ensure_pinned_atlas", lambda: None)
+    captured = _capture_run(monkeypatch)
+
+    apply_migrations("postgresql://example/test")
+
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["PATH"] == os.environ.get("PATH", "")

--- a/apps/agent/agent/tests/unit/test_atlas_download_hardening.py
+++ b/apps/agent/agent/tests/unit/test_atlas_download_hardening.py
@@ -1,0 +1,66 @@
+"""Download-step edge cases for the pinned Atlas cache (#737 review items 1 & 3).
+
+Split out of test_atlas_self_heal.py to keep files under the 200-line ceiling;
+reuses that file's fixture helpers rather than duplicating them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import httpx
+import pytest
+
+from agent.tests import atlas_helper
+from agent.tests.atlas_helper import ensure_pinned_atlas
+from agent.tests.unit.test_atlas_self_heal import (
+    _fixture_cache,
+    _forbidden_get,
+    _pin_current_platform,
+)
+
+
+def test_download_pinned_atlas_follows_redirects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mutation guard: a 301 must be followed, not misread as a bad checksum."""
+    payload = b"redirected Atlas payload"
+    digest = hashlib.sha256(payload).hexdigest()
+    _fixture_cache(monkeypatch, tmp_path)
+    _pin_current_platform(monkeypatch, digest)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/redirect-me"):
+            return httpx.Response(301, headers={"location": "/final"})
+        return httpx.Response(200, content=payload)
+
+    transport = httpx.MockTransport(_handler)
+
+    def _get(url: str, *, timeout: float, follow_redirects: bool) -> httpx.Response:
+        with httpx.Client(
+            transport=transport, follow_redirects=follow_redirects
+        ) as client:
+            return client.get("http://release.test/redirect-me", timeout=timeout)
+
+    monkeypatch.setattr(atlas_helper.httpx, "get", _get)
+
+    bin_dir = ensure_pinned_atlas()
+
+    assert bin_dir is not None
+    assert (bin_dir / "atlas").read_bytes() == payload
+
+
+def test_download_pinned_atlas_mkdir_failure_says_arm_did_not_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mutation guard: mkdir failing must not surface as a bare OSError."""
+    blocker = tmp_path / "blocker"
+    blocker.write_text("occupies the path a cache directory would need")
+    _fixture_cache(monkeypatch, tmp_path)
+    monkeypatch.setattr(atlas_helper, "ATLAS_CACHE_DIR", blocker / "nested")
+    _pin_current_platform(monkeypatch, "0" * 64)
+    monkeypatch.setattr(atlas_helper.httpx, "get", _forbidden_get)
+
+    with pytest.raises(RuntimeError, match="did NOT run.*could not prepare"):
+        ensure_pinned_atlas()

--- a/apps/agent/agent/tests/unit/test_atlas_helper.py
+++ b/apps/agent/agent/tests/unit/test_atlas_helper.py
@@ -1,9 +1,12 @@
-"""Static contract tests for the shared Atlas invocation."""
+"""Static contract tests for the shared Atlas invocation.
+
+Self-heal / cache-provisioning behavior lives in test_atlas_self_heal.py — kept
+separate so this file stays under the repo's 200-line test-file ceiling.
+"""
 
 import hashlib
 from pathlib import Path
 
-import httpx
 import pytest
 
 from agent.tests import atlas_helper
@@ -11,7 +14,6 @@ from agent.tests.atlas_helper import (
     ATLAS_MACOS_ARM64_SHA256,
     ATLAS_TIMEOUT_SECONDS,
     atlas_apply_command,
-    ensure_pinned_atlas,
     parse_atlas_version,
     verify_atlas_checksum,
 )
@@ -66,157 +68,6 @@ def test_atlas_binary_without_recorded_digest_fails_closed(
     )
     with pytest.raises(RuntimeError, match="unverified.*official sha256"):
         verify_atlas_checksum(binary, "FixtureOS", "fixture-cpu")
-
-
-def _use_fixture_cache(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, expected_sha256: str | None
-) -> None:
-    monkeypatch.setattr(atlas_helper, "ATLAS_CACHE_DIR", tmp_path / "cache")
-    monkeypatch.setattr(atlas_helper.platform, "system", lambda: "FixtureOS")
-    monkeypatch.setattr(atlas_helper.platform, "machine", lambda: "fixture-cpu")
-    monkeypatch.setitem(
-        atlas_helper.ATLAS_ARTIFACTS,
-        ("FixtureOS", "fixture-cpu"),
-        ("atlas-fixture", expected_sha256),
-    )
-    monkeypatch.setattr(atlas_helper, "_global_atlas_matching_pin", lambda: None)
-
-
-def test_ensure_pinned_atlas_reuses_matching_global_without_downloading(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        atlas_helper, "_global_atlas_matching_pin", lambda: Path("/usr/local/bin/atlas")
-    )
-
-    def _fail_download(system: str, machine: str) -> Path:
-        raise AssertionError("must not download when the global Atlas already matches")
-
-    monkeypatch.setattr(atlas_helper, "_download_pinned_atlas", _fail_download)
-    assert ensure_pinned_atlas() is None
-
-
-def test_ensure_pinned_atlas_rejects_atlas_version_override(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("ATLAS_VERSION", "1.2.4")
-    with pytest.raises(RuntimeError, match="did NOT run.*ATLAS_VERSION"):
-        ensure_pinned_atlas()
-
-
-def test_ensure_pinned_atlas_downloads_and_verifies_into_cache(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    payload = b"pretend Atlas binary"
-    digest = hashlib.sha256(payload).hexdigest()
-    _use_fixture_cache(monkeypatch, tmp_path, digest)
-
-    class _FakeResponse:
-        content = payload
-
-        def raise_for_status(self) -> None:
-            return None
-
-    monkeypatch.setattr(atlas_helper.httpx, "get", lambda url, timeout: _FakeResponse())
-
-    bin_dir = ensure_pinned_atlas()
-    assert bin_dir is not None
-    cached_binary = bin_dir / "atlas"
-    assert cached_binary.read_bytes() == payload
-    assert cached_binary.stat().st_mode & 0o111  # executable bits set
-
-
-def test_ensure_pinned_atlas_reuses_valid_cache_without_redownloading(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    payload = b"already cached binary"
-    digest = hashlib.sha256(payload).hexdigest()
-    _use_fixture_cache(monkeypatch, tmp_path, digest)
-    cached_binary = atlas_helper._cached_atlas_binary("FixtureOS", "fixture-cpu")
-    cached_binary.parent.mkdir(parents=True)
-    cached_binary.write_bytes(payload)
-
-    def _fail_download(system: str, machine: str) -> Path:
-        raise AssertionError(
-            "must not re-download a cache that already matches the pin"
-        )
-
-    monkeypatch.setattr(atlas_helper, "_download_pinned_atlas", _fail_download)
-    bin_dir = ensure_pinned_atlas()
-    assert bin_dir == cached_binary.parent
-
-
-def test_ensure_pinned_atlas_redownloads_a_corrupted_cache(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    good_payload = b"fresh good binary"
-    digest = hashlib.sha256(good_payload).hexdigest()
-    _use_fixture_cache(monkeypatch, tmp_path, digest)
-    cached_binary = atlas_helper._cached_atlas_binary("FixtureOS", "fixture-cpu")
-    cached_binary.parent.mkdir(parents=True)
-    cached_binary.write_bytes(b"corrupted stale bytes")
-
-    class _FakeResponse:
-        content = good_payload
-
-        def raise_for_status(self) -> None:
-            return None
-
-    monkeypatch.setattr(atlas_helper.httpx, "get", lambda url, timeout: _FakeResponse())
-    bin_dir = ensure_pinned_atlas()
-    assert bin_dir is not None
-    assert (bin_dir / "atlas").read_bytes() == good_payload
-
-
-def test_ensure_pinned_atlas_rejects_a_tampered_download(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Mutation guard: a byte-flipped download must fail closed, not run migrations."""
-    real_payload = b"trustworthy Atlas binary"
-    digest = hashlib.sha256(real_payload).hexdigest()
-    _use_fixture_cache(monkeypatch, tmp_path, digest)
-
-    class _TamperedResponse:
-        content = b"trustworthy Atlas binaryX"  # one byte appended
-
-        def raise_for_status(self) -> None:
-            return None
-
-    monkeypatch.setattr(
-        atlas_helper.httpx, "get", lambda url, timeout: _TamperedResponse()
-    )
-    with pytest.raises(RuntimeError, match="did NOT run.*checksum mismatch"):
-        ensure_pinned_atlas()
-    assert not atlas_helper._cached_atlas_binary("FixtureOS", "fixture-cpu").exists()
-
-
-def test_ensure_pinned_atlas_network_failure_says_arm_did_not_run(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    _use_fixture_cache(monkeypatch, tmp_path, "0" * 64)
-
-    def _raise_network_error(url: str, timeout: float) -> None:
-        raise httpx.ConnectError("no route to host")
-
-    monkeypatch.setattr(atlas_helper.httpx, "get", _raise_network_error)
-    with pytest.raises(RuntimeError, match="did NOT run.*could not download"):
-        ensure_pinned_atlas()
-
-
-def test_ensure_pinned_atlas_unmapped_platform_fails_before_any_download(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(atlas_helper, "ATLAS_CACHE_DIR", tmp_path / "cache")
-    monkeypatch.setattr(atlas_helper.platform, "system", lambda: "PlanNine")
-    monkeypatch.setattr(atlas_helper.platform, "machine", lambda: "exotic")
-    monkeypatch.setattr(atlas_helper, "_global_atlas_matching_pin", lambda: None)
-
-    def _fail_get(url: str, timeout: float) -> None:
-        raise AssertionError("must not attempt a network call for an unmapped platform")
-
-    monkeypatch.setattr(atlas_helper.httpx, "get", _fail_get)
-    with pytest.raises(RuntimeError, match="did NOT run.*no pinned Atlas artifact"):
-        ensure_pinned_atlas()
 
 
 def _route_anime_sql() -> str:

--- a/apps/agent/agent/tests/unit/test_atlas_helper.py
+++ b/apps/agent/agent/tests/unit/test_atlas_helper.py
@@ -3,6 +3,7 @@
 import hashlib
 from pathlib import Path
 
+import httpx
 import pytest
 
 from agent.tests import atlas_helper
@@ -10,6 +11,7 @@ from agent.tests.atlas_helper import (
     ATLAS_MACOS_ARM64_SHA256,
     ATLAS_TIMEOUT_SECONDS,
     atlas_apply_command,
+    ensure_pinned_atlas,
     parse_atlas_version,
     verify_atlas_checksum,
 )
@@ -64,6 +66,157 @@ def test_atlas_binary_without_recorded_digest_fails_closed(
     )
     with pytest.raises(RuntimeError, match="unverified.*official sha256"):
         verify_atlas_checksum(binary, "FixtureOS", "fixture-cpu")
+
+
+def _use_fixture_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, expected_sha256: str | None
+) -> None:
+    monkeypatch.setattr(atlas_helper, "ATLAS_CACHE_DIR", tmp_path / "cache")
+    monkeypatch.setattr(atlas_helper.platform, "system", lambda: "FixtureOS")
+    monkeypatch.setattr(atlas_helper.platform, "machine", lambda: "fixture-cpu")
+    monkeypatch.setitem(
+        atlas_helper.ATLAS_ARTIFACTS,
+        ("FixtureOS", "fixture-cpu"),
+        ("atlas-fixture", expected_sha256),
+    )
+    monkeypatch.setattr(atlas_helper, "_global_atlas_matching_pin", lambda: None)
+
+
+def test_ensure_pinned_atlas_reuses_matching_global_without_downloading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        atlas_helper, "_global_atlas_matching_pin", lambda: Path("/usr/local/bin/atlas")
+    )
+
+    def _fail_download(system: str, machine: str) -> Path:
+        raise AssertionError("must not download when the global Atlas already matches")
+
+    monkeypatch.setattr(atlas_helper, "_download_pinned_atlas", _fail_download)
+    assert ensure_pinned_atlas() is None
+
+
+def test_ensure_pinned_atlas_rejects_atlas_version_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ATLAS_VERSION", "1.2.4")
+    with pytest.raises(RuntimeError, match="did NOT run.*ATLAS_VERSION"):
+        ensure_pinned_atlas()
+
+
+def test_ensure_pinned_atlas_downloads_and_verifies_into_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = b"pretend Atlas binary"
+    digest = hashlib.sha256(payload).hexdigest()
+    _use_fixture_cache(monkeypatch, tmp_path, digest)
+
+    class _FakeResponse:
+        content = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+    monkeypatch.setattr(atlas_helper.httpx, "get", lambda url, timeout: _FakeResponse())
+
+    bin_dir = ensure_pinned_atlas()
+    assert bin_dir is not None
+    cached_binary = bin_dir / "atlas"
+    assert cached_binary.read_bytes() == payload
+    assert cached_binary.stat().st_mode & 0o111  # executable bits set
+
+
+def test_ensure_pinned_atlas_reuses_valid_cache_without_redownloading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = b"already cached binary"
+    digest = hashlib.sha256(payload).hexdigest()
+    _use_fixture_cache(monkeypatch, tmp_path, digest)
+    cached_binary = atlas_helper._cached_atlas_binary("FixtureOS", "fixture-cpu")
+    cached_binary.parent.mkdir(parents=True)
+    cached_binary.write_bytes(payload)
+
+    def _fail_download(system: str, machine: str) -> Path:
+        raise AssertionError(
+            "must not re-download a cache that already matches the pin"
+        )
+
+    monkeypatch.setattr(atlas_helper, "_download_pinned_atlas", _fail_download)
+    bin_dir = ensure_pinned_atlas()
+    assert bin_dir == cached_binary.parent
+
+
+def test_ensure_pinned_atlas_redownloads_a_corrupted_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    good_payload = b"fresh good binary"
+    digest = hashlib.sha256(good_payload).hexdigest()
+    _use_fixture_cache(monkeypatch, tmp_path, digest)
+    cached_binary = atlas_helper._cached_atlas_binary("FixtureOS", "fixture-cpu")
+    cached_binary.parent.mkdir(parents=True)
+    cached_binary.write_bytes(b"corrupted stale bytes")
+
+    class _FakeResponse:
+        content = good_payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+    monkeypatch.setattr(atlas_helper.httpx, "get", lambda url, timeout: _FakeResponse())
+    bin_dir = ensure_pinned_atlas()
+    assert bin_dir is not None
+    assert (bin_dir / "atlas").read_bytes() == good_payload
+
+
+def test_ensure_pinned_atlas_rejects_a_tampered_download(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mutation guard: a byte-flipped download must fail closed, not run migrations."""
+    real_payload = b"trustworthy Atlas binary"
+    digest = hashlib.sha256(real_payload).hexdigest()
+    _use_fixture_cache(monkeypatch, tmp_path, digest)
+
+    class _TamperedResponse:
+        content = b"trustworthy Atlas binaryX"  # one byte appended
+
+        def raise_for_status(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        atlas_helper.httpx, "get", lambda url, timeout: _TamperedResponse()
+    )
+    with pytest.raises(RuntimeError, match="did NOT run.*checksum mismatch"):
+        ensure_pinned_atlas()
+    assert not atlas_helper._cached_atlas_binary("FixtureOS", "fixture-cpu").exists()
+
+
+def test_ensure_pinned_atlas_network_failure_says_arm_did_not_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _use_fixture_cache(monkeypatch, tmp_path, "0" * 64)
+
+    def _raise_network_error(url: str, timeout: float) -> None:
+        raise httpx.ConnectError("no route to host")
+
+    monkeypatch.setattr(atlas_helper.httpx, "get", _raise_network_error)
+    with pytest.raises(RuntimeError, match="did NOT run.*could not download"):
+        ensure_pinned_atlas()
+
+
+def test_ensure_pinned_atlas_unmapped_platform_fails_before_any_download(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(atlas_helper, "ATLAS_CACHE_DIR", tmp_path / "cache")
+    monkeypatch.setattr(atlas_helper.platform, "system", lambda: "PlanNine")
+    monkeypatch.setattr(atlas_helper.platform, "machine", lambda: "exotic")
+    monkeypatch.setattr(atlas_helper, "_global_atlas_matching_pin", lambda: None)
+
+    def _fail_get(url: str, timeout: float) -> None:
+        raise AssertionError("must not attempt a network call for an unmapped platform")
+
+    monkeypatch.setattr(atlas_helper.httpx, "get", _fail_get)
+    with pytest.raises(RuntimeError, match="did NOT run.*no pinned Atlas artifact"):
+        ensure_pinned_atlas()
 
 
 def _route_anime_sql() -> str:

--- a/apps/agent/agent/tests/unit/test_atlas_self_heal.py
+++ b/apps/agent/agent/tests/unit/test_atlas_self_heal.py
@@ -1,0 +1,166 @@
+"""Self-heal contract tests for the pinned Atlas cache (#730, #737 review).
+
+Split out to keep every file under the repo's 200-line test-file ceiling:
+- apply_migrations()'s PATH contract → test_atlas_apply_migrations_path.py
+- download-step edge cases (redirects, mkdir failure) → test_atlas_download_hardening.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import platform
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import pytest
+
+from agent.tests import atlas_helper
+from agent.tests.atlas_helper import ensure_pinned_atlas
+
+
+@dataclass
+class _FakeHttpResponse:
+    content: bytes
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+def _fixture_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(atlas_helper, "ATLAS_CACHE_DIR", tmp_path / "cache")
+    monkeypatch.setattr(atlas_helper, "_global_atlas_matching_pin", lambda: None)
+
+
+def _pin_current_platform(
+    monkeypatch: pytest.MonkeyPatch, digest: str
+) -> tuple[str, str]:
+    system, machine = platform.system(), platform.machine()
+    monkeypatch.setitem(
+        atlas_helper.ATLAS_ARTIFACTS, (system, machine), ("atlas-test-artifact", digest)
+    )
+    return system, machine
+
+
+def _stub_get(payload: bytes) -> Callable[..., _FakeHttpResponse]:
+    def _get(url: str, **kwargs: object) -> _FakeHttpResponse:
+        return _FakeHttpResponse(payload)
+
+    return _get
+
+
+def _forbidden_get(url: str, **kwargs: object) -> httpx.Response:
+    raise AssertionError("must not attempt a network call")
+
+
+def _forbidden_download(system: str, machine: str) -> Path:
+    raise AssertionError("must not download here")
+
+
+def test_ensure_pinned_atlas_reuses_matching_global_without_downloading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        atlas_helper, "_global_atlas_matching_pin", lambda: Path("/usr/local/bin/atlas")
+    )
+    monkeypatch.setattr(atlas_helper, "_download_pinned_atlas", _forbidden_download)
+    assert ensure_pinned_atlas() is None
+
+
+def test_ensure_pinned_atlas_rejects_atlas_version_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ATLAS_VERSION", "1.2.4")
+    with pytest.raises(RuntimeError, match="did NOT run.*ATLAS_VERSION"):
+        ensure_pinned_atlas()
+
+
+def test_ensure_pinned_atlas_downloads_and_verifies_into_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = b"pretend Atlas binary"
+    digest = hashlib.sha256(payload).hexdigest()
+    _fixture_cache(monkeypatch, tmp_path)
+    system, machine = _pin_current_platform(monkeypatch, digest)
+    monkeypatch.setattr(atlas_helper.httpx, "get", _stub_get(payload))
+
+    bin_dir = ensure_pinned_atlas()
+
+    assert bin_dir == atlas_helper._cached_atlas_binary(system, machine).parent
+    cached_binary = bin_dir / "atlas" if bin_dir else None
+    assert cached_binary is not None and cached_binary.read_bytes() == payload
+    assert cached_binary.stat().st_mode & 0o111  # executable bits set
+
+
+def test_ensure_pinned_atlas_reuses_valid_cache_without_redownloading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = b"already cached binary"
+    digest = hashlib.sha256(payload).hexdigest()
+    _fixture_cache(monkeypatch, tmp_path)
+    system, machine = _pin_current_platform(monkeypatch, digest)
+    cached_binary = atlas_helper._cached_atlas_binary(system, machine)
+    cached_binary.parent.mkdir(parents=True)
+    cached_binary.write_bytes(payload)
+    monkeypatch.setattr(atlas_helper, "_download_pinned_atlas", _forbidden_download)
+
+    assert ensure_pinned_atlas() == cached_binary.parent
+
+
+def test_ensure_pinned_atlas_redownloads_a_corrupted_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    good_payload = b"fresh good binary"
+    digest = hashlib.sha256(good_payload).hexdigest()
+    _fixture_cache(monkeypatch, tmp_path)
+    system, machine = _pin_current_platform(monkeypatch, digest)
+    cached_binary = atlas_helper._cached_atlas_binary(system, machine)
+    cached_binary.parent.mkdir(parents=True)
+    cached_binary.write_bytes(b"corrupted stale bytes")
+    monkeypatch.setattr(atlas_helper.httpx, "get", _stub_get(good_payload))
+
+    bin_dir = ensure_pinned_atlas()
+
+    assert bin_dir is not None
+    assert (bin_dir / "atlas").read_bytes() == good_payload
+
+
+def test_ensure_pinned_atlas_rejects_a_tampered_download(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mutation guard: a byte-flipped download must fail closed, not run migrations."""
+    real_payload = b"trustworthy Atlas binary"
+    digest = hashlib.sha256(real_payload).hexdigest()
+    _fixture_cache(monkeypatch, tmp_path)
+    system, machine = _pin_current_platform(monkeypatch, digest)
+    monkeypatch.setattr(atlas_helper.httpx, "get", _stub_get(real_payload + b"X"))
+
+    with pytest.raises(RuntimeError, match="did NOT run.*checksum mismatch"):
+        ensure_pinned_atlas()
+    assert not atlas_helper._cached_atlas_binary(system, machine).exists()
+
+
+def test_ensure_pinned_atlas_network_failure_says_arm_did_not_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fixture_cache(monkeypatch, tmp_path)
+    _pin_current_platform(monkeypatch, "0" * 64)
+
+    def _raise_network_error(url: str, **kwargs: object) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    monkeypatch.setattr(atlas_helper.httpx, "get", _raise_network_error)
+    with pytest.raises(RuntimeError, match="did NOT run.*could not prepare"):
+        ensure_pinned_atlas()
+
+
+def test_ensure_pinned_atlas_unmapped_platform_fails_before_any_download(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fixture_cache(monkeypatch, tmp_path)
+    monkeypatch.setattr(atlas_helper, "ATLAS_ARTIFACTS", {})
+    monkeypatch.setattr(atlas_helper.httpx, "get", _forbidden_get)
+
+    with pytest.raises(RuntimeError, match="did NOT run.*no pinned Atlas artifact"):
+        ensure_pinned_atlas()


### PR DESCRIPTION
Closes #730

## 问题

`make test-integration` 在本地因 Atlas CLI 版本不匹配而整条臂跑不起来:homebrew 全局装的是 `1.2.4`,仓库锁定 `0.30.0`,前置检查直接抛 `RuntimeError`。

真正的危害不是"报错",而是这个报错读起来像"无关的环境噪音",而不是"你的本地门禁少了一整臂"——#724 的排查里,一个执行者连续几轮把它当环境噪音略过,而 CI 上实际藏着两个真失败(`SessionRepository not initialized` + 匿名会话外键违规,见 #729),都靠 CI 才发现。

## 做法

`apps/agent/agent/tests/atlas_helper.py` 新增 `ensure_pinned_atlas()`,取代原来直接抛错的 `verify_atlas_pin()`:

1. **全局 Atlas 已经匹配 pin** → 原样使用,不下载、不碰全局安装。
2. **不匹配** → 从 `release.ariga.io` 下载对应平台(darwin-arm64 / linux-amd64,取自已有的 `ATLAS_ARTIFACTS` 映射)的 `0.30.0` 二进制到仓库内、已加入 `.gitignore` 的缓存目录 `.cache/atlas/<version>-<system>-<machine>/atlas`,用文件里**已经提交、人工核验过**的 sha256 校验(不下载 checksums 文件——同通道拿到的校验和只能证明传输完整性,证不了产物身份,这个判断本仓库在 #723 用过)。
3. 校验通过后,只为 `atlas migrate apply` 这一次 subprocess 调用把缓存目录**前置到 PATH**,调用字面量 `"atlas"`——调用方自己的 shell PATH 和全局安装完全不受影响。
4. 任何失败路径(未收录的平台、断网、校验失败)都以 `"integration test arm did NOT run: ..."` 开头抛错,不再可能被误读成"这一臂本来是绿的"。

`.gitignore` 新增 `/.cache/atlas/`。

## 验证(本机,全局 Atlas 是 1.2.4)

`make test-integration` 跑通整条臂:

```
================ 212 passed, 22 skipped, 16 warnings in 51.69s =================
```

(冷缓存重跑一次结果一致:`212 passed, 22 skipped`。)

全局安装未被触碰:

```
$ which atlas && atlas version
/opt/homebrew/bin/atlas
atlas version v1.2.4-17de4ab-canary
```

变异验证——把缓存二进制改坏一个字节:

```
REJECTED AS EXPECTED (direct checksum check): Atlas checksum mismatch for
atlas-community-darwin-arm64-v0.30.0; the pin may be stale, the release may
have been removed (404), or the download is corrupt
```

再叠加"断网"场景(mock 网络请求抛错),证明自愈失败时会失败关闭而不是静默放行:

```
REJECTED AS EXPECTED (self-heal cannot reach network, arm did NOT run):
integration test arm did NOT run: could not download the pinned Atlas 0.30.0
binary from https://release.ariga.io/atlas/atlas-community-darwin-arm64-v0.30.0
(network disabled for this proof) — this is not an unrelated environment blip,
the integration arm has not executed; check network access and retry, or
install Atlas 0.30.0 manually and put it on PATH
```

## 测试

新增 8 个单元测试覆盖 `ensure_pinned_atlas()`:全局匹配即复用、`ATLAS_VERSION` 覆写拒绝、下载并校验入缓存、有效缓存复用不重下、损坏缓存自动重下、篡改下载被拒绝(变异测试)、断网时明确失败、未收录平台在联网前就拒绝。`apps/agent/agent/tests/unit/test_atlas_helper.py` 全部 22 个用例通过;`make lint` / `make typecheck` 全绿。

## 已知的不相关问题

`make test`(单测臂,非本卡范围)里 `test_routes_health.py::test_cors_middleware_allows_configured_origin` 在跑完整套件时偶发失败(单独跑必过),经核实在应用本改动前后行为一致——是套件里已存在的测试顺序污染,与本 PR 的改动(`atlas_helper.py`)无接触面,未在本卡范围内修复。

## 约束核对

- 未修改用户全局 Atlas 安装(已验证)。
- sha256 校验复用仓库已有摘要,未引入 checksums 文件下载。
- 缓存目录已加入 `.gitignore`。
- 无 suppression(为绕开 ruff S603/S310 误报,改用"PATH 前置 + 字面量命令名"和 `httpx`,而不是加 `noqa`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Atlas integration tests now reliably locate the pinned binary through a verified global installation, local cache, or configured download.
  * Cached and downloaded binaries are checksum-validated and made executable.
  * Corrupted or tampered binaries are rejected, with clear failures when setup cannot complete.
  * Test runs no longer modify the caller’s global environment when using cached binaries.

* **Tests**
  * Added coverage for cache reuse, downloads, checksum failures, network errors, version mismatches, and unsupported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->