### PR TITLE
fix(#741): 修复 chat.py BYOK 登录门的匿名身份判定绕过(已在生产)

### DIFF
--- a/apps/agent/agent/interfaces/routes/_deps.py
+++ b/apps/agent/agent/interfaces/routes/_deps.py
@@ -30,7 +30,7 @@ from agent.interfaces.error_registry import (
 )
 from agent.interfaces.public_api import PublicAPIResponse, RuntimeAPI
 from agent.interfaces.schemas import GRACEFUL_TERMINAL_STATUSES
-from agent.interfaces.usage_metering import ANON_USER_ID_PREFIX, ANONYMOUS_USER_TYPE
+from agent.interfaces.usage_metering import is_anonymous_identity
 
 if TYPE_CHECKING:
     import logfire
@@ -108,7 +108,7 @@ def _normalize_optional_header(value: str | None) -> str | None:
 
 
 def _reject_credentialed_anonymous(
-    user_type: str | None, credential: str | None
+    user_id: str | None, user_type: str | None, credential: str | None
 ) -> None:
     """Refuse an anonymous stamp that arrived with a credential (issue #441).
 
@@ -117,8 +117,13 @@ def _reject_credentialed_anonymous(
     request was demoted anyway, or when the container was reached directly.
     Serving it anonymously would meter and rate-limit the turn under the wrong
     identity and hide the expiry from a client built to refresh on 401.
+
+    Routes through `is_anonymous_identity` rather than a bare `user_type`
+    literal (issue #741 sibling fix): an `anon_`-prefixed `X-User-Id` with a
+    missing or mistyped `X-User-Type` is anonymous by the ID convention too,
+    and would otherwise slip past this check carrying a credential.
     """
-    if user_type != ANONYMOUS_USER_TYPE or credential is None:
+    if not is_anonymous_identity(user_id, user_type) or credential is None:
         return
     # #441 surfaced only through anomalous anonymous spend; its inverse must not
     # be equally invisible. The credential itself is never recorded.
@@ -132,9 +137,12 @@ def _get_trusted_auth_context(
     authorization: Annotated[str | None, Header(alias="Authorization")] = None,
 ) -> TrustedAuthContext:
     user_type = _normalize_optional_header(x_user_type)
-    _reject_credentialed_anonymous(user_type, _normalize_optional_header(authorization))
+    user_id = _normalize_optional_header(x_user_id)
+    _reject_credentialed_anonymous(
+        user_id, user_type, _normalize_optional_header(authorization)
+    )
     return TrustedAuthContext(
-        user_id=_normalize_optional_header(x_user_id),
+        user_id=user_id,
         user_type=user_type,
     )
 
@@ -152,18 +160,18 @@ def _require_non_anonymous_user(
 ) -> TrustedAuthContext:
     """Reject-anonymous, not allow-list (session_migration, #273 Task 3).
 
-    Mirrors ``usage_metering.scope_for_identity``'s classification exactly:
-    anonymous is either the edge's typed marker or the ``anon_`` id prefix.
-    There is no ``"user"`` literal anywhere in the system — real humans are
-    stamped ``"human"``, ``sk_*`` API keys ``"agent"`` — so this must not be
-    an allow-list, which would 403 every genuine caller.
+    Delegates to `is_anonymous_identity` — the single canonical predicate,
+    also `usage_metering.scope_for_identity`'s classification — rather than
+    re-deriving the same "typed marker or `anon_` id prefix" union inline
+    (issue #741 sibling cleanup: a second hand-written copy of that union is
+    exactly how a divergent third definition creeps in). There is no
+    ``"user"`` literal anywhere in the system — real humans are stamped
+    ``"human"``, ``sk_*`` API keys ``"agent"`` — so this must not be an
+    allow-list, which would 403 every genuine caller.
     """
     if auth.user_id is None:
         raise HTTPException(status_code=400, detail="X-User-Id header required.")
-    is_anonymous = auth.user_type == ANONYMOUS_USER_TYPE or auth.user_id.startswith(
-        ANON_USER_ID_PREFIX
-    )
-    if is_anonymous:
+    if is_anonymous_identity(auth.user_id, auth.user_type):
         raise HTTPException(
             status_code=403, detail="Anonymous identity cannot migrate sessions."
         )

--- a/apps/agent/agent/interfaces/routes/byok.py
+++ b/apps/agent/agent/interfaces/routes/byok.py
@@ -66,7 +66,7 @@ from agent.interfaces.routes._deps import (
     _has_byok_headers,
     _require_trusted_user,
 )
-from agent.interfaces.usage_metering import ANONYMOUS_USER_TYPE
+from agent.interfaces.usage_metering import is_anonymous_identity
 
 logger = structlog.get_logger(__name__)
 
@@ -254,7 +254,17 @@ def _probe_response(result: ProbeResult) -> JSONResponse:
 def _probe_login_rejection(
     auth: TrustedAuthContext, request: Request
 ) -> JSONResponse | None:
-    if auth.user_type != ANONYMOUS_USER_TYPE or not _has_byok_headers(request):
+    """Mirrors `chat.py::_byok_login_rejection` — including its fix (#741).
+
+    Routes through `is_anonymous_identity` rather than a bare
+    `user_type != ANONYMOUS_USER_TYPE` check: an `anon_`-prefixed
+    `X-User-Id` with a missing or mistyped `X-User-Type` is anonymous by the
+    ID convention too, and a literal check here would let that caller reach
+    the real credential-probing model call.
+    """
+    if not is_anonymous_identity(auth.user_id, auth.user_type) or not _has_byok_headers(
+        request
+    ):
         return None
     return _error_response(
         "byok_requires_login", "BYOKを使うにはログインが必要です。", status_code=403

--- a/apps/agent/agent/interfaces/routes/chat.py
+++ b/apps/agent/agent/interfaces/routes/chat.py
@@ -47,8 +47,8 @@ from agent.interfaces.routes.chat_stream import stream_chat
 from agent.interfaces.schemas import PublicAPIRequest, PublicAPIResponse
 from agent.interfaces.usage_metering import (
     ANON_BUDGET_EXHAUSTED_CODE,
-    ANONYMOUS_USER_TYPE,
     anonymous_budget_verdict,
+    is_anonymous_identity,
 )
 
 _PREFLIGHT_STATE = "chat_body_preflight_complete"
@@ -121,8 +121,16 @@ async def _budget_rejection(
 
     Only anonymous callers are gated — logged-in traffic never reaches the
     ``daily_usage`` read, let alone the rejection.
+
+    Routes through `is_anonymous_identity` rather than a bare
+    `user_type != ANONYMOUS_USER_TYPE` check (issue #741): a literal check
+    only catches a caller whose `X-User-Type` is exactly `"anonymous"`; an
+    `anon_`-prefixed `X-User-Id` with a missing or mistyped `X-User-Type` is
+    anonymous by the ID convention too, and `is_anonymous_identity` is what
+    the rest of this module and `usage_metering.scope_for_identity` already
+    treat as ground truth.
     """
-    if auth.user_type != ANONYMOUS_USER_TYPE:
+    if not is_anonymous_identity(auth.user_id, auth.user_type):
         return None
     settings = _get_settings_from_request(request)
     verdict = await anonymous_budget_verdict(
@@ -155,8 +163,11 @@ async def _quota_rejection(
     rejected the turn: the global dollar breaker is the more severe, systemic
     concern and wins ties over one visitor's own message ceiling. Only
     anonymous callers are gated — logged-in traffic is never metered here.
+
+    Routes through `is_anonymous_identity` rather than a bare `user_type`
+    literal (issue #741) for the same reason as `_budget_rejection` above.
     """
-    if auth.user_type != ANONYMOUS_USER_TYPE or auth.user_id is None:
+    if auth.user_id is None or not is_anonymous_identity(auth.user_id, auth.user_type):
         return None
     settings = _get_settings_from_request(request)
     verdict = await anonymous_quota_verdict(
@@ -173,8 +184,25 @@ BYOK_REQUIRES_LOGIN_MESSAGE = "BYOKを使うにはログインが必要です。
 def _byok_login_rejection(
     request: Request, auth: TrustedAuthContext
 ) -> JSONResponse | None:
-    """Reject anonymous BYOK presence before parsing its credential shape."""
-    if auth.user_type != ANONYMOUS_USER_TYPE or not _has_byok_headers(request):
+    """Reject anonymous BYOK presence before parsing its credential shape.
+
+    Routes through `is_anonymous_identity` — the single canonical "is this
+    caller anonymous" predicate, also used above by `_budget_rejection` and
+    `_quota_rejection` — rather than a bare `user_type != ANONYMOUS_USER_TYPE`
+    check (issue #741, mirrors the #656 fix in `photo_search_guards.py`). A
+    literal check only catches a caller whose `X-User-Type` is exactly
+    `"anonymous"`; an `anon_`-prefixed `X-User-Id` with a missing or
+    mistyped `X-User-Type` is anonymous by the ID convention too, and
+    `is_anonymous_identity` is what quota metering already treats as ground
+    truth. Without this, that same caller would clear the login gate here
+    yet still resolve to the "anon" scope for billing — one request, two
+    different identity verdicts, and the gap between them was a BYOK bypass
+    for anonymous callers (confirmed in production: the request reached
+    `build_byok_model` and returned 400 egress-validation instead of 403).
+    """
+    if not is_anonymous_identity(auth.user_id, auth.user_type) or not _has_byok_headers(
+        request
+    ):
         return None
     return _error_response(
         "byok_requires_login", BYOK_REQUIRES_LOGIN_MESSAGE, status_code=403

--- a/apps/agent/agent/tests/integration/test_byok_guards_still_apply.py
+++ b/apps/agent/agent/tests/integration/test_byok_guards_still_apply.py
@@ -96,7 +96,7 @@ async def test_an_authenticated_byok_turn_never_reads_daily_usage() -> None:
     `total_cost_usd` is called at all, and even with the budget/quota
     actually configured on (non-default) — a default-disabled budget would
     never touch the repo either way, which would make this test pass even
-    if the `auth.user_type != ANONYMOUS_USER_TYPE` early-return regressed."""
+    if `_budget_rejection`'s `is_anonymous_identity` early-return regressed."""
     from agent.config.settings import Settings
 
     db = build_stub_db()

--- a/apps/agent/agent/tests/integration/test_byok_login_gate_ordering.py
+++ b/apps/agent/agent/tests/integration/test_byok_login_gate_ordering.py
@@ -20,8 +20,9 @@ from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stu
 
 pytestmark = pytest.mark.integration
 
+ANON_ID = "anon_0123456789abcdef0123456789abcdef"
 ANON_HEADERS = {
-    "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
+    "X-User-Id": ANON_ID,
     "X-User-Type": "anonymous",
 }
 BYOK_HEADERS = {
@@ -51,59 +52,60 @@ def _app() -> tuple[FastAPI, MagicMock]:
     return app, runtime
 
 
+def _unresolvable_byok_model() -> object:
+    """Patched onto `build_byok_model` so a login-gate regression that lets
+    the caller through would fail loudly (an assertion) instead of silently
+    constructing a real credential path."""
+    return patch(
+        "agent.interfaces.routes.chat.build_byok_model",
+        AsyncMock(side_effect=AssertionError("must not resolve a BYOK model")),
+    )
+
+
+async def _post_chat(headers: dict[str, str]) -> tuple[object, MagicMock]:
+    app, runtime = _app()
+    with _unresolvable_byok_model():
+        async with async_client(app) as client:
+            response = await client.post("/v1/chat", json=_body(), headers=headers)
+    return response, runtime
+
+
+async def _assert_login_gate_rejects(headers: dict[str, str]) -> None:
+    response, runtime = await _post_chat(headers)
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "byok_requires_login"
+    assert runtime.handle.await_count == 0
+
+
 async def test_malformed_byok_headers_from_anonymous_caller_still_get_403() -> None:
     """`X-BYOK-Key` blank (would 400 for a logged-in caller) — for an
     anonymous caller this must resolve to the login gate first."""
-    app, runtime = _app()
     headers = ANON_HEADERS | {
         "X-BYOK-Provider": "openai-compatible",
         "X-BYOK-Key": "   ",
     }
-    async with async_client(app) as client:
-        response = await client.post("/v1/chat", json=_body(), headers=headers)
-    assert response.status_code == 403
-    assert response.json()["error"]["code"] == "byok_requires_login"
-    assert runtime.handle.await_count == 0
+    await _assert_login_gate_rejects(headers)
 
 
-@pytest.mark.parametrize(
-    "user_type_header",
-    [{}, {"X-User-Type": "authenticated"}],
-    ids=["missing_user_type", "wrong_user_type_value"],
-)
-async def test_anon_id_prefix_gates_byok_even_without_the_literal_anonymous_type(
-    user_type_header: dict[str, str],
-) -> None:
+async def test_anon_id_prefix_gates_byok_when_x_user_type_is_missing() -> None:
+    """Regression (issue #741, production bypass): an `anon_`-prefixed
+    X-User-Id is anonymous by that ID convention even with no X-User-Type
+    header at all — the blind spot every pre-#741 test in this file missed
+    by always pairing the two headers. See
+    `test_anon_id_prefix_gates_byok_when_x_user_type_is_wrong` for the
+    mistyped-value sibling and the fuller regression writeup."""
+    headers = {"X-User-Id": ANON_ID} | BYOK_HEADERS
+    await _assert_login_gate_rejects(headers)
+
+
+async def test_anon_id_prefix_gates_byok_when_x_user_type_is_wrong() -> None:
     """Regression (issue #741, production bypass): the login gate must use
     the same `is_anonymous_identity` predicate quota metering already
-    trusts. An `anon_`-prefixed X-User-Id with a missing or mistyped
-    X-User-Type is anonymous by that convention even though it never equals
-    the literal string "anonymous" — before the fix, a caller shaped
-    exactly like this cleared `_byok_login_rejection`'s bare
-    `user_type != ANONYMOUS_USER_TYPE` check and reached the real
-    `build_byok_model` call (observed in production as a 400
-    egress-validation response instead of the expected 403).
-
-    Every existing test in this file pairs `X-User-Id` with an exact
-    `X-User-Type: anonymous` — this is the blind spot none of them covered.
-    """
-    app, runtime = _app()
-    headers = (
-        {"X-User-Id": "anon_0123456789abcdef0123456789abcdef"}
-        | user_type_header
-        | {
-            "X-BYOK-Provider": "openai-compatible",
-            "X-BYOK-Key": "sk-fake-secret-value",
-            "X-BYOK-Model": "byok-test-model",
-            "X-BYOK-Base-Url": "https://byok.example.test/v1",
-        }
-    )
-    with patch(
-        "agent.interfaces.routes.chat.build_byok_model",
-        AsyncMock(side_effect=AssertionError("must not resolve a BYOK model")),
-    ):
-        async with async_client(app) as client:
-            response = await client.post("/v1/chat", json=_body(), headers=headers)
-    assert response.status_code == 403
-    assert response.json()["error"]["code"] == "byok_requires_login"
-    assert runtime.handle.await_count == 0
+    trusts, not a bare `user_type != ANONYMOUS_USER_TYPE` literal — an
+    `anon_`-prefixed X-User-Id stays anonymous by that convention even when
+    X-User-Type is present but mistyped (here: "authenticated"). Before the
+    fix, a caller shaped exactly like this cleared the old check and reached
+    the real `build_byok_model` call (observed in production as a 400
+    egress-validation response instead of the expected 403)."""
+    headers = {"X-User-Id": ANON_ID, "X-User-Type": "authenticated"} | BYOK_HEADERS
+    await _assert_login_gate_rejects(headers)

--- a/apps/agent/agent/tests/integration/test_byok_login_gate_ordering.py
+++ b/apps/agent/agent/tests/integration/test_byok_login_gate_ordering.py
@@ -9,7 +9,7 @@ real reason (they're not logged in) behind a decoy validation error.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -23,6 +23,12 @@ pytestmark = pytest.mark.integration
 ANON_HEADERS = {
     "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
     "X-User-Type": "anonymous",
+}
+BYOK_HEADERS = {
+    "X-BYOK-Provider": "openai-compatible",
+    "X-BYOK-Key": "sk-fake-secret-value",
+    "X-BYOK-Model": "byok-test-model",
+    "X-BYOK-Base-Url": "https://byok.example.test/v1",
 }
 
 
@@ -55,6 +61,49 @@ async def test_malformed_byok_headers_from_anonymous_caller_still_get_403() -> N
     }
     async with async_client(app) as client:
         response = await client.post("/v1/chat", json=_body(), headers=headers)
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "byok_requires_login"
+    assert runtime.handle.await_count == 0
+
+
+@pytest.mark.parametrize(
+    "user_type_header",
+    [{}, {"X-User-Type": "authenticated"}],
+    ids=["missing_user_type", "wrong_user_type_value"],
+)
+async def test_anon_id_prefix_gates_byok_even_without_the_literal_anonymous_type(
+    user_type_header: dict[str, str],
+) -> None:
+    """Regression (issue #741, production bypass): the login gate must use
+    the same `is_anonymous_identity` predicate quota metering already
+    trusts. An `anon_`-prefixed X-User-Id with a missing or mistyped
+    X-User-Type is anonymous by that convention even though it never equals
+    the literal string "anonymous" — before the fix, a caller shaped
+    exactly like this cleared `_byok_login_rejection`'s bare
+    `user_type != ANONYMOUS_USER_TYPE` check and reached the real
+    `build_byok_model` call (observed in production as a 400
+    egress-validation response instead of the expected 403).
+
+    Every existing test in this file pairs `X-User-Id` with an exact
+    `X-User-Type: anonymous` — this is the blind spot none of them covered.
+    """
+    app, runtime = _app()
+    headers = (
+        {"X-User-Id": "anon_0123456789abcdef0123456789abcdef"}
+        | user_type_header
+        | {
+            "X-BYOK-Provider": "openai-compatible",
+            "X-BYOK-Key": "sk-fake-secret-value",
+            "X-BYOK-Model": "byok-test-model",
+            "X-BYOK-Base-Url": "https://byok.example.test/v1",
+        }
+    )
+    with patch(
+        "agent.interfaces.routes.chat.build_byok_model",
+        AsyncMock(side_effect=AssertionError("must not resolve a BYOK model")),
+    ):
+        async with async_client(app) as client:
+            response = await client.post("/v1/chat", json=_body(), headers=headers)
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "byok_requires_login"
     assert runtime.handle.await_count == 0

--- a/apps/agent/agent/tests/integration/test_byok_probe.py
+++ b/apps/agent/agent/tests/integration/test_byok_probe.py
@@ -99,6 +99,31 @@ async def test_anonymous_caller_with_byok_headers_is_rejected() -> None:
     assert response.json()["error"]["code"] == "byok_requires_login"
 
 
+@pytest.mark.parametrize(
+    "user_type_header",
+    [{}, {"X-User-Type": "authenticated"}],
+    ids=["missing_user_type", "wrong_user_type_value"],
+)
+async def test_anon_id_prefix_gates_the_probe_without_the_literal_anonymous_type(
+    user_type_header: dict[str, str],
+) -> None:
+    """Regression (issue #741 sibling fix): `_probe_login_rejection` mirrors
+    `chat.py::_byok_login_rejection`'s (formerly bare `user_type` literal)
+    gate. An `anon_`-prefixed X-User-Id with a missing or mistyped
+    X-User-Type is anonymous by the ID convention even though it never
+    equals the literal string "anonymous" — every other test in this file
+    pairs the two, which is why this blind spot went uncovered."""
+    built = app()
+    headers = {"X-User-Id": "anon_0123456789abcdef0123456789abcdef"} | user_type_header
+    with patch(
+        "agent.interfaces.routes.byok.build_byok_model",
+        AsyncMock(side_effect=AssertionError("must not resolve a BYOK model")),
+    ):
+        response = await post_probe(built, headers | BYOK_HEADERS)
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "byok_requires_login"
+
+
 async def test_the_cap_transport_is_installed_at_construction_never_reassigned() -> (
     None
 ):

--- a/apps/agent/agent/tests/unit/test_byok_login_gates_unit.py
+++ b/apps/agent/agent/tests/unit/test_byok_login_gates_unit.py
@@ -1,0 +1,123 @@
+"""Unit-level coverage for the BYOK login gates (#741 codecov patch gap).
+
+CI's coverage floor (`.github/workflows/_python-ci.yml`) runs only
+`agent/tests/unit/` — the integration suite (`agent/tests/integration/`,
+where `test_byok_login_gate_ordering.py` and `test_byok_probe.py` already
+pin both gates' behaviour end-to-end) never contributes to the uploaded
+`coverage.xml`. `chat.py::_byok_login_rejection` and
+`byok.py::_probe_login_rejection` were therefore invisible to Codecov's
+patch check even though they were already integration-tested: this file
+exercises both branches of each gate's `is_anonymous_identity(...) or not
+_has_byok_headers(...)` condition at the unit level so the #741 fix has
+patch coverage, not just end-to-end coverage.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.schemas import PublicAPIResponse
+from agent.tests.unit.conftest_fastapi import async_client, build_app, build_stub_db
+
+pytestmark = pytest.mark.unit
+
+ANON_HEADERS = {
+    "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
+    "X-User-Type": "anonymous",
+}
+HUMAN_HEADERS = {"X-User-Id": "user-1", "X-User-Type": "human"}
+BYOK_HEADERS = {
+    "X-BYOK-Provider": "openai-compatible",
+    "X-BYOK-Key": "sk-fake-secret-value",
+    "X-BYOK-Model": "byok-test-model",
+    "X-BYOK-Base-Url": "https://byok.example.test/v1",
+}
+
+
+def _chat_body() -> dict[str, object]:
+    return {
+        "messages": [
+            {"id": "u1", "role": "user", "parts": [{"type": "text", "text": "test"}]}
+        ]
+    }
+
+
+def _chat_app() -> FastAPI:
+    db = build_stub_db()
+    runtime = MagicMock(spec=RuntimeAPI)
+    runtime.handle = AsyncMock(
+        return_value=PublicAPIResponse(success=True, status="ok", intent="qa")
+    )
+    runtime.validate_session_owner = AsyncMock(return_value=None)
+    app, _ = build_app(runtime_api=runtime, db=db)
+    return app
+
+
+async def test_chat_gate_rejects_when_anonymous_and_byok_both_true() -> None:
+    """`_byok_login_rejection`'s "condition False, fall through to the 403"
+    arc — the anon+BYOK combination the login gate exists to catch. The
+    integration suite already proves this end to end; this unit-level call
+    is what makes it count toward Codecov's patch report."""
+    app = _chat_app()
+    async with async_client(app) as client:
+        response = await client.post(
+            "/v1/chat", json=_chat_body(), headers=ANON_HEADERS | BYOK_HEADERS
+        )
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "byok_requires_login"
+
+
+async def test_probe_gate_allows_a_logged_in_caller_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_probe_login_rejection`'s "condition True, return None" arc: a
+    logged-in caller with no BYOK headers clears the gate and reaches the
+    (missing-credential) 400 rather than the 403 login wall."""
+    monkeypatch.setenv("MIMO_API_KEY", "test-key")
+    db = build_stub_db()
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        response = await client.post("/v1/byok/probe", json={}, headers=HUMAN_HEADERS)
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_request"
+
+
+async def test_probe_gate_rejects_when_anonymous_and_byok_both_true() -> None:
+    """`_probe_login_rejection`'s "condition False, fall through to the
+    403" arc — same anon+BYOK combination as the chat gate, on the probe
+    endpoint. Never resolves a real credential: the gate short-circuits
+    first."""
+    db = build_stub_db()
+    app, _ = build_app(db=db)
+    async with async_client(app) as client:
+        response = await client.post(
+            "/v1/byok/probe", json={}, headers=ANON_HEADERS | BYOK_HEADERS
+        )
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "byok_requires_login"
+
+
+async def test_probe_gate_route_never_constructs_a_model_for_the_rejected_caller() -> (
+    None
+):
+    """Belt-and-suspenders companion to the 403 assertion above: an
+    anonymous+BYOK caller must never reach `build_byok_model`, mirroring the
+    integration suite's `must not resolve a BYOK model` guard."""
+    from unittest.mock import patch
+
+    db = build_stub_db()
+    app, _ = build_app(db=db)
+    with patch(
+        "agent.interfaces.routes.byok.build_byok_model",
+        AsyncMock(side_effect=AssertionError("must not resolve a BYOK model")),
+    ):
+        async with async_client(app) as client:
+            response: httpx.Response = await client.post(
+                "/v1/byok/probe", json={}, headers=ANON_HEADERS | BYOK_HEADERS
+            )
+    assert response.status_code == 403

--- a/apps/agent/agent/tests/unit/test_ingress_anonymous_credential.py
+++ b/apps/agent/agent/tests/unit/test_ingress_anonymous_credential.py
@@ -98,3 +98,40 @@ async def test_a_logged_in_stamp_is_unaffected_by_a_lingering_credential() -> No
     response = await _post(app, {**HUMAN_HEADERS, "Authorization": STALE_JWT})
     assert response.status_code == 200
     assert runtime.handle.await_count == 1
+
+
+async def test_anon_id_prefix_with_missing_type_is_still_rejected_with_credential() -> (
+    None
+):
+    """Regression (issue #741 sibling fix): an `anon_`-prefixed X-User-Id
+    carrying no X-User-Type header is anonymous by the ID convention, same
+    as `X-User-Type: anonymous` — a bare `user_type != ANONYMOUS_USER_TYPE`
+    check would have let this combination through with its stale credential
+    still attached, the exact blind spot none of this file's other tests
+    (all paired X-User-Id + X-User-Type: anonymous) covered."""
+    app, runtime = _app()
+    response = await _post(
+        app,
+        {
+            "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
+            "Authorization": STALE_JWT,
+        },
+    )
+    assert response.status_code == 401
+    assert runtime.handle.await_count == 0
+
+
+async def test_anon_id_prefix_with_wrong_type_is_still_rejected_with_credential() -> (
+    None
+):
+    app, runtime = _app()
+    response = await _post(
+        app,
+        {
+            "X-User-Id": "anon_0123456789abcdef0123456789abcdef",
+            "X-User-Type": "authenticated",
+            "Authorization": STALE_JWT,
+        },
+    )
+    assert response.status_code == 401
+    assert runtime.handle.await_count == 0


### PR DESCRIPTION
Closes #741

## 漏洞

`apps/agent/agent/interfaces/routes/chat.py::_byok_login_rejection` 用**字面比对**判匿名：

```python
if auth.user_type != ANONYMOUS_USER_TYPE or not _has_byok_headers(request):
    return None   # 放行
```

但请求流其余部分（`usage_metering.scope_for_identity`）按 **`anon_` 前缀约定**解析身份（`is_anonymous_identity`）。同一个请求在两处被判成不同身份：带 `anon_` 前缀 `X-User-Id`、但 `X-User-Type` **缺失或错误**的调用者，配额侧被正确识别为匿名，却能从登录门底下穿过去，一路走到真实的 `build_byok_model`。

修法与 #739（`photo_search_guards.py`）一致：登录门改用 `is_anonymous_identity(auth.user_id, auth.user_type)` 这一个真源，不再写第二套/第三套匿名判定逻辑。

## 变异验证（四次真实输出）

探测组合：`X-User-Id: anon_0123456789abcdef0123456789abcdef` + 真实 `X-BYOK-*` 头，`X-User-Type` 缺失 / 错误各一次。

**修前**（`git stash` 回到未改动的 `chat.py`，两种情况均绕过登录门，进入真实 BYOK 模型构造，被 egress 校验挡下——400 而非 403 本身就是"确实穿过了"的证据）：

```
=== missing X-User-Type ===
status: 400
body: {'error': {'code': 'invalid_request', 'message': 'base_url failed egress validation.'}}
=== wrong X-User-Type value ===
status: 400
body: {'error': {'code': 'invalid_request', 'message': 'base_url failed egress validation.'}}
```

**修后**（`git stash pop` 恢复本 PR 改动，两种情况均在登录门被拒）：

```
=== missing X-User-Type ===
status: 403
body: {'error': {'code': 'byok_requires_login', 'message': 'BYOKを使うにはログインが必要です。'}}
=== wrong X-User-Type value ===
status: 403
body: {'error': {'code': 'byok_requires_login', 'message': 'BYOKを使うにはログインが必要です。'}}
```

## 第三处排查（`grep -rn` 全仓字面比对 `ANONYMOUS_USER_TYPE`/`"anonymous"`）

| 位置 | 用途 | 判定 | 处理 |
|---|---|---|---|
| `usage_metering.py:73`（`is_anonymous_identity` 内部） | 定义匿名判定的真源本身 | 正确——这是唯一允许出现字面比对的地方 | 不改 |
| `chat.py::_byok_login_rejection`（issue 明确目标） | **授权判定**：BYOK 登录门 | 字面比对，可绕过 | **已修**，改用 `is_anonymous_identity` |
| `chat.py::_budget_rejection` | **授权/计量判定**：匿名日预算断路器只对匿名调用者生效 | 同款字面比对——`anon_` 前缀+缺失/错误 type 的调用者会跳过预算断路器，被当"已登录"计量 | **已修**，改用 `is_anonymous_identity`（与 `photo_search_guards.py::_budget_rejection` 的"防御纵深"处理口径一致） |
| `chat.py::_quota_rejection` | **授权/计量判定**：匿名每日消息配额只对匿名调用者生效 | 同上 | **已修** |
| `byok.py::_probe_login_rejection`（`/v1/byok/probe`） | **授权判定**：BYOK 探测端点登录门，docstring 自称"mirrors `chat.py::_byok_login_rejection`" | 与本次修复目标完全同型的字面比对，同样可绕过（虽然 edge 路由未把该端点列入 `ANON_V1`，理论上匿名调用者到不了这里，但这是"防御纵深"层，容器侧本就该独立成立） | **已修**，改用 `is_anonymous_identity` |
| `_deps.py::_reject_credentialed_anonymous`（issue #441） | **授权判定**：拒绝"匿名戳记 + 携带凭证"的异常请求 | 只收 `user_type` 不收 `user_id`，无法感知 `anon_` 前缀——`anon_` 前缀+缺失/错误 type+凭证的组合会跳过这道 401 拒绝 | **已修**：函数签名加 `user_id` 参数，改用 `is_anonymous_identity` |
| `_deps.py::_require_non_anonymous_user`（session_migration，issue #273） | **授权判定**：拒绝匿名身份迁移会话 | 已经手写了正确的 `user_type == "anonymous" or user_id.startswith("anon_")` 联合判定，功能上不是绕过洞，但是第二套手写的"什么算匿名"逻辑 | **重构**为委托 `is_anonymous_identity`，消除潜在的第三套定义分歧风险；原有 `test_anon_prefixed_user_id_is_rejected_even_with_human_type` 已覆盖该组合，未发现回归 |

结论：除 `_require_non_anonymous_user` 外，**其余全部字面比对都是真正的授权判定，且都可能被同一手法绕过**，本 PR 一并修复。

## 新增测试（覆盖"有 ID、缺失/错误 type"这个盲区）

- `agent/tests/integration/test_byok_login_gate_ordering.py::test_anon_id_prefix_gates_byok_even_without_the_literal_anonymous_type`（parametrize 缺失/错误 `X-User-Type`）——断言 `/v1/chat` 返回 403 `byok_requires_login`，且 `build_byok_model` 从未被调用
- `agent/tests/integration/test_byok_probe.py::test_anon_id_prefix_gates_the_probe_without_the_literal_anonymous_type`——同款组合验证 `/v1/byok/probe`
- `agent/tests/unit/test_ingress_anonymous_credential.py::test_anon_id_prefix_with_missing_type_is_still_rejected_with_credential` / `test_anon_id_prefix_with_wrong_type_is_still_rejected_with_credential`——`anon_` 前缀 + 缺失/错误 type + 过期凭证仍被 401 拒绝
- `test_byok_guards_still_apply.py` 内一处过时注释（引用旧的字面比对代码路径）同步更新为准确描述

## 门禁结果

- `cd apps/agent && uv run pytest agent/tests/unit/ -q`：**1753 passed**（含 4 条新增）
- `make check`（lint + typecheck + test + test-integration，#730 的 Atlas self-heal 已生效，无需手动前置 Atlas 二进制）：
  - `ruff check` / `ruff format --check`：全绿
  - `vulture`：全绿
  - `mypy`（strict）：**Success: no issues found in 140 source files**
  - `pytest agent/tests/unit/`：**1753 passed**，覆盖率 90.40%（地板 87%）
  - `pytest agent/tests/integration/`（offline Docker arm）：**220 passed, 22 skipped**（跳过项均为需要 Neon/E2E 凭证的既有条件跳过，与本 PR 无关）

绝不合并，等待 review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved anonymous identity detection, including IDs with the `anon_` prefix when identity type information is missing or invalid.
  - Consistently rejects anonymous requests attempting to use credentials or Bring Your Own Key (BYOK) access.
  - Returns clearer, consistent authentication responses before credential or model processing begins.

- **Tests**
  - Added regression coverage for anonymous access with missing or incorrect identity headers.
  - Verified rejected requests do not trigger runtime handling or BYOK model resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->