### PR TITLE
ci: install hardening — uv --no-build + semgrep pin (S8541/S8544)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,4 +19,5 @@ runs:
     - if: inputs.python == 'true'
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
+        version: "0.11.14"
         prune-cache: "true"

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -39,12 +39,10 @@ jobs:
 
       - run: uv python install ${{ env.PYTHON_VERSION }}
 
-      # --no-build is deliberately not added here: this project's own editable
-      # package has no wheel, so a blanket --no-build refuses to install it
-      # ("marked as --no-build but has no binary distribution", verified
-      # locally against the pinned uv). See purge-anonymous-sessions.yml's
-      # NOTE (review round 2) for the same finding on the same project.
-      - run: uv sync --frozen --all-extras
+      # Sonar S8541: --no-build blocks third-party sdist builds (setup-script
+      # execution); --no-binary-package animichi exempts the project's own
+      # wheel-less editable install, which blanket --no-build rejects (uv #17416).
+      - run: uv sync --frozen --all-extras --no-build --no-binary-package animichi
 
       - name: Ruff lint
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -85,8 +85,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # Pin the uv binary itself — the flags this file relies on are version-sensitive.
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          version: "0.11.14"
           enable-cache: false
           prune-cache: true
       # --locked pins to the committed script lockfile; --no-build refuses to
@@ -138,6 +140,7 @@ jobs:
       - name: Install zizmor
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          version: "0.11.14"
           # setup-uv's own cache defaults to auto-on and is read-write, which
           # zizmor's cache-poisoning audit rejects in this workflow. zizmor is a
           # single small download; the uv cache buys nothing here.

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -204,7 +204,9 @@ jobs:
         run: uv tool install --no-build "semgrep==$SEMGREP_VERSION"
         shell: bash
       - name: Run Semgrep
-        run: uv tool run --no-build semgrep --config p/python --config p/typescript --config p/javascript --error .
+        # Sonar S8544: run line must carry the version too (uv tool run is an
+        # on-demand install when absent); follows the zizmor@"$VERSION" pattern.
+        run: uv tool run --no-build semgrep@"$SEMGREP_VERSION" --config p/python --config p/typescript --config p/javascript --error . # v1.172.0
         shell: bash
 
   # ── SQL migration lint ───────────────────────────────────────
@@ -223,12 +225,13 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           python: "true"
-      # --no-build rejected: this project's own editable package has no wheel
-      # (see purge-anonymous-sessions.yml's NOTE and reusable-python-ci.yml).
-      - run: uv sync --frozen --all-extras
+      # Sonar S8541: --no-build blocks third-party sdist builds (setup-script
+      # execution); --no-binary-package animichi exempts the project's own
+      # wheel-less editable install, which blanket --no-build rejects (uv #17416).
+      - run: uv sync --frozen --all-extras --no-build --no-binary-package animichi
       # .sqlfluff config lives at repo root; lint the schema dirs we own.
       - name: Lint migrations (postgres dialect)
-        run: uv run --frozen sqlfluff lint ../../db/migrations ../../supabase/neon --dialect postgres
+        run: uv run --frozen --no-build --no-binary-package animichi sqlfluff lint ../../db/migrations ../../supabase/neon --dialect postgres
 
   # ── Deploy-gate script tests ─────────────────────────────────
 


### PR DESCRIPTION
#768 判定时挂账的 Sonar 批次。

- 两个 reusable workflow 的 `uv sync` 加 `--no-build --no-binary-package animichi`:第三方 sdist 的 setup 脚本被禁,自家包照常构建(实测:sync 成功 + 1739 unit tests 全绿;写法经 Sonar 门实证)
- semgrep 版本钉死(S8544),沿用 zizmor 的 `tool@version` 惯例

验证:actionlint clean、test:worker 266/266。

🤖 Generated with [Claude Code](https://claude.com/claude-code)