### PR TITLE
ci: smoke budget covers the container's first cold start (~200s ceiling)

### DIFF
--- a/.github/workflows/reusable-deploy-component.yml
+++ b/.github/workflows/reusable-deploy-component.yml
@@ -724,7 +724,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # First cold start after an image change takes minutes; base 12 →
-          # sleep budget 12*(1+2+3+4)=120s plus 4×20s request timeouts ≈ 200s ceiling, still bounded.
+          # sleep budget 12*(1+2+3+4)=120s plus 5×20s request timeouts ≈ 220s ceiling, still bounded.
           POST_DEPLOY_ASSERT_RETRY_BACKOFF_BASE_SECONDS: "12"
         shell: bash
         run: |

--- a/.github/workflows/reusable-deploy-component.yml
+++ b/.github/workflows/reusable-deploy-component.yml
@@ -723,6 +723,9 @@ jobs:
           ENVIRONMENT: ${{ inputs.environment }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # First cold start after an image change takes minutes; base 12 →
+          # sleep budget 12*(1+2+3+4)=120s plus 4×20s request timeouts ≈ 200s ceiling, still bounded.
+          POST_DEPLOY_ASSERT_RETRY_BACKOFF_BASE_SECONDS: "12"
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
run 30941358447 的验尸:root /healthz 在 smoke 放弃 60 秒后回 200(现已稳定 200,git_commit 真实上报——#694 修复与 #494 bake 双双验证生效)。差的只是窗口:首次冷启动(镜像拉取+启动)≈2-3 分钟 > smoke ~130s 预算。退避基数 5→12,上限 ~200s,仍有界。

🤖 Generated with [Claude Code](https://claude.com/claude-code)