### PR TITLE
infra(#541): activate staging.animichi.com (Custom Domain topology ON)

### DIFF
--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -5,11 +5,11 @@ config:
   seichijunrei-infra:cloudflareZoneId: 44fdcc54545c1152a8e730137b671be4
   seichijunrei-infra:stagingDomain: staging.animichi.com
   #
-  # ── Hostname cutover (#541), OFF today ──────────────────────────────────────
-  # Flipping `webRoutesEnabled` PUBLISHES staging: it creates the Custom Domain
-  # and the /v1, /img, /healthz edge routes together. One flag on purpose — a
-  # hostname that resolves before its routes are narrowed answers a browser
-  # navigation with the edge Worker's JSON 404.
+  # ── Hostname cutover (#541), ENABLED 2026-08-05 ─────────────────────────────
+  # `webRoutesEnabled` PUBLISHED staging: it created the Custom Domain and the
+  # /v1, /img, /healthz edge routes together. One flag on purpose — a hostname
+  # that resolves before its routes are narrowed answers a browser navigation
+  # with the edge Worker's JSON 404.
   #
   #   pulumi config set webRoutesEnabled true                   --stack staging
   #   pulumi config set cloudflareZoneId <animichi.com zone id> --stack staging

--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -1,6 +1,9 @@
 config:
   # Same Cloudflare account as prod (already committed in Pulumi.prod.yaml).
   seichijunrei-infra:cloudflareAccountId: 021233c1880a43aa68565496100e1f8c
+  seichijunrei-infra:webRoutesEnabled: "true"
+  seichijunrei-infra:cloudflareZoneId: 44fdcc54545c1152a8e730137b671be4
+  seichijunrei-infra:stagingDomain: staging.animichi.com
   #
   # ── Hostname cutover (#541), OFF today ──────────────────────────────────────
   # Flipping `webRoutesEnabled` PUBLISHES staging: it creates the Custom Domain


### PR DESCRIPTION
#541 激活半边:zone 已在账号内 active(API 实测),`webRoutesEnabled=true` + zoneId + `staging.animichi.com` 三项明文配置入 staging stack。合并→下次 staging 部署即建 Custom Domain 与 edge 路由;CI 的 URL 解析(resolve-worker-url.sh)自动切到新域。

**后续两步**(单独 PR):①gate secrets(allowedIps/gateToken)——本地 R2 钥过期写不了加密配置,待 owner 晨间十秒决定(刷新 R2 key 或批准派生凭证);②secrets 就位后 `stagingGateEnabled=true` + 全线 workers_dev=false(#541 step 6)。此前 staging 在新域上的公开程度与现在 workers.dev 完全一致,无回退。

🤖 Generated with [Claude Code](https://claude.com/claude-code)