### PR TITLE
infra: zone hardening — DNSSEC + CAA + rate limit + HSTS

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -157,10 +157,91 @@ if (webRoutesEnabled) {
               },
             },
           },
-        },
-      ],
+      },
+    ],
+  });
+  }
+
+  // ── Zone hardening: DNSSEC, CAA, API rate limit, HSTS ───────────────────────
+  // Owner ruling 2026-08-05 (prod security review). All four are zone-scoped
+  // and belong here with the routes: they need `cloudflareZoneId`, which only
+  // becomes available once a stack opts into owning the zone, and none of them
+  // publish anything by themselves. Public repo: no secrets, emails, or IPs —
+  // none of these resources need any.
+  //
+  // Note on the v6 resource names: `ZoneDnssec` (not `ZoneDnssecConfig`) and
+  // `ZoneSetting` with `settingId` were both confirmed against the local
+  // `@pulumi/cloudflare` v6 typings.
+
+  // DNSSEC signing on the zone. Cloudflare holds the keys and publishes the DS
+  // record; there is deliberately nothing Pulumi-visible beyond the zone.
+  new cloudflare.ZoneDnssec("animichi-dnssec", {
+    zoneId: cloudflareZoneId,
+  });
+
+  // CAA: restrict who may issue certificates for the domain to Cloudflare's
+  // Universal SSL certificate partners — letsencrypt.org, pki.goog, ssl.com,
+  // and digicert.com, each encoded as its own record (one tag per record).
+  // Universal SSL keeps working because CF's partner CAs are listed.
+  const caaIssuers = [
+    { name: "animichi-caa-letsencrypt", value: "letsencrypt.org" },
+    { name: "animichi-caa-pki-goog", value: "pki.goog; cansignhttpexchanges=yes" },
+    { name: "animichi-caa-ssl-com", value: "ssl.com" },
+    { name: "animichi-caa-digicert", value: "digicert.com; cansignhttpexchanges=yes" },
+  ];
+  for (const { name, value } of caaIssuers) {
+    new cloudflare.DnsRecord(name, {
+      zoneId: cloudflareZoneId,
+      name: apexDomain,
+      type: "CAA",
+      ttl: 1,
+      data: { flags: 0, tag: "issue", value },
     });
   }
+
+  // One rate-limit rule (the Free plan allows exactly one): a broad
+  // brute-force damper on the API surface — the apex under `/v1/*` — keyed by
+  // IP + colo, challenging bursts past 60 requests per 10s for 10s. Turnstile
+  // and per-route quotas do fine-grained control; this only shaves floods.
+  new cloudflare.Ruleset("animichi-api-rate-limit", {
+    zoneId: cloudflareZoneId,
+    name: "apex /v1 rate limit",
+    kind: "zone",
+    phase: "http_ratelimit",
+    description: "Broad rate-limit damper on the /v1 API surface.",
+    rules: [
+      {
+        action: "managed_challenge",
+        expression:
+          `(http.host eq "${apexDomain}") and (starts_with(http.request.uri.path, "/v1/"))`,
+        description: "Challenge bursts past 60 requests per 10s on /v1.",
+        enabled: true,
+        ratelimit: {
+          characteristics: ["ip.src", "cf.colo.id"],
+          period: 10,
+          requestsPerPeriod: 60,
+          mitigationTimeout: 10,
+        },
+      },
+    ],
+  });
+
+  // HSTS on the zone. `include_subdomains` false because the staging subdomain
+  // policy may differ from prod; `preload` false deliberately — preloading is
+  // near-irreversible (removing a domain from the preload list takes months),
+  // so it must be a conscious follow-up decision, not a default.
+  new cloudflare.ZoneSetting("animichi-security-header", {
+    zoneId: cloudflareZoneId,
+    settingId: "security_header",
+    value: {
+      strict_transport_security: {
+        enabled: true,
+        max_age: 15552000,
+        include_subdomains: false,
+        preload: false,
+      },
+    },
+  });
 }
 
 // ── Staging: WAF gate ─────────────────────────────────────────────────────────

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -162,58 +162,76 @@ if (webRoutesEnabled) {
   });
   }
 
