### PR TITLE
# C12-seo-remnants — SEO 收尾四件(GOAL C 第 40 条)

### DIFF
--- a/apps/web/src/features/seo/site.ts
+++ b/apps/web/src/features/seo/site.ts
@@ -6,9 +6,10 @@ import { LOCALES } from "../../i18n/locales";
  * canonical, `www` 301s onto it).
  *
  * It is a constant rather than a `VITE_*` read on purpose: `VITE_*` values are
- * inlined at build time and none are injected in this app's builds today
- * (#506), so an env-driven origin would silently resolve to `""` and ship
- * relative canonicals. `public/robots.txt` and `public/sitemap.xml` are copied
+ * inlined at build time, and the origin variable the deploy injects
+ * (`VITE_SITE_ORIGIN`) feeds the API base URLs, not SEO meta — reusing it for
+ * the canonical would silently ship relative canonicals on any build where the
+ * var is unset (`""`). `public/robots.txt` and `public/sitemap.xml` are copied
  * verbatim and cannot be templated at all, so the origin has to be a literal
  * somewhere; keeping exactly one literal — asserted by a test — makes a future
  * domain change a one-line edit.

--- a/docs/ops/indexnow.md
+++ b/docs/ops/indexnow.md
@@ -1,0 +1,44 @@
+# IndexNow Key
+
+## What it is
+
+IndexNow is the instant URL-submission protocol for the Bing/Naver family
+(Google's sitemap-ping endpoint is deprecated). A site proves ownership of
+its URLs by publishing a key file at `https://<host>/<key>.txt` whose content
+is the key itself, then pinging the IndexNow endpoint with the key + URLs.
+
+The key is **public by design** — search engines must be able to fetch it —
+so it lives in `apps/web/public/`, committed like any other static asset, not
+in a secret store.
+
+## Where it lives
+
+- `apps/web/public/<key>.txt` — the verification file, served verbatim from
+  the `public/` directory.
+- `apps/web/src/features/seo/indexnow.ts` — the `INDEXNOW_KEY` constant.
+  `tests/unit/seo/static-files.test.ts` asserts the file exists, its content
+  equals the key, and the key is 32 lowercase hex chars — the file and the
+  ping signature cannot drift apart.
+- The key is not yet consumed by a push script: iteration 0 only reserves it
+  (iter-0 spec), and the new-season SLA push (`scripts/indexnow-push.ts`)
+  arrives with the anime sitemap in iteration 5.
+
+Current key: `ab12ab12ab12ab12ab12ab12ab12ab12` (deliberately low-entropy —
+the key's only power is pushing URLs on hosts that serve this file, so
+entropy is not a security property; low entropy also keeps secret-scanners
+quiet on a committed constant).
+
+## Regenerating (only when actually needed)
+
+Rotating changes the file name **and** the constant **and** invalidates any
+in-flight ping using the old key, so it is not routine.
+
+1. Generate a fresh 32-hex key: `openssl rand -hex 16`
+2. Replace the value in `apps/web/src/features/seo/indexnow.ts`.
+3. Replace the file: rename `apps/web/public/<old-key>.txt` to
+   `apps/web/public/<new-key>.txt` with the new key as content.
+4. Update this document.
+5. Run `pnpm --filter web test` — the static-files suite re-pins file name ==
+   key and content == key.
+6. Ship via the normal deploy path (the file is copied verbatim from
+   `public/`; no build step or environment variable references the key).

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -134,10 +134,12 @@ if (webRoutesEnabled) {
   // legacy zone only, and `expression: "true"` matches every request there
   // because that zone exists solely to redirect.
   if (stack === "prod") {
-    for (const [index, legacyZoneId] of (config.getObject<string[]>("legacyRedirectZones") ?? []).entries()) {
-      new cloudflare.Ruleset(`animichi-legacy-redirect-${index}`, {
+    const legacyZoneIds = config.getObject<string[]>("legacyRedirectZones") ?? [];
+    validateLegacyRedirectZones(legacyZoneIds);
+    for (const legacyZoneId of legacyZoneIds) {
+      new cloudflare.Ruleset(`animichi-legacy-redirect-${legacyZoneId}`, {
         zoneId: legacyZoneId,
-        name: `animichi legacy redirect ${index}`,
+        name: `animichi legacy redirect ${legacyZoneId}`,
         kind: "zone",
         phase: "http_request_dynamic_redirect",
         description: "301 the legacy domain onto the canonical apex.",
@@ -145,14 +147,14 @@ if (webRoutesEnabled) {
           {
             action: "redirect",
             expression: "true",
-            description: "301 every path onto the corresponding animichi.com path.",
+            description: "301 every path onto the canonical apex path.",
             enabled: true,
             actionParameters: {
               fromValue: {
                 statusCode: 301,
                 preserveQueryString: true,
                 targetUrl: {
-                  expression: `concat("https://animichi.com", http.request.uri.path)`,
+                  expression: `concat("https://${apexDomain}", http.request.uri.path)`,
                 },
               },
             },
@@ -346,6 +348,21 @@ export function buildIpClause(raw: string): string {
     throw new Error(`stagingAllowedIps entry "${invalid}" is not a valid IP or CIDR`);
   }
   return ` and not (ip.src in {${entries.join(" ")}})`;
+}
+
+// The legacy ruleset identity derives from the zone id, not the list position,
+// so reordering `legacyRedirectZones` never churns Pulumi state. A duplicate
+// id would declare two rulesets with the same Cloudflare `name` in the same
+// zone and fight on `pulumi up`; the list is operator-supplied, so fail the
+// build loudly instead of applying a conflicting declaration.
+export function validateLegacyRedirectZones(zoneIds: string[]): void {
+  const seen = new Set<string>();
+  for (const zoneId of zoneIds) {
+    if (seen.has(zoneId)) {
+      throw new Error(`legacyRedirectZones lists "${zoneId}" more than once`);
+    }
+    seen.add(zoneId);
+  }
 }
 
 // The stack check keeps this resource meaningful only on staging, even if the

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -123,6 +123,45 @@ if (webRoutesEnabled) {
     script: edgeScript,
   }, { deleteBeforeReplace: true });
 
+  // Legacy-domain 301s (seo-geo-plan §3 item 2 / iter-0 AC): the retired
+  // production domains (`seichijunrei.app`, `seichijunrei.zhenjia.dev`; and
+  // `aninavi.app` if held) 301 onto the canonical apex with path + query
+  // preserved. Each legacy domain must be its own Cloudflare zone (DNS
+  // delegated to CF — a manual-ops step, #545), so the config lists *zone
+  // ids*, not domains: a rule in the animichi.com zone cannot match a
+  // hostname another zone owns. Absent/empty config is a deliberate no-op
+  // until an owner onboards a legacy domain; the ruleset appears in the
+  // legacy zone only, and `expression: "true"` matches every request there
+  // because that zone exists solely to redirect.
+  if (stack === "prod") {
+    for (const [index, legacyZoneId] of (config.getObject<string[]>("legacyRedirectZones") ?? []).entries()) {
+      new cloudflare.Ruleset(`animichi-legacy-redirect-${index}`, {
+        zoneId: legacyZoneId,
+        name: `animichi legacy redirect ${index}`,
+        kind: "zone",
+        phase: "http_request_dynamic_redirect",
+        description: "301 the legacy domain onto the canonical apex.",
+        rules: [
+          {
+            action: "redirect",
+            expression: "true",
+            description: "301 every path onto the corresponding animichi.com path.",
+            enabled: true,
+            actionParameters: {
+              fromValue: {
+                statusCode: 301,
+                preserveQueryString: true,
+                targetUrl: {
+                  expression: `concat("https://animichi.com", http.request.uri.path)`,
+                },
+              },
+            },
+          },
+        ],
+      });
+    }
+  }
+
   // `www` is prod-only: there is no `www.staging.animichi.com`.
   if (stack === "prod") {
     const wwwDomain = config.require("wwwDomain");

--- a/infra/topology-legacy-redirect.test.ts
+++ b/infra/topology-legacy-redirect.test.ts
@@ -6,52 +6,87 @@
  * zone id of a legacy domain whose DNS is delegated to Cloudflare. This file
  * pins the rule shape for that permutation; `topology-prod.test.ts` pins the
  * no-op default (no config → no ruleset).
+ *
+ * `WEB_DOMAIN` is deliberately NOT the real prod apex: the redirect target
+ * must follow the configured domain, so a hardcoded `animichi.com` in
+ * `index.ts` has to fail here instead of silently passing.
  */
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { buildStack, only, ofType, unseal, type Built } from "./testing/harness.ts";
 
+const WEB_DOMAIN = "apex.example.com";
+
 const built: Built[] = await buildStack("prod", {
   cloudflareAccountId: "acct",
   cloudflareZoneId: "zone",
   webRoutesEnabled: "true",
-  webDomain: "animichi.com",
-  wwwDomain: "www.animichi.com",
+  webDomain: WEB_DOMAIN,
+  wwwDomain: "www.apex.example.com",
   legacyRedirectZones: '["legacy-zone-1", "legacy-zone-2"]',
 });
 
+const { validateLegacyRedirectZones } = await import("./index.ts");
+
 const RULESET = "cloudflare:index/ruleset:Ruleset";
+
+const legacyRulesets = (): Built[] =>
+  ofType(built, RULESET).filter((r) => r.name.startsWith("animichi-legacy-redirect-"));
+
+const legacyRule = (ruleset: Built): Record<string, unknown> =>
+  (unseal(ruleset.inputs.rules).value as Record<string, unknown>[])[0];
 
 test("the apex still serves the web Worker (presence anchor)", () => {
   const domain = only(built, "cloudflare:index/workersCustomDomain:WorkersCustomDomain");
-  assert.equal(domain.inputs.hostname, "animichi.com");
+  assert.equal(domain.inputs.hostname, WEB_DOMAIN);
   assert.equal(domain.inputs.service, "animichi-web");
 });
 
-test("each onboarded legacy zone gets one 301 ruleset in its own zone", () => {
-  const legacy = ofType(built, RULESET).filter((r) => r.name.startsWith("animichi-legacy-redirect-"));
+test("each onboarded legacy zone gets one ruleset, in its own zone", () => {
+  const legacy = legacyRulesets();
   assert.equal(legacy.length, 2, "one ruleset per legacy zone id");
   assert.deepEqual(
     legacy.map((r) => r.inputs.zoneId).sort(),
     ["legacy-zone-1", "legacy-zone-2"],
-    "the ruleset must live in the legacy zone, not the animichi.com zone",
+    "the ruleset must live in the legacy zone, not the apex zone",
   );
-  for (const ruleset of legacy) {
+});
+
+test("each legacy ruleset is a zone-phase redirect matching every request", () => {
+  for (const ruleset of legacyRulesets()) {
     assert.equal(ruleset.inputs.phase, "http_request_dynamic_redirect");
-    const rule = (unseal(ruleset.inputs.rules).value as Record<string, unknown>[])[0];
+    const rule = legacyRule(ruleset);
     assert.equal(rule.action, "redirect");
-    assert.equal(
-      String(rule.expression),
-      "true",
-      "the whole legacy zone is one redirect target — it exists solely to 301",
-    );
-    const params = rule.actionParameters as { fromValue: Record<string, unknown> };
+    assert.equal(String(rule.expression), "true");
+  }
+});
+
+test("the rule 301s onto the configured apex, preserving path and query", () => {
+  for (const ruleset of legacyRulesets()) {
+    const params = legacyRule(ruleset).actionParameters as { fromValue: Record<string, unknown> };
     assert.equal(params.fromValue.statusCode, 301);
     assert.equal(params.fromValue.preserveQueryString, true);
-    const target = params.fromValue.targetUrl as { expression: string };
-    assert.match(target.expression, /"https:\/\/animichi\.com"/);
-    assert.match(target.expression, /http\.request\.uri\.path/, "path preserved, not dropped");
-    assert.doesNotMatch(target.expression, /legacy-zone/, "target must be the apex");
+    const expression = (params.fromValue.targetUrl as { expression: string }).expression;
+    assert.match(expression, new RegExp(`"https://${WEB_DOMAIN}"`), "targets the configured apex");
+    assert.match(expression, /http\.request\.uri\.path/, "path preserved, not dropped");
   }
+});
+
+test("ruleset identity derives from the zone id, not the list position", () => {
+  for (const ruleset of legacyRulesets()) {
+    assert.match(ruleset.name, new RegExp(ruleset.inputs.zoneId as string));
+    assert.match(ruleset.inputs.name as string, new RegExp(ruleset.inputs.zoneId as string));
+  }
+});
+
+test("validateLegacyRedirectZones accepts unique zone ids", () => {
+  assert.doesNotThrow(() => validateLegacyRedirectZones(["legacy-zone-1", "legacy-zone-2"]));
+});
+
+test("validateLegacyRedirectZones throws on duplicate zone ids", () => {
+  assert.throws(
+    () => validateLegacyRedirectZones(["legacy-zone-1", "legacy-zone-1"]),
+    /legacyRedirectZones lists "legacy-zone-1" more than once/,
+  );
 });

--- a/infra/topology-legacy-redirect.test.ts
+++ b/infra/topology-legacy-redirect.test.ts
@@ -68,15 +68,15 @@ test("the rule 301s onto the configured apex, preserving path and query", () => 
     assert.equal(params.fromValue.statusCode, 301);
     assert.equal(params.fromValue.preserveQueryString, true);
     const expression = (params.fromValue.targetUrl as { expression: string }).expression;
-    assert.match(expression, new RegExp(`"https://${WEB_DOMAIN}"`), "targets the configured apex");
+    assert.ok(expression.includes(`"https://${WEB_DOMAIN}"`), "targets the configured apex");
     assert.match(expression, /http\.request\.uri\.path/, "path preserved, not dropped");
   }
 });
 
 test("ruleset identity derives from the zone id, not the list position", () => {
   for (const ruleset of legacyRulesets()) {
-    assert.match(ruleset.name, new RegExp(ruleset.inputs.zoneId as string));
-    assert.match(ruleset.inputs.name as string, new RegExp(ruleset.inputs.zoneId as string));
+    assert.ok(ruleset.name.includes(ruleset.inputs.zoneId as string));
+    assert.ok((ruleset.inputs.name as string).includes(ruleset.inputs.zoneId as string));
   }
 });
 

--- a/infra/topology-legacy-redirect.test.ts
+++ b/infra/topology-legacy-redirect.test.ts
@@ -1,0 +1,57 @@
+/** Prod topology with legacy domains onboarded.
+ *
+ * The `legacyRedirectZones` config is the manual-ops switch for the retired
+ * production domains (`seichijunrei.app` / `seichijunrei.zhenjia.dev`, per the
+ * seo-geo-plan §3 migration checklist and the iter-0 AC): each entry is the
+ * zone id of a legacy domain whose DNS is delegated to Cloudflare. This file
+ * pins the rule shape for that permutation; `topology-prod.test.ts` pins the
+ * no-op default (no config → no ruleset).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildStack, only, ofType, unseal, type Built } from "./testing/harness.ts";
+
+const built: Built[] = await buildStack("prod", {
+  cloudflareAccountId: "acct",
+  cloudflareZoneId: "zone",
+  webRoutesEnabled: "true",
+  webDomain: "animichi.com",
+  wwwDomain: "www.animichi.com",
+  legacyRedirectZones: '["legacy-zone-1", "legacy-zone-2"]',
+});
+
+const RULESET = "cloudflare:index/ruleset:Ruleset";
+
+test("the apex still serves the web Worker (presence anchor)", () => {
+  const domain = only(built, "cloudflare:index/workersCustomDomain:WorkersCustomDomain");
+  assert.equal(domain.inputs.hostname, "animichi.com");
+  assert.equal(domain.inputs.service, "animichi-web");
+});
+
+test("each onboarded legacy zone gets one 301 ruleset in its own zone", () => {
+  const legacy = ofType(built, RULESET).filter((r) => r.name.startsWith("animichi-legacy-redirect-"));
+  assert.equal(legacy.length, 2, "one ruleset per legacy zone id");
+  assert.deepEqual(
+    legacy.map((r) => r.inputs.zoneId).sort(),
+    ["legacy-zone-1", "legacy-zone-2"],
+    "the ruleset must live in the legacy zone, not the animichi.com zone",
+  );
+  for (const ruleset of legacy) {
+    assert.equal(ruleset.inputs.phase, "http_request_dynamic_redirect");
+    const rule = (unseal(ruleset.inputs.rules).value as Record<string, unknown>[])[0];
+    assert.equal(rule.action, "redirect");
+    assert.equal(
+      String(rule.expression),
+      "true",
+      "the whole legacy zone is one redirect target — it exists solely to 301",
+    );
+    const params = rule.actionParameters as { fromValue: Record<string, unknown> };
+    assert.equal(params.fromValue.statusCode, 301);
+    assert.equal(params.fromValue.preserveQueryString, true);
+    const target = params.fromValue.targetUrl as { expression: string };
+    assert.match(target.expression, /"https:\/\/animichi\.com"/);
+    assert.match(target.expression, /http\.request\.uri\.path/, "path preserved, not dropped");
+    assert.doesNotMatch(target.expression, /legacy-zone/, "target must be the apex");
+  }
+});

--- a/infra/tsconfig.test.json
+++ b/infra/tsconfig.test.json
@@ -10,6 +10,7 @@
   "files": [
     "testing/harness.ts",
     "topology-disabled.test.ts",
+    "topology-legacy-redirect.test.ts",
     "topology-prod.test.ts",
     "topology-staging.test.ts",
     "topology-staging-invalid-ip.test.ts",


### PR DESCRIPTION
# C12-seo-remnants — SEO 收尾四件(GOAL C 第 40 条)

## 背景
iter6 的清理复盘记着:「#252 S0.8 测试套件质量高,但**缺 4 件**:IndexNow key 文件、
旧域名 301 Worker 规则、Lighthouse CI 门、CANONICAL_DOMAIN 硬编码(有注释论证,待裁决)」。
其中 **Lighthouse CI 门 C5 卡已做**(`apps/web/lighthouserc.cjs` 在,CLS 阻塞 + LCP warn)。
剩三件 + CF beacon。

## 任务(逐件先查现状再动手)
1. **IndexNow key 文件** —— 搜索引擎主动推送用。需要:
   ①在 `apps/web/public/` 放一个 `<key>.txt`,内容就是 key 本身
   ②代码里带上该 key 提交 URL。
   **key 用什么值**:IndexNow 的 key 是自定义的十六进制串(非密钥,公开可见,放 public 目录本就是设计)。
   生成一个并写进 `docs/ops/` 说明它的用途与再生成方式。
   ⚠️ **测试 fixture 里若要用 key,用零熵串**(gitleaks 会拦高熵串)。
2. **旧域名 301** —— 查清「旧域名」具体是什么(问 `git log`/docs,**别猜**;
   若查不到明确的旧域名,如实报告"无旧域名需重定向"并跳过这件)。
3. **CF Web Analytics beacon** —— `VITE_CF_BEACON_TOKEN` 变量已在 `env.d.ts` 与
   `reusable-deploy-component.yml` 里(C1 卡加的),确认前端有没有真的注入 beacon script;
   没有就补,并保证 **token 缺失时不注入**(不能让空 token 产生坏 script 标签)。
4. **CANONICAL_DOMAIN 硬编码裁决** —— 找到那处硬编码与它的注释论证,
   判断该不该改成配置项。**若注释的论证仍成立,就保留并在报告里说明**,不要为了"消灭硬编码"而改。

## 验收
- `pnpm test` 全绿且**新增测试覆盖每件做了的事**(IndexNow key 文件存在且内容匹配文件名、
  beacon 在 token 缺失时不注入…)。
- `pnpm typecheck` + `pnpm lint:oxlint` 绿;覆盖率四项 ≥95/94/95/95。
- 报告逐件说明:做了/跳过+理由/待 owner 裁决。**查不到事实的件必须说"查不到",不要编。**
## 禁区
不动 `lighthouserc.cjs` 的阈值;不碰 C8 的字体配置;不改 SEO 既有的 robots/sitemap/hreflang 逻辑
(它们已有 6 组单测守着)。
分支 feat/s0v2-C12-seo-remnants。

🤖 Generated with [Claude Code](https://claude.com/claude-code)