### PR TITLE
#550 修 apps/web 的 base-URL fallback —— 它会静默指向自己

### DIFF
--- a/apps/web/src/api/config.ts
+++ b/apps/web/src/api/config.ts
@@ -4,12 +4,13 @@ import { getRequestUrl } from "@tanstack/react-start/server";
 /**
  * Base-URL resolution for the catalog and users oRPC services.
  *
- * The catalog and users Workers are distinct origins, so each gets its own
- * base URL. SSR `fetch` needs an absolute origin (no `window`): the server
- * reads the TanStack Start request context (`getRequestUrl`), with
- * `VITE_SITE_ORIGIN` as an explicit override; the browser reads
- * `location.origin`. When every source is missing we degrade to a relative
- * origin instead of throwing.
+ * Same-origin by design (#550): the edge Worker fans `/v1/*`, `/v1/users/*`
+ * and `/catalog/public/*` out to the services, so the base is the origin that
+ * serves this app. The browser reads `location.origin`; SSR reads the
+ * TanStack Start request context (`getRequestUrl`) with `VITE_SITE_ORIGIN`
+ * as an explicit override. When the server has neither, resolution FAILS
+ * LOUD: a silent relative base would point every catalog/users request at
+ * this app itself (404s and HTML, no error).
  */
 export interface ApiConfig {
   readonly catalogUrl: string;
@@ -37,10 +38,16 @@ export function resolveOrigin(
   location?: { readonly origin: string },
   contextOrigin: OriginSource = runtimeOrigin,
 ): string {
-  if (location) {
-    return location.origin;
-  }
-  return env.VITE_SITE_ORIGIN ?? contextOrigin() ?? "";
+  if (location) return location.origin;
+  const explicit = env.VITE_SITE_ORIGIN ?? contextOrigin();
+  if (explicit) return explicit;
+  throw missingOriginError();
+}
+
+function missingOriginError(): Error {
+  return new Error(
+    "VITE_SITE_ORIGIN is unset and no SSR request context is available; refusing to let catalog/users requests silently target this app itself",
+  );
 }
 
 export function resolveApiConfig(env: Env, location?: { readonly origin: string }): ApiConfig {

--- a/apps/web/src/api/config.ts
+++ b/apps/web/src/api/config.ts
@@ -46,11 +46,14 @@ export function resolveOrigin(
 
 function missingOriginError(): Error {
   return new Error(
-    "VITE_SITE_ORIGIN is unset and no SSR request context is available; refusing to let catalog/users requests silently target this app itself",
+    "VITE_SITE_ORIGIN is unset and no SSR request context is available; refusing to let API requests silently target this app itself",
   );
 }
 
 export function resolveApiConfig(env: Env, location?: { readonly origin: string }): ApiConfig {
+  if (env.VITE_CATALOG_URL !== undefined && env.VITE_USERS_URL !== undefined) {
+    return { catalogUrl: env.VITE_CATALOG_URL, usersUrl: env.VITE_USERS_URL };
+  }
   const origin = resolveOrigin(env, location);
   return {
     catalogUrl: env.VITE_CATALOG_URL ?? origin,

--- a/apps/web/tests/unit/api/config.test.ts
+++ b/apps/web/tests/unit/api/config.test.ts
@@ -19,17 +19,17 @@ describe("resolveOrigin", () => {
     );
   });
 
-  it("degrades to a relative origin instead of throwing when every source is missing", () => {
-    expect(resolveOrigin({}, undefined, () => undefined)).toBe("");
+  it("fails loud instead of degrading when the server has no origin source", () => {
+    expect(() => resolveOrigin({}, undefined, () => undefined)).toThrow(/VITE_SITE_ORIGIN/);
   });
 
-  it("degrades gracefully with the default request-context source outside a request", () => {
-    expect(resolveOrigin({})).toBe("");
+  it("fails loud with the default request-context source outside a request", () => {
+    expect(() => resolveOrigin({})).toThrow(/VITE_SITE_ORIGIN/);
   });
 });
 
 describe("resolveApiConfig", () => {
-  it("defaults both services to the resolved origin", () => {
+  it("defaults both services to the resolved origin (same-origin fan-out)", () => {
     const config = resolveApiConfig({}, { origin: "https://animichi.app" });
     expect(config).toEqual({
       catalogUrl: "https://animichi.app",

--- a/apps/web/tests/unit/api/config.test.ts
+++ b/apps/web/tests/unit/api/config.test.ts
@@ -45,4 +45,13 @@ describe("resolveApiConfig", () => {
     expect(config.catalogUrl).toBe("https://catalog.test");
     expect(config.usersUrl).toBe("https://users.test");
   });
+
+  it("never resolves the origin when both service URLs are configured", () => {
+    const env = { VITE_CATALOG_URL: "https://catalog.test", VITE_USERS_URL: "https://users.test" };
+    expect(() => resolveApiConfig(env)).not.toThrow();
+    expect(resolveApiConfig(env)).toEqual({
+      catalogUrl: "https://catalog.test",
+      usersUrl: "https://users.test",
+    });
+  });
 });

--- a/apps/web/tests/unit/api/orpc-ssr-isolation.test.ts
+++ b/apps/web/tests/unit/api/orpc-ssr-isolation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { catalog, users } from "../../../src/api/orpc";
 
 /**
@@ -7,6 +7,16 @@ import { catalog, users } from "../../../src/api/orpc";
  * accepted host happened to serve the first SSR request.
  */
 describe("orpc utils on the server", () => {
+  beforeEach(() => {
+    // A well-formed server config: outside a request context `resolveOrigin`
+    // fails loud (no VITE_SITE_ORIGIN, no request URL), so the freshness
+    // checks below need the explicit override.
+    vi.stubEnv("VITE_SITE_ORIGIN", "https://ssr.test");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
   it("builds fresh catalog utils per call instead of caching the first origin", () => {
     expect(catalog()).not.toBe(catalog());
   });

--- a/apps/web/tests/unit/chat/config.test.ts
+++ b/apps/web/tests/unit/chat/config.test.ts
@@ -19,8 +19,8 @@ describe("resolveChatConfig", () => {
     expect(config.chatUrl).toBe("http://localhost:3000/v1/chat");
   });
 
-  it("degrades to a relative chat base instead of throwing without any origin source", () => {
-    expect(resolveChatConfig({}).chatUrl).toBe("/v1/chat");
+  it("fails loud without any origin source instead of degrading to a relative base", () => {
+    expect(() => resolveChatConfig({})).toThrow(/VITE_SITE_ORIGIN/);
   });
 });
 


### PR DESCRIPTION
Task: #550 修 apps/web 的 base-URL fallback —— 它会静默指向自己

issue #550 的标题点名:「fix apps/web's base-URL fallback that silently points at itself」。

## 症状

API base URL 没配置时,fallback 落到**当前 origin**(即前端自己),
于是请求打到自己身上 —— 不会报错,只会得到 404 或 HTML,**表现为"接口挂了"而不是"配置漏了"**。
这是典型的**静默降级**:最该报警的时候最安静。

## 做什么

1. **先读 `apps/web/src/api/config.ts`,把当前的 fallback 链完整写进报告**:
   每一级是什么、什么条件下命中、命中后请求会去哪。**不要凭 issue 描述动手。**
2. **判断每一级 fallback 是否正当**。判据:
   - 开发环境的本地默认值(如 `http://localhost:xxxx`)—— **正当**,但要确认它只在 dev 生效。
   - 落到 `window.location.origin` / 相对路径 —— **如果后端不在同源,这就是那个 bug。**
     先确认部署形态:`workers/edge` 是不是把 `/v1` 反代到同源?
     (读 `workers/edge/entry.ts` 的路由,别猜。)**如果同源反代确实存在,那这个 fallback 就是对的,
     那样的话本卡的结论是"issue 描述有误",要在报告里论证,不要硬改。**
3. **配置缺失必须 fail-loud**。无论上一步结论如何,「必需的 base URL 未配置」都不该静默通过:
   - 构建期能判断的 → 构建期失败(参考 `.github/scripts/vite-env-preflight.sh` 的 fail-closed 做法)
   - 只能运行期判断的 → 启动时抛明确错误,信息里写清缺哪个环境变量
4. **写测试**,并做**变异验证**:把配置置空,确认测试变红;还原,确认变绿。证据贴报告。

## 边界(重要,apps/web 现在很挤)
- **只改 `apps/web/src/api/config.ts` 及其测试**,外加必要的类型定义。
- **不要碰** `apps/web/src/components/`、`apps/web/src/routes/`、`apps/web/src/lib/auth/`、
  `apps/web/src/i18n/`、`apps/web/src/features/seo/` —— 这几处都有别的卡在改,会冲突。
- **不要动子域拓扑**(`api.animichi.com` / `chat.animichi.com`)—— 那是 #550 的另一半,涉及 DNS,不在本卡。
- 不许新增依赖。

## Verify
`cd apps/web && pnpm test && pnpm typecheck && pnpm lint:oxlint`

Edit files only; do not commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)