### PR TITLE
ci(#486): deploy.yml 收敛为共享部署管线的 thin caller

### DIFF
--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -406,6 +406,8 @@ jobs:
             *\?*) scoped_url="${NEON_DATABASE_URL}&search_path=public" ;;
             *) scoped_url="${NEON_DATABASE_URL}?search_path=public" ;;
           esac
+          # 486: the manual thin-caller path has no db-validate job, so validate here (cheap, seconds) before mutating.
+          atlas migrate validate --dir "file://db/migrations"
           atlas migrate apply --dir "file://db/migrations" --url "$scoped_url" --revisions-schema public
         env:
           NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,8 @@ jobs:
 
   deploy-users-prod:
     name: Deploy users production
+    # mirrors ci.yml's intra-prod ordering (root routes to users; users must be live first)
+    needs: [deploy-prod]
     uses: ./.github/workflows/_deploy-component.yml
     with:
       component: users
@@ -85,6 +87,8 @@ jobs:
 
   deploy-maintenance-prod:
     name: Deploy maintenance production
+    # mirrors ci.yml's intra-prod ordering (root routes to users; users must be live first)
+    needs: [deploy-prod]
     uses: ./.github/workflows/_deploy-component.yml
     with:
       component: maintenance
@@ -101,6 +105,8 @@ jobs:
 
   deploy-root-prod:
     name: Deploy root production
+    # mirrors ci.yml's intra-prod ordering (root routes to users; users must be live first)
+    needs: [deploy-users-prod]
     uses: ./.github/workflows/_deploy-component.yml
     with:
       component: root

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,19 @@
+# Manual production deploy — thin caller of _deploy-component.yml (issue #486).
+#
+# Six jobs mirror the production promotion stage of ci.yml (deploy-prod … post-prod)
+# so the manual path and the CI path exercise identical inputs. Every `with:` /
+# `secrets:` / `concurrency:` line here must stay verbatim-identical to ci.yml's
+# corresponding job (the guard apps/agent/agent/tests/unit/
+# test_deploy_model_env_consistency.py enforces the root job's secret lists).
+# Allowed deltas: `needs:` / `if:` that reference ci.yml-only jobs are dropped;
+# post-prod keeps needs on the five deploy jobs.
+#
+# The GitHub `production` environment approval gate lives inside
+# _deploy-component.yml (`environment: ${{ inputs.environment }}` at the job
+# level), so no separate approval block is needed here.
+#
+# Concurrency groups are shared with ci.yml's prod jobs: a manual dispatch and a
+# CI promotion of the same component can never deploy concurrently.
 name: Deploy (Manual)
 
 on:
@@ -10,332 +26,129 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  deploy:
-    timeout-minutes: 30
-    name: Deploy to Production
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
 
