### PR TITLE
chore: complete Matt Pocock skills setup

### DIFF
--- a/.claude/rules/naming-ownership.md
+++ b/.claude/rules/naming-ownership.md
@@ -1,0 +1,19 @@
+# 命名归属:helper / util / manager 是设计气味
+
+- **禁止 `helper` / `util(s)` / `manager` / `common` / `misc` 作为文件名或函数名**,以及泛指的
+  `handler`、`_do_*`、`process_*`。这类名字等于承认「我不知道这段逻辑属于谁」——
+  它意味着某处的 OOP/SOLID 没做到位。
+- **按归属命名**:属于已有类型 → 该类型的方法或其模块内私有函数;属于尚未命名的概念 →
+  **给概念命名**(值对象、策略、规格),文件名 = 概念名。测试构造器命名为**它构造的东西**
+  (`make_selected_route_result`、`makeChatShellProps`),不是 `_helper` / `_setup`。
+- **1-10-50 与 SOLID 冲突时,SOLID 优先。** 为凑 ≤10 行切出无归属的一段,是行数驱动的切割而非内聚;
+  该重审原函数是否多职责,**按职责拆,不按行数拆**。
+- 例外(不算气味):框架惯例位置——`conftest.py` 的 fixture、vitest `setup` 文件。
+
+## 测试构造:优先 fixture,其次 builder
+
+- **零参数的规范实例** → `@pytest.fixture`(TS:`test.extend`)。它自带 scope 缓存与跨文件复用,
+  且天然按「提供什么」命名。有资源要释放时用 **`yield` 形态**(生成器 fixture),不要手写散落的清理。
+- **带参数的变体** → Builder / Object Mother,按构造的概念命名;不要硬塞进 fixture 变成
+  `request.param` 间接层。
+- 同一维度的多变体 → `@pytest.mark.parametrize` / `fixture(params=...)`,不要复制粘贴测试体。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,3 +149,19 @@ Role definitions live in `.claude/agents/`:
 ## File placement
 
 Never save working files to the repo root. Doc placement + the doc-change checklist → `docs/DOCS_POLICY.md`.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues (`lifeodyssey/animichi`) via `gh`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical five roles map 1:1 to label strings; plus `wayfinder:*` for decision maps. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Multi-context monorepo: root `CONTEXT-MAP.md` points at per-package `CONTEXT.md`. System ADRs in `docs/adr/`. See `docs/agents/domain.md`.
+
+Workflow overview (Matt × Policy C): `docs/workflow.md`.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -2,7 +2,7 @@
 
 Multi-context monorepo. Glossaries are pure language (no implementation). Layout target: `docs/superpowers/specs/2026-08-06-monorepo-target-layout.md`.
 
-Consumer rules: `docs/agents/domain.md` (when present).
+Consumer rules: `docs/agents/domain.md` (when present). Per-package `CONTEXT.md` files are **created lazily** when a term or decision is resolved — missing files are normal.
 
 ## Contexts
 
@@ -17,6 +17,8 @@ Consumer rules: `docs/agents/domain.md` (when present).
 | **Jobs** (retention cron; was Maintenance) | `workers/jobs/CONTEXT.md` (target; today `workers/maintenance/CONTEXT.md`) | `workers/jobs` (target path) |
 | **Migrations** | `migrations/CONTEXT.md` (lazy) | `migrations/neon`, `migrations/supabase` (target paths) |
 | **Infra** | `infra/CONTEXT.md` (lazy) | `infra` |
