### PR TITLE
fix(test): main 红灯热修 — authConfig 守卫适配 #751 的三处 JWKS 映射

### DIFF
--- a/workers/edge/authConfig.test.ts
+++ b/workers/edge/authConfig.test.ts
@@ -111,10 +111,12 @@ void test("deploy.yml keeps its JWKS secret path complete", () => {
 void test("_deploy-component.yml keeps its JWKS declaration and paths complete", () => {
   const workflowText = readFileSync(`${ROOT}.github/workflows/_deploy-component.yml`, "utf8");
   assert.equal(countMatches(workflowText, /^\s+NEON_AUTH_JWKS_URL:\s*$/gm), 1, "_deploy-component.yml must declare JWKS");
+  // PR #751's resolve step legitimately repeats the env block for bash indirect expansion,
+  // so NEON_AUTH_JWKS_URL appears once in wrangler env, once in the post-deploy env, and once in the resolve-step env.
   assert.equal(
     countMatches(workflowText, /^\s+NEON_AUTH_JWKS_URL: \$\{\{ secrets\.NEON_AUTH_JWKS_URL \}\}$/gm),
-    2,
-    "_deploy-component.yml JWKS secret mappings must stay complete",
+    3,
+    "_deploy-component.yml JWKS secret mappings must stay complete (wrangler env + post-deploy env + resolve-step env)",
   );
   assert.equal(workflowText.includes("NEON_AUTH_ENABLED"), false, "_deploy-component.yml must not turn the disabled public var into a secret");
   assert.equal(workflowText.includes("NEON_AUTH_ISSUER"), false, "_deploy-component.yml must not turn the public issuer into a secret");


### PR DESCRIPTION
**main 的 Edge worker CI 自 #751 合入起红**:守卫断言 `NEON_AUTH_JWKS_URL` 映射恰 2 处,而 #751 的 resolve 步骤合法复制了 env 块(bash `${!name}` 间接展开需要)→ 3 处。守卫没错——计数就是它的职责——期望改 3,信息里点名三个消费者,此后掉到 3 以下意味着某个消费者丢了映射。

**漏检归因(诚实记录)**:#751 合并前跑了 shellcheck/actionlint/zizmor/脚本自测/Python 部署守卫,**唯独没跑 `pnpm run test:worker`**——edge 守卫住在那。#752(glob 化)合入后这类守卫至少不会因清单漏列而缺席,但「改 workflow 必须跑 worker 测试」这条要进流程。

独立验收:authConfig 7/7;变异(删三处映射之一,cp 法还原)红→绿。worktree 里 containerEnv 的失败是缺 node_modules 的环境噪音(主树 21/21)。

执行者:opencode(`opencode-go/deepseek-v4-flash --variant max`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)