### PR TITLE
infra: hold webRoutesEnabled — Pulumi token lacks route/domain scopes

### DIFF
--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -1,7 +1,8 @@
 config:
   # Same Cloudflare account as prod (already committed in Pulumi.prod.yaml).
   seichijunrei-infra:cloudflareAccountId: 021233c1880a43aa68565496100e1f8c
-  seichijunrei-infra:webRoutesEnabled: "true"
+  # false until CLOUDFLARE_PULUMI_API_TOKEN gains Workers Routes + Custom Domains permissions (2026-08-05 401s, run 30939789276)
+  seichijunrei-infra:webRoutesEnabled: "false"
   seichijunrei-infra:cloudflareZoneId: 44fdcc54545c1152a8e730137b671be4
   seichijunrei-infra:stagingDomain: staging.animichi.com
   #

--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -6,11 +6,12 @@ config:
   seichijunrei-infra:cloudflareZoneId: 44fdcc54545c1152a8e730137b671be4
   seichijunrei-infra:stagingDomain: staging.animichi.com
   #
-  # ── Hostname cutover (#541), ENABLED 2026-08-05 ─────────────────────────────
-  # `webRoutesEnabled` PUBLISHED staging: it created the Custom Domain and the
-  # /v1, /img, /healthz edge routes together. One flag on purpose — a hostname
-  # that resolves before its routes are narrowed answers a browser navigation
-  # with the edge Worker's JSON 404.
+  # ── Hostname cutover (#541), PREPARED but held 2026-08-05 ────────────────────────
+  # cutover PREPARED but held (token scopes pending, see the flag comment
+  # above); flipping the flag publishes. `webRoutesEnabled` creates the Custom
+  # Domain and the /v1, /img, /healthz edge routes together. One flag on
+  # purpose — a hostname that resolves before its routes are narrowed answers a
+  # browser navigation with the edge Worker's JSON 404.
   #
   #   pulumi config set webRoutesEnabled true                   --stack staging
   #   pulumi config set cloudflareZoneId <animichi.com zone id> --stack staging


### PR DESCRIPTION
决胜部署(run 30939789276)在 WorkersRoute/WorkersCustomDomain 创建上 401:#674 最小权限拆分的 `CLOUDFLARE_PULUMI_API_TOKEN` 早于路由启用,缺 Zone:Workers Routes + Account:Workers Custom Domains 权限。

flag 翻回 false 止损:部署链恢复,#694 冷启动修复得以 smoke 验证;zoneId/stagingDomain 保留就位,owner 在控制台给 token 补两个权限后一行翻回。

🤖 Generated with [Claude Code](https://claude.com/claude-code)