### PR TITLE
infra(#541): staging 免浏览器挑战 — IP 闸接管防护(Track 0.1)

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -362,6 +362,40 @@ if (stagingGateEnabled && stack === "staging") {
   });
 }
 
+// ── Staging: per-host config settings (CI smoke) ─────────────────────────────
+// The IP-allowlist gate above is the staging hostname's protection. The WAF's
+// browser-facing defenses would fight it here: a Browser Integrity Check (BIC)
+// or Security Level challenge on the staging host makes the Playwright smoke
+// suite (and any curl) answer a challenge instead of the app. One zone-scoped
+// ruleset turns both off for the staging hostname only — every other hostname
+// on the zone keeps the defaults. Gated on the web routes so preview stacks
+// stay clean: this is meaningful only where the staging hostname actually
+// serves the app.
+if (webRoutesEnabled && stack === "staging") {
+  const settingsZoneId = config.require("cloudflareZoneId");
+  const settingsDomain = config.require("stagingDomain");
+
+  new cloudflare.Ruleset("staging-http-config-settings", {
+    zoneId: settingsZoneId,
+    name: "staging http config settings",
+    kind: "zone",
+    phase: "http_config_settings",
+    description: "Per-host config overrides for the staging hostname.",
+    rules: [
+      {
+        action: "set_config",
+        expression: `http.host eq "${settingsDomain}"`,
+        description: "staging: CI smoke must not be browser-challenged; the IP-allowlist gate owns protection here",
+        enabled: true,
+        actionParameters: {
+          bic: false,
+          securityLevel: "essentially_off",
+        },
+      },
+    ],
+  });
+}
+
 
 export const wave0 = pulumi.output("spike-validated");
 export const catalogBucketName = catalogMediaBucket.name;

--- a/infra/topology-staging.test.ts
+++ b/infra/topology-staging.test.ts
@@ -52,7 +52,7 @@ test("staging gets the SAME API and map routes as prod", () => {
 test("no www placeholder and no redirect on staging", () => {
   assert.deepEqual(ofType(built, DNS).filter((r) => r.inputs.name === "www.animichi.com"), []);
   const rulesets = ofType(built, RULESET).map((r) => r.name).sort();
-  assert.deepEqual(rulesets, ["staging-access-gate"]);
+  assert.deepEqual(rulesets, ["staging-access-gate", "staging-http-config-settings"]);
 });
 
 test("staging declares no CAA records — prod owns the zone certificates", () => {
@@ -74,6 +74,18 @@ test("the WAF gate blocks, and matches the staging host", () => {
   // exchange path passes through ahead of any future endpoint existing.
   assert.match(expression, /not \(ip\.src in \{1\.2\.3\.4 203\.0\.113\.0\/24\}\)/);
   assert.match(expression, /not \(http\.request\.uri\.path eq "\/staging-gate\/exchange"\)/);
+});
+
+test("staging builds exactly one http_config_settings ruleset with bic=false", () => {
+  const settings = ofType(built, RULESET).filter((r) => r.inputs.phase === "http_config_settings");
+  assert.equal(settings.length, 1);
+  const rule = (unseal(settings[0].inputs.rules).value as Record<string, unknown>[])[0];
+  assert.equal(rule.action, "set_config");
+  assert.equal(String(rule.expression), 'http.host eq "staging.animichi.com"');
+  const params = rule.actionParameters as Record<string, unknown>;
+  assert.equal(params.bic, false);
+  assert.equal(params.securityLevel, "essentially_off");
+  assert.equal(settings[0].inputs.zoneId, "zone");
 });
 
 test("the gate rule is sealed as a SECRET before it reaches state", () => {


### PR DESCRIPTION
main push 的 smoke 被 CF「Just a moment」挑战页拦成 403(GHA 数据中心 IP 触发 BIC/security level)。staging stack 持有的 http_config_settings 规则对 staging 主机关闭 BIC + security level(先例:gate ruleset 同为 staging 持有的 zone 级规则);该主机的真实防护 = #541 IP 白名单闸(step 6 随后收口)。topology 测试锁 bic=false。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated staging web traffic protections to prevent unnecessary Browser Integrity Check and security-level challenges.
  * Preserved the existing staging web application firewall protections.

* **Tests**
  * Added validation to ensure the staging security configuration targets the correct hostname and zone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->