-      - name: Preflight - maintenance database secret
-        shell: bash
-        env:
-          AGENT_DATABASE_URL: ${{ secrets.AGENT_DATABASE_URL }}
-        run: |
-          if [ -z "$AGENT_DATABASE_URL" ]; then
-            echo "::error::AGENT_DATABASE_URL is empty/unset for the maintenance Worker in environment=production. Refusing to deploy a scheduled purge that cannot reach the agent data plane."
-            exit 1
-          fi
+  deploy-prod:
+    name: Deploy production
+    uses: ./.github/workflows/_deploy-component.yml
+    with:
+      component: catalog
+      environment: production
+      pulumi_stack: prod
+      working_directory: workers/catalog
+      worker_secrets: DATABASE_URL
+    secrets:
+      NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_PULUMI_API_TOKEN: ${{ secrets.CLOUDFLARE_PULUMI_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+      PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+    concurrency: deploy-prod
 
-      # ── Preflight: post-deploy secrets (validates BEFORE anything deploys,
-      #    same reasoning as _deploy-component.yml's "Preflight - post-deploy
-      #    secrets" step — a failure here cannot leave a Worker half-deployed).
-      #    This workflow always targets `environment: production`, and
-      #    `wrangler.toml`'s `env.production.vars.ANON_ACCESS_ENABLED` is
-      #    "false", so TURNSTILE_SECRET/ANON_ID_SECRET are genuinely inert
-      #    here today (workers/edge/auth.ts:anonymousEnabled requires both the flag
-      #    AND the secret) — read the live flag instead of assuming that stays
-      #    true, so this doesn't quietly go stale if the flag ever flips. ──
-      - name: Preflight - post-deploy secrets
-        shell: bash
-        env:
-          TARGET_COMPONENT: root
-          TARGET_ENVIRONMENT: production
-          POST_DEPLOY_SECRETS: |
-            TURNSTILE_SECRET
-            ANON_ID_SECRET
-          TURNSTILE_SECRET: ${{ secrets.TURNSTILE_SECRET }}
-          ANON_ID_SECRET: ${{ secrets.ANON_ID_SECRET }}
-        run: |
-          anon_flag=$(awk -F'"' -v want="[env.${TARGET_ENVIRONMENT}.vars]" '
-            $0 == want { in_block=1; next }
-            /^\[/ { in_block=0 }
-            in_block && $1 ~ /^ANON_ACCESS_ENABLED[ \t]*=/ { print $2 }
-          ' wrangler.toml 2>/dev/null || true)
-          # Ambiguity is fail-closed, not fail-open — see the matching check
-          # in _deploy-component.yml's "Preflight - post-deploy secrets" step
-          # for the full reasoning. A parse that isn't exactly "true"/"false"
-          # must not silently fall through to the soft-warn branch below.
-          if [ "$anon_flag" != "true" ] && [ "$anon_flag" != "false" ]; then
-            echo "::error::Could not determine ANON_ACCESS_ENABLED for environment=$TARGET_ENVIRONMENT from wrangler.toml (parsed value: '$anon_flag', expected exactly \"true\" or \"false\"). Refusing to guess."
-            exit 1
-          fi
-          missing=0
-          while IFS= read -r name; do
-            [ -z "$name" ] && continue
-            value="${!name-}"
-            if [ -z "$value" ]; then
-              if [ "$anon_flag" = "true" ]; then
-                echo "::error::$name is empty/unset for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT, where ANON_ACCESS_ENABLED=\"true\" makes it load-bearing (workers/edge/turnstile.ts fails CLOSED). Refusing to start the deploy without it. Set it with: gh secret set $name"
-                missing=1
-              else
-                echo "::warning::$name is empty/unset for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT, but ANON_ACCESS_ENABLED is not \"true\" there, so this environment's code path never reads it. Soft warning only; the post-deploy push step will skip it."
-              fi
-              continue
-            fi
-            # TURNSTILE_SECRET-specific validity probe — see the matching
-            # (fully commented) check in _deploy-component.yml's "Preflight -
-            # post-deploy secrets" step for the full reasoning, including why
-            # this retries with backoff instead of fail-closing on the first
-            # ambiguous result (network flakiness isn't the same kind of
-            # ambiguity as the local TOML-parse case above — and this is the
-            # manual production path, so an unreachable third-party validator
-            # must not block an unrelated production hotfix).
-            if [ "$name" = "TURNSTILE_SECRET" ] && [ "$anon_flag" = "true" ]; then
-              turnstile_verdict=""
-              shape_seen="false"
-              attempt=1
-              while [ "$attempt" -le 3 ]; do
-                turnstile_probe=$(printf '%s' "$value" | curl -sS --max-time 10 \
-                  --data-urlencode "secret@-" \
-                  --data-urlencode "response=preflight-probe-not-a-real-token" \
-                  https://challenges.cloudflare.com/turnstile/v0/siteverify 2>/dev/null || true)
-                # Shape sentinel — see the matching (fully commented) check in
-                # _deploy-component.yml for why this exists.
-                printf '%s' "$turnstile_probe" | grep -q '"success"' && shape_seen="true"
-                if printf '%s' "$turnstile_probe" | grep -q '"invalid-input-secret"'; then
-                  turnstile_verdict="invalid"
-                  break
-                elif printf '%s' "$turnstile_probe" | grep -q '"invalid-input-response"'; then
-                  turnstile_verdict="valid"
-                  break
-                fi
-                attempt=$((attempt + 1))
-                [ "$attempt" -le 3 ] && sleep $((attempt * 2))
-              done
-              if [ "$turnstile_verdict" = "invalid" ]; then
-                echo "::error::TURNSTILE_SECRET failed Cloudflare siteverify validation for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT (error-code: invalid-input-secret). This is what happens when the stored value is a Site Key instead of the Secret Key, or any other string siteverify doesn't recognize. Refusing to deploy with it. Re-provision with: gh secret set TURNSTILE_SECRET"
-                missing=1
-              elif [ "$turnstile_verdict" = "valid" ]; then
-                echo "TURNSTILE_SECRET passed Cloudflare siteverify validation for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT."
-              elif [ "$shape_seen" = "true" ]; then
-                echo "::warning::Could not reach Cloudflare's siteverify endpoint to validate TURNSTILE_SECRET after 3 attempts for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT (network failure or endpoint outage) — treating this as validator unavailability, not evidence the secret itself is wrong. Proceeding without this specific check; the empty-value check above still applies."
-              else
-                echo "::warning::Cloudflare's siteverify response never contained a \"success\" field across 3 attempts for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT — this looks like the response SHAPE changed, not just a network blip. Treating as validator-unavailable for now, but this needs someone to look at whether the probe logic itself is stale, not just retry later. Proceeding without this specific check; the empty-value check above still applies."
-              fi
-            fi
-          done <<< "$POST_DEPLOY_SECRETS"
-          if [ "$missing" = "1" ]; then
-            exit 1
-          fi
+  deploy-web-prod:
+    name: Deploy web production
+    uses: ./.github/workflows/_deploy-component.yml
+    with:
+      component: web
+      environment: production
+      pulumi_stack: prod
+      working_directory: apps/web
+      build_filter: web
+      run_pulumi: false
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_PULUMI_API_TOKEN: ${{ secrets.CLOUDFLARE_PULUMI_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    concurrency: deploy-web-prod
 
-      # ── Node toolchain (wrangler + workspace deps; no app build — issue #537
-      # retired the legacy Next.js package, so the root Worker ships as source) ──
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          run_install: false
+  deploy-users-prod:
+    name: Deploy users production
+    uses: ./.github/workflows/_deploy-component.yml
+    with:
+      component: users
+      environment: production
+      pulumi_stack: prod
+      working_directory: workers/users
+      run_pulumi: false
+      worker_secrets: |
+        DATABASE_URL
+        NEON_AUTH_JWKS_URL
+    secrets:
+      NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_PULUMI_API_TOKEN: ${{ secrets.CLOUDFLARE_PULUMI_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      NEON_AUTH_JWKS_URL: ${{ secrets.NEON_AUTH_JWKS_URL }}
+    concurrency: deploy-users-prod
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.4.0
-        # No `cache:` key at all. `cache: ""` still counts as opting in to
-        # setup-node's cache machinery, which zizmor's cache-poisoning audit
-        # flags because this workflow reaches a deploy step; omitting the key
-        # is the only way to be genuinely cache-free. The former
-        # `zizmor: ignore` sat on this line while the finding anchors on the
-        # deploy step below, so it never applied — and suppression is banned
-        # here anyway.
-        with:
-          node-version: "24"
+  deploy-maintenance-prod:
+    name: Deploy maintenance production
+    uses: ./.github/workflows/_deploy-component.yml
+    with:
+      component: maintenance
+      environment: production
+      pulumi_stack: prod
+      working_directory: workers/maintenance
+      run_pulumi: false
+      worker_secrets: AGENT_DATABASE_URL
+    secrets:
+      AGENT_DATABASE_URL: ${{ secrets.AGENT_DATABASE_URL }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    concurrency: deploy-maintenance-prod
 
-      - run: pnpm install --frozen-lockfile --ignore-scripts
+  deploy-root-prod:
+    name: Deploy root production
+    uses: ./.github/workflows/_deploy-component.yml
+    with:
+      component: root
+      environment: production
+      pulumi_stack: prod
+      working_directory: "."
+      run_pulumi: false
+      worker_secrets: |
+        SUPABASE_URL
+        SUPABASE_ANON_KEY
+        SUPABASE_SERVICE_ROLE_KEY
+        SUPABASE_DB_URL
+        MIMO_API_KEY
+        DEEPSEEK_API_KEY
+        GOOGLE_MAPS_API_KEY
+        LOGFIRE_TOKEN
+        CORS_ALLOWED_ORIGIN
+      optional_worker_secrets: |
+        POST_DEPLOY_DIAG_TOKEN
+      post_deploy_secrets: |
+        TURNSTILE_SECRET
+        ANON_ID_SECRET
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_PULUMI_API_TOKEN: ${{ secrets.CLOUDFLARE_PULUMI_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+      MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+      LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+      CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
+      TURNSTILE_SECRET: ${{ secrets.TURNSTILE_SECRET }}
+      ANON_ID_SECRET: ${{ secrets.ANON_ID_SECRET }}
+      POST_DEPLOY_DIAG_TOKEN: ${{ secrets.POST_DEPLOY_DIAG_TOKEN }}
+    concurrency: deploy-root-prod
 
-      # ── Validate the migration authority before a manual code redeploy ──
-      # Production schema changes run in the approval-gated main promotion
-      # (`_deploy-component.yml`), which applies db/migrations with Atlas before
-      # the catalog/users Worker rollout. This manual hotfix path is deliberately
-      # non-mutating at the database layer; it must not revive the old
-      # legacy Supabase all-schema push path.
-      - name: Install pinned Atlas CLI
-        shell: bash
-        run: |
-          mkdir -p "$RUNNER_TEMP/atlas-bin"
-          curl --proto '=https' --tlsv1.2 -sSfL \
-            "https://release.ariga.io/atlas/atlas-community-linux-amd64-v0.30.0" \
-            -o "$RUNNER_TEMP/atlas-bin/atlas"
-          echo "dbaaf350634304d4bf92753559261a67afb399fe4ff0ea6ae5bb5d1ce6e0011a  $RUNNER_TEMP/atlas-bin/atlas" \
-            | sha256sum --check --strict
-          chmod +x "$RUNNER_TEMP/atlas-bin/atlas"
-          echo "$RUNNER_TEMP/atlas-bin" >> "$GITHUB_PATH"
-
-      - name: Validate Atlas migration directory
-        run: atlas migrate validate --dir file://db/migrations
-
-      # ── Deploy catalog Worker FIRST (before root, as root's [[services]] binding depends on it) ──
-      - name: Deploy catalog Worker
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Reuse the workspace-locked Wrangler installed above. An explicit
-          # duplicate version can drift and trigger wrangler-action's
-          # mutating package-install fallback inside a frozen workspace.
-          # #516: workers/catalog has no lockfile of its own (pnpm workspace
-          # member — the lockfile lives at repo root), so the action's
-          # auto-detection falls back to npm, which then chokes on
-          # `@animichi/contract: workspace:*` in this package.json. See
-          # the fully-commented fix in _deploy-component.yml's "Deploy
-          # Worker" step for the confirmed root cause (read from
-          # dist/index.mjs at the pinned SHA, not just the docs).
-          packageManager: pnpm
-          workingDirectory: workers/catalog
-          command: deploy
-          environment: production
-          # The catalog uses env.DATABASE_URL with the Neon HTTP client, matching
-          # the CI promotion path. A pooled binding is optional and not required
-          # by the current deployment topology.
-          secrets: |
-            DATABASE_URL
-        env:
-          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
-
-      # ── Deploy users Worker (before root — root's USERS [[services]] binding depends on it) ──
-      - name: Deploy users Worker
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # #516: same lockfile-detection fallback bug as catalog above.
-          packageManager: pnpm
-          workingDirectory: workers/users
-          command: deploy
-          environment: production
-          secrets: |
-            DATABASE_URL
-            NEON_AUTH_JWKS_URL
-        env:
-          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
-          NEON_AUTH_JWKS_URL: ${{ secrets.NEON_AUTH_JWKS_URL }}
-
-      # ── Deploy scheduled maintenance Worker (private, agent-domain Neon) ──
-      - name: Deploy maintenance Worker
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          packageManager: pnpm
-          workingDirectory: workers/maintenance
-          command: deploy
-          environment: production
-          secrets: |
-            AGENT_DATABASE_URL
-        env:
-          AGENT_DATABASE_URL: ${{ secrets.AGENT_DATABASE_URL }}
-
-      # ── Verify Dockerfile exists before root deploy ──
-      - run: test -f Dockerfile
-
-      # ── Resolve effective worker secrets for the root deploy ──
-      - name: Resolve effective worker secrets
-        id: effective_secrets
-        # Optional (diagnostic-only) secrets are appended to the upload list
-        # only when their value is present. wrangler-action's uploadSecrets()
-        # hard-fails on any listed name whose env value is empty — which is
-        # correct for load-bearing secrets and wrong for diagnostics: on
-        # 2026-08-04 an unconfigured POST_DEPLOY_DIAG_TOKEN blocked every
-        # staging deploy (run 30895422110). A diagnostic credential must not
-        # be able to block delivery; the post-deploy check owns that failure.
-        shell: bash
-        env:
-          REQUIRED_LIST: |
-            SUPABASE_URL
-            SUPABASE_ANON_KEY
-            SUPABASE_SERVICE_ROLE_KEY
-            SUPABASE_DB_URL
-            MIMO_API_KEY
-            DEEPSEEK_API_KEY
-            GOOGLE_MAPS_API_KEY
-            LOGFIRE_TOKEN
-            CORS_ALLOWED_ORIGIN
-          OPTIONAL_LIST: |
-            POST_DEPLOY_DIAG_TOKEN
-          # Same env block as the Deploy via Wrangler step below — the
-          # indirect `${!name}` expansion above looks up OPTIONAL_LIST names
-          # here.
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
-          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
-          LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
-          CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
-          POST_DEPLOY_DIAG_TOKEN: ${{ secrets.POST_DEPLOY_DIAG_TOKEN }}
-        run: |
-          effective="$REQUIRED_LIST"
-          while IFS= read -r name; do
-            name="${name//$'\r'/}"          # tolerate CRLF checkouts
-            name="${name#"${name%%[![:space:]]*}"}"   # ltrim
-            name="${name%"${name##*[![:space:]]}"}"   # rtrim
-            [ -z "$name" ] && continue
-            if ! [[ "$name" =~ ^[A-Z][A-Z0-9_]*$ ]]; then
-              echo "::warning title=optional secret ignored::'$name' is not a valid secret name (expected ^[A-Z][A-Z0-9_]*$); skipping"
-              continue
-            fi
-            if [ -n "${!name:-}" ]; then
-              effective="$effective"$'\n'"$name"
-            else
-              echo "::warning title=optional secret skipped::$name is unset; deploy continues, post-deploy check will report it"
-            fi
-          done <<< "$OPTIONAL_LIST"
-          {
-            echo "list<<EOF"
-            printf '%s\n' "$effective" | sed '/^[[:space:]]*$/d'
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      # ── Deploy root (edge + container) ──
-      - name: Deploy via Wrangler
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # root's implicit workingDirectory (repo root) does have its own
-          # lockfile, so auto-detection already resolves to pnpm correctly
-          # here — set explicitly anyway so this doesn't silently start
-          # relying on directory-based detection again if that ever changes.
-          packageManager: pnpm
-          command: deploy
-          environment: production
-          secrets: ${{ steps.effective_secrets.outputs.list }}
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
-          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
-          LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
-          CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
-          POST_DEPLOY_DIAG_TOKEN: ${{ secrets.POST_DEPLOY_DIAG_TOKEN }}
-
-      # ── Push post-deploy secrets (after root deploy — same list-driven
-      #    pattern as _deploy-component.yml, kept in sync with the
-      #    post_deploy_secrets list in ci.yml's deploy-root-* jobs. Empty
-      #    values are skipped, not failed, here: the preflight step above
-      #    already decided whether an empty value is fatal.) ──
-      - name: Push post-deploy secrets to Worker
-        shell: bash
-        env:
-          TARGET_COMPONENT: root
-          TARGET_ENVIRONMENT: production
-          POST_DEPLOY_SECRETS: |
-            TURNSTILE_SECRET
-            ANON_ID_SECRET
-          TURNSTILE_SECRET: ${{ secrets.TURNSTILE_SECRET }}
-          ANON_ID_SECRET: ${{ secrets.ANON_ID_SECRET }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          while IFS= read -r name; do
-            [ -z "$name" ] && continue
-            value="${!name-}"
-            if [ -z "$value" ]; then
-              echo "::warning::$name is empty/unset for component=$TARGET_COMPONENT, environment=$TARGET_ENVIRONMENT — skipping the push (the preflight step already validated it is safe to skip here)."
-              continue
-            fi
-            printf '%s' "$value" | pnpm exec wrangler secret put "$name" --env "$TARGET_ENVIRONMENT"
-          done <<< "$POST_DEPLOY_SECRETS"
+  post-prod:
+    name: Post-deploy (production)
+    needs: [deploy-prod, deploy-web-prod, deploy-users-prod, deploy-maintenance-prod, deploy-root-prod]
+    uses: ./.github/workflows/_post-deploy-test.yml
+    with:
+      environment: production
+      suite: smoke
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      POST_DEPLOY_DIAG_TOKEN: ${{ secrets.POST_DEPLOY_DIAG_TOKEN }}

--- a/apps/agent/agent/tests/unit/test_deploy_model_env_consistency.py
+++ b/apps/agent/agent/tests/unit/test_deploy_model_env_consistency.py
@@ -30,16 +30,6 @@ def _typescript_string_list(source: str, const_name: str) -> set[str]:
     return set(re.findall(r'["\']([A-Z][A-Z0-9_]*)["\']', assignment["body"]))
 
 
-def _named_workflow_step(source: str, name: str) -> str:
-    step = re.search(
-        rf"(?ms)^(?P<indent>[ ]*)-\s+name:\s*{re.escape(name)}\s*$"
-        rf"(?P<body>.*?)(?=^(?P=indent)-\s+|\Z)",
-        source,
-    )
-    assert step is not None, f"missing workflow step: {name}"
-    return step["body"]
-
-
 def _named_workflow_job(source: str, job_id: str) -> str:
     job = re.search(
         rf"(?ms)^  {re.escape(job_id)}:\s*$\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\s*$|\Z)",
@@ -51,11 +41,13 @@ def _named_workflow_job(source: str, job_id: str) -> str:
 
 def _wrangler_secret_names(step: str) -> set[str]:
     # Since the optional-secret change, a deploy's names live in up to two
-    # blocks (e.g. `worker_secrets` + `optional_worker_secrets` on the CI
-    # side, `REQUIRED_LIST` + `OPTIONAL_LIST` on the manual deploy.yml side).
-    # Optional names are still provisioned secrets and belong in the same
-    # consistency accounting, so the union across every found block is what a
-    # deploy provisions.
+    # blocks (`worker_secrets` + `optional_worker_secrets`) on both the CI
+    # callers and the manual deploy.yml caller. The old deploy.yml inline
+    # `REQUIRED_LIST`/`OPTIONAL_LIST` step was superseded by the reusable
+    # workflow's own optional handling (issue #486), so this helper only ever
+    # sees caller-job bodies now. Optional names are still provisioned secrets
+    # and belong in the same consistency accounting, so the union across every
+    # found block is what a deploy provisions.
     blocks = re.findall(
         r"(?m)^[ \t]+(?:worker_secrets|optional_worker_secrets|secrets|REQUIRED_LIST|OPTIONAL_LIST):\s*\|\s*$\n"
         r"(?P<body>(?:^[ \t]+[A-Z][A-Z0-9_]*[ \t]*$\n?)+)",
@@ -82,11 +74,13 @@ def _required_deploy_keys() -> tuple[set[str], set[str], set[str]]:
     required = _typescript_string_list(entrypoint, "CONTAINER_REQUIRED_KEYS")
     forwarded = _typescript_string_list(entrypoint, "CONTAINER_ENV_KEYS")
     deploy = _DEPLOY_WORKFLOW.read_text(encoding="utf-8")
-    # The literal secret-name lists moved into the "Resolve effective worker
-    # secrets" step when POST_DEPLOY_DIAG_TOKEN became optional; the "Deploy via
-    # Wrangler" step now consumes them indirectly via its `secrets:` output.
+    # The manual path is now a thin caller of _deploy-component.yml (issue
+    # #486): the literal secret-name lists live in the deploy-root-prod JOB's
+    # `worker_secrets`/`optional_worker_secrets` inputs. The old inline
+    # "Resolve effective worker secrets" step is gone — the reusable workflow
+    # owns optional-secret resolution now.
     provisioned = _wrangler_secret_names(
-        _named_workflow_step(deploy, "Resolve effective worker secrets")
+        _named_workflow_job(deploy, "deploy-root-prod")
     )
     return required, forwarded, provisioned
 
@@ -100,9 +94,12 @@ def test_container_required_keys_are_forwarded_and_deployed() -> None:
 
 def test_ci_root_deploys_match_manual_root_secrets() -> None:
     deploy = _DEPLOY_WORKFLOW.read_text(encoding="utf-8")
-    # The literal lists live in the "Resolve effective worker secrets" step.
-    root_step = _named_workflow_step(deploy, "Resolve effective worker secrets")
-    manual_secrets = _wrangler_secret_names(root_step)
+    # The literal lists live in the deploy-root-prod JOB (a thin caller of
+    # _deploy-component.yml); the reusable workflow owns optional-secret
+    # resolution, so there is no inline "Resolve effective worker secrets"
+    # step to read anymore (issue #486).
+    root_job = _named_workflow_job(deploy, "deploy-root-prod")
+    manual_secrets = _wrangler_secret_names(root_job)
     ci = _CI_WORKFLOW.read_text(encoding="utf-8")
     staging = _named_workflow_job(ci, "deploy-root-staging")
     production = _named_workflow_job(ci, "deploy-root-prod")

--- a/workers/edge/dependabotWorkflow.test.ts
+++ b/workers/edge/dependabotWorkflow.test.ts
@@ -6,9 +6,10 @@ import { fileURLToPath } from "node:url";
 const ROOT = fileURLToPath(new URL("../../", import.meta.url));
 const WORKFLOW = readFileSync(`${ROOT}.github/workflows/dependabot-agent.yml`, "utf8");
 const PACKAGE_JSON = readFileSync(`${ROOT}package.json`, "utf8");
-const DEPLOY_WORKFLOWS = ["_deploy-component.yml", "deploy.yml"].map((name) =>
+const DEPLOY_WORKFLOWS = ["_deploy-component.yml"].map((name) =>
   readFileSync(`${ROOT}.github/workflows/${name}`, "utf8"),
 );
+const DEPLOY_CALLER = readFileSync(`${ROOT}.github/workflows/deploy.yml`, "utf8");
 interface PackageManifest {
   devDependencies?: Record<string, string>;
 }
@@ -61,6 +62,8 @@ void test("Dependabot uses the shared Node verification command", () => {
 });
 
 void test("deploy workflows use the locked workspace Wrangler", () => {
+  // #486 thin caller: deploy.yml only invokes the reusable pipeline, which owns the wrangler-action steps.
+  assert.match(DEPLOY_CALLER, /uses: \.\/\.github\/workflows\/_deploy-component\.yml/);
   DEPLOY_WORKFLOWS.forEach(assertUsesLockedWrangler);
 });
 

--- a/workers/edge/migrationBoundary.test.ts
+++ b/workers/edge/migrationBoundary.test.ts
@@ -44,8 +44,10 @@ void test("CI and deploy workflows use Atlas, never the old all-schema push", ()
   const promotion = read(".github/workflows/_deploy-component.yml");
   assert.match(ci, /atlas migrate validate --dir file:\/\/db\/migrations/);
   assert.match(ci, /atlas migrate apply --dry-run[\s\S]*--revisions-schema public/);
-  assert.match(deploy, /atlas migrate validate --dir file:\/\/db\/migrations/);
-  assert.match(promotion, /atlas migrate apply --dir ["']?file:\/\/db\/migrations/);
+  // #486 thin caller: the manual path cannot skip Atlas — every job runs the reusable pipeline.
+  assert.match(deploy, /uses: \.\/\.github\/workflows\/_deploy-component\.yml/);
+  assert.match(promotion, /atlas migrate apply --dir ["']?file:\/\/db\/migrations[\s\S]*--revisions-schema public/);
+  assert.match(promotion, /atlas migrate validate --dir ["']?file:\/\/db\/migrations/);
   assert.doesNotMatch(ci, /supabase db push/);
   assert.doesNotMatch(deploy, /supabase db push/);
 });

--- a/workers/maintenance/test/config.worker.test.ts
+++ b/workers/maintenance/test/config.worker.test.ts
@@ -33,7 +33,8 @@ describe("maintenance deployment configuration", () => {
     expect(reusableDeploy).toContain("AGENT_DATABASE_URL: ${{ secrets.AGENT_DATABASE_URL }}");
     expect(ciWorkflow).toContain("component: maintenance");
     expect(ciWorkflow).toContain("AGENT_DATABASE_URL: ${{ secrets.AGENT_DATABASE_URL }}");
-    expect(deployWorkflow).toContain("workingDirectory: workers/maintenance");
+    // #486 thin caller: deploy.yml passes inputs/secrets; env and Atlas live in _deploy-component.yml.
+    expect(deployWorkflow).toContain("working_directory: workers/maintenance");
     expect(deployWorkflow).toContain("AGENT_DATABASE_URL: ${{ secrets.AGENT_DATABASE_URL }}");
     expect(secretsDocs).toContain("| `AGENT_DATABASE_URL` |");
   });


### PR DESCRIPTION
Closes #486。

## 问题

手动生产部署(`workflow_dispatch`)是 `_deploy-component.yml` 的 291 行手抄本,已三向漂移:

1. **从不跑 Pulumi** —— 手动部署静默跳过全部 infra 对账
2. **零 `concurrency` 组** —— dispatch 可与流水线部署赛跑,同一 Worker 两个 `wrangler deploy` 互踩
3. 每个新 secret/步骤要加两遍(#751 的 optional-secret 就是最新一例:两处各改一次)

(卡片原文的第 2 点「`supabase db push` 迁移引擎分叉」已过时——现文件早已用 pinned Atlas,#723 还加了校验和。)

## 做法

291 → **154 行**:六个 job 逐字镜像 ci.yml 的 prod caller 块(`with:`/`secrets:`/`concurrency:` 全同;丢弃 ci-only 的 `needs:`/`if:`;`post-prod` needs 五个部署 job)。**同名 concurrency 组**让手动 dispatch 与流水线互斥;production 环境审批经 `_deploy-component.yml` 的 `environment` 输入照常生效。

守卫 `test_deploy_model_env_consistency.py` 改读 `deploy-root-prod` caller job 的 `worker_secrets ∪ optional_worker_secrets`。

## 独立验收(reviewer 复跑)

- 六个 job 的块级抽取比对:**零非允许差异**
- 守卫 3/3;**变异**:从 deploy.yml 删掉 optional token 块 → ci-vs-manual 匹配测试红;还原 → 绿
- actionlint、zizmor 净

执行者:opencode(`opencode-go/deepseek-v4-flash --variant max`)。诚实记录:初稿曾被 reviewer 的 `git checkout` 失误销毁重做,变异还原已改用文件副本法。

⚠️ reusable workflow 的输入契约错误只在 GitHub 解析时暴露(仓库已有教训)——合并前请看本 PR 的 workflow 解析是否正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)