### PR TITLE
ci(#487): infra gates — topology tests + staging pulumi preview in ci-infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,7 @@ jobs:
           PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           CLOUDFLARE_PULUMI_API_TOKEN: ${{ secrets.CLOUDFLARE_PULUMI_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
@@ -259,6 +260,7 @@ jobs:
             PULUMI_BACKEND_URL \
             PULUMI_CONFIG_PASSPHRASE \
             CLOUDFLARE_PULUMI_API_TOKEN \
+            CLOUDFLARE_ACCOUNT_ID \
             R2_ACCESS_KEY_ID \
             R2_SECRET_ACCESS_KEY
           do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,12 +249,29 @@ jobs:
         id: pulumi_gate
         env:
           PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+          CLOUDFLARE_PULUMI_API_TOKEN: ${{ secrets.CLOUDFLARE_PULUMI_API_TOKEN }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
-          if [ -n "$PULUMI_BACKEND_URL" ]; then
+          missing=()
+          for name in \
+            PULUMI_BACKEND_URL \
+            PULUMI_CONFIG_PASSPHRASE \
+            CLOUDFLARE_PULUMI_API_TOKEN \
+            R2_ACCESS_KEY_ID \
+            R2_SECRET_ACCESS_KEY
+          do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -eq 0 ]; then
             echo "ready=true" >> "$GITHUB_OUTPUT"
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::warning title=pulumi preview skipped::PULUMI_BACKEND_URL is not configured; preview cannot run. The deploy path will still take a pre-up state backup, but infra changes merge without a plan diff."
+            echo "::warning title=pulumi preview skipped::Pulumi preview prerequisites are not fully configured; missing: ${missing[*]}. The deploy path will still take a pre-up state backup, but infra changes merge without a plan diff."
           fi
       - name: Pulumi preview (staging)
         if: ${{ steps.pulumi_gate.outputs.ready == 'true' }}
@@ -268,6 +285,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
 
   # ── Security (cross-language; always runs, no affected gate) ──
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,31 @@ jobs:
         run: pnpm install --ignore-workspace --frozen-lockfile --ignore-scripts --lockfile-only
       - name: Typecheck infra
         run: npm run typecheck
+      - name: Infra topology tests
+        run: npm test
+      - name: Check Pulumi preview prerequisites
+        id: pulumi_gate
+        env:
+          PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
+        run: |
+          if [ -n "$PULUMI_BACKEND_URL" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=pulumi preview skipped::PULUMI_BACKEND_URL is not configured; preview cannot run. The deploy path will still take a pre-up state backup, but infra changes merge without a plan diff."
+          fi
+      - name: Pulumi preview (staging)
+        if: ${{ steps.pulumi_gate.outputs.ready == 'true' }}
+        uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7.0.0
+        with:
+          command: preview
+          stack-name: staging
+          work-dir: infra
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PULUMI_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+          PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
 
   # ── Security (cross-language; always runs, no affected gate) ──
 


### PR DESCRIPTION
#487 的 CI 半边(index.ts 资源加固拆下一个小 PR,等本门落地后受益)。

## 变化(仅 ci.yml 的 ci-infra job)
1. **Infra topology tests**:`npm test`(17 个用例)此前从未在 CI 跑过
2. **Pulumi preview (staging)**:合并前出 plan diff;secrets 不可用时大声 warning 跳过(bash gate 步骤解析,不用 continue-on-error)

## 验证
- actionlint clean
- `pnpm run test:worker` 272/272(workflow 守卫规约,#758 新规)
- infra 本地:pnpm install + npm test → 17/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved infrastructure validation by adding topology checks and verifying required deployment credentials.
  * Added clearer CI warnings when staging preview prerequisites are unavailable.
  * Staging previews now run automatically when all required credentials are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->