### PR TITLE
feat(#494): /healthz reports real git metadata in deployed containers

### DIFF
--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -614,12 +614,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Whitelist-sanitize: a ref name may contain characters that break a
+          # quoted Python literal; GITHUB_SHA is hex and safe as-is.
+          branch="${GITHUB_REF_NAME//[^A-Za-z0-9._\/-]/-}"
           mkdir -p apps/agent/agent
           cat > apps/agent/agent/build_info.py <<EOF
           """Build-time git metadata baked by CI (#494). Do not edit."""
 
           GIT_COMMIT = "${GITHUB_SHA::7}"
-          GIT_BRANCH = "${GITHUB_REF_NAME}"
+          GIT_BRANCH = "${branch}"
           EOF
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0

--- a/.github/workflows/_deploy-component.yml
+++ b/.github/workflows/_deploy-component.yml
@@ -601,6 +601,26 @@ jobs:
             printf '%s\n' "$effective" | sed '/^[[:space:]]*$/d'
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+      # #494: bake git metadata into the container image. The root image is
+      # built by the "Deploy Worker" step below (`wrangler deploy`, driven by
+      # wrangler.toml's [[containers]] image = "./Dockerfile"), and wrangler
+      # cannot pass `--build-arg` through to docker (workers-sdk #12991). So we
+      # write apps/agent/agent/build_info.py into the build context instead;
+      # the Dockerfile's existing `COPY apps/agent/agent /app/agent` ships it
+      # into the image at build time. The file is gitignored (#494) and
+      # regenerated on every deploy, so it never goes stale in a PR.
+      - name: Bake git build info for root container
+        if: ${{ inputs.component == 'root' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p apps/agent/agent
+          cat > apps/agent/agent/build_info.py <<EOF
+          """Build-time git metadata baked by CI (#494). Do not edit."""
+
+          GIT_COMMIT = "${GITHUB_SHA::7}"
+          GIT_BRANCH = "${GITHUB_REF_NAME}"
+          EOF
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,8 @@ backend/tests/eval/results/agent_openai-mimo-*
 # tool-generated local state (rebuildable)
 .codegraph/
 test-results/
+
+# CI-generated build metadata (#494) — written into the checkout just before
+# `wrangler deploy` builds the root container; never committed (a committed
+# copy would go stale with the deploy).
+/apps/agent/agent/build_info.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,18 @@ WORKDIR /app
 COPY --from=builder /app /app
 
 RUN useradd -r -s /bin/false appuser
+
+# #494: build-time git metadata. The CI deploy path builds this image through
+# `wrangler deploy` (wrangler.toml [[containers]] image = "./Dockerfile"), which
+# cannot pass `--build-arg` (workers-sdk #12991) — CI instead bakes
+# apps/agent/agent/build_info.py before deploying, and the existing COPY of
+# that directory ships it into /app/agent. These ARG/ENV pairs cover manual
+# `docker build --build-arg GIT_COMMIT=... GIT_BRANCH=...` builds; empty
+# defaults keep a plain build healthy (health.py falls through to git).
+ARG GIT_COMMIT=""
+ARG GIT_BRANCH=""
+ENV GIT_COMMIT=${GIT_COMMIT} \
+    GIT_BRANCH=${GIT_BRANCH}
 USER appuser
 
 EXPOSE 8080

--- a/apps/agent/agent/interfaces/routes/health.py
+++ b/apps/agent/agent/interfaces/routes/health.py
@@ -27,7 +27,9 @@ def _baked_build_info() -> tuple[str, str]:
     """Return (commit, branch) from the CI-generated build_info.py, or empty."""
     try:
         build_info = importlib.import_module("agent.build_info")
-    except ImportError:
+    except (
+        Exception
+    ):  # diagnostic path: any import failure must fall back, never crash startup
         return "", ""
     return (
         str(getattr(build_info, "GIT_COMMIT", "")),

--- a/apps/agent/agent/interfaces/routes/health.py
+++ b/apps/agent/agent/interfaces/routes/health.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+import os
 import subprocess
 from datetime import UTC, datetime
 
@@ -21,6 +23,18 @@ router = APIRouter(tags=["health"])
 _STARTED_AT = datetime.now(UTC).isoformat()
 
 
+def _baked_build_info() -> tuple[str, str]:
+    """Return (commit, branch) from the CI-generated build_info.py, or empty."""
+    try:
+        build_info = importlib.import_module("agent.build_info")
+    except ImportError:
+        return "", ""
+    return (
+        str(getattr(build_info, "GIT_COMMIT", "")),
+        str(getattr(build_info, "GIT_BRANCH", "")),
+    )
+
+
 def _git_short(args: list[str]) -> str:
     """Run a git command and return stdout stripped, or 'unknown' on failure."""
     try:
@@ -30,8 +44,23 @@ def _git_short(args: list[str]) -> str:
         return "unknown"
 
 
-_GIT_COMMIT = _git_short(["git", "rev-parse", "--short", "HEAD"])
-_GIT_BRANCH = _git_short(["git", "branch", "--show-current"])
+def _git_info(baked: str, env_name: str, args: list[str]) -> str:
+    """Resolve build metadata: baked value, then env, then git, then 'unknown'."""
+    if baked:
+        return baked
+    env_value = os.environ.get(env_name)
+    if env_value:
+        return env_value
+    return _git_short(args)
+
+
+_BUILT_GIT_COMMIT, _BUILT_GIT_BRANCH = _baked_build_info()
+_GIT_COMMIT = _git_info(
+    _BUILT_GIT_COMMIT, "GIT_COMMIT", ["git", "rev-parse", "--short", "HEAD"]
+)
+_GIT_BRANCH = _git_info(
+    _BUILT_GIT_BRANCH, "GIT_BRANCH", ["git", "branch", "--show-current"]
+)
 
 
 @router.get("/")

--- a/apps/agent/agent/tests/unit/test_routes_health.py
+++ b/apps/agent/agent/tests/unit/test_routes_health.py
@@ -5,11 +5,19 @@ Covers: GET /healthz, CORS middleware, create_fastapi_app state.
 
 from __future__ import annotations
 
+import importlib
+import re
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+from pytest import MonkeyPatch
 
 from agent.config.settings import Settings
 from agent.infrastructure.session.memory import InMemorySessionStore
 from agent.interfaces.public_api import RuntimeAPI
+from agent.interfaces.routes import health
 from agent.tests.unit.conftest_fastapi import (
     async_client,
     build_app,
@@ -106,3 +114,72 @@ async def test_app_state_accessible_when_injected() -> None:
     assert app.state.runtime_api is runtime_api
     assert app.state.settings is settings
     assert app.state.db_client is mock_db
+
+
+# ---------------------------------------------------------------------------
+# #494: /healthz git_commit / git_branch resolve baked build_info.py -> env
+# vars -> git shell-out -> "unknown". The values are captured at module load,
+# so each test sets up its condition, reloads the module, then asserts
+# through the endpoint.
+# ---------------------------------------------------------------------------
+
+
+async def test_healthz_reports_baked_build_info(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.build_info",
+        SimpleNamespace(GIT_COMMIT="baked0ab", GIT_BRANCH="baked-branch"),
+    )
+    importlib.reload(health)
+    app, _ = build_app()
+    async with async_client(app) as client:
+        resp = await client.get("/healthz")
+
+    body = resp.json()
+    assert body["git_commit"] == "baked0ab"
+    assert body["git_branch"] == "baked-branch"
+
+
+async def test_healthz_reports_git_env_vars(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("GIT_COMMIT", "env0000")
+    monkeypatch.setenv("GIT_BRANCH", "env-branch")
+    importlib.reload(health)
+    app, _ = build_app()
+    async with async_client(app) as client:
+        resp = await client.get("/healthz")
+
+    body = resp.json()
+    assert body["git_commit"] == "env0000"
+    assert body["git_branch"] == "env-branch"
+
+
+async def test_healthz_git_fallback_returns_real_commit(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GIT_COMMIT", raising=False)
+    monkeypatch.delenv("GIT_BRANCH", raising=False)
+    monkeypatch.delitem(sys.modules, "agent.build_info", raising=False)
+    importlib.reload(health)
+    app, _ = build_app()
+    async with async_client(app) as client:
+        resp = await client.get("/healthz")
+
+    body = resp.json()
+    assert re.fullmatch(r"[0-9a-f]{7,}", body["git_commit"])
+
+
+async def test_healthz_git_absent_returns_unknown(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("GIT_COMMIT", raising=False)
+    monkeypatch.delenv("GIT_BRANCH", raising=False)
+    monkeypatch.delitem(sys.modules, "agent.build_info", raising=False)
+    monkeypatch.chdir(tmp_path)
+    importlib.reload(health)
+    app, _ = build_app()
+    async with async_client(app) as client:
+        resp = await client.get("/healthz")
+
+    body = resp.json()
+    assert body["git_commit"] == "unknown"
+    assert body["git_branch"] == "unknown"


### PR DESCRIPTION
Closes #494.

## 问题
容器镜像不含 `.git`,`/healthz` 的 `git_branch`/`git_commit` 在一切部署环境恒为 "unknown" — 使「E2E 前核对后端身份」的规约形同虚设。

## 机制
`wrangler deploy` 自建镜像且无法传 `--build-arg`(workers-sdk #12991),改走生成文件:
- CI(`_deploy-component.yml` root 组件)在构建前写入 gitignored 的 `apps/agent/agent/build_info.py`,既有 `COPY apps/agent/agent` 顺带打进镜像
- `health.py` 解析序:`build_info` import → 环境变量 → git shell-out(本地开发)→ "unknown"
- Dockerfile 增 `ARG/ENV GIT_COMMIT GIT_BRANCH` 作为 env 路径的承载

## 与 #753 的关系
原 worktree 里 deploy.yml 的重复 bake hunk 已在 rebase 时丢弃 — thin caller 下手动路径同走 reusable,单处 bake 两路径受益。

## 验证
- `test_routes_health.py` 8/8(env 优先、build_info 优先、双缺回退 unknown、非 repo cwd 不崩)
- 全量 1747 passed,覆盖率 90.88%(≥87)
- `make typecheck` clean;`actionlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)