### PR TITLE
fix(ci): agnix warn-only lint 装不上二进制的回归 (#738)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,36 +258,66 @@ jobs:
   # suppression): it surfaces context-doc rot without failing CI. Kept out of the
   # deploy `needs:` chain so it never gates a release. Promote to blocking once proven.
   #
-  # NOTE (2026-08-04, #738): do NOT add --ignore-scripts to the npx invocation below.
-  # agnix ships no prebuilt binary in its npm tarball — its own `postinstall` hook
-  # (install.js) is the only thing that fetches the platform binary from its GitHub
-  # release and verifies its sha256 before use. #723 (S6505 hardening) added
-  # --ignore-scripts here on the assumption it was a no-behavior-change formalization;
-  # that assumption was verified against a machine with a stale npx cache (binary
-  # already present from an earlier unrestricted run), so the postinstall skip went
-  # unnoticed locally. On every CI runner the npx cache starts empty, so
-  # --ignore-scripts deterministically skips the fetch and every run fails with
-  # "agnix binary not found" — bisected exactly to that commit (run 30876322672,
-  # success, vs. 30877440998, failure, first run after 2d1a50c6 landed) and
-  # reproduced locally by clearing ~/.npm/_npx and rerunning both flag variants.
-  # --ignore-scripts buys no real protection here anyway: running agnix at all means
-  # executing its downloaded binary, so the trust boundary is the same with or
-  # without the flag — only the flag also breaks the intended install path.
+  # NOTE (2026-08-04, #738): this step does NOT go through npm/npx at all — do not
+  # "simplify" it back to `npx agnix@0.37.5 .`. History:
+  #
+  # 1. agnix ships no prebuilt binary in its npm tarball; its own `postinstall` hook
+  #    (install.js) is the only thing that fetches the platform binary from its
+  #    GitHub release. #723 (S6505 hardening, commit 2d1a50c6) added
+  #    --ignore-scripts to the old `npx --yes agnix@0.37.5 .` invocation, believing
+  #    it a no-behavior-change formalization, and recorded a local verification
+  #    that it "still runs and reports its usual findings."
+  # 2. That verification was a false positive: it ran on a machine with a stale npx
+  #    cache (binary already present from an earlier unrestricted run), so
+  #    postinstall never needed to fire. Every GitHub Actions runner starts with an
+  #    empty npx cache, so --ignore-scripts deterministically skipped the fetch
+  #    there and every run failed with "agnix binary not found" — bisected exactly
+  #    to that commit (run 30876322672, success, vs. 30877440998, failure, the
+  #    first run after 2d1a50c6 landed) and reproduced locally by clearing
+  #    ~/.npm/_npx and rerunning both flag variants.
+  # 3. Dropping --ignore-scripts (the first fix attempted) restored the lint but
+  #    reopened the exact npm-lifecycle-script execution surface S6505 exists to
+  #    close, which SonarCloud correctly flagged again on that revision.
+  #
+  # This step resolves both: it downloads the same GitHub-release tarball
+  # install.js would have fetched (the linux/x86_64 target, matching ubuntu-latest),
+  # but verifies it against a sha256 pinned in THIS file rather than the
+  # `.sha256` sidecar published alongside it in the same release. Per #723's own
+  # standard (see the Atlas CLI pin a few jobs down, and
+  # apps/agent/agent/tests/atlas_helper.py), a same-channel checksum only proves
+  # the bytes weren't corrupted in transit — it can't prove the published artifact
+  # is the one that was reviewed. The hash below was computed independently
+  # (`shasum -a 256`) against a fresh download on 2026-08-04 and cross-checked
+  # against the release's own `.sha256` sidecar (matched); it now lives here,
+  # decoupled from that channel. No `npm`/`npx`, so no lifecycle scripts run at
+  # all — S6505 doesn't apply to this step anymore.
 
   agnix:
     timeout-minutes: 15
     name: Agent config lint (agnix, warn-only)
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      AGNIX_VERSION: "0.37.5"
+      AGNIX_SHA256: "312e81a2caf58ef47004f5c708a0fadf0c4758eda99814f8c37a82c925c47cf2"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
+      - name: Install pinned agnix binary
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/agnix-bin"
+          curl --proto '=https' --tlsv1.2 -sSfL \
+            "https://github.com/agent-sh/agnix/releases/download/v${AGNIX_VERSION}/agnix-x86_64-unknown-linux-gnu.tar.gz" \
+            -o "$RUNNER_TEMP/agnix-bin/agnix.tar.gz"
+          echo "$AGNIX_SHA256  $RUNNER_TEMP/agnix-bin/agnix.tar.gz" \
+            | sha256sum --check --strict
+          tar -xzf "$RUNNER_TEMP/agnix-bin/agnix.tar.gz" -C "$RUNNER_TEMP/agnix-bin"
+          chmod +x "$RUNNER_TEMP/agnix-bin/agnix"
+          echo "$RUNNER_TEMP/agnix-bin" >> "$GITHUB_PATH"
       - name: Lint AI agent configs
-        run: npx --yes agnix@0.37.5 .
+        run: agnix .
 
   # ── DB migrations (Atlas validation + optional Neon dry-run) ──
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,22 @@ jobs:
   # `continue-on-error` is an intentional warn-only gate policy (not a code-quality
   # suppression): it surfaces context-doc rot without failing CI. Kept out of the
   # deploy `needs:` chain so it never gates a release. Promote to blocking once proven.
+  #
+  # NOTE (2026-08-04, #738): do NOT add --ignore-scripts to the npx invocation below.
+  # agnix ships no prebuilt binary in its npm tarball — its own `postinstall` hook
+  # (install.js) is the only thing that fetches the platform binary from its GitHub
+  # release and verifies its sha256 before use. #723 (S6505 hardening) added
+  # --ignore-scripts here on the assumption it was a no-behavior-change formalization;
+  # that assumption was verified against a machine with a stale npx cache (binary
+  # already present from an earlier unrestricted run), so the postinstall skip went
+  # unnoticed locally. On every CI runner the npx cache starts empty, so
+  # --ignore-scripts deterministically skips the fetch and every run fails with
+  # "agnix binary not found" — bisected exactly to that commit (run 30876322672,
+  # success, vs. 30877440998, failure, first run after 2d1a50c6 landed) and
+  # reproduced locally by clearing ~/.npm/_npx and rerunning both flag variants.
+  # --ignore-scripts buys no real protection here anyway: running agnix at all means
+  # executing its downloaded binary, so the trust boundary is the same with or
+  # without the flag — only the flag also breaks the intended install path.
 
   agnix:
     timeout-minutes: 15
@@ -271,7 +287,7 @@ jobs:
         with:
           node-version: "24"
       - name: Lint AI agent configs
-        run: npx --ignore-scripts --yes agnix@0.37.5 .
+        run: npx --yes agnix@0.37.5 .
 
   # ── DB migrations (Atlas validation + optional Neon dry-run) ──
 


### PR DESCRIPTION
## 问题

`Agent config lint (agnix, warn-only)` 从 2026-08-04 04:21 起持续失败,报的是:

```
agnix binary not found. Try reinstalling:
  npm install -g agnix
```

lint 根本没跑起来,不是发现了问题。

## 根因(已核验,不是猜测)

用 `gh run view --json jobs` 二分定位:run `30876322672`(03:59:48, headSha `9c419d2a`)job 级别 `success`;下一次 run `30877440998`(04:21:39, headSha `3a6aa91c`)开始 `failure`。两次 run 之间只合入了 10 个 commit,`git diff` 出 `ci.yml` 的唯一相关改动是 #723(commit `2d1a50c6`,S6505 加固)把这一行

```
- run: npx --yes agnix@0.37.5 .
+ run: npx --ignore-scripts --yes agnix@0.37.5 .
```

`npm pack agnix@0.37.5` 拉包检查发现:agnix **不在 npm tarball 里带预编译二进制**,靠自己的 `postinstall`(`install.js`)从 GitHub Release 下载对应平台的二进制并校验 sha256。`--ignore-scripts` 会无条件跳过这个 `postinstall`。

`2d1a50c6` 的提交信息里写着已经验证过 `npx --ignore-scripts --yes agnix@0.37.5 .` "still runs and reports its usual findings"——**这个验证是假阳性**。本地复现:

```
$ find ~/.npm/_npx -iname "*agnix*"          # 之前跑过 agnix,缓存里已经有二进制
.../node_modules/agnix/bin/agnix-binary

$ npx --ignore-scripts --yes agnix@0.37.5 --version
agnix 0.37.5                                  # "能跑" —— 但只是因为二进制已经在缓存里,postinstall 根本没被触发

$ rm -rf ~/.npm/_npx/*                        # 清空缓存,模拟每次全新的 CI runner
$ npx --ignore-scripts --yes agnix@0.37.5 --version
agnix binary not found. Try reinstalling:
  npm install -g agnix                        # 复现 CI 上的确切失败
EXIT=1
```

GitHub Actions 的 `npx` 缓存在每次 run 都是全新的(这个 workflow 没有配置 npm cache),所以 `--ignore-scripts` 在 CI 上**必现**失败,和网络无关——这解释了为什么它是从那一次合并起 100% 稳定失败,而不是间歇性的。

（附带排除了另一个假设:不是 npm 上游把 `0.37.5` 重新发布或下架了平台包——`npm view agnix@0.37.5` 的 `dist.integrity`/发布时间都对得上历史,`optionalDependencies` 本来就是空的,因为它压根不走 npm 的可选依赖机制。这一步排查用的是 docker 容器测试,后来发现那个容器访问不了 github.com,所以「加不加 flag 都失败」这组对照本身不具备区分能力——依赖的是上面 CI 日志二分 + 本地清缓存复现,不是容器测试。）

## 处置的迭代(review 抓出了第一版方案的问题)

**第一版**只是去掉了 `--ignore-scripts`,恢复了 lint,但同时也**重新打开了 #723(S6505)本来要关掉的 npm 生命周期脚本执行面**——SonarCloud 在那一版上重新报了 S6505。这不是无成本的选择,不能含糊过去。

**第二版(当前版本)**:改成完全不走 npm/npx。仿照仓库里 #730 给 Atlas CLI 建的模式(`_deploy-component.yml`、`apps/agent/agent/tests/atlas_helper.py`)——按版本号直接 `curl` GitHub Release 的 linux/x86_64 tarball,用**写死在 `ci.yml` 里的 sha256**(而不是 agnix 自己发布的同渠道 `.sha256` sidecar)校验,校验通过后解压、加到 `PATH`,直接跑二进制。

这里刻意对齐 #723 自己定的标准:同一发布渠道里的校验和只能证明「传输没被破坏」,证不了「这就是被审查过的产物」。所以 hash 是我今天独立用 `shasum -a 256` 对新下载的文件算出来的,写死在这个文件里,和 agnix 的发布渠道解耦。整个过程不再有任何 npm/npx,S6505 对这一步不再适用。

**已验证,不是只改了代码就完事**:
- `sha256sum --check --strict` 对写死的 hash 通过校验;把 hash 改坏一个字节后,校验按预期拒绝(两种情况都实测)
- 把 linux/x86_64 二进制解压后,在 `ubuntu:24.04`(对应 `runs-on: ubuntu-latest`)容器里跑通 `agnix --version` 和完整的 `agnix .`,复现出和上一次成功 CI run 完全一致的 `Found 0 errors, 123 warnings, 1 info message`

## 这个 lint 到底有没有报出过有价值的东西(含一次自我纠正)

第一版 PR 描述里说它"有价值,值得修而不是删",证据是最后一次成功 run 报了 `Found 0 errors, 123 warnings, 1 info`,抽样几条看起来是真发现(比如引用了已退役的 `route_optimizer.py`)。**Review 追问了这 123 条里真信号占比,深挖之后这个判断需要修正**:

- 123 条里 78 条(63%)是同一类规则:`AGENTS.md references missing file`
- 对着**被那次 CI run 实际检查的那个 commit**(`9c419d2a`,而不是当前 HEAD——避免"后来加上了这个文件"的时间错位),用 `git cat-file -e` 抽样核对了 10 条被标为"missing"的路径(`docs/data-sources.md`、`packages/contract/README.md`、`workers/catalog/src/lib/errors.ts`、`apps/agent/agent/clients/catalog_errors.py` 等)——**10 条全部在那个 commit 就已经存在**。agnix 自己的"文件是否存在"检查在跨目录引用上有确认的、非偶发的假阳性(很可能是它只按 AGENTS.md 自身所在目录做相对路径解析,没有回退到仓库根)。
- 剩下的 45 条(37%)是主观启发式规则:"critical keyword at 40-60% lost-in-the-middle zone"(13 条)、"negative instruction without positive alternative"(4 条)、"missing project context section"(9 条)、"nested AGENTS.md detected"(9 条)、"hard-coded Claude Code path"(4 条)等。这些不是"错了"的判定,是风格/结构性建议,价值见仁见智,但至少不是"检查文件是否存在"这种可以被验伪的类型。

**修正后的结论**:agnix 的旗舰规则(占了 63% 的输出)在这个仓库的跨目录引用场景下,实测假阳性率是 10/10——不能再说它"有价值",这条规则本身不可信。剩下的结构性检查(nested AGENTS.md、missing project context section)看起来是可靠的,值得保留。所以"删除"不再是因为"零信号",而应该更精确地说:**信号质量参差,旗舰规则不可靠,但不是纯噪音**。

**摆出来但这次没做**:既然旗舰规则不可信,一个更窄的自制检查(grep 出 AGENTS.md 里反引号包起来的路径样式 token,按仓库根 + 引用文件所在目录两种方式解析,`test -e` 断言存在)在覆盖率和准确率上可能双双超过 agnix,而且不再有任何供应链下载面。没有在这个 PR 里做,因为这个 PR 的范围是"把坏掉的 gate 修好",不是"重新设计这个 lint"——但这是一个有证据支撑的后续候选,值得单独开 issue。

## 处置

保留这个 job(不删),按上面"处置的迭代"里描述的 pin 方式修好,`continue-on-error: true` 不变——仍然是规约认可的 warn-only 策略,没有被扩大使用范围。

## 验证

- `actionlint .github/workflows/ci.yml` — 通过
- `zizmor .github/workflows/ci.yml` — 通过(0 findings,15 条既有 baseline suppression 未变化)
- sha256 pin 的变异验证:改坏一个字节,`sha256sum --check --strict` 按预期拒绝
- 端到端跑通:`ubuntu:24.04` 容器里执行 pin 下来的二进制,`agnix .` 输出和上次成功 CI run 一致

Closes #738