### PR TITLE
infra(#541): re-enable staging.animichi.com (token scopes granted)

### DIFF
--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -8,7 +8,7 @@ config:
   #
   # ── Hostname cutover (#541), ENABLED 2026-08-05 ────────────────────────
   # Flipping the flag publishes. `webRoutesEnabled` creates the Custom
-  # Domain and the /v1, /img, /healthz edge routes together. One flag on
+  # Domain and the /v1, /img, /tiles, /healthz edge routes together. One flag on
   # purpose — a hostname that resolves before its routes are narrowed answers a
   # browser navigation with the edge Worker's JSON 404.
   #

--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -1,14 +1,13 @@
 config:
   # Same Cloudflare account as prod (already committed in Pulumi.prod.yaml).
   seichijunrei-infra:cloudflareAccountId: 021233c1880a43aa68565496100e1f8c
-  # false until CLOUDFLARE_PULUMI_API_TOKEN gains Workers Routes + Custom Domains permissions (2026-08-05 401s, run 30939789276)
-  seichijunrei-infra:webRoutesEnabled: "false"
+  # re-enabled 2026-08-05: token gained Workers Routes (zone) + Workers Scripts (account) edit scopes
+  seichijunrei-infra:webRoutesEnabled: "true"
   seichijunrei-infra:cloudflareZoneId: 44fdcc54545c1152a8e730137b671be4
   seichijunrei-infra:stagingDomain: staging.animichi.com
   #
-  # ── Hostname cutover (#541), PREPARED but held 2026-08-05 ────────────────────────
-  # cutover PREPARED but held (token scopes pending, see the flag comment
-  # above); flipping the flag publishes. `webRoutesEnabled` creates the Custom
+  # ── Hostname cutover (#541), ENABLED 2026-08-05 ────────────────────────
+  # Flipping the flag publishes. `webRoutesEnabled` creates the Custom
   # Domain and the /v1, /img, /healthz edge routes together. One flag on
   # purpose — a hostname that resolves before its routes are narrowed answers a
   # browser navigation with the edge Worker's JSON 404.


### PR DESCRIPTION
owner 已给 `CLOUDFLARE_PULUMI_API_TOKEN` 补 Workers Routes(zone)+ Workers Scripts(account)权限;`webRoutesEnabled` 翻回 true。合并→staging 部署建 Custom Domain 与 edge 路由,URL 解析自动切换。前次 401 见 run 30939789276(#777 为止损)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Re-enabled web routes in the staging environment.
  * Updated deployment notes to reflect the active routing configuration and required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->