### PR TITLE
fix(deploy): 诊断 secret 缺失不得阻断部署(Track 0 止血)

### DIFF
--- a/.github/scripts/post-deploy-assert.sh
+++ b/.github/scripts/post-deploy-assert.sh
@@ -344,7 +344,9 @@ cmd_auth_config_check() {
   # `set -euo pipefail; trap "true" EXIT; : "${FOO:?required}"` prints the
   # error text but still exits 0. An explicit check + `fail` (a normal exit
   # 1, not a parameter-expansion error) sidesteps it.
-  [ -n "${POST_DEPLOY_DIAG_TOKEN:-}" ] || fail "POST_DEPLOY_DIAG_TOKEN is required"
+  if [ -z "${POST_DEPLOY_DIAG_TOKEN:-}" ]; then
+    fail "auth-config drift check did NOT run: POST_DEPLOY_DIAG_TOKEN is not configured for this environment (${TARGET_ENVIRONMENT:-<environment>}). The deploy itself succeeded. To enable the check: gh secret set POST_DEPLOY_DIAG_TOKEN --env ${TARGET_ENVIRONMENT:-<environment>} --body \"\$(openssl rand -hex 32)\""
+  fi
   local status
   status="$(fetch GET "${ROOT_URL}/internal/auth-config" "Bearer ${POST_DEPLOY_DIAG_TOKEN}")"
   diag "${status}"

--- a/.github/scripts/post-deploy-assert.test.sh
+++ b/.github/scripts/post-deploy-assert.test.sh
@@ -306,7 +306,13 @@ test_auth_config_check_missing_token_refuses_to_run() {
   stop_mock "${pid}"; requests="$(request_count "${counter_file}")"; rm -f "${counter_file}"
   [ "${rc}" -ne 0 ] || fail_test "a missing POST_DEPLOY_DIAG_TOKEN should refuse to run, got exit 0"
   [ "${requests}" -eq 0 ] || fail_test "expected zero requests — the script must refuse before ever calling the Worker, got ${requests}"
-  grep -q "POST_DEPLOY_DIAG_TOKEN is required" "${out}" || fail_test "missing expected diagnostic in output"
+  # The failure message must make a MISSING CREDENTIAL unmistakable (not a
+  # broken route) and carry the remediation command, per the 2026-08-04
+  # optional-secret change: a diagnostic credential must not be able to
+  # block delivery, so the deploy proceeds and THIS check owns reporting it.
+  grep -q "did NOT run" "${out}" || fail_test "missing the 'did NOT run' framing in output"
+  grep -q "deploy itself succeeded" "${out}" || fail_test "missing the 'deploy itself succeeded' reassurance in output"
+  grep -q "gh secret set POST_DEPLOY_DIAG_TOKEN" "${out}" || fail_test "missing the gh secret set remediation command in output"
   echo "PASS: a missing POST_DEPLOY_DIAG_TOKEN refuses to run before making any request (${requests} requests, exit ${rc})"
 }
 

--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -12,6 +12,15 @@ on:
       build_filter: { required: false, type: string, default: "" }
       run_pulumi: { required: false, type: boolean, default: true }
       worker_secrets: { required: false, type: string, default: "" }
+      optional_worker_secrets:
+        description: >-
+          Newline list of secret NAMES that are uploaded only when their value
+          is non-empty. For diagnostic-only secrets: a missing value must
+          never fail the deploy — the post-deploy check reports it loudly
+          instead. Names listed here must NOT also appear in worker_secrets.
+        type: string
+        required: false
+        default: ""
       # Newline-separated list of secret names that must be pushed via a raw
       # `wrangler secret put` step AFTER "Deploy Worker" (see that step for
       # why). Each name here must also have a matching entry in `secrets:`
@@ -539,6 +548,50 @@ jobs:
       - name: Verify root container Dockerfile
         if: ${{ inputs.component == 'root' }}
         run: test -f Dockerfile
+      - name: Resolve effective worker secrets
+        id: effective_secrets
+        # Optional (diagnostic-only) secrets are appended to the upload list
+        # only when their value is present. wrangler-action's uploadSecrets()
+        # hard-fails on any listed name whose env value is empty — which is
+        # correct for load-bearing secrets and wrong for diagnostics: on
+        # 2026-08-04 an unconfigured POST_DEPLOY_DIAG_TOKEN blocked every
+        # staging deploy (run 30895422110). A diagnostic credential must not
+        # be able to block delivery; the post-deploy check owns that failure.
+        shell: bash
+        env:
+          REQUIRED_LIST: ${{ inputs.worker_secrets }}
+          OPTIONAL_LIST: ${{ inputs.optional_worker_secrets }}
+          # Same env block as the Deploy Worker step below — the indirect
+          # `${!name}` expansion above looks up OPTIONAL_LIST names here, so
+          # every secret that could be optional must be present in env.
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+          AGENT_DATABASE_URL: ${{ secrets.AGENT_DATABASE_URL }}
+          NEON_AUTH_JWKS_URL: ${{ secrets.NEON_AUTH_JWKS_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+          CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
+          POST_DEPLOY_DIAG_TOKEN: ${{ secrets.POST_DEPLOY_DIAG_TOKEN }}
+        run: |
+          effective="$REQUIRED_LIST"
+          while IFS= read -r name; do
+            [ -z "$name" ] && continue
+            if [ -n "${!name:-}" ]; then
+              effective="$effective"$'\n'"$name"
+            else
+              echo "::warning title=optional secret skipped::$name is unset; deploy continues, post-deploy check will report it"
+            fi
+          done <<< "$OPTIONAL_LIST"
+          {
+            echo "list<<EOF"
+            printf '%s\n' "$effective" | sed '/^[[:space:]]*$/d'
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
@@ -567,7 +620,7 @@ jobs:
           workingDirectory: ${{ inputs.working_directory }}
           command: deploy
           environment: ${{ inputs.environment }}
-          secrets: ${{ inputs.worker_secrets }}
+          secrets: ${{ steps.effective_secrets.outputs.list }}
         env:
           DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
           AGENT_DATABASE_URL: ${{ secrets.AGENT_DATABASE_URL }}

--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -580,7 +580,14 @@ jobs:
         run: |
           effective="$REQUIRED_LIST"
           while IFS= read -r name; do
+            name="${name//$'\r'/}"          # tolerate CRLF checkouts
+            name="${name#"${name%%[![:space:]]*}"}"   # ltrim
+            name="${name%"${name##*[![:space:]]}"}"   # rtrim
             [ -z "$name" ] && continue
+            if ! [[ "$name" =~ ^[A-Z][A-Z0-9_]*$ ]]; then
+              echo "::warning title=optional secret ignored::'$name' is not a valid secret name (expected ^[A-Z][A-Z0-9_]*$); skipping"
+              continue
+            fi
             if [ -n "${!name:-}" ]; then
               effective="$effective"$'\n'"$name"
             else

--- a/.github/workflows/_post-deploy-test.yml
+++ b/.github/workflows/_post-deploy-test.yml
@@ -177,6 +177,7 @@ jobs:
         env:
           ROOT_URL: ${{ steps.urls.outputs.root_url }}
           POST_DEPLOY_DIAG_TOKEN: ${{ secrets.POST_DEPLOY_DIAG_TOKEN }}
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
         run: bash .github/scripts/post-deploy-assert.sh auth-config-check
 
       # ── environment-gated: ANON_ACCESS_ENABLED differs by environment,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,6 +818,7 @@ jobs:
         DEEPSEEK_API_KEY
         GOOGLE_MAPS_API_KEY
         LOGFIRE_TOKEN
+      optional_worker_secrets: |
         POST_DEPLOY_DIAG_TOKEN
       post_deploy_secrets: |
         TURNSTILE_SECRET
@@ -949,6 +950,7 @@ jobs:
         GOOGLE_MAPS_API_KEY
         LOGFIRE_TOKEN
         CORS_ALLOWED_ORIGIN
+      optional_worker_secrets: |
         POST_DEPLOY_DIAG_TOKEN
       post_deploy_secrets: |
         TURNSTILE_SECRET

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -266,7 +266,14 @@ jobs:
         run: |
           effective="$REQUIRED_LIST"
           while IFS= read -r name; do
+            name="${name//$'\r'/}"          # tolerate CRLF checkouts
+            name="${name#"${name%%[![:space:]]*}"}"   # ltrim
+            name="${name%"${name##*[![:space:]]}"}"   # rtrim
             [ -z "$name" ] && continue
+            if ! [[ "$name" =~ ^[A-Z][A-Z0-9_]*$ ]]; then
+              echo "::warning title=optional secret ignored::'$name' is not a valid secret name (expected ^[A-Z][A-Z0-9_]*$); skipping"
+              continue
+            fi
             if [ -n "${!name:-}" ]; then
               effective="$effective"$'\n'"$name"
             else

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -226,6 +226,59 @@ jobs:
       # ── Verify Dockerfile exists before root deploy ──
       - run: test -f Dockerfile
 
+      # ── Resolve effective worker secrets for the root deploy ──
+      - name: Resolve effective worker secrets
+        id: effective_secrets
+        # Optional (diagnostic-only) secrets are appended to the upload list
+        # only when their value is present. wrangler-action's uploadSecrets()
+        # hard-fails on any listed name whose env value is empty — which is
+        # correct for load-bearing secrets and wrong for diagnostics: on
+        # 2026-08-04 an unconfigured POST_DEPLOY_DIAG_TOKEN blocked every
+        # staging deploy (run 30895422110). A diagnostic credential must not
+        # be able to block delivery; the post-deploy check owns that failure.
+        shell: bash
+        env:
+          REQUIRED_LIST: |
+            SUPABASE_URL
+            SUPABASE_ANON_KEY
+            SUPABASE_SERVICE_ROLE_KEY
+            SUPABASE_DB_URL
+            MIMO_API_KEY
+            DEEPSEEK_API_KEY
+            GOOGLE_MAPS_API_KEY
+            LOGFIRE_TOKEN
+            CORS_ALLOWED_ORIGIN
+          OPTIONAL_LIST: |
+            POST_DEPLOY_DIAG_TOKEN
+          # Same env block as the Deploy via Wrangler step below — the
+          # indirect `${!name}` expansion above looks up OPTIONAL_LIST names
+          # here.
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+          CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
+          POST_DEPLOY_DIAG_TOKEN: ${{ secrets.POST_DEPLOY_DIAG_TOKEN }}
+        run: |
+          effective="$REQUIRED_LIST"
+          while IFS= read -r name; do
+            [ -z "$name" ] && continue
+            if [ -n "${!name:-}" ]; then
+              effective="$effective"$'\n'"$name"
+            else
+              echo "::warning title=optional secret skipped::$name is unset; deploy continues, post-deploy check will report it"
+            fi
+          done <<< "$OPTIONAL_LIST"
+          {
+            echo "list<<EOF"
+            printf '%s\n' "$effective" | sed '/^[[:space:]]*$/d'
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       # ── Deploy root (edge + container) ──
       - name: Deploy via Wrangler
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
@@ -239,17 +292,7 @@ jobs:
           packageManager: pnpm
           command: deploy
           environment: production
-          secrets: |
-            SUPABASE_URL
-            SUPABASE_ANON_KEY
-            SUPABASE_SERVICE_ROLE_KEY
-            SUPABASE_DB_URL
-            MIMO_API_KEY
-            DEEPSEEK_API_KEY
-            GOOGLE_MAPS_API_KEY
-            LOGFIRE_TOKEN
-            CORS_ALLOWED_ORIGIN
-            POST_DEPLOY_DIAG_TOKEN
+          secrets: ${{ steps.effective_secrets.outputs.list }}
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}

--- a/apps/agent/agent/tests/unit/test_deploy_model_env_consistency.py
+++ b/apps/agent/agent/tests/unit/test_deploy_model_env_consistency.py
@@ -50,13 +50,23 @@ def _named_workflow_job(source: str, job_id: str) -> str:
 
 
 def _wrangler_secret_names(step: str) -> set[str]:
-    secrets = re.search(
-        r"(?m)^[ \t]+(?:worker_)?secrets:\s*\|\s*$\n"
+    # Since the optional-secret change, a deploy's names live in up to two
+    # blocks (e.g. `worker_secrets` + `optional_worker_secrets` on the CI
+    # side, `REQUIRED_LIST` + `OPTIONAL_LIST` on the manual deploy.yml side).
+    # Optional names are still provisioned secrets and belong in the same
+    # consistency accounting, so the union across every found block is what a
+    # deploy provisions.
+    blocks = re.findall(
+        r"(?m)^[ \t]+(?:worker_secrets|optional_worker_secrets|secrets|REQUIRED_LIST|OPTIONAL_LIST):\s*\|\s*$\n"
         r"(?P<body>(?:^[ \t]+[A-Z][A-Z0-9_]*[ \t]*$\n?)+)",
         step,
     )
-    assert secrets is not None, "missing Wrangler secrets block"
-    return set(re.findall(r"(?m)^[ \t]+([A-Z][A-Z0-9_]*)[ \t]*$", secrets["body"]))
+    assert blocks, "missing Wrangler secrets block"
+    return {
+        name
+        for body in blocks
+        for name in re.findall(r"(?m)^[ \t]+([A-Z][A-Z0-9_]*)[ \t]*$", body)
+    }
 
 
 def _mapped_secret_names(source: str) -> set[str]:
@@ -72,8 +82,11 @@ def _required_deploy_keys() -> tuple[set[str], set[str], set[str]]:
     required = _typescript_string_list(entrypoint, "CONTAINER_REQUIRED_KEYS")
     forwarded = _typescript_string_list(entrypoint, "CONTAINER_ENV_KEYS")
     deploy = _DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+    # The literal secret-name lists moved into the "Resolve effective worker
+    # secrets" step when POST_DEPLOY_DIAG_TOKEN became optional; the "Deploy via
+    # Wrangler" step now consumes them indirectly via its `secrets:` output.
     provisioned = _wrangler_secret_names(
-        _named_workflow_step(deploy, "Deploy via Wrangler")
+        _named_workflow_step(deploy, "Resolve effective worker secrets")
     )
     return required, forwarded, provisioned
 
@@ -87,7 +100,8 @@ def test_container_required_keys_are_forwarded_and_deployed() -> None:
 
 def test_ci_root_deploys_match_manual_root_secrets() -> None:
     deploy = _DEPLOY_WORKFLOW.read_text(encoding="utf-8")
-    root_step = _named_workflow_step(deploy, "Deploy via Wrangler")
+    # The literal lists live in the "Resolve effective worker secrets" step.
+    root_step = _named_workflow_step(deploy, "Resolve effective worker secrets")
     manual_secrets = _wrangler_secret_names(root_step)
     ci = _CI_WORKFLOW.read_text(encoding="utf-8")
     staging = _named_workflow_job(ci, "deploy-root-staging")


### PR DESCRIPTION
## 问题

#740 把 `POST_DEPLOY_DIAG_TOKEN` 接进了必须上传的 `worker_secrets` 清单。该 secret 尚未配置,于是**从 2026-08-04 起每次 staging 部署都在 secret 上传阶段硬失败**(run 30895422110),产物根本没上线。

**诊断工具不该有能力阻断交付。** 失败应当发生在 post-deploy 检查那一步——大声、带修复指引——而不是部署那一步。

## 做法

| 文件 | 改动 |
|---|---|
| `_deploy-component.yml` | 新增 `optional_worker_secrets` 输入:列在其中的名字**只在值存在时**才进上传清单,缺失时发 `::warning` 并继续部署 |
| `ci.yml` ×2 | `POST_DEPLOY_DIAG_TOKEN` 从 `worker_secrets` 移入 `optional_worker_secrets`(值仍然传递,owner 配好后自动恢复上传) |
| `deploy.yml` | 直接调 wrangler-action,内联同一 resolve 步骤 |
| `post-deploy-assert.sh` | 缺 token 的失败信息改为三要素:**检查没有运行**、**部署本身成功了**、以及精确的 `gh secret set POST_DEPLOY_DIAG_TOKEN --env <环境名>` 命令(环境名经 `TARGET_ENVIRONMENT` 注入) |
| `post-deploy-assert.test.sh` | 断言新信息含全部三要素 |

## 验证

- shellcheck / actionlint / zizmor 全净
- `post-deploy-assert.test.sh` 12/12
- resolve 逻辑在 bash 下两态实测:未配置 → 只上传必需清单、零空行、发 warning;已配置 → 追加上传

## 执行方式记录(opencode 试验第一单)

初稿由 **opencode + deepseek-v4-flash(free 档)** 产出:5 个文件全部按任务书落位,其中 `ci.yml` 的改法比任务书写的更优雅(把 `optional_worker_secrets: |` 插在原 token 行上方,靠重新归属实现移动,最小 diff)。free 档 5 次调用 3 次 503,编辑完成后收尾轮也撞了 503(产物已落盘)。人工 review 后加固三处:输出清单滤空行、环境名用真实变量、检查步骤补 `TARGET_ENVIRONMENT` 注入。

⚠️ **owner 后续动作**(不阻塞本 PR):`gh secret set POST_DEPLOY_DIAG_TOKEN --env staging --body "$(openssl rand -hex 32)"`,production 同理换一个值。配置前 post-deploy 检查会红(信息已说明原因),部署不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployments no longer fail when optional post-deployment diagnostic secrets are not configured.
  * Required secrets continue to be validated and uploaded as before.
  * Deployment workflows now warn when optional diagnostic secrets are skipped.
  * Missing diagnostic tokens provide clearer guidance, including the target environment and setup command.
  * Post-deployment checks now receive the correct deployment environment for more accurate diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->