-  // ── Zone hardening: DNSSEC, CAA, API rate limit, HSTS ───────────────────────
-  // Owner ruling 2026-08-05 (prod security review). All four are zone-scoped
-  // and belong here with the routes: they need `cloudflareZoneId`, which only
-  // becomes available once a stack opts into owning the zone, and none of them
-  // publish anything by themselves. Public repo: no secrets, emails, or IPs —
-  // none of these resources need any.
-  //
-  // Note on the v6 resource names: `ZoneDnssec` (not `ZoneDnssecConfig`) and
-  // `ZoneSetting` with `settingId` were both confirmed against the local
-  // `@pulumi/cloudflare` v6 typings.
+}
+
+// ── Zone hardening: DNSSEC, CAA, API rate limit, HSTS ───────────────────────
+// Owner ruling 2026-08-05 (prod security review), restructured per PR #776:
+// these four are zone-scoped, and prod is the single owner of zone metadata.
+// They started inside the `webRoutesEnabled` block, which meant staging and
+// prod would BOTH declare the same zone resources and fight over them on
+// `pulumi up`, and hardening was wrongly coupled to the publish flag.
+// Guarded on the zoneId alone: a prod stack without the config simply skips —
+// hardening activates when prod gains its zone config, independent of
+// publishing. Public repo: no secrets, emails, or IPs — none of these
+// resources need any.
+//
+// Note on the v6 resource names: `ZoneDnssec` (not `ZoneDnssecConfig`) and
+// `ZoneSetting` with `settingId` were both confirmed against the local
+// `@pulumi/cloudflare` v6 typings.
+const hardeningZoneId = stack === "prod" ? config.get("cloudflareZoneId") : undefined;
+if (hardeningZoneId) {
+  const webDomain = config.get("webDomain");
 
   // DNSSEC signing on the zone. Cloudflare holds the keys and publishes the DS
   // record; there is deliberately nothing Pulumi-visible beyond the zone.
   new cloudflare.ZoneDnssec("animichi-dnssec", {
-    zoneId: cloudflareZoneId,
+    zoneId: hardeningZoneId,
   });
 
   // CAA: restrict who may issue certificates for the domain to Cloudflare's
   // Universal SSL certificate partners — letsencrypt.org, pki.goog, ssl.com,
   // and digicert.com, each encoded as its own record (one tag per record).
   // Universal SSL keeps working because CF's partner CAs are listed.
-  const caaIssuers = [
-    { name: "animichi-caa-letsencrypt", value: "letsencrypt.org" },
-    { name: "animichi-caa-pki-goog", value: "pki.goog; cansignhttpexchanges=yes" },
-    { name: "animichi-caa-ssl-com", value: "ssl.com" },
-    { name: "animichi-caa-digicert", value: "digicert.com; cansignhttpexchanges=yes" },
-  ];
-  for (const { name, value } of caaIssuers) {
-    new cloudflare.DnsRecord(name, {
-      zoneId: cloudflareZoneId,
-      name: apexDomain,
-      type: "CAA",
-      ttl: 1,
-      data: { flags: 0, tag: "issue", value },
-    });
+  // The records pin the apex hostname, which prod sets via `webDomain`; until
+  // that config exists they are skipped while DNSSEC, the rate limit, and
+  // HSTS activate on the zoneId alone.
+  if (webDomain !== undefined) {
+    const caaIssuers = [
+      { name: "animichi-caa-letsencrypt", value: "letsencrypt.org" },
+      { name: "animichi-caa-pki-goog", value: "pki.goog; cansignhttpexchanges=yes" },
+      { name: "animichi-caa-ssl-com", value: "ssl.com" },
+      { name: "animichi-caa-digicert", value: "digicert.com; cansignhttpexchanges=yes" },
+    ];
+    for (const { name, value } of caaIssuers) {
+      new cloudflare.DnsRecord(name, {
+        zoneId: hardeningZoneId,
+        name: webDomain,
+        type: "CAA",
+        ttl: 1,
+        data: { flags: 0, tag: "issue", value },
+      });
+    }
   }
 
   // One rate-limit rule (the Free plan allows exactly one): a broad
-  // brute-force damper on the API surface — the apex under `/v1/*` — keyed by
-  // IP + colo, challenging bursts past 60 requests per 10s for 10s. Turnstile
-  // and per-route quotas do fine-grained control; this only shaves floods.
+  // brute-force damper on the API surface — `/v1/*` — keyed by IP + colo,
+  // challenging bursts past 60 requests per 10s for 10s. Turnstile and
+  // per-route quotas do fine-grained control; this only shaves floods.
+  // Scoped to the zone WITHOUT a host match: on this zone only the apex
+  // serves `/v1/*` (www is a placeholder that 301-redirects in
+  // `http_request_dynamic_redirect`, which runs before `http_ratelimit`), so
+  // a bare path match is equivalent to the apex match and needs no `webDomain`
+  // dependency.
   new cloudflare.Ruleset("animichi-api-rate-limit", {
-    zoneId: cloudflareZoneId,
-    name: "apex /v1 rate limit",
+    zoneId: hardeningZoneId,
+    name: "zone /v1 rate limit",
     kind: "zone",
     phase: "http_ratelimit",
     description: "Broad rate-limit damper on the /v1 API surface.",
     rules: [
       {
         action: "managed_challenge",
-        expression:
-          `(http.host eq "${apexDomain}") and (starts_with(http.request.uri.path, "/v1/"))`,
+        expression: `starts_with(http.request.uri.path, "/v1/")`,
         description: "Challenge bursts past 60 requests per 10s on /v1.",
         enabled: true,
         ratelimit: {
@@ -231,7 +249,7 @@ if (webRoutesEnabled) {
   // near-irreversible (removing a domain from the preload list takes months),
   // so it must be a conscious follow-up decision, not a default.
   new cloudflare.ZoneSetting("animichi-security-header", {
-    zoneId: cloudflareZoneId,
+    zoneId: hardeningZoneId,
     settingId: "security_header",
     value: {
       strict_transport_security: {

--- a/infra/topology-disabled.test.ts
+++ b/infra/topology-disabled.test.ts
@@ -22,11 +22,14 @@ test("only private R2 buckets exist when an ungated stack is built", () => {
   ]);
 });
 
-test("nothing that could publish the site is declared", () => {
-  const publishing = built.filter((r) => /workersCustomDomain|workersRoute|dnsRecord|ruleset/i.test(r.type));
+test("nothing that could publish the site or harden the zone is declared", () => {
+  const publishing = built.filter((r) =>
+    /workersCustomDomain|workersRoute|dnsRecord|ruleset|zoneDnssec|zoneSetting/i.test(r.type),
+  );
   assert.deepEqual(
     publishing.map((r) => `${r.type} ${r.name}`),
     [],
-    "a resource here means the default-off flag no longer gates the cutover",
+    "a resource here means the default-off flag no longer gates the cutover, or hardening " +
+      "activates without the zoneId config",
   );
 });

--- a/infra/topology-prod.test.ts
+++ b/infra/topology-prod.test.ts
@@ -22,6 +22,8 @@ const CUSTOM_DOMAIN = "cloudflare:index/workersCustomDomain:WorkersCustomDomain"
 const ROUTE = "cloudflare:index/workersRoute:WorkersRoute";
 const DNS = "cloudflare:index/dnsRecord:DnsRecord";
 const RULESET = "cloudflare:index/ruleset:Ruleset";
+const ZONE_DNSSEC = "cloudflare:index/zoneDnssec:ZoneDnssec";
+const ZONE_SETTING = "cloudflare:index/zoneSetting:ZoneSetting";
 
 test("the apex serves the web Worker, not the edge Worker", () => {
   const domain = only(built, CUSTOM_DOMAIN);
@@ -43,15 +45,30 @@ test("the API and map asset surfaces are routed to the edge Worker", () => {
   }
 });
 
-test("no apex DnsRecord — the Custom Domain owns that record", () => {
-  // Declaring one here would fight Cloudflare for a record it creates and
-  // marks read-only. The only Pulumi-owned record is the www placeholder.
-  const names = ofType(built, DNS).map((r) => r.inputs.name);
-  assert.deepEqual(names, ["www.animichi.com"]);
+test("the apex DNS records are exactly the four CAA issuers", () => {
+  // The Custom Domain owns the apex hostname record itself (Cloudflare creates
+  // it and marks it read-only); declaring any other apex record would fight it.
+  // CAA is the deliberate exception: it is the one record class that must live
+  // beside the hostname it constrains.
+  const apex = ofType(built, DNS).filter((r) => r.inputs.name === "animichi.com");
+  assert.equal(apex.length, 4);
+  assert.equal(apex.every((r) => r.inputs.type === "CAA"), true);
+  assert.equal(apex.every((r) => r.inputs.zoneId === "zone"), true);
+  assert.equal(apex.every((r) => (r.inputs.data as { tag: string }).tag === "issue"), true);
+  const issuers = apex
+    .map((r) => (r.inputs.data as { value: string }).value)
+    .sort();
+  assert.deepEqual(issuers, [
+    "digicert.com; cansignhttpexchanges=yes",
+    "letsencrypt.org",
+    "pki.goog; cansignhttpexchanges=yes",
+    "ssl.com",
+  ]);
 });
 
 test("the www placeholder is the reserved originless address AND proxied", () => {
-  const record = only(built, DNS);
+  const record = ofType(built, DNS).find((r) => r.inputs.name === "www.animichi.com");
+  assert.ok(record, "www placeholder record missing");
   assert.equal(record.inputs.content, "192.0.2.0");
   // Unproxied, the request goes to a reserved address that answers nothing and
   // the redirect rule never runs. This is the assertion that catches that.
@@ -59,7 +76,9 @@ test("the www placeholder is the reserved originless address AND proxied", () =>
 });
 
 test("the redirect points www AT the apex, not the other way round", () => {
-  const rules = unseal(only(built, RULESET).inputs.rules).value as Record<string, unknown>[];
+  const redirect = ofType(built, RULESET).find((r) => r.name === "animichi-www-redirect");
+  assert.ok(redirect, "www redirect ruleset missing");
+  const rules = unseal(redirect.inputs.rules).value as Record<string, unknown>[];
   const rule = rules[0];
   assert.equal(
     String(rule.expression),
@@ -77,8 +96,43 @@ test("the staging WAF gate stays off on prod", () => {
   // Its own flag is unset here, but the `stack === "staging"` guard is the
   // structural one: a Block rule on the production zone is the worst thing
   // this file could emit.
-  const rulesets = ofType(built, RULESET).map((r) => r.name);
-  assert.deepEqual(rulesets, ["animichi-www-redirect"]);
+  const rulesets = ofType(built, RULESET).map((r) => r.name).sort();
+  assert.deepEqual(rulesets, ["animichi-api-rate-limit", "animichi-www-redirect"]);
+  for (const ruleset of ofType(built, RULESET)) {
+    const rules = unseal(ruleset.inputs.rules).value as { action: string }[];
+    assert.notEqual(rules[0].action, "block", `${ruleset.name} must not block`);
+  }
+});
+
+test("DNSSEC is enabled on the zone", () => {
+  assert.equal(only(built, ZONE_DNSSEC).inputs.zoneId, "zone");
+});
+
+test("the API rate limit dampens /v1 bursts on the apex", () => {
+  const ruleset = ofType(built, RULESET).find((r) => r.name === "animichi-api-rate-limit");
+  assert.ok(ruleset, "rate limit ruleset missing");
+  assert.equal(ruleset.inputs.phase, "http_ratelimit");
+  const rule = (unseal(ruleset.inputs.rules).value as Record<string, unknown>[])[0];
+  assert.equal(rule.action, "managed_challenge");
+  const ratelimit = rule.ratelimit as Record<string, unknown>;
+  assert.deepEqual(ratelimit.characteristics, ["ip.src", "cf.colo.id"]);
+  assert.equal(ratelimit.period, 10);
+  assert.equal(ratelimit.requestsPerPeriod, 60);
+  assert.equal(ratelimit.mitigationTimeout, 10);
+  assert.match(String(rule.expression), /http\.host eq "animichi\.com"/);
+  assert.match(String(rule.expression), /starts_with\(http\.request\.uri\.path, "\/v1\/"\)/);
+});
+
+test("HSTS is on with a deliberate no-preload policy", () => {
+  const setting = only(built, ZONE_SETTING);
+  assert.equal(setting.inputs.settingId, "security_header");
+  assert.equal(setting.inputs.zoneId, "zone");
+  const sts = (setting.inputs.value as Record<string, unknown>)
+    .strict_transport_security as Record<string, unknown>;
+  assert.equal(sts.enabled, true);
+  assert.equal(sts.max_age, 15552000);
+  assert.equal(sts.include_subdomains, false);
+  assert.equal(sts.preload, false);
 });
 
 test("production map bucket is private and uses the stable Wrangler name", () => {

--- a/infra/topology-prod.test.ts
+++ b/infra/topology-prod.test.ts
@@ -108,7 +108,7 @@ test("DNSSEC is enabled on the zone", () => {
   assert.equal(only(built, ZONE_DNSSEC).inputs.zoneId, "zone");
 });
 
-test("the API rate limit dampens /v1 bursts on the apex", () => {
+test("the API rate limit dampens /v1 bursts across the zone", () => {
   const ruleset = ofType(built, RULESET).find((r) => r.name === "animichi-api-rate-limit");
   assert.ok(ruleset, "rate limit ruleset missing");
   assert.equal(ruleset.inputs.phase, "http_ratelimit");
@@ -119,7 +119,10 @@ test("the API rate limit dampens /v1 bursts on the apex", () => {
   assert.equal(ratelimit.period, 10);
   assert.equal(ratelimit.requestsPerPeriod, 60);
   assert.equal(ratelimit.mitigationTimeout, 10);
-  assert.match(String(rule.expression), /http\.host eq "animichi\.com"/);
+  // Zone-scoped per PR #776: on this zone only the apex serves `/v1/*` (www
+  // 301-redirects in http_request_dynamic_redirect, before http_ratelimit),
+  // so a bare path match equals the apex match with no config coupling.
+  assert.doesNotMatch(String(rule.expression), /http\.host/, "must not match a host");
   assert.match(String(rule.expression), /starts_with\(http\.request\.uri\.path, "\/v1\/"\)/);
 });
 

--- a/infra/topology-staging-invalid-ip.test.ts
+++ b/infra/topology-staging-invalid-ip.test.ts
@@ -29,7 +29,10 @@ const built: Built[] = await buildStack("staging", {
 const { buildIpClause } = await import("./index.ts");
 
 test("the gate ruleset still builds when the allowlist is absent", () => {
-  assert.equal(ofType(built, RULESET).length, 1);
+  const gates = ofType(built, RULESET).filter(
+    (r) => r.inputs.phase === "http_request_firewall_custom",
+  );
+  assert.equal(gates.length, 1);
 });
 
 test("buildIpClause throws on a non-IP entry", () => {

--- a/infra/topology-staging.test.ts
+++ b/infra/topology-staging.test.ts
@@ -22,6 +22,8 @@ const CUSTOM_DOMAIN = "cloudflare:index/workersCustomDomain:WorkersCustomDomain"
 const ROUTE = "cloudflare:index/workersRoute:WorkersRoute";
 const DNS = "cloudflare:index/dnsRecord:DnsRecord";
 const RULESET = "cloudflare:index/ruleset:Ruleset";
+const ZONE_DNSSEC = "cloudflare:index/zoneDnssec:ZoneDnssec";
+const ZONE_SETTING = "cloudflare:index/zoneSetting:ZoneSetting";
 
 test("staging targets the stack-suffixed Workers, not the production ones", () => {
   const domain = only(built, CUSTOM_DOMAIN);
@@ -48,13 +50,25 @@ test("staging gets the SAME API and map routes as prod", () => {
 });
 
 test("no www placeholder and no redirect on staging", () => {
-  assert.deepEqual(ofType(built, DNS), []);
-  const rulesets = ofType(built, RULESET).map((r) => r.name);
-  assert.deepEqual(rulesets, ["staging-access-gate"]);
+  assert.deepEqual(ofType(built, DNS).filter((r) => r.inputs.name === "www.animichi.com"), []);
+  const rulesets = ofType(built, RULESET).map((r) => r.name).sort();
+  assert.deepEqual(rulesets, ["animichi-api-rate-limit", "staging-access-gate"]);
+});
+
+test("the apex CAA issuers pin the staging host, not prod's", () => {
+  const caa = ofType(built, DNS).filter((r) => r.inputs.type === "CAA");
+  assert.equal(caa.length, 4);
+  for (const record of caa) {
+    assert.equal(record.inputs.name, "staging.animichi.com");
+    assert.equal(record.inputs.zoneId, "zone");
+    assert.equal((record.inputs.data as { tag: string }).tag, "issue");
+  }
 });
 
 test("the WAF gate blocks, and matches the staging host", () => {
-  const rules = unseal(only(built, RULESET).inputs.rules).value as Record<string, unknown>[];
+  const gate = ofType(built, RULESET).find((r) => r.name === "staging-access-gate");
+  assert.ok(gate, "staging access gate missing");
+  const rules = unseal(gate.inputs.rules).value as Record<string, unknown>[];
   assert.equal(rules[0].action, "block");
   const expression = String(rules[0].expression);
   assert.match(expression, /http\.host eq "staging\.animichi\.com"/);
@@ -80,7 +94,18 @@ test("the gate rule is sealed as a SECRET before it reaches state", () => {
   // fails this test. That is the correct sensitivity for a defence-in-depth
   // invariant: it asserts the property (sealed), not either mechanism, so
   // refactoring one away stays green while actually losing the seal goes red.
-  assert.equal(unseal(only(built, RULESET).inputs.rules).isSecret, true);
+  const gate = ofType(built, RULESET).find((r) => r.name === "staging-access-gate");
+  assert.ok(gate, "staging access gate missing");
+  assert.equal(unseal(gate.inputs.rules).isSecret, true);
+});
+
+test("zone hardening applies to staging too", () => {
+  assert.equal(only(built, ZONE_DNSSEC).inputs.zoneId, "zone");
+  const setting = only(built, ZONE_SETTING);
+  assert.equal(setting.inputs.settingId, "security_header");
+  const sts = (setting.inputs.value as Record<string, unknown>)
+    .strict_transport_security as Record<string, unknown>;
+  assert.equal(sts.include_subdomains, false);
 });
 
 test("an ordinary input on this same stack is NOT sealed", () => {

--- a/infra/topology-staging.test.ts
+++ b/infra/topology-staging.test.ts
@@ -52,17 +52,13 @@ test("staging gets the SAME API and map routes as prod", () => {
 test("no www placeholder and no redirect on staging", () => {
   assert.deepEqual(ofType(built, DNS).filter((r) => r.inputs.name === "www.animichi.com"), []);
   const rulesets = ofType(built, RULESET).map((r) => r.name).sort();
-  assert.deepEqual(rulesets, ["animichi-api-rate-limit", "staging-access-gate"]);
+  assert.deepEqual(rulesets, ["staging-access-gate"]);
 });
 
-test("the apex CAA issuers pin the staging host, not prod's", () => {
-  const caa = ofType(built, DNS).filter((r) => r.inputs.type === "CAA");
-  assert.equal(caa.length, 4);
-  for (const record of caa) {
-    assert.equal(record.inputs.name, "staging.animichi.com");
-    assert.equal(record.inputs.zoneId, "zone");
-    assert.equal((record.inputs.data as { tag: string }).tag, "issue");
-  }
+test("staging declares no CAA records — prod owns the zone certificates", () => {
+  // PR #776: zone hardening is prod-only. A staging CAA record would pin a
+  // hostname on the same zone the prod stack manages.
+  assert.deepEqual(ofType(built, DNS).filter((r) => r.inputs.type === "CAA"), []);
 });
 
 test("the WAF gate blocks, and matches the staging host", () => {
@@ -99,13 +95,15 @@ test("the gate rule is sealed as a SECRET before it reaches state", () => {
   assert.equal(unseal(gate.inputs.rules).isSecret, true);
 });
 
-test("zone hardening applies to staging too", () => {
-  assert.equal(only(built, ZONE_DNSSEC).inputs.zoneId, "zone");
-  const setting = only(built, ZONE_SETTING);
-  assert.equal(setting.inputs.settingId, "security_header");
-  const sts = (setting.inputs.value as Record<string, unknown>)
-    .strict_transport_security as Record<string, unknown>;
-  assert.equal(sts.include_subdomains, false);
+test("staging owns none of the zone-hardening resources", () => {
+  // PR #776: prod is the single owner of zone metadata. Two stacks declaring
+  // the same zone resources (DNSSEC, security header, rate-limit ruleset)
+  // would fight over them on `pulumi up`, so staging must expect NONE of them
+  // even with zoneId and routes configured.
+  assert.deepEqual(ofType(built, ZONE_DNSSEC), []);
+  assert.deepEqual(ofType(built, ZONE_SETTING), []);
+  const rateLimit = ofType(built, RULESET).find((r) => r.name === "animichi-api-rate-limit");
+  assert.equal(rateLimit, undefined, "staging must not declare the rate-limit ruleset");
 });
 
 test("an ordinary input on this same stack is NOT sealed", () => {


### PR DESCRIPTION
prod 安全评审的 DNS/IP 层四项(零秘密,全 zone 元数据):

- **DNSSEC** 开启
- **CAA**:签证书权限钉死到 CF Universal SSL 伙伴 CA
- **限速**:Free 档仅有的 1 条 http_ratelimit 用在 /v1 洪峰(60req/10s/IP → managed_challenge);细粒度控制仍归 Turnstile+配额
- **HSTS** 180 天,不含 preload(近不可逆,注释言明)与子域

验证:infra typecheck clean、topology 22/22(新资源断言已入拓扑测试)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Production environments now include enhanced DNS and web security protections, including DNSSEC, security headers, CAA records, and API rate limiting.
  - These protections are enabled only when the required production configuration is provided.

- **Bug Fixes**
  - Improved staging and production topology validation.
  - Prevented staging configurations from inadvertently enabling production-only hardening.
  - More accurately validates firewall rules and DNS records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->