### PR TITLE
fix(#694): staging container cold-start — lazy DB connect + bounded edge retry

### DIFF
--- a/apps/agent/agent/infrastructure/memory.py
+++ b/apps/agent/agent/infrastructure/memory.py
@@ -8,23 +8,27 @@ from typing import cast
 from pydantic_ai_harness.memory import PostgresConnection, PostgresMemoryStore
 
 from agent.infrastructure.supabase.client import SupabaseClient
-from agent.infrastructure.supabase.client_types import AsyncPGPool
 
 
 class AsyncpgMemoryPool:
     """Present asyncpg's overloads as the harness's narrow pool protocol."""
 
-    def __init__(self, pool: AsyncPGPool) -> None:
-        self._pool = pool
+    def __init__(self, db: SupabaseClient) -> None:
+        self._db = db
 
     def acquire(self) -> AbstractAsyncContextManager[PostgresConnection]:
         return cast(
-            AbstractAsyncContextManager[PostgresConnection], self._pool.acquire()
+            AbstractAsyncContextManager[PostgresConnection],
+            self._db.pool.acquire(),
         )
 
 
 def postgres_memory_store(db: object) -> PostgresMemoryStore | None:
-    """Reuse a connected SupabaseClient pool without owning its lifecycle."""
+    """Reuse a SupabaseClient pool without owning its lifecycle.
+
+    The pool is resolved on first acquire, not at construction (issue #694):
+    the lifespan may build the store before ``connect()`` has run.
+    """
     if not isinstance(db, SupabaseClient):
         return None
-    return PostgresMemoryStore(AsyncpgMemoryPool(db.pool))
+    return PostgresMemoryStore(AsyncpgMemoryPool(db))

--- a/apps/agent/agent/interfaces/fastapi_service.py
+++ b/apps/agent/agent/interfaces/fastapi_service.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import httpx
+import structlog
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -43,8 +44,19 @@ from agent.interfaces.routes.runtime import router as runtime_router
 from agent.interfaces.routes.search_preview import router as search_preview_router
 from agent.interfaces.routes.session_migration import router as session_migration_router
 
+logger = structlog.get_logger(__name__)
+
 # Re-export _call_optional_async for test backward compatibility.
 _call_optional_async = call_optional_async
+
+
+def _log_connect_failure(task: asyncio.Task[object]) -> None:
+    """Warn immediately when the background pool connect fails (issue #694)."""
+    if not task.cancelled() and task.exception() is not None:
+        logger.warning(
+            "database pool connect failed in the background",
+            error=task.exception(),
+        )
 
 
 def build_catalog_client(settings: Settings) -> CatalogClient:
@@ -102,6 +114,7 @@ async def _lifespan_build_runtime(
     # completes, DB work surfaces the client's "call connect() first" as a
     # clean 500 — see RuntimeAPI's lazy-repo comment in public_api.py.
     connect_task = asyncio.create_task(call_optional_async(runtime_db, "connect"))
+    connect_task.add_done_callback(_log_connect_failure)
     # Schema changes are never applied by the application. Neon catalog/user migrations run
     # through Atlas from db/migrations; the remaining Supabase compatibility surface has its
     # own operator path. See docs/ops/migrations.md.

--- a/apps/agent/agent/interfaces/fastapi_service.py
+++ b/apps/agent/agent/interfaces/fastapi_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -96,7 +97,11 @@ async def _lifespan_build_runtime(
     """Lifespan branch: build RuntimeAPI from scratch (normal startup)."""
     runtime_db = db if db is not None else build_supabase_client(resolved_settings)
     runtime_session_store = _resolve_session_store(session_store, runtime_db)
-    await call_optional_async(runtime_db, "connect")
+    # The pool connect must not gate the container's readiness (issue #694):
+    # it runs in the background so the port binds immediately. Until it
+    # completes, DB work surfaces the client's "call connect() first" as a
+    # clean 500 — see RuntimeAPI's lazy-repo comment in public_api.py.
+    connect_task = asyncio.create_task(call_optional_async(runtime_db, "connect"))
     # Schema changes are never applied by the application. Neon catalog/user migrations run
     # through Atlas from db/migrations; the remaining Supabase compatibility surface has its
     # own operator path. See docs/ops/migrations.md.
@@ -115,11 +120,14 @@ async def _lifespan_build_runtime(
         yield
     finally:
         try:
-            await catalog_client.aclose()
+            await connect_task
         finally:
-            await aclose_geocoding_client()
-        await call_optional_async(runtime_session_store, "close")
-        await call_optional_async(runtime_db, "close")
+            try:
+                await catalog_client.aclose()
+            finally:
+                await aclose_geocoding_client()
+            await call_optional_async(runtime_session_store, "close")
+            await call_optional_async(runtime_db, "close")
 
 
 def create_fastapi_app(

--- a/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
+++ b/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
@@ -247,9 +247,13 @@ def test_lifespan_startup_does_not_block_on_db_connect() -> None:
         settings=Settings(),
     )
     with TestClient(app) as client:
-        response = client.get("/healthz")
-        assert response.status_code == 200
-        release.set()
+        try:
+            response = client.get("/healthz")
+            assert response.status_code == 200
+        finally:
+            # Release the connect task before the TestClient exits and awaits
+            # it, so a failing assertion cannot hang the shutdown await.
+            release.set()
 
 
 def test_require_supabase_returns_client_when_valid(mock_db: MagicMock) -> None:

--- a/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
+++ b/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
@@ -7,6 +7,8 @@ repository-wide coverage gate green.
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -223,6 +225,31 @@ async def test_call_optional_async_awaits_async_method() -> None:
 async def test_call_optional_async_ignores_missing_method() -> None:
     target = SimpleNamespace()
     await _call_optional_async(target, "close")
+
+
+def test_lifespan_startup_does_not_block_on_db_connect() -> None:
+    """Issue #694: the pool connect runs in the background, not before yield.
+
+    Startup completes while ``connect`` is still blocked (a hang here means
+    the readiness probe regressed to waiting on the database), and shutdown
+    still awaits the connect task.
+    """
+    release = threading.Event()
+
+    async def slow_connect() -> None:
+        await asyncio.to_thread(release.wait)
+
+    db = MagicMock(spec=SupabaseClient)
+    db.connect = slow_connect
+    app = create_fastapi_app(
+        db=db,
+        session_store=InMemorySessionStore(),
+        settings=Settings(),
+    )
+    with TestClient(app) as client:
+        response = client.get("/healthz")
+        assert response.status_code == 200
+        release.set()
 
 
 def test_require_supabase_returns_client_when_valid(mock_db: MagicMock) -> None:

--- a/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
+++ b/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 from agent.config.settings import Settings
 from agent.infrastructure.session.memory import InMemorySessionStore
 from agent.infrastructure.supabase.client import SupabaseClient
+from agent.interfaces import fastapi_service
 from agent.interfaces.fastapi_service import (
     _call_optional_async,
     _contains_json_invalid_error,
@@ -315,3 +316,39 @@ def test_setup_logfire_configures_without_instrumenting_when_token_not_set(
     logfire_mock.instrument_fastapi.assert_not_called()
     logfire_mock.instrument_httpx.assert_not_called()
     logfire_mock.instrument_asyncpg.assert_not_called()
+
+
+class _DoneTaskStub(asyncio.Task[object]):
+    """Minimal done-task stand-in exposing only what the callback reads."""
+
+    def __init__(self, outcome: Exception | None) -> None:
+        self._outcome = outcome
+
+    def cancelled(self) -> bool:
+        return False
+
+    def exception(self) -> Exception | None:
+        return self._outcome
+
+
+def test_log_connect_failure_warns_when_background_connect_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warning = MagicMock()
+    monkeypatch.setattr(fastapi_service, "logger", SimpleNamespace(warning=warning))
+
+    fastapi_service._log_connect_failure(_DoneTaskStub(RuntimeError("boom")))
+
+    warning.assert_called_once()
+    assert warning.call_args.kwargs["error"].args == ("boom",)
+
+
+def test_log_connect_failure_is_silent_when_connect_succeeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warning = MagicMock()
+    monkeypatch.setattr(fastapi_service, "logger", SimpleNamespace(warning=warning))
+
+    fastapi_service._log_connect_failure(_DoneTaskStub(None))
+
+    warning.assert_not_called()

--- a/workers/edge/app.ts
+++ b/workers/edge/app.ts
@@ -18,7 +18,8 @@ export { isAuthRateLimited } from "./routing-policy.ts";
  * starting, its fetch answers a 500 whose body carries this marker (or throws
  * an error that does). /healthz retries briefly instead of failing the
  * readiness probe, then passes the final failure through unchanged. */
-const NOT_RUNNING_MARKER = "not running";
+// Exact phrase from the error string raised by @cloudflare/containers start().
+const NOT_RUNNING_MARKER = "The container is not running";
 const NOT_RUNNING_RETRIES = 3;
 
 /** Backoff before the 2nd and 3rd attempts: 400ms then 800ms (issue #694). */

--- a/workers/edge/app.ts
+++ b/workers/edge/app.ts
@@ -14,6 +14,68 @@ export type { Env } from "./env.ts";
 export { catalogOutbound } from "./forward.ts";
 export { isAuthRateLimited } from "./routing-policy.ts";
 
+/** Container cold-start hardening (issue #694): while a container is still
+ * starting, its fetch answers a 500 whose body carries this marker (or throws
+ * an error that does). /healthz retries briefly instead of failing the
+ * readiness probe, then passes the final failure through unchanged. */
+const NOT_RUNNING_MARKER = "not running";
+const NOT_RUNNING_RETRIES = 3;
+
+/** Backoff before the 2nd and 3rd attempts: 400ms then 800ms (issue #694). */
+function startupBackoffMs(attempt: number): number {
+  return attempt === 1 ? 400 : 800;
+}
+
+function realSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isNotRunningError(error: unknown): error is Error {
+  return error instanceof Error && error.message.includes(NOT_RUNNING_MARKER);
+}
+
+async function isNotRunningResponse(response: Response): Promise<boolean> {
+  if (response.status !== 500) return false;
+  return (await response.clone().text()).includes(NOT_RUNNING_MARKER);
+}
+
+/** One container fetch attempt: the response to return, or the failure to
+ * retry (re-thrown immediately when it is not a cold-start failure). */
+async function containerFetchAttempt(
+  fetchFn: (request: Request) => Promise<Response>,
+  request: Request,
+): Promise<{ ok: true; response: Response } | { ok: false; failure: Response | Error }> {
+  try {
+    const response = await fetchFn(request);
+    if (!(await isNotRunningResponse(response))) return { ok: true, response };
+    return { ok: false, failure: response };
+  } catch (error) {
+    if (!isNotRunningError(error)) throw error;
+    return { ok: false, failure: error };
+  }
+}
+
+function finalFailureResponse(failure: Response | Error): Response {
+  if (failure instanceof Error) throw failure;
+  return failure;
+}
+
+async function fetchContainerWithStartupRetry(
+  fetchFn: (request: Request) => Promise<Response>,
+  request: Request,
+  sleep: (ms: number) => Promise<void>,
+): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    const lastAttempt = attempt === NOT_RUNNING_RETRIES - 1;
+    if (attempt > 0) await sleep(startupBackoffMs(attempt));
+    const outcome = await containerFetchAttempt(fetchFn, request.clone());
+    if (lastAttempt) {
+      return outcome.ok ? outcome.response : finalFailureResponse(outcome.failure);
+    }
+    if (outcome.ok) return outcome.response;
+  }
+}
+
 /** The main Worker app: a pure API and asset gateway (`/v1`, `/healthz`, the
  * image and private R2 tile proxies, and one allowlisted public catalog read).
  * NOTE: no /catalog/* route —
@@ -28,6 +90,8 @@ type WorkerApp = Hono<{ Bindings: Env }>;
 interface WorkerDeps {
   authenticate?: (request: Request, env: Env, ctx: WorkerExecutionContext) => Promise<AuthResult>;
   turnstileGate?: TurnstileGate;
+  /** Injectable sleep for the container cold-start retry (tests avoid real waits). */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 function registerWorkerRoutes(app: WorkerApp, deps: WorkerDeps): void {
@@ -37,9 +101,14 @@ function registerWorkerRoutes(app: WorkerApp, deps: WorkerDeps): void {
   // short-lived pass window is shared by every request on the same isolate —
   // that window is what stops a visitor being re-challenged per message.
   const turnstileGate = deps.turnstileGate ?? createTurnstileGate();
-  app.get("/healthz", (c) =>
-    c.env.CONTAINER.get(c.env.CONTAINER.idFromName("default")).fetch(c.req.raw),
-  );
+  app.get("/healthz", (c) => {
+    const container = c.env.CONTAINER.get(c.env.CONTAINER.idFromName("default"));
+    return fetchContainerWithStartupRetry(
+      (request) => container.fetch(request),
+      c.req.raw,
+      deps.sleep ?? realSleep,
+    );
+  });
   app.all("/tiles/*", (c) => handleTiles(c.req.raw, c.env.MAP_TILES, c.executionCtx));
   app.all("/img/*", (c) => handleImageProxy(c.req.raw, c.executionCtx));
   app.get("/catalog/public/anime-overview/:bangumiId{[0-9]+}", async (c) => {

--- a/workers/edge/containerRetry.test.ts
+++ b/workers/edge/containerRetry.test.ts
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createWorkerApp } from "./app.ts";
+
+const NOT_RUNNING_BODY = "The container is not running, consider calling start()";
+
+/** A CONTAINER binding stub whose fetch serves the given attempts in order. */
+function notRunningEnv(attempts: (() => Promise<Response>)[]) {
+  return {
+    CONTAINER: {
+      idFromName: () => "id",
+      get: () => ({
+        fetch: () => {
+          const next = attempts.shift();
+          if (next === undefined) {
+            throw new Error("container fetch called more times than stubbed");
+          }
+          return next();
+        },
+      }),
+    },
+  } as never;
+}
+
+/** Resolves instantly, recording the backoff durations it was asked to wait. */
+function instantSleep(called: number[]): (ms: number) => Promise<void> {
+  return (ms) => {
+    called.push(ms);
+    return Promise.resolve();
+  };
+}
+
+// Issue #694: while a container is still starting, /healthz fetches can 500
+// with a "not running" body. The edge retries briefly instead of failing the
+// readiness probe, then passes the final failure through unchanged.
+
+void test("a not-running 500 is retried with 400/800ms backoff and the eventual success is returned", async () => {
+  const sleeps: number[] = [];
+  const app = createWorkerApp({ sleep: instantSleep(sleeps) });
+  const env = notRunningEnv([
+    () => Promise.resolve(new Response(NOT_RUNNING_BODY, { status: 500 })),
+    () => Promise.resolve(new Response(NOT_RUNNING_BODY, { status: 500 })),
+    () => Promise.resolve(new Response("ok")),
+  ]);
+
+  const res = await app.request("/healthz", {}, env);
+
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), "ok");
+  assert.deepEqual(sleeps, [400, 800]);
+});
+
+void test("a persistently not-running container returns the final 500 unchanged after 3 attempts", async () => {
+  const sleeps: number[] = [];
+  const app = createWorkerApp({ sleep: instantSleep(sleeps) });
+  const env = notRunningEnv([
+    () => Promise.resolve(new Response(NOT_RUNNING_BODY, { status: 500 })),
+    () => Promise.resolve(new Response(NOT_RUNNING_BODY, { status: 500 })),
+    () => Promise.resolve(new Response(NOT_RUNNING_BODY, { status: 500 })),
+  ]);
+
+  const res = await app.request("/healthz", {}, env);
+
+  assert.equal(res.status, 500);
+  assert.equal(await res.text(), NOT_RUNNING_BODY);
+  assert.deepEqual(sleeps, [400, 800]);
+});
+
+void test("a thrown not-running fetch error is retried like the 500 body", async () => {
+  const sleeps: number[] = [];
+  const app = createWorkerApp({ sleep: instantSleep(sleeps) });
+  const env = notRunningEnv([
+    () => Promise.reject(new Error(NOT_RUNNING_BODY)),
+    () => Promise.reject(new Error(NOT_RUNNING_BODY)),
+    () => Promise.resolve(new Response("ok")),
+  ]);
+
+  const res = await app.request("/healthz", {}, env);
+
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), "ok");
+  assert.deepEqual(sleeps, [400, 800]);
+});
+
+void test("a plain 500 is returned immediately without retrying", async () => {
+  const sleeps: number[] = [];
+  const app = createWorkerApp({ sleep: instantSleep(sleeps) });
+  const env = notRunningEnv([() => Promise.resolve(new Response("boom", { status: 500 }))]);
+
+  const res = await app.request("/healthz", {}, env);
+
+  assert.equal(res.status, 500);
+  assert.equal(await res.text(), "boom");
+  assert.deepEqual(sleeps, []);
+});
+
+void test("a non-not-running fetch error passes through without retry", async () => {
+  const sleeps: number[] = [];
+  const app = createWorkerApp({ sleep: instantSleep(sleeps) });
+  const env = notRunningEnv([() => Promise.reject(new Error("disk full"))]);
+
+  const res = await app.request("/healthz", {}, env);
+
+  assert.equal(res.status, 500);
+  assert.equal(await res.text(), "Internal Server Error");
+  assert.deepEqual(sleeps, []);
+});


### PR DESCRIPTION
staging /healthz 500('container not running')的双侧修复,今晚每次 staging 部署都被它拦在 smoke。

**根因**(agent 侧):`_lifespan_build_runtime` 在 yield 前内联 `await db.connect()`——Neon 握手一慢,uvicorn 迟迟不绑端口,容器永远不 ready。现改为 background task(失败仍在 shutdown 边界浮出),AsyncpgMemoryPool 改首次 acquire 时取 pool;新增测试证明 connect 阻塞时启动照常完成。

**缓解**(edge 侧):对 cold-start 特征 500/异常做 3 次有界重试(400/800ms,注入式 sleep,测试零真实等待);非冷启动失败原样透传。5 个新测试。

验证:test:worker 277/277、py 1734 passed 覆盖 91.06%、typecheck/lint clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service startup so readiness is not blocked while database connections are established.
  - Added clearer connection-failure logging and safer shutdown handling.
  - Improved health checks during container cold starts by retrying temporary startup failures.
  - Preserved final health-check errors and immediately reports unrelated failures.

- **Tests**
  - Added coverage for asynchronous startup, shutdown behavior, connection failures, and health-check retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->