### PR TITLE
S0-v2 B3 — supply-chain toggles: repo-level CF token cleanup runbook + sha-pinning assertion.

### DIFF
--- a/.github/scripts/check-actions-pinned.sh
+++ b/.github/scripts/check-actions-pinned.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # Supply-chain pinning gate (S0-v2 B3): every `uses:` in
-# .github/workflows/*.yml and .github/actions/**/*.yml must reference a full
-# 40-char commit SHA. Local `./` action/workflow paths are allowed; `docker://`
-# images cannot be SHA-pinned and are allowed only with a trailing `#` comment.
-# Commented-out YAML lines (e.g. CodeQL's `# uses: actions/setup-example@v1`
-# example) are ignored.
+# .github/workflows/*.yml|*.yaml and .github/actions/**/*.yml|*.yaml must
+# reference a full 40-char commit SHA. Local `./` action/workflow paths are
+# allowed; `docker://` images cannot be SHA-pinned and are allowed only with a
+# trailing `#` comment. `uses:` is recognized only at the start of a YAML
+# mapping entry (anchored match), so `run:` scripts merely containing the text
+# and commented-out lines (e.g. CodeQL's `# uses: actions/setup-example@v1`
+# example) are ignored by the same rule.
 #
 # ── Operator toggles — merge-PR body MUST instruct, never do them from code ──
 # 1. Require SHA pinning at repo level (Settings > Actions > General > "Require
@@ -39,23 +41,31 @@ TOTAL_USES=0
 TOTAL_BAD=0
 
 list_workflow_files() {
-  git ls-files ':(glob).github/workflows/*.yml' ':(glob).github/actions/**/*.yml'
+  git ls-files \
+    ':(glob).github/workflows/*.yml' \
+    ':(glob).github/workflows/*.yaml' \
+    ':(glob).github/actions/**/*.yml' \
+    ':(glob).github/actions/**/*.yaml'
 }
 
