### PR TITLE
S0-v2 I1 — flip NEON_AUTH_ENABLED on for staging (edge dual-issuer verification), with full evidence trail. HIGH-RISK AUTH CARD — be surgical, change the minimum.

### DIFF
--- a/docs/ops/auth-migration-neon.md
+++ b/docs/ops/auth-migration-neon.md
@@ -143,3 +143,49 @@ Related API surface (in `@neon/sdk`, mostly unwrapped by CLI): `updateNeonAuthEm
 4. **OAuth production credentials** (pre-cutover): Google/Apple/X client id+secret via `neonctl neon-auth oauth-provider update`; LINE via generic OAuth. Current `google` entry uses shared dev credentials — not for production.
 5. **Supabase-side branding (optional, recommend skip):** live magic-link emails are still Seichijunrei-branded inside the deployed `send-auth-email` Edge Function; changing it means `supabase login` + function redeploy (deploy-coupled). Cutover retires it entirely — spend nothing here unless pre-cutover polish matters.
 6. **Decide** whether the skipped disposable signup (`je***@gmeenramy.com`, never confirmed) should be preserved anywhere before Supabase deletion. Default: let it die with Supabase.
+
+## 8. Staging edge dual-issuer flip (S0-v2 I1, #312 slice 1)
+
+Status: **deployed but inert until the real issuer lands** — committed to `main` (28298459,
+owner-approved 2026-08-03) and already deployed to staging (root deploys succeeded twice,
+2026-08-04 19:01Z and 2026-08-05 02:26Z, both containing the flip commit). The flag change is live;
+whether it does anything is decided by the issuer, below.
+
+**What verifies staging tokens today:** the edge Worker (`workers/edge/auth.ts`) runs in dual-issuer
+mode. `verifyJwt` routes by token header/claims: `alg == "EdDSA"` or `iss == NEON_AUTH_ISSUER` →
+Neon Auth EdDSA verification against `NEON_AUTH_JWKS_URL`; anything else → legacy Supabase
+verification (`ES256`/`RS256` against `${SUPABASE_URL}/auth/v1/.well-known/jwks.json`). The flag
+gates only the Neon branch: `NEON_AUTH_ENABLED = "true"` + non-empty JWKS/issuer env ⇒ Neon path
+active; `false`/absent ⇒ EdDSA tokens reject without a JWKS fetch (fail-closed — no Supabase
+fallback for them). It is **not** a hard switch: legacy Supabase tokens keep verifying.
+
+**What the flip changed (staging only, `[env.staging.vars]` in `wrangler.toml`):**
+`NEON_AUTH_ENABLED` `false → "true"`, with the pinned `NEON_AUTH_ISSUER` and derived
+`NEON_AUTH_JWKS_URL`. Root `[vars]` and `[env.production.vars]` stay `"false"` — prod cutover is a
+separate owner-approved step. Locked by `workers/edge/authConfig.test.ts` (staging stays on, prod
+stays off, CI/deploy workflows keep their JWKS secret paths).
+
+**Prerequisite reality (as of the deploy above):** the flip is **not** yet functionally live on
+staging. The pinned `NEON_AUTH_ISSUER` in `wrangler.toml` `[env.staging.vars]` is a literal
+placeholder (`https://REDACTED-NEON-ENDPOINT.neonauth…`), and that endpoint's JWKS returns HTTP 500.
+Consequence: with `NEON_AUTH_ENABLED = "true"`, real Neon Auth tokens are **rejected** on staging
+today (the Neon path fails closed on the placeholder JWKS), while Supabase tokens are **unaffected**
+(dual mode still verifies them on the Supabase path) — a silent no-op, not an outage. Filling in the
+real issuer is an **owner-sequenced step**: it requires synchronized changes to the issuer-pinning
+tests in `workers/edge/authConfig.test.ts` (which assert the exact placeholder string), plus
+re-deploy. Worth converging on in that step: `workers/users` derives its issuer from a single secret
+via `issuerFromJwksUrl()` (`workers/users/src/auth/jwt.ts`), while the edge needs a separate
+plaintext issuer var — the edge's split-var design is the root cause of this placeholder gap.
+
+What is genuinely in place: `NEON_AUTH_JWKS_URL` provisioned as a staging+production secret (#527);
+`apps/web` Better Auth client and the `workers/users` EdDSA verification are already Neon-capable.
+
+**Tests (edge, `workers/edge/auth-neon.test.ts`, mock JWKS via jose):** flag absent/false reject
+EdDSA without a JWKS fetch; flag true accepts a valid EdDSA Neon-issuer JWT; wrong issuer /
+expired / wrong audience / wrong key rejected; **dual mode**: a valid legacy Supabase JWT still
+passes with the flag true; missing JWKS URL rejects without throwing. Verified green:
+`pnpm run test:worker`, `workers/users` (42/42), `actionlint .github/workflows/ci.yml`.
+
+**Rollback:** flip `NEON_AUTH_ENABLED` back to `"false"` in `[env.staging.vars]` and redeploy —
+one deploy, no data migration, no token re-issue. The rollback direction never touches legacy
+Supabase tokens (they verify on the Supabase path regardless of the flag).

--- a/docs/ops/auth-migration-neon.md
+++ b/docs/ops/auth-migration-neon.md
@@ -177,7 +177,19 @@ re-deploy. Worth converging on in that step: `workers/users` derives its issuer 
 via `issuerFromJwksUrl()` (`workers/users/src/auth/jwt.ts`), while the edge needs a separate
 plaintext issuer var — the edge's split-var design is the root cause of this placeholder gap.
 
-What is genuinely in place: `NEON_AUTH_JWKS_URL` provisioned as a staging+production secret (#527);
+What is genuinely in place — `NEON_AUTH_JWKS_URL` is **dual-source**, and the two sources feed
+different consumers (rotate the right one):
+- **Checked-in var** — `[env.staging.vars]` in `wrangler.toml` (line 308), pinned by
+  `workers/edge/authConfig.test.ts`; consumed **only** by the edge worker's staging dual-issuer
+  path (`workers/edge/auth.ts`). Root `[vars]`/`[env.production.vars]` leave it empty and the root
+  worker's `worker_secrets` lists never upload a JWKS secret, so the edge worker has no Neon path
+  in production.
+- **Environment secret (#527, staging + production)** — consumed **only** by `workers/users`:
+  `ci.yml` (staging + production) and `deploy.yml` (production) upload it to that Worker via
+  `worker_secrets`, and `workers/users/src/index.ts` reads it at runtime (deriving the issuer via
+  `issuerFromJwksUrl()`). It is not forwarded to the agent container (`CONTAINER_ENV_KEYS` does
+  not list it) and is not legacy — `workers/users` is its live consumer.
+
 `apps/web` Better Auth client and the `workers/users` EdDSA verification are already Neon-capable.
 
 **Tests (edge, `workers/edge/auth-neon.test.ts`, mock JWKS via jose):** flag absent/false reject


### PR DESCRIPTION
Task: S0-v2 I1 — flip NEON_AUTH_ENABLED on for staging (edge dual-issuer verification), with full evidence trail. HIGH-RISK AUTH CARD — be surgical, change the minimum.
Read first: workers/edge/ (search NEON_AUTH_ENABLED — how the flag gates dual-issuer JWT verification; the verifier code paths for Supabase vs Neon Auth issuers), wrangler.toml [env.staging.vars] (where edge env flags live — find which wrangler config owns the edge worker), docs/ops/auth-migration-neon.md (SD-31 migration doc: cutover steps + rollback), apps/web auth integration (Better Auth client — is the web side already issuing Neon Auth tokens on staging?), workers/users JWT verification if separate.
Do:
1. Establish the CURRENT truth first and write it into log-friendly comments in your diff description: which issuer verifies edge tokens on staging today, what the flag flips, what Neon Auth prerequisites exist (JWKS URL env — NEON_AUTH_JWKS_URL is a staging env secret per #527).
2. Flip NEON_AUTH_ENABLED to "true" for the STAGING env section only (wherever the edge worker's staging vars live). Do NOT touch production vars.
3. DUAL-VERIFY window: confirm from the code that the flag enables dual-issuer (accepts BOTH Supabase and Neon tokens) rather than hard-switching — if it hard-switches (Supabase tokens rejected), STOP and instead write a finding in the diff as a comment block: the card then only adds a test proving the hard-switch semantics, no flip (fail-safe: we need owner sequencing).
4. Tests: extend the edge worker tests (workers/edge/*.test.ts) — with flag true: a valid Neon-issuer JWT (mock JWKS) passes; a valid Supabase JWT still passes IF dual mode; invalid issuer rejected. Follow existing edge test patterns (jose mocks).
5. Update docs/ops/auth-migration-neon.md: mark the staging flip step done-pending-deploy with date, note rollback = flip the var back (one deploy).
Verify: pnpm run test:worker 2>&1 | tail -2 && (cd workers/users && pnpm test 2>&1 | tail -2) && actionlint .github/workflows/ci.yml.
Edit files only; do not commit.

--- FIX ROUND (Opus-deep REJECT: the doc misstates reality; docs-only fix, do NOT touch wrangler.toml) ---
Two corrections in docs/ops/auth-migration-neon.md (the only file this card may touch):
1. Prerequisites section: state the TRUTH — staging's pinned NEON_AUTH_ISSUER in wrangler.toml is a literal placeholder (REDACTED-NEON-ENDPOINT); its JWKS endpoint returns HTTP 500. Therefore with the flag on, real Neon Auth tokens are REJECTED on staging today (Supabase tokens unaffected — silent no-op, not an outage). Filling the real issuer requires synchronized changes to the issuer-pinning tests and is an owner-sequenced step; note that workers/users derives issuer from a single secret via issuerFromJwksUrl() and the edge requiring a separate plaintext var is the root cause worth converging on in that step.
2. Status: replace any "pending deploy"/"live once the next deploy runs" wording — the flag flip is ALREADY DEPLOYED (staging root deploys succeeded twice, 08-04 19:01Z and 08-05 02:26Z, both containing the flip commit). Correct status: "deployed but inert until the real issuer lands."
Verify: pnpm run test:worker 2>&1 | tail -2 (unchanged, 266 pass). No other files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)