### PR TITLE
fix(chat): let D13/D14 BYOK failures surface on recompute turns

### DIFF
--- a/apps/web/src/features/chat/use-turn-failure.ts
+++ b/apps/web/src/features/chat/use-turn-failure.ts
@@ -111,15 +111,14 @@ export function useTurnFailure(chat: ChatSession, baseUrl: string, gate: TurnFai
 }
 
 /**
- * A failed recompute retries inline on the tray, never as a full-page D-state
- * — except D12, which the tray cannot recover from: its retry would re-send
- * the same bypass into the same exhausted quota forever. The quota banner and
- * its lock must surface even when the refusal arrived on a recompute turn.
+ * The tray can recover only failures where an inline retry is meaningful.
+ * D12 (quota lock), D13 (login journey), and D14 (key rejected, no retry)
+ * must surface as full states even on recompute turns.
  */
 export function maskRecomputeFailure(
   recompute: RecomputeTurn,
   failure: TurnFailureView | undefined,
 ): TurnFailureView | undefined {
-  if (failure?.state === "D12") return failure;
+  if (failure?.state === "D12" || failure?.state === "D13" || failure?.state === "D14") return failure;
   return recompute.status === "failed" ? undefined : failure;
 }

--- a/apps/web/tests/unit/chat/turn-failure-state.test.ts
+++ b/apps/web/tests/unit/chat/turn-failure-state.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { TURNSTILE_REQUIRED_CODE } from "../../../src/lib/chat/errorClassifier";
-import { turnFailureState } from "../../../src/features/chat/use-turn-failure";
+import { maskRecomputeFailure, turnFailureState } from "../../../src/features/chat/use-turn-failure";
 import type { FailingTurn } from "../../../src/features/chat/use-turn-failure";
+import type { TurnFailureView } from "../../../src/features/chat/components/ErrorStates/TurnFailure";
+import type { RecomputeTurn } from "../../../src/features/chat/selection/useRecomputeTurn";
+import type { ChatErrorState } from "../../../src/lib/chat/errorClassifier";
 
 /**
  * Classification-level guards for the two suppressions that decide whether an
@@ -19,6 +22,12 @@ function settledTurn(code: string | undefined, status = 403): FailingTurn {
     lastErrorCode: () => code,
     lastHttpStatus: () => status,
   };
+}
+
+const failedRecompute: RecomputeTurn = { status: "failed", lastSentIds: undefined, fire: vi.fn() };
+
+function failureView(state: ChatErrorState): TurnFailureView {
+  return { state, onRetry: vi.fn(), onExpiredResume: vi.fn(), recovering: false };
 }
 
 describe("Turnstile suppression (#447 P1-3)", () => {
@@ -51,5 +60,26 @@ describe("turnFailureState's other gates", () => {
   it("reports nothing for a turn that never failed", () => {
     const clean = { ...settledTurn(undefined), error: undefined };
     expect(turnFailureState(clean, false, false)).toBeUndefined();
+  });
+});
+
+describe("maskRecomputeFailure", () => {
+  it("surfaces D12 after a failed recompute", () => {
+    const failure = failureView("D12");
+    expect(maskRecomputeFailure(failedRecompute, failure)).toBe(failure);
+  });
+
+  it("surfaces D13 after a failed recompute", () => {
+    const failure = failureView("D13");
+    expect(maskRecomputeFailure(failedRecompute, failure)).toBe(failure);
+  });
+
+  it("surfaces D14 after a failed recompute", () => {
+    const failure = failureView("D14");
+    expect(maskRecomputeFailure(failedRecompute, failure)).toBe(failure);
+  });
+
+  it("masks a retryable failure after a failed recompute", () => {
+    expect(maskRecomputeFailure(failedRecompute, failureView("D4"))).toBeUndefined();
   });
 });


### PR DESCRIPTION
#759 清欠台账条目(源自 #480 评审,对现行代码核验仍活着)。

maskRecomputeFailure 只放行 D12——BYOK 密钥被拒(D14,重试必败故不许 retry)与匿名持凭证(D13,应走登录旅程)在 recompute 回合被吞成通用重试。现与 D12 同等放行。

验证:vitest 10/10、typecheck clean、oxlint clean、变异(去 D14 放行)→ 红。

🤖 Generated with [Claude Code](https://claude.com/claude-code)