### PR TITLE
infra(#769): staging gate secrets (encrypted config) land

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,15 +275,21 @@ jobs:
             echo "ready=false" >> "$GITHUB_OUTPUT"
             echo "::warning title=pulumi preview skipped::Pulumi preview prerequisites are not fully configured; missing: ${missing[*]}. The deploy path will still take a pre-up state backup, but infra changes merge without a plan diff."
           fi
-      - name: Pulumi preview (staging)
+      # Installs the Pulumi CLI onto PATH without running a command (omitting
+      # `command:` is the documented install-only mode) so the plain `pulumi`
+      # steps below can use it.
+      - name: Install Pulumi CLI
         if: ${{ steps.pulumi_gate.outputs.ready == 'true' }}
         uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7.0.0
-        with:
-          command: preview
-          stack-name: staging
-          work-dir: infra
-          # Self-managed S3/R2 backend — without this the action demands a Pulumi Cloud token.
-          cloud-url: ${{ secrets.PULUMI_BACKEND_URL }}
+      - name: Pulumi preview (staging)
+        if: ${{ steps.pulumi_gate.outputs.ready == 'true' }}
+        working-directory: infra
+        # pulumi/actions' automation-api login chokes on the query-string s3:// R2
+        # backend URL ('unknown backend cloudUrl format'); the CLI login is the same proven path the deploy uses.
+        run: |
+          pulumi login "$PULUMI_BACKEND_URL"
+          pulumi stack select staging
+          pulumi preview --non-interactive --diff
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PULUMI_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,8 @@ jobs:
           command: preview
           stack-name: staging
           work-dir: infra
+          # Self-managed S3/R2 backend — without this the action demands a Pulumi Cloud token.
+          cloud-url: ${{ secrets.PULUMI_BACKEND_URL }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PULUMI_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -41,3 +41,9 @@ config:
   # ── Data plane ──────────────────────────────────────────────────────────────
   # catalogDatabaseUrl is a secret — set it per stack, never commit the raw value:
   #   pulumi config set --secret catalogDatabaseUrl "<neon staging branch connstr>" --stack staging
+
+  seichijunrei-infra:stagingAllowedIps:
+    secure: v1:JdIOD3OKFdVIeY0k:tUp/2ewVRnvCWIAUckYhbEkntw0N3AKGwk0M+22rG9/BmQ==
+  seichijunrei-infra:stagingGateToken:
+    secure: v1:JKZcAEWw0x0uHQ+g:2k4G1a7NLuYjkiIVfFmy/2zs6qYcuQqG1FGPW29+8tDXArzLF/quxiqs/LxArvfNmNlnWvAjvyjzIs5kkAVNLT9ooz2tzFLAQwMEaS+Lr6c=
+encryptionsalt: v1:bb6ougr5yww=:v1:MPqbekIeu662Z0D8:6ttvr6yA1zxnpD2CdbOXThJW9rHwfA==


### PR DESCRIPTION
方案 B(owner 已批)执行:派生 S3 凭证登 Pulumi 后端,`stagingAllowedIps`(我们的出口 /32)与 `stagingGateToken` 以 passphrase 密文写入 staging stack;同 token 已入 `STAGING_GATE_TOKEN`(staging environment secret)供 CI E2E。`stagingGateEnabled` 保持 off——与 workers_dev 关闭在 #541 step 6 收口 PR 一起翻,两扇门同时关。

密文安全性:仓库公开但值为 passphrase 加密 `secure:` 密文,与既有 secrets 同等级。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging environment configuration with encrypted access controls and gate credentials.
  * Refreshed the encrypted configuration salt for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->