+| **Auth appliance** | — | `supabase/` (auth-only, no package guide) |
+| **Browser E2E** | `e2e/CONTEXT.md` (lazy) | `e2e/` |
 
 System-wide ADRs: `docs/adr/` (incl. [0002 published language](./docs/adr/0002-published-language-point-bangumi-itinerary.md)).
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,48 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT-MAP.md`** at the repo root — index of per-package glossaries.
+- The **`CONTEXT.md`** files the map points at for the packages you are touching (created lazily by `/domain-modeling` / `/grill-with-docs`).
+- **`docs/adr/`** — system-wide architectural decisions.
+- Package guides: each package's `AGENTS.md` (conventions and commands; not a glossary).
+- Live runtime story: `docs/ARCHITECTURE.md`. Policy: `docs/DOCS_POLICY.md`. Workflow: `docs/workflow.md`.
+
+If a `CONTEXT.md` does not exist yet, **proceed silently**. Don't flag its absence; don't suggest creating it upfront. The `/domain-modeling` skill creates glossary files lazily when terms or decisions actually get resolved.
+
+## File structure (this monorepo)
+
+Multi-context — one glossary per deployable / shared package:
+
+```
+/
+├── CONTEXT-MAP.md                 ← index (always present after setup)
+├── docs/adr/                      ← system-wide ADRs
+├── docs/agents/                   ← skill config (this file, issue-tracker, labels)
+├── apps/agent/CONTEXT.md          ← lazy
+├── apps/web/CONTEXT.md            ← lazy
+├── workers/edge/CONTEXT.md        ← lazy (package guide may still be missing)
+├── workers/catalog/CONTEXT.md     ← lazy
+├── workers/users/CONTEXT.md       ← lazy
+├── workers/maintenance/CONTEXT.md ← lazy
+├── packages/contract/CONTEXT.md   ← lazy
+├── db/CONTEXT.md                  ← lazy
+├── infra/CONTEXT.md               ← lazy
+└── e2e/CONTEXT.md                 ← lazy
+```
+
+Do **not** put package ADRs under a fictional `src/<context>/docs/adr/` tree — this repo uses package roots (`apps/*`, `workers/*`, …) and a single `docs/adr/` for cross-cutting decisions. Package-local irreversible decisions can live next to that package as `docs/adr/` only if a future effort deliberately splits them; until then keep system ADRs in `docs/adr/`.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in the relevant `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0001 (map stack) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,50 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `lifeodyssey/animichi`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.
+
+## Repo-specific notes
+
+- Orchestration policy (Matt × Policy C, fleet, dual-seat review): `docs/workflow.md`.
+- Path-campaign / repo-restructure work: **do not** open fleet worktrees while layout moves are in flight; serial PRs only.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,25 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+## Wayfinder labels (decision maps)
+
+| Label | Meaning |
+| ----- | ------- |
+| `wayfinder:map` | Index issue for a wayfinding effort |
+| `wayfinder:research` | AFK research ticket (primary sources) |
+| `wayfinder:prototype` | HITL prototype ticket |
+| `wayfinder:grilling` | HITL grilling / domain-modeling ticket |
+| `wayfinder:task` | Manual task that unblocks a decision |
+
+Edit the right-hand column only if the tracker vocabulary changes.


### PR DESCRIPTION
## Summary
Completes `/setup-matt-pocock-skills` for this monorepo so `/wayfinder`, `/to-spec`, `/to-tickets`, and friends know where issues and domain docs live.

## Changes
- `docs/agents/issue-tracker.md` — GitHub + wayfinding ops
- `docs/agents/triage-labels.md` — five triage roles + `wayfinder:*`
- `docs/agents/domain.md` — multi-context monorepo layout
- `CONTEXT-MAP.md` — package glossary index (glossaries still lazy)
- `AGENTS.md` — `## Agent skills` block

Labels created on the repo (not in this PR): `needs-triage`, `needs-info`, `ready-for-human`, `wayfinder:map|research|prototype|grilling|task` (`ready-for-agent` / `wontfix` already existed).

## Test plan
- [ ] Confirm labels: `gh label list -R lifeodyssey/animichi | grep wayfinder`
- [ ] Fresh agent session can resolve tracker via `docs/agents/issue-tracker.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for agent skills, including issue tracking, triage labels, and repository workflows.
  * Documented the monorepo’s domain context, package glossary, architectural decision records, and special-case areas.
  * Added instructions for using domain documentation and handling missing context files or conflicting decisions.
  * Documented issue creation, lookup, triage, labeling, dependencies, and resolution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->