### PR TITLE
ci(#750): integration coverage uploads to codecov (flagged + carryforward)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,7 @@ jobs:
         # No --cov-fail-under here: the enforced floor belongs to the unit arm
         # (apps/agent/pyproject.toml); the integration arm alone is legitimately
         # far below it. Coverage is uploaded to codecov under the integration flag.
-        run: uv run --frozen pytest agent/tests/integration -q --cov --cov-report=xml --cov-fail-under=0
+        run: uv run --frozen --no-build --no-binary-package animichi pytest agent/tests/integration -q --cov --cov-report=xml --cov-fail-under=0
 
       - name: Upload coverage (integration)
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,7 +482,18 @@ jobs:
       - name: Run Neon integration tests
         env:
           TEST_DB: neon
-        run: uv run --frozen pytest agent/tests/integration -q --no-cov
+        # No --cov-fail-under here: the enforced floor belongs to the unit arm
+        # (apps/agent/pyproject.toml); the integration arm alone is legitimately
+        # far below it. Coverage is uploaded to codecov under the integration flag.
+        run: uv run --frozen pytest agent/tests/integration -q --cov --cov-report=xml --cov-fail-under=0
+
+      - name: Upload coverage (integration)
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: apps/agent/coverage.xml
+          fail_ci_if_error: true
+          use_oidc: true
+          flags: integration
 
   catalog-spikes:
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # codecov OIDC upload needs id-token
     needs: changes
     if: >-
       ${{

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -68,11 +68,12 @@ jobs:
           inputs: apps/${{ inputs.app }}
 
       # No --cov-fail-under here on purpose: a CLI value OVERRIDES the addopts in
-      # apps/agent/pytest.ini, so the hardcoded 80 meant CI enforced 80 while the
-      # repo's ratcheted floor (82, now 88) applied only to local `make test`.
-      # The two gates disagreed silently, and the ratchet rule was paper-only.
-      # The floor now lives in exactly one place: apps/agent/pytest.ini.
-      - name: Unit tests (coverage floor from apps/agent/pytest.ini)
+      # apps/agent/pyproject.toml [tool.pytest.ini_options], so a hardcoded 80
+      # meant CI enforced 80 while the repo's ratcheted floor (82, now 88) applied
+      # only to local `make test`. The two gates disagreed silently, and the
+      # ratchet rule was paper-only. The floor now lives in exactly one place:
+      # apps/agent/pyproject.toml.
+      - name: Unit tests (coverage floor from apps/agent/pyproject.toml)
         run: uv run --frozen pytest agent/tests/unit/ -v --cov --cov-report=xml
 
       - name: Upload coverage
@@ -81,3 +82,4 @@ jobs:
           files: apps/${{ inputs.app }}/coverage.xml
           fail_ci_if_error: true
           use_oidc: true
+          flags: unit

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
+flag_management:
+  individual_flags:
+    - name: integration
+      carryforward: true
+    - name: unit
+      carryforward: true
+
 coverage:
   status:
     # Project status = global floor (informational; per-component floors are


### PR DESCRIPTION
Closes #750。

- Neon 集成 job:`--no-cov` → `--cov --cov-report=xml --cov-fail-under=0`(地板归 unit 臂,注释言明)+ codecov 上传 `flags: integration`
- unit 上传补 `flags: unit`
- codecov.yml 增 flag carryforward——条件触发的集成 job 不跑时不再显示覆盖暴跌
- 顺手清 reusable-python-ci 两处 pytest.ini 陈旧注释

验证:actionlint clean、test:worker 266/266、codecov.io/validate → Valid!

🤖 Generated with [Claude Code](https://claude.com/claude-code)