-# A `uses:` that sits on a YAML comment line (anything before it contains '#')
-# is not live config and must be ignored.
-line_uses_commented() {
-  local line="$1"
-  case "${line%%uses:*}" in
-    *'#'*) return 0 ;;
-  esac
-  return 1
-}
-
-# Prints the `uses:` value (everything up to the first '#' or whitespace).
+# Prints the `uses:` value (everything up to the first whitespace). A '#'
+# glued to the value (e.g. docker://img#frag) is part of the ref, not a
+# comment, matching YAML's whitespace-separated comment rule.
 uses_ref() {
   local line="$1"
-  printf '%s' "${line#*uses:}" | sed 's/^[[:space:]]*//; s/[[:space:]#].*//'
+  printf '%s' "${line#*uses:}" | sed 's/^[[:space:]]*//; s/[[:space:]].*//'
+}
+
+# True when a real YAML trailing comment (a '#' preceded by whitespace)
+# follows the ref. A '#' inside a quoted value or glued to the ref is not a
+# comment and must not satisfy the docker:// exemption.
+line_has_trailing_comment() {
+  local line="$1" ref="$2" rest
+  rest="${line#*"${ref}"}"
+  case "${rest}" in
+    *[[:space:]]#*) return 0 ;;
+  esac
+  return 1
 }
 
 bad() {
@@ -65,14 +75,17 @@ bad() {
 }
 
 check_line() {
-  local file="$1" line_no="$2" line="$3" ref="$4" has_comment=0
-  case "${line}" in
-    *'#'*) has_comment=1 ;;
-  esac
+  local file="$1" line_no="$2" line="$3" ref="$4"
   case "${ref}" in
+    \"*|\'*)
+      bad "${file}" "${line_no}" "uses: ${ref} — quoted value; write the ref unquoted"
+      return 0
+      ;;
     ./*) return 0 ;;
     docker://*)
-      if [ "${has_comment}" -eq 1 ]; then return 0; fi
+      if line_has_trailing_comment "${line}" "${ref}"; then
+        return 0
+      fi
       bad "${file}" "${line_no}" "uses: ${ref} — docker:// cannot be SHA-pinned; add a trailing '# pinned by <image>@<digest>' comment"
       return 0
       ;;
@@ -91,10 +104,9 @@ check_line() {
 check_file() {
   local file="$1" line_no line
   while IFS=: read -r line_no line; do
-    line_uses_commented "${line}" && continue
     TOTAL_USES=$((TOTAL_USES + 1))
     check_line "${file}" "${line_no}" "${line}" "$(uses_ref "${line}")"
-  done < <(grep -n 'uses:' "${file}")
+  done < <(grep -nE '^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]+' -- "${file}")
 }
 
 main() {

--- a/.github/scripts/check-actions-pinned.sh
+++ b/.github/scripts/check-actions-pinned.sh
@@ -2,10 +2,15 @@
 # Supply-chain pinning gate (S0-v2 B3): every `uses:` in
 # .github/workflows/*.yml|*.yaml and .github/actions/**/*.yml|*.yaml must
 # reference a full 40-char commit SHA. Local `./` action/workflow paths are
-# allowed; `docker://` images cannot be SHA-pinned and are allowed only with a
-# trailing `#` comment. `uses:` is recognized only at the start of a YAML
-# mapping entry (anchored match), so `run:` scripts merely containing the text
-# and commented-out lines (e.g. CodeQL's `# uses: actions/setup-example@v1`
+# allowed. `docker://` images must be digest-pinned
+# (`docker://image@sha256:<64-hex>`); an exemption exists only for images that
+# genuinely cannot be digest-pinned, in which case the trailing `#` comment
+# must state the reason (it must contain both "cannot" and "digest"). This
+# repo currently has no docker:// uses at all. `uses:` is recognized only at
+# the start of a YAML mapping entry (anchored match) and only outside block
+# scalars: `run: |`/`run: >` literal and folded blocks are skipped by
+# tracking their indentation, so workflow snippets echoed inside scripts and
+# commented-out lines (e.g. CodeQL's `# uses: actions/setup-example@v1`
 # example) are ignored by the same rule.
 #
 # ── Operator toggles — merge-PR body MUST instruct, never do them from code ──
@@ -68,6 +73,27 @@ line_has_trailing_comment() {
   return 1
 }
 
+# Prints the text after the trailing comment's '#' (leading whitespace and
+# the '#' itself stripped). Only call when line_has_trailing_comment passed.
+trailing_comment() {
+  local line="$1" ref="$2"
+  printf '%s' "${line#*"${ref}"}" | sed 's/^[[:space:]]*#//'
+}
+
+# Counts leading whitespace characters (spaces or tabs) of a line.
+leading_indent() {
+  printf '%s' "${1}" | sed 's/[^[:space:]].*//' | wc -c | tr -d ' '
+}
+
+# True when the line is a mapping value that opens a literal (`|`) or folded
+# (`>`) block scalar, e.g. `run: |`, `if: >-`, `worker_secrets: |+`. Chomping
+# and explicit-indentation indicators (`|2`, `>-`) are accepted; a comment
+# after the indicator is allowed. Not a full YAML parser — a line whose value
+# is a plain string containing `|` does not match.
+block_indicator() {
+  printf '%s' "${1}" | grep -qE '^[[:space:]]*[^#].*:[[:space:]]*[|>][+-]?[0-9]*([[:space:]]*#.*)?$'
+}
+
 bad() {
   local file="$1" line_no="$2" msg="$3"
   TOTAL_BAD=$((TOTAL_BAD + 1))
@@ -83,10 +109,18 @@ check_line() {
       ;;
     ./*) return 0 ;;
     docker://*)
-      if line_has_trailing_comment "${line}" "${ref}"; then
+      if printf '%s' "${ref}" | grep -Eq '^docker://[^[:space:]]+@sha256:[0-9a-f]{64}$'; then
         return 0
       fi
-      bad "${file}" "${line_no}" "uses: ${ref} — docker:// cannot be SHA-pinned; add a trailing '# pinned by <image>@<digest>' comment"
+      if line_has_trailing_comment "${line}" "${ref}"; then
+        local comment
+        comment="$(trailing_comment "${line}" "${ref}")"
+        if printf '%s' "${comment}" | grep -qi 'cannot' \
+          && printf '%s' "${comment}" | grep -qi 'digest'; then
+          return 0
+        fi
+      fi
+      bad "${file}" "${line_no}" "uses: ${ref} — docker:// must be digest-pinned (docker://image@sha256:<64-hex>); if digest-pinning is impossible, state why in a trailing comment containing 'cannot' and 'digest'"
       return 0
       ;;
   esac
@@ -102,11 +136,36 @@ check_line() {
 }
 
 check_file() {
-  local file="$1" line_no line
-  while IFS=: read -r line_no line; do
-    TOTAL_USES=$((TOTAL_USES + 1))
-    check_line "${file}" "${line_no}" "${line}" "$(uses_ref "${line}")"
-  done < <(grep -nE '^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]+' -- "${file}")
+  local file="$1" line_no=0 line indent in_block=0 block_indent=-1
+  while IFS= read -r line; do
+    line_no=$((line_no + 1))
+    # Block-scalar tracking: lines indented deeper than the block's first
+    # content line are literal/folded text, never `uses:` entries. A blank
+    # line stays inside the block; a dedent ends it.
+    if [ "${in_block}" -eq 1 ]; then
+      if [ -z "${line}" ]; then
+        continue
+      fi
+      indent="$(leading_indent "${line}")"
+      if [ "${block_indent}" -eq -1 ]; then
+        block_indent="${indent}"
+        continue
+      fi
+      if [ "${indent}" -ge "${block_indent}" ]; then
+        continue
+      fi
+      in_block=0
+      block_indent=-1
+    fi
+    if block_indicator "${line}"; then
+      in_block=1
+      block_indent=-1
+    fi
+    if printf '%s' "${line}" | grep -qE '^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]+'; then
+      TOTAL_USES=$((TOTAL_USES + 1))
+      check_line "${file}" "${line_no}" "${line}" "$(uses_ref "${line}")"
+    fi
+  done < "${file}"
 }
 
 main() {

--- a/.github/scripts/check-actions-pinned.sh
+++ b/.github/scripts/check-actions-pinned.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Supply-chain pinning gate (S0-v2 B3): every `uses:` in
+# .github/workflows/*.yml and .github/actions/**/*.yml must reference a full
+# 40-char commit SHA. Local `./` action/workflow paths are allowed; `docker://`
+# images cannot be SHA-pinned and are allowed only with a trailing `#` comment.
+# Commented-out YAML lines (e.g. CodeQL's `# uses: actions/setup-example@v1`
+# example) are ignored.
+#
+# ── Operator toggles — merge-PR body MUST instruct, never do them from code ──
+# 1. Require SHA pinning at repo level (Settings > Actions > General > "Require
+#    SHA-pinned actions", or the API). Measured shape (design-CI-1-pipeline-
+#    refactor.md): GET /actions/permissions returns sha_pinning_required:false
+#    today. The operator must flip it:
+#      gh api -X PUT repos/lifeodyssey/animichi/actions/permissions \
+#        -f sha_pinning_required=true
+#    then verify: gh api repos/lifeodyssey/animichi/actions/permissions
+#    (expected: sha_pinning_required=true). The card's "workflow-sha-pinning
+#    style endpoint" phrasing is the Settings checkbox; if the PUT above 404s,
+#    use the Settings UI toggle instead — the endpoint name has drifted in the
+#    past, the goal (sha_pinning_required=true) is what matters.
+# 2. Repo-level CLOUDFLARE_* secret cleanup — verify, do not assume. Per
+#    docs/ops/secrets.md:113-114, CLOUDFLARE_PULUMI_API_TOKEN has NO repo-level
+#    copy (env-only), and CLOUDFLARE_API_TOKEN's repo copy is documented as
+#    "required in caller secret maps" — possibly stale, unverified. Operator:
+#    run `gh secret list` to verify actual tiers, reconcile with
+#    docs/ops/secrets.md:113-114 (its caller-map caveat may itself be stale),
+#    and only then delete confirmed-dead repo-level copies — record findings
+#    in the PR:
+#      gh secret delete <confirmed-dead-name> -R lifeodyssey/animichi
+# ────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+ROOT="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "${ROOT}")"
+cd "${ROOT}"
+
+TOTAL_FILES=0
+TOTAL_USES=0
+TOTAL_BAD=0
+
+list_workflow_files() {
+  git ls-files ':(glob).github/workflows/*.yml' ':(glob).github/actions/**/*.yml'
+}
+
+# A `uses:` that sits on a YAML comment line (anything before it contains '#')
+# is not live config and must be ignored.
+line_uses_commented() {
+  local line="$1"
+  case "${line%%uses:*}" in
+    *'#'*) return 0 ;;
+  esac
+  return 1
+}
+
+# Prints the `uses:` value (everything up to the first '#' or whitespace).
+uses_ref() {
+  local line="$1"
+  printf '%s' "${line#*uses:}" | sed 's/^[[:space:]]*//; s/[[:space:]#].*//'
+}
+
+bad() {
+  local file="$1" line_no="$2" msg="$3"
+  TOTAL_BAD=$((TOTAL_BAD + 1))
+  echo "${file}:${line_no}: ${msg}"
+}
+
+check_line() {
+  local file="$1" line_no="$2" line="$3" ref="$4" has_comment=0
+  case "${line}" in
+    *'#'*) has_comment=1 ;;
+  esac
+  case "${ref}" in
+    ./*) return 0 ;;
+    docker://*)
+      if [ "${has_comment}" -eq 1 ]; then return 0; fi
+      bad "${file}" "${line_no}" "uses: ${ref} — docker:// cannot be SHA-pinned; add a trailing '# pinned by <image>@<digest>' comment"
+      return 0
+      ;;
+  esac
+  local sha="${ref##*@}"
+  if [ "${sha}" = "${ref}" ]; then
+    bad "${file}" "${line_no}" "uses: ${ref} — no @ref at all; must be pinned to a full 40-char SHA"
+    return 0
+  fi
+  if [ "${#sha}" -eq 40 ] && printf '%s' "${sha}" | grep -Eq '^[0-9a-f]{40}$'; then
+    return 0
+  fi
+  bad "${file}" "${line_no}" "uses: ${ref} — not pinned to a full 40-char SHA (got '${sha}')"
+}
+
+check_file() {
+  local file="$1" line_no line
+  while IFS=: read -r line_no line; do
+    line_uses_commented "${line}" && continue
+    TOTAL_USES=$((TOTAL_USES + 1))
+    check_line "${file}" "${line_no}" "${line}" "$(uses_ref "${line}")"
+  done < <(grep -n 'uses:' "${file}")
+}
+
+main() {
+  local file
+  while read -r file; do
+    TOTAL_FILES=$((TOTAL_FILES + 1))
+    check_file "${file}"
+  done < <(list_workflow_files)
+  summarize
+}
+
+summarize() {
+  if [ "${TOTAL_BAD}" -gt 0 ]; then
+    exit 1
+  fi
+  echo "checked ${TOTAL_FILES} files, ${TOTAL_USES} uses, all pinned to full 40-char SHAs"
+}
+
+main

--- a/.github/scripts/check-actions-pinned.sh
+++ b/.github/scripts/check-actions-pinned.sh
@@ -17,9 +17,11 @@
 # 1. Require SHA pinning at repo level (Settings > Actions > General > "Require
 #    SHA-pinned actions", or the API). Measured shape (design-CI-1-pipeline-
 #    refactor.md): GET /actions/permissions returns sha_pinning_required:false
-#    today. The operator must flip it:
+#    today. The operator must flip it — note the PUT needs the full permissions
+#    object: `enabled` is a required boolean, and `-F` (not `-f`) sends typed
+#    booleans instead of strings, which the API rejects:
 #      gh api -X PUT repos/lifeodyssey/animichi/actions/permissions \
-#        -f sha_pinning_required=true
+#        -F enabled=true -F allowed_actions=all -F sha_pinning_required=true
 #    then verify: gh api repos/lifeodyssey/animichi/actions/permissions
 #    (expected: sha_pinning_required=true). The card's "workflow-sha-pinning
 #    style endpoint" phrasing is the Settings checkbox; if the PUT above 404s,

--- a/.github/scripts/check-actions-pinned.test.sh
+++ b/.github/scripts/check-actions-pinned.test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Behavioral tests for check-actions-pinned.sh, driven against throwaway
+# fixture git repos in mktemp -d (the script resolves its root via
+# `git rev-parse --show-toplevel` and scans git-tracked files, so each case
+# cd's into its own repo). One pass case per allowed form, two red cases.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SH="${SCRIPT_DIR}/check-actions-pinned.sh"
+
+SHA="3d3c42e5aac5ba805825da76410c181273ba90b1"
+
+fail_test() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# Commits whatever the caller has staged in the fixture repo ($1).
+commit_fixture() {
+  git -C "$1" init -q
+  git -C "$1" add .
+  git -C "$1" -c user.name=test -c user.email=test@example.com commit -q -m init
+}
+
+# Runs the real script from inside the fixture repo ($1), writing combined
+# output to $2, and prints the exit code for the caller to capture.
+run_check() {
+  local repo="$1" out="$2" rc=0
+  (cd "${repo}" && bash "${CHECK_SH}") >"${out}" 2>&1 || rc=$?
+  echo "${rc}"
+}
+
+# ── Case 1: SHA-pinned workflow `uses:` -> passes ──────────────────────────
+test_sha_pinned_passes() {
+  local repo out=/tmp/actions-pin-case1.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' "- uses: actions/checkout@${SHA} # v7.0.1" > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -eq 0 ] || fail_test "SHA-pinned use should pass, got exit ${rc}: $(cat "${out}")"
+  grep -q "all pinned" "${out}" || fail_test "missing one-line summary in output"
+  echo "PASS: SHA-pinned workflow use passes"
+}
+
+# ── Case 2: local `./` action/workflow paths are allowed -> passes ─────────
+test_local_paths_pass() {
+  local repo out=/tmp/actions-pin-case2.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows" "${repo}/.github/actions/setup"
+  printf '%s\n' 'steps:' '- uses: ./.github/actions/setup' '- uses: ./.github/workflows/reusable-ts-ci.yml' > "${repo}/.github/workflows/ci.yml"
+  printf '%s\n' 'name: setup' 'runs:' '  using: composite' '  steps:' '    - run: echo hi' > "${repo}/.github/actions/setup/action.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -eq 0 ] || fail_test "local ./ paths should pass, got exit ${rc}: $(cat "${out}")"
+  grep -q "all pinned" "${out}" || fail_test "missing one-line summary in output"
+  echo "PASS: local ./ action and workflow paths pass"
+}
+
+# ── Case 3: docker:// with a trailing comment is allowed -> passes ─────────
+test_docker_with_comment_passes() {
+  local repo out=/tmp/actions-pin-case3.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' '- uses: docker://ghcr.io/animichi/some-tool:v1 # pinned by digest, cannot SHA-pin docker://' > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -eq 0 ] || fail_test "docker:// with comment should pass, got exit ${rc}: $(cat "${out}")"
+  grep -q "all pinned" "${out}" || fail_test "missing one-line summary in output"
+  echo "PASS: docker:// use with trailing comment passes"
+}
+
+# ── Case 4: commented-out tag-pinned example -> ignored, passes ────────────
+test_commented_line_ignored() {
+  local repo out=/tmp/actions-pin-case4.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' 'steps:' '  # - name: Setup runtime (example)' '  #   uses: actions/setup-example@v1' "  - uses: actions/checkout@${SHA} # v7.0.1" > "${repo}/.github/workflows/codeql.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -eq 0 ] || fail_test "commented-out tag pin should be ignored, got exit ${rc}: $(cat "${out}")"
+  grep -q "1 uses" "${out}" || fail_test "only the live use should be counted: $(cat "${out}")"
+  echo "PASS: commented-out tag-pinned use is ignored"
+}
+
+# ── Case 5: composite action under .github/actions/**/*.yml -> passes ──────
+test_composite_action_checked_and_passes() {
+  local repo out=/tmp/actions-pin-case5.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/actions/setup"
+  printf '%s\n' "- uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10" > "${repo}/.github/actions/setup/action.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -eq 0 ] || fail_test "SHA-pinned composite action use should pass, got exit ${rc}: $(cat "${out}")"
+  grep -q "all pinned" "${out}" || fail_test "missing one-line summary in output"
+  echo "PASS: composite action under .github/actions/ is scanned and passes"
+}
+
+# ── Case 6 (red): tag-pinned `uses:` -> fails, naming file + line + ref ────
+test_tag_pin_fails() {
+  local repo out=/tmp/actions-pin-case6.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' 'steps:' '- uses: actions/checkout@v4' > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -ne 0 ] || fail_test "tag-pinned use must fail the gate, got exit 0"
+  grep -q "ci.yml:2: uses: actions/checkout@v4 — not pinned to a full 40-char SHA (got 'v4')" "${out}" || fail_test "output must name file, line, and ref: $(cat "${out}")"
+  echo "PASS: tag-pinned use fails and names file + line + ref"
+}
+
+# ── Case 7 (red): docker:// without a comment -> fails ─────────────────────
+test_docker_without_comment_fails() {
+  local repo out=/tmp/actions-pin-case7.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' '- uses: docker://ghcr.io/animichi/some-tool:v1' > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -ne 0 ] || fail_test "docker:// without comment must fail the gate, got exit 0"
+  grep -q "ci.yml:1: uses: docker://ghcr.io/animichi/some-tool:v1 — docker:// cannot be SHA-pinned" "${out}" || fail_test "output must name file, line, and ref: $(cat "${out}")"
+  echo "PASS: docker:// use without comment fails"
+}
+
+test_sha_pinned_passes
+test_local_paths_pass
+test_docker_with_comment_passes
+test_commented_line_ignored
+test_composite_action_checked_and_passes
+test_tag_pin_fails
+test_docker_without_comment_fails
+
+echo "All check-actions-pinned.sh behavioral tests passed."

--- a/.github/scripts/check-actions-pinned.test.sh
+++ b/.github/scripts/check-actions-pinned.test.sh
@@ -3,13 +3,15 @@
 # fixture git repos in mktemp -d (the script resolves its root via
 # `git rev-parse --show-toplevel` and scans git-tracked files, so each case
 # cd's into its own repo). One pass case per allowed form, one red case per
-# gate behavior (tag pins, docker:// comment rule, anchoring, .yaml scans).
+# gate behavior (tag pins, docker:// digest rule, block-scalar skipping,
+# anchoring, .yaml scans).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHECK_SH="${SCRIPT_DIR}/check-actions-pinned.sh"
 
 SHA="3d3c42e5aac5ba805825da76410c181273ba90b1"
+DOCKER_SHA="$(printf 'a%.0s' {1..64})"
 
 fail_test() {
   echo "FAIL: $1" >&2
@@ -58,17 +60,17 @@ test_local_paths_pass() {
   echo "PASS: local ./ action and workflow paths pass"
 }
 
-# ── Case 3: docker:// with a trailing comment is allowed -> passes ─────────
-test_docker_with_comment_passes() {
+# ── Case 3: docker:// pinned by @sha256:<64-hex> digest -> passes ───────────
+test_docker_digest_passes() {
   local repo out=/tmp/actions-pin-case3.out rc
   repo="$(mktemp -d)"
   mkdir -p "${repo}/.github/workflows"
-  printf '%s\n' '- uses: docker://ghcr.io/animichi/some-tool:v1 # pinned by digest, cannot SHA-pin docker://' > "${repo}/.github/workflows/ci.yml"
+  printf '%s\n' "- uses: docker://ghcr.io/animichi/some-tool:v1@sha256:${DOCKER_SHA} # v1" > "${repo}/.github/workflows/ci.yml"
   commit_fixture "${repo}"
   rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
-  [ "${rc}" -eq 0 ] || fail_test "docker:// with comment should pass, got exit ${rc}: $(cat "${out}")"
+  [ "${rc}" -eq 0 ] || fail_test "digest-pinned docker:// use should pass, got exit ${rc}: $(cat "${out}")"
   grep -q "all pinned" "${out}" || fail_test "missing one-line summary in output"
-  echo "PASS: docker:// use with trailing comment passes"
+  echo "PASS: docker:// use pinned by sha256 digest passes"
 }
 
 # ── Case 4: commented-out tag-pinned example -> ignored, passes ────────────
@@ -110,17 +112,17 @@ test_tag_pin_fails() {
   echo "PASS: tag-pinned use fails and names file + line + ref"
 }
 
-# ── Case 7 (red): docker:// without a comment -> fails ─────────────────────
-test_docker_without_comment_fails() {
+# ── Case 7 (red): docker:// without digest or reason comment -> fails ──────
+test_docker_without_digest_fails() {
   local repo out=/tmp/actions-pin-case7.out rc
   repo="$(mktemp -d)"
   mkdir -p "${repo}/.github/workflows"
   printf '%s\n' '- uses: docker://ghcr.io/animichi/some-tool:v1' > "${repo}/.github/workflows/ci.yml"
   commit_fixture "${repo}"
   rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
-  [ "${rc}" -ne 0 ] || fail_test "docker:// without comment must fail the gate, got exit 0"
-  grep -q "ci.yml:1: uses: docker://ghcr.io/animichi/some-tool:v1 — docker:// cannot be SHA-pinned" "${out}" || fail_test "output must name file, line, and ref: $(cat "${out}")"
-  echo "PASS: docker:// use without comment fails"
+  [ "${rc}" -ne 0 ] || fail_test "docker:// without digest must fail the gate, got exit 0"
+  grep -q "ci.yml:1: uses: docker://ghcr.io/animichi/some-tool:v1 — docker:// must be digest-pinned" "${out}" || fail_test "output must name file, line, and ref: $(cat "${out}")"
+  echo "PASS: docker:// use without digest fails"
 }
 
 # ── Case 8 (red): `uses:` substring in a run: script is ignored; real tag violation still fails ──
@@ -151,11 +153,11 @@ test_docker_ref_hashtag_not_comment() {
     '- uses: docker://ghcr.io/animichi/some-tool:v1#frag' > "${repo}/.github/workflows/ci.yml"
   commit_fixture "${repo}"
   rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
-  [ "${rc}" -ne 0 ] || fail_test "docker:// ref carrying its own '#' must not dodge the comment requirement, got exit 0"
+  [ "${rc}" -ne 0 ] || fail_test "docker:// ref carrying its own '#' must not dodge the digest requirement, got exit 0"
   grep -q 'ci.yml:1: uses: "docker://ghcr.io/animichi/some-tool:v1" — quoted value' "${out}" \
     || fail_test "quoted docker:// ref must be rejected: $(cat "${out}")"
-  grep -q "ci.yml:2: uses: docker://ghcr.io/animichi/some-tool:v1#frag — docker:// cannot be SHA-pinned" "${out}" \
-    || fail_test "docker:// ref with glued '#' must still require a real comment: $(cat "${out}")"
+  grep -q "ci.yml:2: uses: docker://ghcr.io/animichi/some-tool:v1#frag — docker:// must be digest-pinned" "${out}" \
+    || fail_test "docker:// ref with glued '#' must still require digest pinning: $(cat "${out}")"
   echo "PASS: docker:// '#' inside the ref is not treated as a trailing comment"
 }
 
@@ -173,15 +175,101 @@ test_yaml_extension_fails() {
   echo "PASS: .yaml workflow is scanned and tag-pinned use fails"
 }
 
+# ── Case 11: `uses:` text inside run: | and run: > literal blocks -> ignored, passes ──
+test_literal_block_uses_text_ignored() {
+  local repo out=/tmp/actions-pin-case11.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' \
+    'steps:' \
+    '  - name: echo sample workflow' \
+    '    run: |' \
+    '      echo "example workflow:"' \
+    '      uses: actions/checkout@v4' \
+    '      uses: docker://ghcr.io/animichi/some-tool:v1' \
+    '  - name: folded block' \
+    '    run: >' \
+    '      text line' \
+    '      uses: foo/bar@v1' \
+    "  - uses: actions/checkout@${SHA} # v7.0.1" > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -eq 0 ] || fail_test "uses: text inside literal/folded blocks must be ignored, got exit ${rc}: $(cat "${out}")"
+  grep -q "1 uses" "${out}" || fail_test "only the live use after the blocks should be counted: $(cat "${out}")"
+  echo "PASS: uses: text inside run: | and run: > blocks is ignored; scanning resumes after the block"
+}
+
+# ── Case 12 (red): tag-pinned `uses:` after a literal block still fails ────
+test_literal_block_then_violation_fails() {
+  local repo out=/tmp/actions-pin-case12.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' \
+    'steps:' \
+    '  - name: echo sample workflow' \
+    '    run: |' \
+    '      uses: actions/checkout@v4' \
+    '      more block text' \
+    '  - uses: actions/checkout@v4' > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -ne 0 ] || fail_test "real tag-pinned use after a literal block must fail the gate, got exit 0"
+  grep -q "ci.yml:6: uses: actions/checkout@v4 — not pinned to a full 40-char SHA (got 'v4')" "${out}" \
+    || fail_test "violation after the block must be named: $(cat "${out}")"
+  grep -q "ci.yml:4:" "${out}" && fail_test "block content must not be treated as an action reference: $(cat "${out}")"
+  echo "PASS: real tag-pinned use after a literal block still fails"
+}
+
+# ── Case 13: docker:// exemption — comment stating a reason passes; a bare comment fails ──
+test_docker_reason_comment_exemption() {
+  local repo out=/tmp/actions-pin-case13.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' '- uses: docker://ghcr.io/animichi/some-tool:v1 # cannot digest-pin: upstream registry is tag-only' > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -eq 0 ] || fail_test "docker:// with a reason-stating comment should pass, got exit ${rc}: $(cat "${out}")"
+  grep -q "all pinned" "${out}" || fail_test "missing one-line summary in output"
+  echo "PASS: docker:// exemption accepted when the trailing comment states the reason"
+
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' '- uses: docker://ghcr.io/animichi/some-tool:v1 # image is immutable' > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -ne 0 ] || fail_test "docker:// with a bare comment must fail the gate, got exit 0"
+  grep -q "ci.yml:1: uses: docker://ghcr.io/animichi/some-tool:v1 — docker:// must be digest-pinned" "${out}" \
+    || fail_test "comment without a stated reason must be rejected: $(cat "${out}")"
+  echo "PASS: docker:// exemption rejected when the trailing comment states no reason"
+}
+
+# ── Case 14 (red): docker:// digest of wrong shape -> fails ────────────────
+test_docker_short_digest_fails() {
+  local repo out=/tmp/actions-pin-case14.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' '- uses: docker://ghcr.io/animichi/some-tool@sha256:abc123' > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -ne 0 ] || fail_test "docker:// with a short digest must fail the gate, got exit 0"
+  grep -q "ci.yml:1: uses: docker://ghcr.io/animichi/some-tool@sha256:abc123 — docker:// must be digest-pinned" "${out}" \
+    || fail_test "short digest must be rejected: $(cat "${out}")"
+  echo "PASS: docker:// digest shorter than 64 hex chars fails"
+}
+
 test_sha_pinned_passes
 test_local_paths_pass
-test_docker_with_comment_passes
+test_docker_digest_passes
 test_commented_line_ignored
 test_composite_action_checked_and_passes
 test_tag_pin_fails
-test_docker_without_comment_fails
+test_docker_without_digest_fails
 test_uses_substring_in_run_ignored
 test_docker_ref_hashtag_not_comment
 test_yaml_extension_fails
+test_literal_block_uses_text_ignored
+test_literal_block_then_violation_fails
+test_docker_reason_comment_exemption
+test_docker_short_digest_fails
 
 echo "All check-actions-pinned.sh behavioral tests passed."

--- a/.github/scripts/check-actions-pinned.test.sh
+++ b/.github/scripts/check-actions-pinned.test.sh
@@ -2,7 +2,8 @@
 # Behavioral tests for check-actions-pinned.sh, driven against throwaway
 # fixture git repos in mktemp -d (the script resolves its root via
 # `git rev-parse --show-toplevel` and scans git-tracked files, so each case
-# cd's into its own repo). One pass case per allowed form, two red cases.
+# cd's into its own repo). One pass case per allowed form, one red case per
+# gate behavior (tag pins, docker:// comment rule, anchoring, .yaml scans).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -122,6 +123,56 @@ test_docker_without_comment_fails() {
   echo "PASS: docker:// use without comment fails"
 }
 
+# ── Case 8 (red): `uses:` substring in a run: script is ignored; real tag violation still fails ──
+test_uses_substring_in_run_ignored() {
+  local repo out=/tmp/actions-pin-case8.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' \
+    'steps:' \
+    '  - run: echo "uses: actions/checkout@v4" > /tmp/note' \
+    '  - uses: actions/checkout@v4' > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -ne 0 ] || fail_test "real tag-pinned use must fail the gate, got exit 0"
+  grep -q "ci.yml:3: uses: actions/checkout@v4 — not pinned to a full 40-char SHA (got 'v4')" "${out}" \
+    || fail_test "real violation must be named: $(cat "${out}")"
+  grep -q "ci.yml:2:" "${out}" && fail_test "run: script containing 'uses:' must not be treated as an action reference: $(cat "${out}")"
+  echo "PASS: uses: substring in run: script ignored; real violation still fails"
+}
+
+# ── Case 9 (red): '#' inside the docker:// ref (quoted or glued) is not a trailing comment ──
+test_docker_ref_hashtag_not_comment() {
+  local repo out=/tmp/actions-pin-case9.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' \
+    '- uses: "docker://ghcr.io/animichi/some-tool:v1"' \
+    '- uses: docker://ghcr.io/animichi/some-tool:v1#frag' > "${repo}/.github/workflows/ci.yml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -ne 0 ] || fail_test "docker:// ref carrying its own '#' must not dodge the comment requirement, got exit 0"
+  grep -q 'ci.yml:1: uses: "docker://ghcr.io/animichi/some-tool:v1" — quoted value' "${out}" \
+    || fail_test "quoted docker:// ref must be rejected: $(cat "${out}")"
+  grep -q "ci.yml:2: uses: docker://ghcr.io/animichi/some-tool:v1#frag — docker:// cannot be SHA-pinned" "${out}" \
+    || fail_test "docker:// ref with glued '#' must still require a real comment: $(cat "${out}")"
+  echo "PASS: docker:// '#' inside the ref is not treated as a trailing comment"
+}
+
+# ── Case 10 (red): .yaml workflow files are scanned too ────────────────────
+test_yaml_extension_fails() {
+  local repo out=/tmp/actions-pin-case10.out rc
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/.github/workflows"
+  printf '%s\n' 'steps:' '- uses: actions/checkout@v4' > "${repo}/.github/workflows/ci.yaml"
+  commit_fixture "${repo}"
+  rc="$(run_check "${repo}" "${out}")"; rm -rf "${repo}"
+  [ "${rc}" -ne 0 ] || fail_test ".yaml workflow with tag-pinned use must fail the gate, got exit 0"
+  grep -q "ci.yaml:2: uses: actions/checkout@v4 — not pinned to a full 40-char SHA (got 'v4')" "${out}" \
+    || fail_test "output must name the .yaml file: $(cat "${out}")"
+  echo "PASS: .yaml workflow is scanned and tag-pinned use fails"
+}
+
 test_sha_pinned_passes
 test_local_paths_pass
 test_docker_with_comment_passes
@@ -129,5 +180,8 @@ test_commented_line_ignored
 test_composite_action_checked_and_passes
 test_tag_pin_fails
 test_docker_without_comment_fails
+test_uses_substring_in_run_ignored
+test_docker_ref_hashtag_not_comment
+test_yaml_extension_fails
 
 echo "All check-actions-pinned.sh behavioral tests passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,12 @@ jobs:
   #    agnix, whose 63% false-positive rate gated nothing.
   # 2. Root allowlist check (S0-v2 Track A.3): top-level tracked entries are
   #    locked to the explicit allowlist in check-root-allowlist.sh.
+  # 3. Actions pinning check (S0-v2 B3, supply chain): every `uses:` must be
+  #    pinned to a full 40-char SHA; local `./` action/workflow paths are
+  #    allowed and `docker://` images must be digest-pinned (documented
+  #    exception in .github/scripts/check-actions-pinned.sh). The companion
+  #    sha_pinning_required toggle + repo-level CF token deletion are
+  #    operator actions, documented in that script's header.
 
   agnix:
     timeout-minutes: 5
@@ -322,6 +328,10 @@ jobs:
         run: bash .github/scripts/check-e2e-promotion.test.sh
       - name: E2E promotion guard
         run: bash .github/scripts/check-e2e-promotion.sh
+      - name: Actions pinning check self-tests
+        run: bash .github/scripts/check-actions-pinned.test.sh
+      - name: Actions pinning check
+        run: bash .github/scripts/check-actions-pinned.sh
 
   # ── DB migrations (Atlas validation + optional Neon dry-run) ──
 


### PR DESCRIPTION
Task: S0-v2 B3 — supply-chain toggles: repo-level CF token cleanup runbook + sha-pinning assertion.
This card is SMALL and mostly verification-infrastructure (the actual toggle/deletion are operator API calls recorded for the merge PR body):
1. Write .github/scripts/check-actions-pinned.sh + .test.sh (style of check-agents-refs): assert every `uses:` in .github/workflows/*.yml and .github/actions/**/*.yml is pinned to a full 40-char SHA (allow local `./` action paths and `docker://` skipped with a comment). Fixture-based test: pass + one red case (tag-pinned uses).
2. Wire it as a blocking step in the same job that runs check-agents-refs.sh in ci.yml.
3. In the script header, document the two operator toggles this card's PR body must instruct (do NOT attempt them from code): gh api -X PUT repos/lifeodyssey/animichi/actions/permissions/workflow-sha-pinning style endpoint for sha_pinning_required=true, and deletion of repo-level CLOUDFLARE_API_TOKEN / CLOUDFLARE_PULUMI_API_TOKEN (env-level copies exist; integration.md documents target state).
Verify: bash .github/scripts/check-actions-pinned.test.sh && bash .github/scripts/check-actions-pinned.sh && actionlint .github/workflows/ci.yml.
Edit files only; do not commit.

--- FIX ROUND (Opus-lite REJECT, one item: the CF-token operator note conflicts with docs/ops/secrets.md) ---
Rewrite the check-actions-pinned.sh header's CF-token paragraph: do NOT assert repo-level copies are dead weight. Per docs/ops/secrets.md:113-114, CLOUDFLARE_PULUMI_API_TOKEN has NO repo-level copy (env-only), and CLOUDFLARE_API_TOKEN's repo copy is documented as "required in caller secret maps" (possibly stale, unverified). Change the instruction to: "operator: run `gh secret list` to verify actual tiers, reconcile with docs/ops/secrets.md:113-114 (its caller-map caveat may itself be stale), and only then delete confirmed-dead repo-level copies — record findings in the PR." Verify: bash .github/scripts/check-actions-pinned.test.sh still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated checks to ensure GitHub Actions use secure, immutable commit references.
  * Added validation for local actions and documented Docker action references.
  * CI now enforces these checks and reports the affected file and line when violations are found.

* **Tests**
  * Added coverage for valid pins, invalid tags, Docker references, composite actions, workflow formats, and false-positive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->