### PR TITLE
fix(agent): lifespan robustness — post-merge review round of #773

### DIFF
--- a/apps/agent/agent/interfaces/fastapi_service.py
+++ b/apps/agent/agent/interfaces/fastapi_service.py
@@ -98,6 +98,26 @@ def _resolve_session_store(
     )
 
 
+async def _close_runtime_resources(
+    connect_task: asyncio.Task[object],
+    catalog_client: CatalogClient,
+    runtime_session_store: SessionStore,
+    runtime_db: object,
+) -> None:
+    """Close runtime resources; every close attempt still runs."""
+    try:
+        await connect_task
+    finally:
+        try:
+            await catalog_client.aclose()
+        finally:
+            await aclose_geocoding_client()
+        try:
+            await call_optional_async(runtime_session_store, "close")
+        finally:
+            await call_optional_async(runtime_db, "close")
+
+
 @asynccontextmanager
 async def _lifespan_build_runtime(
     app: FastAPI,
@@ -109,12 +129,6 @@ async def _lifespan_build_runtime(
     """Lifespan branch: build RuntimeAPI from scratch (normal startup)."""
     runtime_db = db if db is not None else build_supabase_client(resolved_settings)
     runtime_session_store = _resolve_session_store(session_store, runtime_db)
-    # The pool connect must not gate the container's readiness (issue #694):
-    # it runs in the background so the port binds immediately. Until it
-    # completes, DB work surfaces the client's "call connect() first" as a
-    # clean 500 — see RuntimeAPI's lazy-repo comment in public_api.py.
-    connect_task = asyncio.create_task(call_optional_async(runtime_db, "connect"))
-    connect_task.add_done_callback(_log_connect_failure)
     # Schema changes are never applied by the application. Neon catalog/user migrations run
     # through Atlas from db/migrations; the remaining Supabase compatibility surface has its
     # own operator path. See docs/ops/migrations.md.
@@ -129,18 +143,18 @@ async def _lifespan_build_runtime(
         memory_store=postgres_memory_store(runtime_db),
     )
     app.state.db_client = runtime_db
+    # The pool connect must not gate the container's readiness (issue #694):
+    # it runs in the background so the port binds immediately. Until it
+    # completes, DB work surfaces the client's "call connect() first" as a
+    # clean 500 — see RuntimeAPI's lazy-repo comment in public_api.py.
+    connect_task = asyncio.create_task(call_optional_async(runtime_db, "connect"))
+    connect_task.add_done_callback(_log_connect_failure)
     try:
         yield
     finally:
-        try:
-            await connect_task
-        finally:
-            try:
-                await catalog_client.aclose()
-            finally:
-                await aclose_geocoding_client()
-            await call_optional_async(runtime_session_store, "close")
-            await call_optional_async(runtime_db, "close")
+        await _close_runtime_resources(
+            connect_task, catalog_client, runtime_session_store, runtime_db
+        )
 
 
 def create_fastapi_app(

--- a/apps/agent/agent/interfaces/fastapi_service.py
+++ b/apps/agent/agent/interfaces/fastapi_service.py
@@ -98,6 +98,25 @@ def _resolve_session_store(
     )
 
 
+async def _close_clients(catalog_client: CatalogClient) -> None:
+    """Close catalog then geocoding clients; both attempts run."""
+    try:
+        await catalog_client.aclose()
+    finally:
+        await aclose_geocoding_client()
+
+
+async def _close_stores(
+    runtime_session_store: SessionStore,
+    runtime_db: object,
+) -> None:
+    """Close session store then db; both attempts run."""
+    try:
+        await call_optional_async(runtime_session_store, "close")
+    finally:
+        await call_optional_async(runtime_db, "close")
+
+
 async def _close_runtime_resources(
     connect_task: asyncio.Task[object],
     catalog_client: CatalogClient,
@@ -109,13 +128,9 @@ async def _close_runtime_resources(
         await connect_task
     finally:
         try:
-            await catalog_client.aclose()
+            await _close_clients(catalog_client)
         finally:
-            await aclose_geocoding_client()
-        try:
-            await call_optional_async(runtime_session_store, "close")
-        finally:
-            await call_optional_async(runtime_db, "close")
+            await _close_stores(runtime_session_store, runtime_db)
 
 
 @asynccontextmanager

--- a/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
+++ b/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
@@ -21,6 +21,7 @@ from agent.infrastructure.supabase.client import SupabaseClient
 from agent.interfaces import fastapi_service
 from agent.interfaces.fastapi_service import (
     _call_optional_async,
+    _close_runtime_resources,
     _contains_json_invalid_error,
     _http_error_code,
     create_fastapi_app,
@@ -228,6 +229,30 @@ async def test_call_optional_async_ignores_missing_method() -> None:
     await _call_optional_async(target, "close")
 
 
+@pytest.mark.asyncio
+async def test_close_runtime_resources_isolates_close_failures() -> None:
+    """A failing session-store close must not skip the db close."""
+    events: list[str] = []
+
+    async def session_close() -> None:
+        events.append("session")
+        raise RuntimeError("session close failed")
+
+    db = MagicMock()
+    db.close = AsyncMock(side_effect=lambda: events.append("db"))
+    catalog = MagicMock()
+    catalog.aclose = AsyncMock(side_effect=lambda: events.append("catalog"))
+    session_store = MagicMock()
+    session_store.close = session_close
+    connect_task = asyncio.create_task(asyncio.sleep(0))
+
+    with pytest.raises(RuntimeError, match="session close failed"):
+        await _close_runtime_resources(connect_task, catalog, session_store, db)
+
+    assert events == ["catalog", "session", "db"]
+
+
+@staticmethod
 def test_lifespan_startup_does_not_block_on_db_connect() -> None:
     """Issue #694: the pool connect runs in the background, not before yield.
 

--- a/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
+++ b/apps/agent/agent/tests/unit/test_fastapi_service_helpers.py
@@ -229,27 +229,66 @@ async def test_call_optional_async_ignores_missing_method() -> None:
     await _call_optional_async(target, "close")
 
 
-@pytest.mark.asyncio
-async def test_close_runtime_resources_isolates_close_failures() -> None:
-    """A failing session-store close must not skip the db close."""
+def _closable_mock(events: list[str], tag: str, attr: str = "close") -> AsyncMock:
+    """Build a mock whose close method records ``tag`` into ``events``."""
+    mock = AsyncMock()
+    setattr(mock, attr, AsyncMock(side_effect=lambda: events.append(tag)))
+    return mock
+
+
+def _failing_close(events: list[str], tag: str, message: str) -> AsyncMock:
+    """Record ``tag`` then raise, so the attempted close is observable."""
+
+    def record_and_fail() -> None:
+        events.append(tag)
+        raise RuntimeError(message)
+
+    return AsyncMock(side_effect=record_and_fail)
+
+
+def _close_stub_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[str], asyncio.Task[object], AsyncMock, AsyncMock, AsyncMock]:
+    """Build _close_runtime_resources stubs recording close order."""
     events: list[str] = []
-
-    async def session_close() -> None:
-        events.append("session")
-        raise RuntimeError("session close failed")
-
-    db = MagicMock()
-    db.close = AsyncMock(side_effect=lambda: events.append("db"))
-    catalog = MagicMock()
-    catalog.aclose = AsyncMock(side_effect=lambda: events.append("catalog"))
-    session_store = MagicMock()
-    session_store.close = session_close
+    catalog = _closable_mock(events, "catalog", "aclose")
+    monkeypatch.setattr(
+        fastapi_service,
+        "aclose_geocoding_client",
+        AsyncMock(side_effect=lambda: events.append("geocoding")),
+    )
+    session_store = _closable_mock(events, "session")
+    db = _closable_mock(events, "db")
     connect_task = asyncio.create_task(asyncio.sleep(0))
+    return events, connect_task, catalog, session_store, db
+
+
+@pytest.mark.asyncio
+async def test_close_runtime_resources_isolates_close_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing session-store close must not skip the db close."""
+    events, connect_task, catalog, session_store, db = _close_stub_bundle(monkeypatch)
+    session_store.close = _failing_close(events, "session", "session close failed")
 
     with pytest.raises(RuntimeError, match="session close failed"):
         await _close_runtime_resources(connect_task, catalog, session_store, db)
 
-    assert events == ["catalog", "session", "db"]
+    assert events == ["catalog", "geocoding", "session", "db"]
+
+
+@pytest.mark.asyncio
+async def test_close_runtime_resources_catalog_failure_still_closes_stores(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing catalog close must not skip geocoding/session/db closes."""
+    events, connect_task, catalog, session_store, db = _close_stub_bundle(monkeypatch)
+    catalog.aclose = _failing_close(events, "catalog", "catalog close failed")
+
+    with pytest.raises(RuntimeError, match="catalog close failed"):
+        await _close_runtime_resources(connect_task, catalog, session_store, db)
+
+    assert events == ["catalog", "geocoding", "session", "db"]
 
 
 @staticmethod


### PR DESCRIPTION
coderabbit 合并后 13 秒补评的两条实质项(复盘见 #773 评论区):

1. connect_task 建于可失败的构造之前 → 构造抛出时泄漏未 await 任务;现移至构造成功后
2. shutdown 关闭链未逐一隔离 → session-store close 失败会跳过 db close;现 `_close_runtime_resources` 嵌套 finally 保证每个 close 都执行

验证:1740 passed、typecheck clean、lint clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)