### PR TITLE
docs(#833): PATH-DELTA + CONTEXT-MAP + package CONTEXT + design specs

### DIFF
--- a/.github/scripts/check-root-allowlist.sh
+++ b/.github/scripts/check-root-allowlist.sh
@@ -26,6 +26,7 @@ ALLOWED_ROOT_ENTRIES=(
   .sqlfluff
   AGENTS.md
   CLAUDE.md
+  CONTEXT-MAP.md
   Dockerfile
   Makefile
   README.ja.md

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,59 @@
+# Context map — Animichi
+
+Multi-context monorepo. Glossaries are pure language (no implementation). Layout target: `docs/superpowers/specs/2026-08-06-monorepo-target-layout.md`.
+
+Consumer rules: `docs/agents/domain.md` (when present).
+
+## Contexts
+
+| Context | Glossary | Deployable / home |
+| --- | --- | --- |
+| **Contract** (published language) | [`packages/contract/CONTEXT.md`](./packages/contract/CONTEXT.md) | `packages/contract` |
+| **Catalog** | [`workers/catalog/CONTEXT.md`](./workers/catalog/CONTEXT.md) | `workers/catalog` |
+| **Users** | [`workers/users/CONTEXT.md`](./workers/users/CONTEXT.md) | `workers/users` |
+| **Agent** | [`apps/agent/CONTEXT.md`](./apps/agent/CONTEXT.md) | `apps/agent` |
+| **Edge** | [`workers/edge/CONTEXT.md`](./workers/edge/CONTEXT.md) | `workers/edge` |
+| **Web** | `apps/web/CONTEXT.md` (lazy) | `apps/web` |
+| **Jobs** (retention cron; was Maintenance) | `workers/jobs/CONTEXT.md` (target; today `workers/maintenance/CONTEXT.md`) | `workers/jobs` (target path) |
+| **Migrations** | `migrations/CONTEXT.md` (lazy) | `migrations/neon`, `migrations/supabase` (target paths) |
+| **Infra** | `infra/CONTEXT.md` (lazy) | `infra` |
+
+System-wide ADRs: `docs/adr/` (incl. [0002 published language](./docs/adr/0002-published-language-point-bangumi-itinerary.md)).
+
+Greenfield (no dual wire names / table aliases):  
+[`docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md`](./docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md).
+
+## Relationships
+
+- **Web → Edge**: Browser talks only to the public edge (and its own Worker for SSR assets as configured).
+- **Edge → Agent / Catalog / Users**: Gateway; Edge resolves **Identity**, does not own pilgrimage models.
+- **Agent → Catalog**: Customer–supplier; Agent needs Points / Bangumi / Itineraries; Catalog owns master data and planning.
+- **Users → Catalog (by id only)**: **SavedRoute** stores `point_ids`, not Point rows; Users does not redefine Point.
+- **Agent ↔ Users**: Claim anonymous **Session** / saved data after login (via Users APIs / product flows).
+- **Jobs → Agent data plane**: Cron retention jobs over anonymous Session / quota tables; no public route (`workers/jobs`, was maintenance).
+- **All → Contract**: Published language for cross-boundary DTOs; prefer glossary terms above over ad-hoc synonyms.
+
+## Core vocabulary (cross-context)
+
+| Term | Means | Avoid |
+| --- | --- | --- |
+| **Point** | Visitable seichi stop | PilgrimagePoint (legacy type name), Spot in contracts |
+| **Bangumi** | One anime title in the catalog | Work, Anime-as-title |
+| **Itinerary** | Computed ordered plan | bare Route |
+| **SavedRoute** | User-owned saved record | bare Route |
+| **Session** | Agent dialogue context | auth cookie “session” without qualifier |
+
+## Domain model presence (skeleton refactor)
+
+| Package | Pilgrimage `domain/` | Notes |
+| --- | --- | --- |
+| `workers/catalog` | **Yes** (target) | Full CA: domain / application / adapters |
+| `apps/agent` | **Yes** (target) | Domain free of FastAPI/PydanticAI runtime imports |
+| `workers/users` | **Shallow** | Pure rules + ports; no heavy DDD tree |
+| `workers/edge` | **No** | Gateway only — never `src/domain/` for pilgrimage |
+| `apps/web` | **No** | UI — no `src/domain/` |
+| `workers/jobs` (today `maintenance`) | **No** | Job + Schedule only |
+| `infra` | **No** | Topology / Cloudflare only |
+| `packages/contract` | N/A | Published language, not a BC with domain/ |
+
+Campaign: [#829](https://github.com/lifeodyssey/animichi/issues/829) · path tracker: [`docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md`](./docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md) · structure index: [`docs/superpowers/specs/2026-08-06-structure-refactor-index.md`](./docs/superpowers/specs/2026-08-06-structure-refactor-index.md).

--- a/apps/agent/CONTEXT.md
+++ b/apps/agent/CONTEXT.md
@@ -1,0 +1,41 @@
+# Agent
+
+Orchestrates the pilgrimage dialogue: tool loop, Session state, and calls out to Catalog (and related ports). Does not own Point master data or SavedRoute persistence.
+
+Greenfield language + data plane:  
+`docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md`
+
+## Language
+
+**Session**:
+The agent-side dialogue and tool state for one ongoing chat (anonymous or authenticated).
+_Avoid_: Using “session” alone for auth cookies
+
+**Conversation**:
+Persisted dialogue log (messages). Agent write authority; Users may list SessionSummary as read-only projection.
+
+**Point** · **Bangumi** · **Itinerary**:
+Same as published language; obtained via Catalog. Not owned as master data here.
+_Avoid_: PilgrimagePoint, Work, bare Route
+
+**Fact ledger / hard constraint**:
+In-session constraints that survive compaction. Not cross-session UserMemory (Users).
+
+## Owns / does not own
+
+| Owns | Does not own |
+|---|---|
+| Session runtime, messages, in-session memory | Point/Bangumi master data |
+| Anon quota / usage metering hooks | SavedRoute / Share / Check-in |
+| Catalog **read** client | Catalog ingest / write |
+| | Cross-session `user_memory` (Users when awake) |
+
+## Greenfield code targets
+
+- Types: `Point`, `Itinerary` (drop `Route` / `PilgrimagePoint` mirrors).
+- Catalog paths follow contract (`/catalog/itinerary`, `bangumi_id`, …).
+- **Delete** direct master-data write ports (no dual-path debt).
+
+## Design
+
+`docs/superpowers/specs/2026-08-06-agent-clean-architecture-design.md` (ACCEPTED + greenfield).

--- a/apps/web/CONTEXT.md
+++ b/apps/web/CONTEXT.md
@@ -1,0 +1,32 @@
+# Web (UI)
+
+Browser surface only (TanStack Start). **Does not own** pilgrimage master data or SavedRoute authority.
+
+## Domain model?
+
+**No.** There is **no** `src/domain/` and no DDD aggregate layer for Point / Bangumi / Itinerary / SavedRoute.
+
+- **Contract DTOs** (`@animichi/contract`) are the published wire language at the API boundary.
+- **Features** hold UI state and composition only.
+- Rules and persistence live in Catalog / Users / Agent.
+
+## Language (wire / UI)
+
+Use published terms in code identifiers: **Point**, **Bangumi**, **Itinerary**, **SavedRoute**, **Session** (chat). Product copy may stay localized.
+
+## Layout target
+
+See `docs/superpowers/specs/2026-08-06-web-ui-structure-design.md`.
+
+```text
+routes → features → api/hooks → api clients → public /v1
+platform/ = cross-feature auth, byok, turnstile, styles
+```
+
+## Owns / does not own
+
+| Owns | Does not own |
+|---|---|
+| Pages, features, SSR shell | Catalog ingest / itinerary algorithms |
+| Client transport + MSW against contract | Users persistence authority |
+| Neon Auth **client** (login UI) | JWT verification for users worker |

--- a/docs/adr/0002-published-language-point-bangumi-itinerary.md
+++ b/docs/adr/0002-published-language-point-bangumi-itinerary.md
@@ -1,0 +1,26 @@
+# Published language: Point, Bangumi, Itinerary, SavedRoute, Session
+
+Cross-service speech used overloaded English **Route** (computed plan vs user-owned save) and **Work** / **PilgrimagePoint** in ways that fight the monorepo boundaries. We lock the published language below.
+
+**Canonical terms**
+
+- **Point** — one visitable seichi stop (coordinates / media / bangumi link). Not `PilgrimagePoint`.
+- **Bangumi** — one anime title in the catalog (typically `bangumi_id`). Not `Work` / `work_id`.
+- **Itinerary** — Catalog-computed ordered plan over Points (optional pacing/timing). Not bare `Route`.
+- **SavedRoute** — user-owned saved record (`point_ids` + metadata + status). Not bare `Route` / `UserRoute`.
+- **Session** — user–agent dialogue context. Not an auth cookie without a qualifier.
+
+**Why**
+
+- Catalog owns Itinerary computation; Users owns SavedRoute persistence; Agent owns Session. One English word must not span three owners.
+- Bangumi matches the external id space we already key on; Work is too broad in a multi-service codebase.
+
+**Consequences**
+
+- Glossaries: `CONTEXT-MAP.md` and per-package `CONTEXT.md`.
+- New docs, issues, and package-internal domain names use the table above.
+- **Greenfield (2026-08-06):** no production users → **wire types, HTTP paths, and DB column/table names move to the table above in the same migration train**. No long-lived dual names. Detail: `docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md`.
+
+**Supersedes**
+
+- Earlier wording that “wire type renames may lag” — lag is **not** the default under greenfield.

--- a/docs/iterations/refactor-skeleton-2026-08/GOAL.md
+++ b/docs/iterations/refactor-skeleton-2026-08/GOAL.md
@@ -1,0 +1,359 @@
+# GOAL — Monorepo 骨架重构（全波次 · 编排锁定）
+
+**正式 spec：** https://github.com/lifeodyssey/animichi/issues/829  
+**本文件：** 战役关账板 + **全波次计划** + 编排/合 PR 闸；与 #829 冲突时以本文件最新波次表为准并回写 #829 评论。  
+**工作目录：** `~/work/animichi`
+
+**Matt 流（已完成 → 执行中）：**  
+grill ✅ → to-spec ✅ #829 → to-tickets ✅ → **implement 全波次** → **每 PR `/code-review`** → **两路 PR 评论闸** → merge → 本文件勾选
+
+### 如何用 `/goal` 驱动本文件
+
+本文件是**战役合同**；`/goal` 是**让 agent 一直干到完成条件成立**的开关。用法：
+
+1. **工作目录**切到 `~/work/animichi`（或 monorepo 根）。  
+2. 开新会话或当前会话发（Grok Build）：
+
+```text
+/goal 执行 docs/iterations/refactor-skeleton-2026-08/GOAL.md：从 W0 起按波次推进；一票一 worktree 一 PR；写码可用 opencode-go 或 subagent；每 PR 必经 Matt code-review（Standards∥Spec，base=origin/main）+ 两路 PR 评论闸（行级 threads 全处理 + 顶层 qodo/Sonar 判定 + 顶层「线程判定」）后才 merge；live≤6；HITL 波（W2 密钥、W6–W8）停住人确认；完成条件=本文件 W0–W8 与 §4 验收勾选齐（W7/W8 可显式 WONT 并写进变更日志）
+```
+
+3. **只开一波**（更稳）：
+
+```text
+/goal 只做 GOAL W0：合完 #833 #830 #859 并勾选 W0；纪律同 GOAL §1.2–1.3
+```
+
+4. 查询 / 暂停 / 取消（Grok）：`/goal status` · `/goal pause` · `/goal resume` · `/goal clear`  
+
+5. **没有 `/goal` 时**直接说同一段自然语言即可（「按 GOAL 从 W0 开干」）。  
+
+6. Claude Code 若用 planning-with-files：可先把本 GOAL 链进 plan，再 `/plan-goal` 或 `/goal <同上完成条件>`。
+
+**完成条件（agent 自证用）：**  
+`GOAL.md` 中 W0–W6 的「W? 完成」为 `[x]`（W7/W8 完成或变更日志写明延期）；每个已合 PR 有 code-review 记录与「线程判定」类 ACK；`gh pr list --state open` 无本战役遗留阻塞 PR。
+
+---
+
+## 一句话
+
+只重构：目录/边界/竖切/配置/CI 骨架/DB 角色与迁移史/可选 rename；未完成 `TODO(refactor-skeleton)`；**无新产品功能**。  
+执行能快则快；写码 **opencode-go 与 subagent 均可**；**合 PR 前 Matt review + 全部 PR 评论处理完**。
+
+---
+
+## 0. 非目标（违反即 scope creep）
+
+- [ ] 无 Share / Check-in / しおり / 新 API 行为（仅 TODO 指针）
+- [ ] edge / web / jobs / infra **无** 巡礼空 `domain/`
+- [ ] **不** 改 branch protection **required check 名**
+- [ ] **不** 在自动波次做 production DSN 切换（→ W7 HITL）
+- [ ] **不** 放宽 coverage / typecheck / 1-10-50 / `--deny-warnings`
+- [ ] **不** 在未完成评论闸时 `gh pr merge`（hook 也会拦）
+
+**TODO 约定：** `// TODO(refactor-skeleton): <what> — see #<issue>|GOAL§`
+
+---
+
+## 1. 编排锁定
+
+### 1.1 单元
+
+| 单元 | 规则 |
+|---|---|
+| 票 | 一 GitHub issue = 一 worktree = **一 PR**（不大杂烩） |
+| 实现 | Matt **`/implement`** 语义（tdd 优先、包门禁、再提交） |
+| 写码执行器 | **opencode-go** 与/或 **Grok subagent** 均可；**同一 worktree 同时只有一个写者** |
+| Track lead | 可 subagent / 主会话：写 brief → 派执行器 → GATE → 开 PR → review → 评论闸 → merge |
+| 并行 | 同波次内无依赖的票可并行；**live ≤ 6**；opencode 仅 **一个 serve** |
+| 关账 | 本文件波次勾选 + PR URL 证据 + 票 CLOSED |
+
+### 1.2 单 PR 生命周期（强制顺序）
+
+```text
+1. worktree from origin/main + brief（票 AC 全文）
+2. implement（opencode 和/或 subagent）
+3. GATE：相关包 typecheck/lint/test（覆盖本 PR 改动路径）
+4. commit + push + gh pr create（body：Closes #票 · Parent #829）
+5. ★ Matt /code-review
+     - fixed point: origin/main（三点 diff / merge-base）
+     - Spec 轴：本票 body + 本 GOAL 对应波次
+     - Standards 轴：AGENTS.md · 1-10-50 · 无 Any · 包 AGENTS · Fowler smell 基线
+     - 阻塞 findings → FIX → 回 3–5 再 review
+6. CI 全绿
+7. ★ 两路 PR 评论闸（见 §1.3）— 全部完成才可 merge
+8. gh pr merge（rebase-only；过全局 hook）
+9. 本 GOAL 对应项 [x] + 证据 PR 号
+```
+
+### 1.3 两路 PR 评论闸（owner rule · 合前必做）
+
+与 `AGENTS.md` + `~/.claude/hooks/check-pr-comments.sh` 一致。**只查一路 = 禁止合并。**
+
+| 载体 | 查法 | 必须 |
+|---|---|---|
+| **行级 review threads** | GraphQL `reviewThreads(isResolved:false)` | 逐条读完：真问题→修；误报/已过时→**线程内 inline 回复理由**再 resolve |
+| **顶层 issue comments** | `gh pr view <n> --json comments` | qodo Code Review 汇总（Bugs / Rule violations）、SonarCloud Quality Gate、codecov 等；非零 Bugs/violations 或 QG Failed → 修或书面判定 |
+
+**放行条件（全部满足）：**
+
+1. 未解决线程 = 0  
+2. 顶层无未处理的阻塞 bot findings（或已在 maintainer 评论中判定）  
+3. 顶层有一条 **OWNER/MEMBER/COLLABORATOR** 评论，含 **`线程判定`** 或 **`findings triaged`** 字样（hook ACK）  
+4. Matt `/code-review` 双轴无未处理阻塞项（报告可贴 PR 或 lead 日志）  
+5. `gh pr checks` 全绿  
+
+**顺序：** inline 回复线程 → resolve → **最后** 发顶层「线程判定」→ 再 merge（避免 bot 刷新时间戳顶掉判定）。
+
+**责任：** 编排 / lead **必须关注该 PR 全部 comments**（行级 + 顶层）；未 triage 不得合。
+
+### 1.4 执行器选择（能快则快）
+
+| 类型 | 优先 |
+|---|---|
+| 纯文档 / PATH-DELTA / N3 | subagent 或 opencode，**谁快用谁** |
+| 包内竖切 / 重构代码 | 两者均可；厚逻辑可 opencode-go |
+| CI YAML / 敏感路径 | 执行后 lead **逐行** diff；GATE 必须盖到改动包 |
+| 需 Neon/staging 真密钥 / prod / force 历史 | **HITL**，不自动 merge |
+
+---
+
+## 2. 已锁定产品/结构决策（grill 摘要）
+
+| 主题 | 决策 |
+|---|---|
+| Catalog 竖切 | PlanItinerary |
+| Agent | CatalogReadGateway → HandleUserMessage |
+| Users | 纯规则 → SavedRouteRepo；Share/Check-in TODO |
+| 搬家 | Train 路径与竖切分 PR；尽量 git mv |
+| Greenfield 名 | 竖切路径可用新名；全量 rename = W5 |
+| CI | `actions/` 文件夹 composite；1–2 pipeline 样板；不改 required check **名** |
+| ROLE/GRANT | Atlas；RLS 本波不作授权主路径 |
+| Runtime DSN | 密钥面；staging = W2；prod = W7 HITL |
+| Migration 史 squash | W6 HITL epic #845 |
+| Git 日折叠 | W8 最后；#851 |
+
+---
+
+## 3. 全波次计划（按序；波内可并行）
+
+状态：`[ ]` 未开 · 进行中写 PR · `[x]` 波次关（该波所有票合且评论闸过）
+
+---
+
+### W0 — 地图与文档基线（可立即并行）
+
+**目标：** 导航真相与表归属文档，不堵代码轨。
+
+| 票 | 内容 | 依赖 |
+|---|---|---|
+| #833 | SK-0 PATH-DELTA + CONTEXT-MAP | — |
+| #830 | DB-1 表归属 + 角色矩阵文档 | — |
+| #859 | N3 Neon 环境拓扑一页纸 | — |
+
+**关波：** 三票 CLOSED + 文档在 main。
+
+- [ ] **W0 完成**
+
+---
+
+### W1 — 薄代码轨并行（needs W0 的仅 jobs/edge 配置可后置）
+
+**目标：** 无互依赖或仅弱依赖的竖切骨架同时推进。
+
+| 轨 | 票序 | 依赖 |
+|---|---|---|
+| Users | #834 → #835 | — |
+| Catalog | #837 → #838 | 建议 #833 已合（可弱依赖并行） |
+| Agent | #839 → #840 | 建议 #833 |
+| Jobs | #836 | #833 |
+| Edge | #841 | #833 |
+| Web | #842 | #833 |
+| Infra | #843 | #833 |
+| CI 样板 | #844 | #833 |
+| 工具 | #857 GH-1 日折叠 dry-run 脚本 | — |
+
+**关波：** 上表票均合；GOAL §B/C 相关项可勾。
+
+- [ ] **W1 完成**
+
+---
+
+### W2 — DB 角色落地 staging（串行）
+
+| 票 | 内容 | 依赖 |
+|---|---|---|
+| #831 | DB-2 Atlas ROLE+GRANT 迁移 | #830 |
+| #832 | DB-3 staging apply + 最小权限 DSN | #831；**密钥部分 HITL** |
+
+**关波：** 迁移在 staging apply；DSN 接线完成或缺口写清 TODO；#832 评论闸 + 人确认密钥。
+
+- [ ] **W2 完成**
+
+---
+
+### W3 — 配置下沉与文档卫生
+
+| 票 | 内容 | 依赖 |
+|---|---|---|
+| #853 | SK-P1 Dockerfile / edge package-ize 收尾 | #833 · 宜 #841 |
+| #856 | HY-1 文档/根卫生 | #833；宜 W1 大路径稳后 |
+| #860 | N5 备份/监控/RPO stub | —（doc）；告警 HITL 可选 |
+
+- [ ] **W3 完成**
+
+---
+
+### W4 — Greenfield 全量 rename（wide · expand–contract）
+
+| 票 | 内容 | 依赖 |
+|---|---|---|
+| #852 | SK-G1 routes→saved_routes · work_id→bangumi_id 等 | 宜 #831 · #835 · #838；与 W6 二选一协调 |
+
+**关波：** 合同+Workers+agent 新名；迁移+GRANT；测绿。
+
+- [ ] **W4 完成**
+
+---
+
+### W5 — migrations 目录搬家（N4）
+
+| 票 | 内容 | 依赖 |
+|---|---|---|
+| #854 | SK-M1 `db/migrations` → `migrations/neon` + CI | 宜 **W6 后** 搬短链，或 W6 前搬（冻结选一侧） |
+
+- [ ] **W5 完成**
+
+---
+
+### W6 — Atlas 历史 squash + gazetteer 出链（HITL 重）
+
+| 票 | 内容 | 依赖 |
+|---|---|---|
+| #846 | MS-1 baseline spike | #845 决策 D1–D6 |
+| #847 | MS-2 gazetteer seed 路径 | 可与 #846 并行 |
+| #848 | MS-3 staging 彩排 | #846 · #847 · owner D1 |
+| #850 | MS-5 替换 main 链 | #848 |
+| #849 | MS-4 prod soft baseline | #848 · owner 窗口 |
+
+Epic：#845。**不** force-push git 历史（那是 W8）。
+
+- [ ] **W6 完成**
+
+---
+
+### W7 — 生产权限（HITL）
+
+| 票 | 内容 | 依赖 |
+|---|---|---|
+| #855 | DB-N2 prod 最小权限 DSN | #832 稳 |
+
+- [ ] **W7 完成**（或显式 WONT 留到下战役）
+
+---
+
+### W8 — Git 日折叠（最后 · 冻结 main）
+
+| 票 | 内容 | 依赖 |
+|---|---|---|
+| #857 | GH-1 dry-run 脚本 | —（可 W1 已做） |
+| #858 | GH-2 执行 runbook + 备份 + swap/force-with-lease | #857 · **W0–W6 大波结束或显式冻结** |
+| #851 | Epic 关账 | #858 |
+
+**关波：** tip tree 不变；~1 commit/天；`main-legacy` 保留 ≥30 天。
+
+- [ ] **W8 完成**
+
+---
+
+## 4. 验收勾选（与波次对应 · 关战役用）
+
+### A. 仓骨架 — W0 · W3
+
+- [ ] PATH-DELTA 覆盖目标树  
+- [ ] CONTEXT-MAP / 包 CONTEXT 与有无 domain 一致  
+- [ ] 配置 owner-local（#853）  
+
+### B. 业务包 — W1
+
+- [ ] Catalog CA + PlanItinerary  
+- [ ] Agent gateway + HandleUserMessage  
+- [ ] Users 规则 + SavedRouteRepo；产品 TODO  
+
+### C. Edge / Web / Jobs — W1
+
+- [ ] 无巡礼 domain；测绿  
+
+### D. Infra / CI — W1 · W3
+
+- [ ] Infra 分段  
+- [ ] package-ci 文件夹 + 1–2 pipeline；required check **名**不变  
+
+### E. Neon / 角色 — W0 · W2 · W6 · W7
+
+- [ ] 归属文档  
+- [ ] staging 角色+DSN  
+- [ ] （可选）migration 史干净 + gazetteer 外置  
+- [ ] （可选）prod DSN  
+
+### F. 历史 — W8
+
+- [ ] git 日折叠完成或显式延期  
+
+### G. 质量与合 PR 纪律（**每个 PR**）
+
+- [ ] 包门禁绿  
+- [ ] 无用户可见 API 行为变更  
+- [ ] 1-10-50 破线不增  
+- [ ] **Matt `/code-review` 双轴通过**  
+- [ ] **两路 PR 评论闸完成 + 顶层「线程判定」**  
+
+---
+
+## 5. 票板索引（全）
+
+| Issue | 波次 | 标题摘要 |
+|---|---|---|
+| #829 | — | Spec 父票 |
+| #833 | W0 | SK-0 PATH-DELTA |
+| #830 | W0 | DB-1 归属文档 |
+| #859 | W0 | N3 拓扑 |
+| #834–#835 | W1 | Users |
+| #837–#838 | W1 | Catalog |
+| #839–#840 | W1 | Agent |
+| #836 | W1 | Jobs |
+| #841–#844 | W1 | Edge/Web/Infra/CI |
+| #857 | W1/W8 | GH-1 脚本 |
+| #831–#832 | W2 | DB 角色 staging |
+| #853 #856 #860 | W3 | 配置/卫生/N5 |
+| #852 | W4 | Greenfield rename |
+| #854 | W5 | migrations/neon |
+| #845–#850 | W6 | Atlas squash |
+| #855 | W7 | Prod DSN |
+| #851 #858 | W8 | Git 日折叠 |
+
+---
+
+## 6. 默认并行节奏（能快则快）
+
+```text
+现在：     W0 三票并行 + W1 多轨并行（live≤6）+ #857
+W0∪W1 后： W2 串行（#831→#832）
+           W3 并行
+W2 后：    W4 或 W6（owner 选 rename 与 baseline 谁先；避免双改迁移史）
+W6 后：    W5 搬家（若未提前）
+           W7 HITL
+全部代码波结束后冻结：W8
+```
+
+**每 PR 不加速项：** Matt code-review + 两路评论闸（不可跳）。
+
+---
+
+## 7. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿 GOAL |
+| 2026-08-06 | #829 镜像勾选板 |
+| 2026-08-06 | **全波次 W0–W8**；编排锁定；双执行器；**Matt code-review 强制**；**两路 PR 评论闸（线程判定）** 写入 GOAL |

--- a/docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md
+++ b/docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md
@@ -25,3 +25,5 @@
 | greenfield Point/Itinerary/SavedRoute | 旧 wire 名仍在 | TODO | 可与结构同波 |
 
 **规则：** 未搬完成前，代码里允许 `TODO(refactor-skeleton): move to <target>`。
+
+<!-- ci-retrigger: force Actions webhook after outage -->

--- a/docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md
+++ b/docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md
@@ -1,0 +1,27 @@
+# PATH-DELTA — 目标路径 vs 现状
+
+**Parent:** [#829](https://github.com/lifeodyssey/animichi/issues/829) · **Ticket:** [#833](https://github.com/lifeodyssey/animichi/issues/833)
+**Layout target:** `docs/superpowers/specs/2026-08-06-monorepo-target-layout.md`
+**Structure index:** `docs/superpowers/specs/2026-08-06-structure-refactor-index.md`
+
+
+实现过程中更新。状态：`TODO` | `IN_PROGRESS` | `DONE` | `WONT`（附理由）。
+
+| 目标 | 现状 | 状态 | 备注 |
+|---|---|---|---|
+| `workers/edge/wrangler.toml` | 根 `wrangler.toml` | TODO | Edge E1 |
+| `workers/edge/package.json` runtime deps | 根 `package.json` | TODO | Edge E1 |
+| `apps/agent/Dockerfile` | 根 `Dockerfile` | TODO | 容器 pin |
+| `workers/jobs/` | `workers/maintenance/` | TODO | J1 |
+| `migrations/neon/` | `db/migrations/` | TODO | DBA D19 |
+| `migrations/supabase/` | 根 `supabase/` | TODO | 过渡 |
+| `tests/e2e/` | 根 `e2e/` | TODO | monorepo 树 |
+| `infra/src/*` | `infra/index.ts` 单文件 | TODO | Pulumi P1 |
+| `reusable-package-ci.yml` | 无；`pipeline-*.yml` 复制 | TODO | CI C2 |
+| catalog `domain/`… | 部分 lib/api 扁平 | TODO | structure B1 |
+| agent application use cases | 主路径在 agents/runner | TODO | B2 |
+| users pure rules + port | `api/routes.ts` 上帝 | TODO | B3 |
+| web feature 去双栖 | `lib/chat` + `features/chat` | TODO | C2 |
+| greenfield Point/Itinerary/SavedRoute | 旧 wire 名仍在 | TODO | 可与结构同波 |
+
+**规则：** 未搬完成前，代码里允许 `TODO(refactor-skeleton): move to <target>`。

--- a/docs/iterations/refactor-skeleton-2026-08/README.md
+++ b/docs/iterations/refactor-skeleton-2026-08/README.md
@@ -1,0 +1,19 @@
+# Refactor skeleton 2026-08
+
+| 文件 | 用途 |
+|---|---|
+| **[GOAL.md](./GOAL.md)** | **全波次 W0–W8 · 编排 · 合 PR 闸 · 勾选关账** |
+| [PATH-DELTA.md](./PATH-DELTA.md) | 路径差 |
+| [#829](https://github.com/lifeodyssey/animichi/issues/829) | 正式 spec |
+
+## 合 PR 前（不可跳）
+
+1. Matt `/code-review`（Standards + Spec）  
+2. 行级 threads **全部**处理（inline + resolve）  
+3. 顶层 bot findings 判定  
+4. 顶层 `线程判定` / `findings triaged`  
+5. CI 绿 → merge  
+
+## 执行器
+
+opencode-go **或** subagent；一 worktree 一写者；live ≤ 6。

--- a/docs/superpowers/specs/2026-08-06-agent-clean-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-06-agent-clean-architecture-design.md
@@ -1,0 +1,295 @@
+# Agent 教科书式 DDD + Clean Architecture 设计
+
+- Status: **ACCEPTED** — owner 确认 2026-08-06；**设计锁定，不含实现**
+- Date: 2026-08-06
+- Package: `apps/agent`（Python / PydanticAI / FastAPI 容器）
+- Language: ADR-0002 · `CONTEXT-MAP.md` · `apps/agent/CONTEXT.md`
+- Sibling: [Catalog 设计（已 ACCEPTED）](./2026-08-06-catalog-clean-architecture-design.md)
+- Parent: `docs/superpowers/specs/2026-08-06-monorepo-target-layout.md`
+- Accepted: A1–A5（含 §0.1 只读校准 / X12·G4 A3）
+- Greenfield: `2026-08-06-greenfield-language-and-data-plane.md`（语言/契约/删直连写 **一次最佳**）
+- Refactor train: **已有代码** 真·结构重构（移文件/抽 use case/化简/SOLID），**不止 rename**；未写产品能力归既有 ticket
+
+---
+
+## 0. 目标
+
+在 **已有** `domain/` · `application/` · `infrastructure/` · `interfaces/` · `agents/` 骨架上，收敛成教科书依赖方向与清晰用例边界，使：
+
+1. **Session** 与工具循环的领域规则可单测、不绑 FastAPI  
+2. **Catalog** 访问只经明确 port（客户–供应商）——对齐 **X12 / G4**  
+3. **SavedRoute / 身份** 不在 Agent 内重建  
+4. 与 monorepo Full tier、ADR-0002 **greenfield 语言**一致（Point / Itinerary / Session）  
+
+**非目标：** 本文阶段直接改生产代码；重写 PydanticAI。  
+**已否决：** 长期保留 Python `Route` / `PilgrimagePoint` 镜像旧名。
+
+### 0.1 「只读」校准（对齐早期定案，避免误解）
+
+| 层 | 是否只读 | 权威来源 |
+|---|---|---|
+| **Catalog 主数据**（Point / Bangumi / Itinerary 算法与结果） | **只读客户** | X12 去数据化；`apps/agent/AGENTS.md`；ingest 归 catalog |
+| **Agent 会话 / 编排**（Session、messages、fact ledger、anon quota 等） | **可写** | G4：agent 只保留 session/orchestration state |
+| **用户域**（SavedRoute、打卡、しおり） | **不新增 agent 数据端点** | G4 / SD-2 → `workers/users` |
+| **LLM tools 副作用** | **工具面只读**（无写 catalog/用户主数据） | SD-19 架构不变量 |
+
+一句话：**对 catalog 主数据只读；对 Session/编排可写；禁止往 agent 服务新增数据端点。**  
+「全服务零写库」**不是**目标。
+
+---
+
+## 1. 现状诊断
+
+### 1.1 今日目录（概要）
+
+```text
+apps/agent/src/animichi/
+  domain/           # entities, ports, fact_ledger, errors, …
+  application/      # 偏薄
+  infrastructure/   # gateways, session, supabase, observability
+  interfaces/       # FastAPI, persistence, chat_wire, routes
+  agents/           # runner, tools, catalog_adapter, handlers
+  clients/ tools/ config/ utils/ scripts/ tests/
+```
+
+### 1.2 已有正确碎片
+
+| 碎片 | 评价 |
+|---|---|
+| `domain/ports.py` Protocol | 出站 port 形状已有 |
+| `domain/entities.py` | Point/Bangumi 等存在；**Route → Itinerary 改名**（greenfield） |
+| `domain/fact_ledger.py` | Session 内硬约束记忆 — 真 domain |
+| interfaces 与 infrastructure 分离意识 | 接近 CA |
+| catalog 只读客户 | BC 关系正确 |
+
+### 1.3 差距
+
+| 期望 | 现状 |
+|---|---|
+| agents/ 是 application 还是 framework？ | **混杂**：编排 + PydanticAI + catalog 适配 |
+| application 用例清晰列表 | **偏薄**；主路径在 `animichi_runner` / tools |
+| domain 不依赖基础设施 | 大体如此，但 entities 命名与 ADR-0002 未对齐 |
+| 单一「对话用例」入口 | 分散在 public_api / routes / runner |
+
+**结论：** 比 catalog **更接近** 分层命名，但仍需 **教科书式收紧依赖与用例**，不是从零 mkdir。
+
+---
+
+## 2. 领域模型（Agent BC）
+
+### 2.1 语言（LOCKED 跨包 + 本包）
+
+| 词 | 含义 |
+|---|---|
+| **Session** | 一次用户–agent 对话与工具状态（可匿名、可 claim） |
+| **Point / Bangumi / Itinerary** | 与 Catalog 同义；Agent **不拥有**主数据，只消费 |
+| **SavedRoute** | Users 拥有；Agent 至多触发/引用 |
+| **Fact ledger / hard constraint** | Session 内必须保留的用户约束（如 pacing） |
+| **Tool turn** | 一次模型–工具交互步（实现细节可留 agents，概念上属 application） |
+
+### 2.2 拥有 / 不拥有
+
+| 拥有 | 不拥有 |
+|---|---|
+| Session 生命周期与状态机语义 | Point/Bangumi 主数据 |
+| **Conversation / 消息 / 会话内 memory**（写权威；见 Users §2.1.1） | **Users.listSessions 投影的「产品列表面」**（可挂 Users，数据仍本 BC） |
+| 对话策略、工具选择边界、compaction 保留规则 | Itinerary **算法**（Catalog 算） |
+| 对 Catalog/Users/LLM 的 **调用意图** | JWT 签发、Edge 限流 |
+| 匿名配额计数语义（与 maintenance 清理对象对齐） | SavedRoute 持久化权威；跨会话 `user_memory`（唤醒后归 Users） |
+
+### 2.3 不变量（草案，确认后 LOCK）
+
+1. Session 有稳定 id；匿名 Session 可被 claim 到用户，不能无主合并丢约束。  
+2. 硬约束进入 fact ledger 后，compaction 不得静默丢弃。  
+3. Agent **不**在本地「发明」与 Catalog 冲突的 Point 几何权威；**不写** catalog 主数据表。  
+4. 需要 Itinerary 时，经 Catalog port，不在 Agent 内复制规划 kernel（SD-28 已统一到 catalog）。  
+5. 对外 HTTP 错误经 registry 映射，不把领域异常直接当 500 文本泄漏。  
+6. **X12 / G4：** 不往 agent 服务新增任何 **数据端点**（catalog 域或用户域）；新能力问归属桶（catalog / users / session-only）。  
+7. **SD-19：** 面向模型的 tools 默认只读副作用；写 Session/配额走应用层与 port，不经「工具随便写库」。
+
+---
+
+## 3. Clean Architecture 圈层
+
+```text
+FastAPI · PydanticAI · asyncpg/Neon · HTTP clients · Logfire
+        ▲
+interfaces/ (inbound HTTP, wire) + infrastructure/ (outbound impls)
+        ▲
+application/  (use cases: HandleUserMessage, …)
+        ▲
+domain/       (Session rules, entities, port *protocols*)
+```
+
+**依赖硬规则：**
+
+- `domain/` 不 import FastAPI、PydanticAI agent 运行时、infrastructure 实现类  
+- `application/` 只依赖 domain + port 协议  
+- `agents/` 定位：**PydanticAI 适配器 + 工具绑定**（framework adapter），调用 application/domain，而不是反向  
+- `interfaces/`：HTTP 入站适配  
+- `infrastructure/`：port 的具体实现  
+
+**与现状命名对齐（不必强行改文件夹名）：**
+
+| 教科书 | 今日可对应 |
+|---|---|
+| domain | `domain/` |
+| application | `application/` + 从 `agents/runner` 抽出的用例 |
+| inbound adapters | `interfaces/` |
+| outbound adapters | `infrastructure/` + `agents/catalog_adapter` |
+| framework agent runtime | `agents/*`（明确降为适配器层文档角色） |
+
+---
+
+## 4. 目标职责树（设计，非强制一次改名）
+
+```text
+animichi/
+  domain/
+    model/              # entities 分文件（可选整理）
+    session/            # Session 规则、fact_ledger、compaction_retention
+    ports.py            # 仅 Protocol
+    errors.py
+  application/
+    handle_user_message.py
+    restore_session.py
+    claim_related.py    # 若有
+    ports 使用 domain.ports
+  adapters/
+    inbound/            # 目标名；今日 interfaces/
+      http/
+    outbound/           # 目标名；今日 infrastructure/ + catalog_adapter
+      catalog/
+      session_store/
+      llm/              # 若需
+  agents/               # framework: build agent, tool defs → 调 application
+  config/
+  tests/
+    domain/
+    application/
+    …
+```
+
+**近端不强制改路径：** 可先 **文档 + 依赖规则 + 用例边界** 落地，目录 rename 分期（同 catalog P 分期思想）。
+
+---
+
+## 5. 端口（出站）
+
+沿用并收紧 `domain/ports.py` 语义（名称可逐步对齐 ADR-0002）：
+
+| Port | 职责 | 读写 |
+|---|---|---|
+| **CatalogLookup / CatalogGateway** | search/resolve/points/itinerary 等（今 `catalog_adapter` / `CatalogClient`） | **只读**（X12） |
+| **SessionRepo** | Session 持久化 | 读写（G4 允许） |
+| **ConversationLog** | 消息日志 | 读写（G4 允许） |
+| **RouteArchive** | 与 SavedRoute/归档相关（命名应对齐 Users，避免与 Itinerary 混淆） | 目标迁 Users 或仅引用 |
+| **UsageMeter / AnonQuotaCounter** | 配额 | 读写（会话/计量域） |
+| **BangumiRepo / PointsRepo（直连）** | 旧双路径 | **Greenfield：删除写路径**；读一律 CatalogGateway |
+
+**目标依赖方向（= X12 + greenfield）：**
+
+- 巡礼主数据 **只经 Catalog HTTP/oRPC 读**（新 path：`/catalog/itinerary` 等）。  
+- **禁止** Agent→Neon 主数据写入；**无包袱 → 删 upsert 而非长期标债**。  
+- Session / messages / fact ledger / anon quota：**保留写**（Agent 表）。  
+- 类型名与 contract 对齐：**Point / Itinerary / Bangumi / Session**。
+
+---
+
+## 6. 主要用例（Application）
+
+| Use case | 说明 |
+|---|---|
+| HandleUserMessage | 鉴权后的一轮用户输入 → 加载 Session → agent turn → 持久化 |
+| StreamAgentTurn | 同上，流式（AI SDK wire） |
+| RestoreSession | 按 id 恢复状态与 fact ledger |
+| ApplyHardConstraint | 写入/合并 pacing 等约束 |
+| RequestItinerary | 选点后经 Catalog 取 Itinerary |
+| SearchPoints | 经 Catalog search（含 partial 语义理解） |
+| PhotoSearch / BYOK 相关 | 边界用例，port 另列 |
+
+---
+
+## 7. 与 Catalog / Users / Edge
+
+| 邻居 | 关系 |
+|---|---|
+| **Catalog** | 供应商：Point/Bangumi/Itinerary |
+| **Users** | SavedRoute claim/列表 — Agent 不拥有 |
+| **Edge** | 入站身份头、容器调度 — Agent 不实现网关 |
+| **Contract** | 跨服务 DTO；domain 内可 map 为内部类型 |
+
+---
+
+## 8. 测试策略（设计）
+
+| 层 | 内容 |
+|---|---|
+| domain | fact_ledger、实体守卫、compaction 规则 — 无 DB |
+| application | use case + fake ports |
+| adapters | 现有 integration / api 测 |
+| eval | 模型相关仍独立 `tests/eval` |
+
+---
+
+## 9. 分阶段（仅计划）
+
+| 阶段 | 内容 |
+|---|---|
+| **A0** | 本文 DESIGN → owner ACCEPTED — **DONE 2026-08-06** |
+| **A1** | 文档化 agents/ 为 framework adapter；禁止 domain→agents import（边界检查） |
+| **A2** | **Greenfield 语言 + CatalogClient**：Point/Itinerary；跟 contract 新 path；**删除**主数据直连写 |
+| **A3** | Catalog 调用统一单一 gateway port；Session 写路径保留且文档化 |
+| **A4** | 抽出 HandleUserMessage（或等价）application，runner 变薄 |
+| **A5** | 可选目录 rename 与 AGENTS 更新（只读口径与 §0.1 一致） |
+
+每阶段独立 PR；**A0 无代码。** A2 可并入仓级 **G1**。
+
+### 9.1 重构列车里 Agent **做什么 / 不做什么**
+
+| 做（已有 `apps/agent` 码） | 不做（留给 ticket） |
+|---|---|
+| `agents/` 降为 framework adapter；**抽出** HandleUserMessage 等已有主路径 use case | 新 tool / 新数据端点 / 新记忆产品 |
+| **移动** catalog 适配到单一 gateway；**删除** 已存在的主数据直连写 | UserMemory 跨会话（Users/SD-15） |
+| 化简 runner/deps 上帝对象；port 可测；SOLID / 1-10-50 拆文件 | match_scene 全管线等未落地能力的首次实现 |
+| greenfield 类型名与 CatalogClient path | 产品 ticket 自有范围 |
+
+**抽象：** 少而深的 port > 一层层空 interface；PydanticAI 留在 adapter 圈，不渗 domain。
+
+---
+
+## 10. Owner 确认（Agent 设计）— **全部 ACCEPTED 2026-08-06**
+
+| # | 议题 | 决议 |
+|---|---|---|
+| **A1** | 整体圈层与依赖规则 | **ACCEPTED** — §3 |
+| **A2** | `agents/` = framework adapter，不是 domain | **ACCEPTED** |
+| **A3** | **X12/G4 + greenfield：** catalog 只读；Session 可写；不新增 agent 数据端点；主数据直连写 **删除** | **ACCEPTED** |
+| **A4** | 分期 A1–A5（代码阶段） | **ACCEPTED** — A0 已完成；A1–A5 实施后置 |
+| **A5** | 本文 Status → ACCEPTED | **ACCEPTED** |
+
+---
+
+## 11. 相关文档
+
+| 文档 | 角色 |
+|---|---|
+| `apps/agent/CONTEXT.md` · `apps/agent/AGENTS.md` | 语言；只读 catalog 消费者口径 |
+| `2026-07-06-frontend-rebuild-inputs.md` **X12** | Agent 去数据化 |
+| `2026-07-06-frontend-rebuild-spec.md` **G4** · **SD-19** | 归属桶；tools 只读不变量 |
+| Catalog CA 设计（ACCEPTED） | 供应商边界 |
+| ADR-0002 | 发布语言 |
+| monorepo-target-layout | 仓级进度 |
+
+---
+
+## 12. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿 DESIGN ONLY；Catalog 已 ACCEPTED 后开写 |
+| 2026-08-06 | §0.1「只读」校准 + A3 对齐 X12/G4：catalog 只读、Session 可写、遗留 PointsRepo 标债 |
+| 2026-08-06 | Owner 确认 A1–A5 → Status **ACCEPTED**（仍无实现） |
+| 2026-08-06 | 与 Users §2.1.1 对齐：Conversation 写权威在 Agent；跨会话 memory 归 Users |
+| 2026-08-06 | Greenfield：删直连主数据写优先；Route→Itinerary 全量；并入仓级 G1 |
+| 2026-08-06 | §9.1：重构 = 已有码搬家/抽用例/化简/SOLID，不止 rename；未写能力归 ticket |

--- a/docs/superpowers/specs/2026-08-06-agent-structure-refactor-design.md
+++ b/docs/superpowers/specs/2026-08-06-agent-structure-refactor-design.md
@@ -1,0 +1,505 @@
+# Agent 结构重构设计（已有代码 · 真搬家 / 化简 / SOLID）
+
+- Status: **ACCEPTED**（owner 2026-08-06 — best-practice 默认；**不含实现 / 不含产品 enabler**）
+- Date: 2026-08-06
+- Package: `apps/agent` only（`src/animichi/`）
+- Parent CA: [`2026-08-06-agent-clean-architecture-design.md`](./2026-08-06-agent-clean-architecture-design.md)（ACCEPTED）
+- Greenfield: [`2026-08-06-greenfield-language-and-data-plane.md`](./2026-08-06-greenfield-language-and-data-plane.md)
+- Inventory basis: **仓库实文件**（2026-08-06 读盘）；禁止凭想象补目录
+
+---
+
+## 0. 范围与原则
+
+| 锁 | 含义 |
+|---|---|
+| **ONLY `apps/agent`** | 不设计 edge / web / users 产品能力 |
+| **已有代码** | 移文件、抽 use case / port、删死路径、对齐 SOLID 与 1-10-50 |
+| **非只 rename** | 语言改名只作为搬家列车的同车或紧邻切片，不单独当目标 |
+| **Catalog 只读客户** | 删主数据双写 / 双读死路径；**Session / Conversation / fact ledger / quota / usage 写保留** |
+| **未写产品** | `match_scene` 全管线等 → **ticket 指针 only**，本文件不落 runtime |
+
+**发布语言（本包）：** `Point` · `Itinerary` · `Session` · `Bangumi`。  
+**SavedRoute** 归属 Users；Agent 侧若仍有 session 内 `routes` 归档表，语义是 **Session 附属行程快照**，不得冒充 SavedRoute 权威。
+
+依赖硬规则（继承 parent CA §3）：
+
+```text
+FastAPI · PydanticAI · asyncpg · httpx · Logfire
+        ▲
+interfaces/ (inbound) + infrastructure/ (outbound impl)
+        ▲
+application/  (use cases)
+        ▲
+domain/       (Session 规则 · entities · Port Protocols)
+```
+
+- `domain/` 不 import FastAPI / PydanticAI runtime / infrastructure 实现  
+- `application/` 只依赖 domain + Protocol  
+- `agents/` = **PydanticAI 外圈适配器**（tool 绑定 + runner），调用 application/domain，禁止反向  
+- 抽象纪律：优先 **删** 错误分层与上帝对象，再加 port；禁止空 interface 表演
+
+---
+
+## 1. Current inventory
+
+路径根：`apps/agent/src/animichi/`。下列为 **实存** 模块角色与主要职责（非愿望目录）。
+
+### 1.1 `agents/` — 现状最大混合包（framework + 编排 + 部分 domain 形状）
+
+| 文件 / 子树 | 角色（今日） | 目标层 |
+|---|---|---|
+| `animichi_agent.py` | PydanticAI `Agent` 构造、instructions、hooks、memory capability | **agents/** 外圈（保留） |
+| `animichi_runner.py` (~330 LOC) | `run_animichi_agent`：注入 RuntimeDeps、preflight、模型 run、partial/blocked | **agents/** 薄 runner；主路径语义 → **application** |
+| `animichi_tools.py` | 四 catalog tools 的 PydanticAI 包装 → `catalog_tools` / `catalog_route_tools` | **agents/** tool surface |
+| `web_tools.py` · `web_trust.py` | web_search / 注入检测 | **agents/** |
+| `catalog_tools.py` (~278 LOC) | resolve / search_bangumi / search_nearby 业务循环 + Session 写入 | **application**（catalog 用例）+ 适配残留在 agents |
+| `catalog_route_tools.py` | plan_route | 同上 |
+| `catalog_adapter.py` | Catalog DTO → `SessionState` / wire payload（`build_search_state` / `build_route_*`） | **application** 或 `infrastructure/catalog` 映射；**不属 domain** |
+| `catalog_failures.py` | 失败文案 / 结果形状 | agents 或 application 错误映射 |
+| `runtime_deps.py` | `RuntimeDeps`：`db: CatalogLookup` + **`catalog: CatalogClientProtocol`** + tool_state | 拆：catalog port 单路径；`db` 主数据侧删除 |
+| `runtime_models.py` | 模型 output types（Search/Route/Clarify/…） | **agents/**（PydanticAI 外圈 DTO） |
+| `session_state.py` (~293 LOC) | 版本化 Session 注册表（search/route refs、fact_ledger 挂载） | **domain/session** |
+| `session_ownership.py` | 会话归属 | domain 或 application |
+| `tool_state.py` · `tool_outcomes.py` · `tool_event_bridge.py` | 工具状态 / 判别结果 / 生命周期事件 | agents 运行时细节；outcomes 可留 agents |
+| `selection.py` (~373 LOC) · `selection_messages.py` | multi/place 选择（旁路模型） | **application**（`ApplySelection` 类用例） |
+| `selected_route.py` | 选点直算 Itinerary（`catalog.route`） | **application**（`RequestItinerary`） |
+| `agent_result.py` | 运行结果 / provenance / usage | agents ↔ application 边界 DTO（可放 application 或 agents） |
+| `step_recording.py` | 服务端 step 记录 | agents / application 协作 |
+| `history_compaction.py` | 历史压缩 capability | agents（PydanticAI）+ domain 规则已在 `compaction_retention` |
+| `photo_search.py` · `photo_vision.py` | 图片搜圣地 | application use case + agents 适配 |
+| `translation.py` · `title_matching.py` | 标题翻译 / 变体匹配 | application 或 agents 工具侧 |
+| `byok_models.py` | BYOK 模型构建（依赖 egress_*） | **infrastructure/llm** 或 agents 外圈；egress 留 infrastructure |
+| `base.py` | model alias 解析、httpx model client | infrastructure 或 agents/llm |
+| `error_boundary.py` · `error_messages.py` | 工具错误边界 / 用户可见文案 | agents + interfaces 映射 |
+| `export/` · `route_export.py` · `route_area_splitter.py` | ICS / maps URL / 区域切分 | application 工具函数或 agents/export |
+| `geo_utils.py` · `geo_names.py` · `data/city_names_jp.json` | 地理辅助 | domain VO 辅助 或 infrastructure/geo |
+| `models.py` | `TimedItinerary` / `TimedStop` / `TransitLeg` / `ToolName` | **domain** 或 catalog 消费 DTO（与 greenfield `Itinerary` 对齐） |
+| `source_tiering.py` | 来源分层 | domain / application 策略 |
+| `handlers/_helpers.py` | 图片 URL rewrite、nearby groups | **infrastructure** 或 catalog adapter 内部 |
+| `handlers/__init__.py` | 空壳说明 | 可删或收敛 |
+
+**观察：** 工具链路已 **catalog-only**（`deps.catalog`）；`RuntimeDeps.db: CatalogLookup` 在 `agents/` 内 **无 `deps.db` 读点**（grep 空），但是 runner / RuntimeAPI 仍注入并 cast —— **死双路径注入**。
+
+### 1.2 `application/` — 极薄
+
+| 文件 | 内容 |
+|---|---|
+| `__init__.py` | 仅说明 errors |
+| `errors.py` | `ApplicationError` 族 + `ErrorCode` |
+
+**无** `HandleUserMessage` / `StreamAgentTurn` / `RestoreSession` 等用例模块。主路径在 `interfaces/public_api.RuntimeAPI` + `agents/animichi_runner`。
+
+### 1.3 `domain/`
+
+| 文件 | 内容 | 评价 |
+|---|---|---|
+| `entities.py` | `Coordinates`, `Station`, `Bangumi`, `Point`, **`Route`/`RouteSegment`**, `AnimichiSession`, `TransportInfo` | 真 domain 碎片；**`Route` 应 → `Itinerary`**；`AnimichiSession` 与 runtime `SessionState` **双轨** |
+| `ports.py` | `BangumiRepo`（含 **upsert**）、`PointsRepo`（含 **upsert_points_batch**）、`CatalogLookup`、`SessionRepo`、`RouteArchive`、`UsageMeter`、`AnonQuotaCounter`、`ConversationLog`、`RequestAudit` | Port 形状正确一半；**主数据写 + CatalogLookup 聚合是债** |
+| `fact_ledger.py` | pacing / scene refs；`record_turn_facts` | **真 Session domain** |
+| `compaction_retention.py` | 压缩保留实体账本 | **真 Session domain** |
+| `text_sanitize.py` | 截断 | domain 工具 |
+| `errors.py` | `DomainException` 等 | 与部分旧流程相关；审计是否仍被调用 |
+| `llm_schemas.py` | 旧 Gemini 抽取 schema（`BangumiNameExtraction` 等） | **疑似遗留**；重构时确认引用后删或迁 spikes |
+
+`domain/` 内部 import 仅 domain 自引用 —— **依赖方向已干净**。
+
+### 1.4 `infrastructure/`
+
+| 子树 / 文件 | 角色 |
+|---|---|
+| `supabase/client.py` · `client_types.py` · `helpers.py` | Neon/asyncpg 客户端门面 |
+| `supabase/repositories/bangumi.py` | 含 **`upsert_bangumi` / `upsert_bangumi_title`**、`filter_existing_ids`、list/get |
+| `supabase/repositories/points.py` | **读** + **`upsert_point` / `upsert_points_batch`** |
+| `supabase/repositories/routes.py` | `save_route` → 表 `routes`（**Session 侧归档**，非 Users SavedRoute） |
+| `supabase/repositories/session.py` | sessions / conversations / claim / purge 查询 |
+| `supabase/repositories/messages.py` | `conversation_messages` |
+| `supabase/repositories/usage.py` · `anon_quota.py` · `feedback.py` | 计量 / 配额 / 反馈 |
+| `session/` | `SessionStore` factory / memory / supabase_session |
+| `gateways/geocoding.py` | 出站 geocode（若仍用） |
+| `egress_*.py` | SSRF 防护传输（BYOK） |
+| `memory.py` | postgres memory store |
+| `observability/` | logfire spans |
+| `safe_output_path.py` | 路径安全 |
+| `migrations/` | 空包占位 |
+
+### 1.5 `interfaces/` — 入站 + **部分应用编排**
+
+| 文件 | 角色 |
+|---|---|
+| `fastapi_service.py` | app 工厂、lifespan、catalog client 注入 |
+| `public_api.py` (~896 LOC) | **`RuntimeAPI`**：会话准备、pipeline、选择旁路、翻译门、持久化编排、usage —— **上帝对象** |
+| `persistence.py` (~400+ LOC) | `persist_result` / messages / session / **`maybe_persist_route`**（读 `bangumi_repo.filter_existing_ids`） |
+| `session_facade.py` | session envelope 归一、context block、history |
+| `response_builder.py` | `AgentResult` → `PublicAPIResponse` |
+| `chat_wire.py` · `schemas.py` | wire DTO |
+| `db_repos.py` | `db: object` → 窄 Protocol 抽取（含 `bangumi_repo`） |
+| `anon_quota.py` · `usage_metering.py` | 配额 / 计量用例式函数 |
+| `error_registry.py` | 对外错误映射 |
+| `routes/chat.py` · `chat_stream.py` · `chat_body.py` | AI SDK 入站 |
+| `routes/photo_search*.py` · `byok.py` · `conversations.py` · `session_migration.py` | 边界路由 |
+| `routes/bangumi.py` | **直连 DB 读** `points`/`bangumi`（**主数据双读**） |
+| `routes/search_preview.py` | **直连 DB 读** |
+| `routes/health.py` · `runtime.py` · `feedback.py` | 运维 / 反馈 |
+| `routes/_deps.py` · `_middleware.py` | 依赖与中间件 |
+
+### 1.6 `clients/`
+
+| 文件 | 角色 |
+|---|---|
+| `catalog_client.py` (~370 LOC) | HTTP Catalog；镜像类型 **`PilgrimagePoint`**, **`Route`**（应对齐 **Point / Itinerary**）；`CatalogClientProtocol` |
+| `catalog_errors.py` | oRPC 错误镜像 |
+| `geocode.py` | geocode DTO（client 侧） |
+| `errors.py` | `APIError` / `TransientAPIError` |
+
+### 1.7 其它（本重构不强制搬家）
+
+| 路径 | 说明 |
+|---|---|
+| `config/` | settings、model aliases、cron、byok defaults |
+| `utils/` | language、logger |
+| `scripts/` · `spikes/codemode/` | 运维 / 实验；spike 不进生产分层 |
+| `tests/` | unit / integration / eval；随切片改 import，不预建空 domain 测试树 |
+
+### 1.8 主数据双路径（写 / 读）— 实况
+
+| 路径 | 存在位置 | 生产调用 |
+|---|---|---|
+| **写** `upsert_points*` / `upsert_bangumi*` | `domain/ports.py` Protocol + `infrastructure/.../points|bangumi.py` | **无业务调用点**；仅 unit / `NullDatabase` / repo 单测 |
+| **读** catalog 工具 | `CatalogClient` only | 主路径正确 |
+| **读** HTTP `routes/bangumi.py` · `search_preview.py` | 直连 `db.bangumi` / `db.points` | **仍活**；违反 X12「只经 Catalog」 |
+| **读** `filter_existing_ids` | `maybe_persist_route` | Session 归档时校验 bangumi id 是否在本地表 — **主数据读耦合** |
+| **注入** `RuntimeDeps.db: CatalogLookup` | runner / RuntimeAPI | agents 内未用；可删 |
+
+Greenfield / parent A3：**删除** 写端口与实现优先于标债；读统一 **CatalogGateway**；Session 写保留。
+
+---
+
+## 2. File / function move table（from → to）
+
+目标树（与 parent CA §4 对齐；**近端可保留 `interfaces/` 名**，不强制一次改成 `adapters/`）：
+
+```text
+animichi/
+  domain/
+    model/                 # Point, Bangumi, Itinerary, Coordinates, …
+    session/               # SessionState, fact_ledger, compaction_retention
+    ports.py               # 仅 Protocol（无主数据 upsert）
+    errors.py
+  application/
+    handle_user_message.py
+    stream_agent_turn.py   # 若从 chat_stream 抽出
+    apply_selection.py
+    request_itinerary.py
+    search_points.py       # 自 catalog_tools 抽出的纯用例内核
+    photo_search.py
+    persist_turn.py        # 自 persistence 抽出的会话写编排
+    errors.py              # 已有
+  agents/                  # PydanticAI only: agent, tools, runner 薄壳, runtime_models
+  infrastructure/
+    catalog/               # CatalogClient 实现 + DTO 映射
+    session_store/
+    supabase/…             # Session/messages/quota 等（无 points/bangumi 写）
+    egress/ · observability/
+  interfaces/              # FastAPI routes, wire, RuntimeAPI 薄 facade
+  config/ · tests/
+```
+
+### 2.1 必做搬家 / 函数迁移
+
+| from | to | 备注 |
+|---|---|---|
+| `agents/session_state.py`（`SessionState`, ref 注册表, PointState…） | `domain/session/state.py`（或 `domain/session/session_state.py`） | Session 权威形状；agents/application 共引 |
+| `domain/fact_ledger.py` | `domain/session/fact_ledger.py` | 可选同 PR 子目录整理 |
+| `domain/compaction_retention.py` | `domain/session/compaction_retention.py` | 同上 |
+| `domain/entities.py` 中 `Point`/`Bangumi`/`Coordinates`/`Station` | `domain/model/*.py` | **`Route` → `Itinerary`**；删或合并与 `SessionState` 重复的 `AnimichiSession`（确认无引用后删） |
+| `agents/models.py` 中 `TimedItinerary`/`TimedStop`/`TransitLeg` | `domain/model/itinerary.py` **或** 与 catalog 消费 DTO 合并到 `infrastructure/catalog/dto.py` 再 map 进 domain | 避免三套 Itinerary |
+| `clients/catalog_client.py` 类型 `PilgrimagePoint`/`Route` | 改名 **`Point`/`Itinerary`**；实现迁 `infrastructure/catalog/client.py`；**Protocol** 升为 `domain/ports.CatalogGateway` | Protocol 在 domain；httpx 实现在 infrastructure |
+| `agents/catalog_adapter.py` | `infrastructure/catalog/session_mapper.py` 或 `application/catalog_mapping.py` | 纯函数映射；不碰 DB |
+| `agents/catalog_tools.py` 内核 `run_resolve` / `run_work_search` / `run_nearby_search` | `application/search_points.py`（+ 细分文件若 >300 LOC） | PydanticAI `RunContext` 包装留 `agents/animichi_tools.py` |
+| `agents/catalog_route_tools.py` `run_route` | `application/request_itinerary.py` | 同上 |
+| `agents/selected_route.py` `execute_selected_route` | `application/request_itinerary.py`（同用例族） | 选点旁路 |
+| `agents/selection.py` `execute_multi_selection` / `execute_place_selection` / `validate_candidate_selection` | `application/apply_selection.py` | 确定性旁路 |
+| `interfaces/public_api.py` `RuntimeAPI.handle` 主体 | `application/handle_user_message.py` | RuntimeAPI 只做 DI + 调 use case + 错误→HTTP |
+| `interfaces/public_api.py` 选择 / 翻译 / pipeline 私有方法 | 同上 use case 或 `application/translate_title_gate.py` | 拆 1-10-50 |
+| `interfaces/persistence.py` `persist_result` 族 | `application/persist_turn.py` | ports: SessionRepo, ConversationLog, RouteArchive, … |
+| `interfaces/session_facade.py` 中 **无 FastAPI** 的 session 归并 | `application/session_context.py` 或 domain 服务 | wire 相关留 interfaces |
+| `interfaces/anon_quota.py` · `usage_metering.py` | 可标为 application 配额用例（物理搬家或文档层角色二选一，优先搬家） | 已接近 use case 形态 |
+| `agents/photo_search.py` 业务 | `application/photo_search.py` | route 与 vision 钩子留 interfaces/agents |
+| `agents/handlers/_helpers.py` | `infrastructure/catalog/image_proxy.py` + nearby group helper 旁路 | 去掉空 `handlers/` 包若无其他模块 |
+| `agents/byok_models.py` 中 egress 组装 | 可留 agents 或 `infrastructure/llm/byok.py` | 保持 T12 工厂不散落 |
+| `domain/ports.BangumiRepo` upsert* · `PointsRepo` upsert* | **删除** | 连同 repository 写方法 |
+| `domain/ports.CatalogLookup` | **删除**；读一律 `CatalogGateway` | RuntimeDeps 去掉 `db` |
+| `infrastructure/.../points.py` upsert* | **删除** | 测删或改断言「不存在」 |
+| `infrastructure/.../bangumi.py` upsert* | **删除** | `filter_existing_ids`：改为不读主表（见 §2.2） |
+| `interfaces/routes/bangumi.py` · `search_preview.py` | 经 **CatalogGateway** 重写 **或** 删除端点（X12：不新增 agent 数据端点；旧数据端点能删则删） | 产品若仍要 guide/popular → **Catalog/Workers 拥有**；agent 不代持 |
+| `interfaces/db_repos.bangumi_repo` | 删除或仅保留 session 侧需要的窄协议 | 与主数据解耦 |
+| `domain/llm_schemas.py` | 确认零引用后 **删除** | 非 CA 装饰 |
+
+### 2.2 `maybe_persist_route` / `RouteArchive` 语义
+
+| 今日 | 目标 |
+|---|---|
+| `RoutesRepository.save_route` → 表 `routes` + `route_anime` | **保留为 Session 附属归档**（G4 允许写编排状态） |
+| 名称 `RouteArchive` | 文档与代码注释标明 **非 SavedRoute**；可选 rename → `SessionItineraryArchive`（与 Users 语言切割） |
+| `bangumi_repo.filter_existing_ids` 过滤 anime_ids | **删除该主数据读**：直接信任本回合 Catalog 结果中的 `bangumi_id`，或只写 session_state 内已有 id，**不**再查本地 `bangumi` 表 |
+
+### 2.3 明确 **不** 因「好看」搬家
+
+| 项 | 原因 |
+|---|---|
+| `tests/eval/**` 整树重排 | 非生产分层；import 跟随即可 |
+| `spikes/codemode/**` | 实验 |
+| 一次把 `interfaces/` 全局 rename 为 `adapters/inbound/` | parent A5 **可选**；独立 PR，非阻塞 |
+
+---
+
+## 3. SOLID / god-object / 1-10-50 smells（带路径）
+
+仓库规则：函数 ≤10 行、类 ≤50、文件 ≤300、≤2 缩进。下列为重构列车应处理的实味，不是风格洁癖清单。
+
+### 3.1 上帝对象 / 过重编排
+
+| 路径 | 问题 | 处置 |
+|---|---|---|
+| `interfaces/public_api.py` (~896 LOC) `RuntimeAPI` | SRP 失败：会话生命周期 + 模型解析 + 选择旁路 + 翻译 + 持久化 + 计量 + span | 抽 `HandleUserMessage`；类变 DI facade |
+| `interfaces/persistence.py` | 多持久化关注点 + 主数据 `filter_existing_ids` | 抽 `PersistTurn`；去 bangumi 耦合 |
+| `agents/catalog_tools.py` | 多工具实现同文件；Session 突变 + catalog IO | 按工具或按「resolve / search / nearby」拆 application |
+| `agents/selection.py` (~373 LOC) | multi + place 选择纠缠 | 拆文件或拆私有模块；进 application |
+| `clients/catalog_client.py` | DTO + Protocol + HTTP + retry 一体 | Protocol→domain；DTO/HTTP→infrastructure |
+| `agents/runtime_deps.py` | 仍持有无用的 `CatalogLookup db` | 删字段；只保留 `CatalogGateway` |
+| `domain/entities.AnimichiSession` vs `agents/session_state.SessionState` | 双 Session 模型 | 收敛到 **一个** Session 权威（runtime `SessionState`） |
+
+### 3.2 SOLID 违反
+
+| 原则 | 现状 | 目标 |
+|---|---|---|
+| **S** | `RuntimeAPI` / `public_api` 多责 | 一用例一模块 |
+| **O** | 新 catalog 能力易直接改 tools 大文件 | tools 薄包装 + application 扩展 |
+| **L** | `CatalogLookup` 暗示「半个 DB」 | 窄 `CatalogGateway`；Session ports 分离 |
+| **I** | `BangumiRepo` 塞满 upsert + find + filter | 删写；读迁 Catalog；Session 归档不依赖宽接口 |
+| **D** | application 空缺导致 interfaces→agents→clients 硬依赖 | use case 依赖 Protocol；interfaces 只组装 |
+
+### 3.3 1-10-50 与分层污染
+
+| 路径 | 味 |
+|---|---|
+| `agents/animichi_agent.py` | 已 import `infrastructure.observability`（外圈可接受，但 domain 禁止；保持 observability 不渗 domain） |
+| `agents/byok_models.py` | 直接依赖 `egress_*` — 可接受外圈；勿上提 domain |
+| `interfaces/routes/bangumi.py` · `search_preview.py` | 入站适配器直读主数据表 — **架构违规** |
+| `domain/ports.py` upsert 方法 | 端口定义了 **禁止的写能力** |
+| `handlers/` 空包 + 仅 helpers | 名不副实的「handler 层」；删除误导 |
+| `application/` 仅 errors | 分层名存实亡 — 本设计核心是 **填实 application** |
+
+### 3.4 语言债务（同列车或紧邻 G1）
+
+| 今日符号 | 目标 |
+|---|---|
+| `PilgrimagePoint` | `Point` |
+| `Route`（catalog 规划结果 / domain.entities.Route） | `Itinerary` |
+| `plan_route` 工具名 | 产品 ticket 前可 **保留工具字符串** 以免 eval 抖动；类型与 path 先改；工具 rename 另卡评估 |
+| `RouteArchive` / 表 `routes` | 语义文档化；表 rename 跟 greenfield agent 审计（Session 快照 ≠ SavedRoute） |
+
+---
+
+## 4. Patterns
+
+### 4.1 Use Case（Application）
+
+每个用例：**输入 DTO（非 FastAPI）→ 调 ports → 领域规则 → 输出 DTO**。  
+不 import FastAPI `Request`；不构造 PydanticAI `Agent`（那是 agents 的事）。
+
+| Use case（目标模块） | 覆盖的已有路径 | Ports |
+|---|---|---|
+| **HandleUserMessage** | `RuntimeAPI.handle` 非流式主路径 | SessionRepo, SessionStore, CatalogGateway, ConversationLog, RouteArchive, UsageMeter, RequestAudit, MemoryStore? |
+| **StreamAgentTurn** | `routes/chat_stream` + on_step | 同上 + step sink |
+| **ApplySelection** | `selection.execute_*` | CatalogGateway |
+| **RequestItinerary** | `selected_route` + `plan_route` 内核 | CatalogGateway |
+| **SearchPoints / ResolveAnime** | `catalog_tools` | CatalogGateway |
+| **PersistTurn** | `persistence.persist_result` | Session* ports only |
+| **PhotoSearch** | `photo_search` | CatalogGateway + vision port |
+| **EnforceAnonQuota** | `anon_quota` | AnonQuotaCounter |
+
+### 4.2 Port（Protocol）— `domain/ports.py` 目标集
+
+| Port | 读写 | 说明 |
+|---|---|---|
+| **CatalogGateway** | **只读** | resolve / points-by-bangumi / nearby / itinerary / geocode-as-exposed-by-catalog |
+| **SessionRepo** | 读写 | sessions / conversations ownership |
+| **ConversationLog** | 读写 | messages |
+| **SessionItineraryArchive**（今 RouteArchive） | 写（会话快照） | **非** SavedRoute |
+| **UsageMeter** · **AnonQuotaCounter** | 读写 | 计量 / 配额 |
+| **RequestAudit** | 写 | request_log |
+| ~~BangumiRepo / PointsRepo / CatalogLookup~~ | — | **删除** |
+
+实现：`infrastructure/catalog/client.py`、`infrastructure/supabase/repositories/*`（仅 session 域表）。
+
+### 4.3 Adapter
+
+| 方向 | 位置 | 例子 |
+|---|---|---|
+| **Inbound** | `interfaces/routes/*`, 薄 `RuntimeAPI` | HTTP/SSE → use case 输入 |
+| **Outbound** | `infrastructure/*` | Protocol 实现 |
+| **Framework** | `agents/*` | PydanticAI tools 调 application；`build_animichi_agent` |
+
+### 4.4 PydanticAI 留在外圈
+
+- **保留在 `agents/`：** `animichi_agent`, tool 注册, `runtime_models` output_type, hooks, history compaction capability, runner 的 `agent.run` 调用。  
+- **禁止渗入 `domain/`：** `RunContext`, `Agent`, `Model`, tool decorators。  
+- **application** 可依赖「已完成的工具结果 DTO」或调用 **CatalogGateway**，但不依赖 PydanticAI 类型（必要时 application 定义自己的 Command/Result）。
+
+### 4.5 明确 **NOT** 使用
+
+| 反模式 | 原因 |
+|---|---|
+| 为每个 repo 再套一层空 ABC / BaseRepository | 已有 Protocol 结构子类型足够 |
+| 领域事件总线 / Unit of Work 框架 | 现有 turn 边界清晰；增加噪音 |
+| CQRS 全套 read model | 过重；Session 读模型已在 `SessionState` |
+| 微服务内再拆进程 | monorepo 单容器 agent 足够 |
+| 在 agent 内重建 Catalog 规划 kernel | SD-28 / X12：Itinerary 算法归 Catalog |
+| 在 agent 实现 SavedRoute / Share / Check-in | Users BC；本包禁止 |
+| 用「接口层 Facade」无限膨胀代替 use case | 正是 `RuntimeAPI` 现状 |
+| 兼容层双名（`Route` alias `Itinerary`） | greenfield **无兼容** |
+
+---
+
+## 5. PR slices（仅已有代码）
+
+每片可合并、可测、独立绿。对齐 parent **A1–A5** 与仓级 **G1/G2**。  
+命令：`make check`（agent 相关 lane）；切片后跑触及的 unit + 关键的 integration。
+
+### Slice S0 — 边界文档与 import 护栏（小）
+
+- AGENTS.md / CONTEXT：写明 `agents/` = framework adapter；**禁止** `domain → agents|interfaces|infrastructure`。  
+- 可选：简单 import-linter / 测试断言 domain 无出界 import。  
+- **无行为变更。**  
+- 对应 parent **A1**。
+
+### Slice S1 — Greenfield 语言 + 删除主数据写（G1）
+
+- `PilgrimagePoint`→`Point`，catalog `Route`→`Itinerary`（client + adapter + tests/eval fixtures 在 **agent 包内**）。  
+- 删除：`upsert_*` Protocol 方法、repository 实现、相关 unit 测试（或改为「方法不存在」）。  
+- `CatalogClient` path 跟随 contract 列车（若 contract 未合，本片可先类型改名、path 紧后）。  
+- **不**改产品行为除命名与删死写。  
+- 对应 parent **A2** 前半。
+
+### Slice S2 — 统一 CatalogGateway；杀死双读 / 死注入（G2）
+
+- 提升 `CatalogClientProtocol` → `domain.ports.CatalogGateway`；infrastructure 实现。  
+- 从 `RuntimeDeps` / `run_animichi_agent` / `RuntimeAPI` **移除** `CatalogLookup db`。  
+- `routes/bangumi.py` · `search_preview.py`：改走 Catalog **或删除**（优先删除 agent 数据端点；若 web 仍依赖，先在 **catalog worker** 提供等价 API，再删 agent 路由——该协调属 contract/catalog 列车，agent 侧只停直连表）。  
+- `maybe_persist_route` 去掉 `filter_existing_ids`。  
+- 删除/收缩 `BangumiRepo`/`PointsRepo` 与 supabase bangumi/points **写后的只读死代码**（若全无引用则整 repo 删除）。  
+- 对应 parent **A3**。
+
+### Slice S3 — 抽出 HandleUserMessage + PersistTurn（核心结构）
+
+- 新建 `application/handle_user_message.py`：自 `RuntimeAPI.handle` 迁编排。  
+- 新建 `application/persist_turn.py`：自 `persistence.py` 迁。  
+- `RuntimeAPI` 退化为构造 ports + 调用。  
+- 单测：对 use case 用 fake ports（可从现有 public_api 单测迁）。  
+- 对应 parent **A4**。
+
+### Slice S4 — Selection / Itinerary / Search 进 application
+
+- `apply_selection.py` ← `selection.py`  
+- `request_itinerary.py` ← `selected_route` + route tool 内核  
+- `search_points.py` ← `catalog_tools` 内核  
+- `agents/*_tools.py` 仅 `RunContext` 胶水。  
+- 目标：agents 不再持有大块业务分支。
+
+### Slice S5 — Session domain 归位
+
+- `SessionState` + fact_ledger + compaction_retention → `domain/session/`。  
+- 收敛 `entities.AnimichiSession` / 过时 `llm_schemas`。  
+- 保证 compaction / fact 规则 **无 DB 单测** 路径更短。
+
+### Slice S6 — 1-10-50 拆文件与去 handlers 空壳
+
+- 拆超标文件（`public_api` 剩余、`catalog_client`、selection 遗留）。  
+- `handlers/` 清空或删除；helpers 迁出。  
+- `RouteArchive` 文档/rename 与 SavedRoute 切割。
+
+### Slice S7 — 可选目录 A5
+
+- 文档层角色稳定后，评估 `interfaces`→`adapters/inbound` 等 **大 rename**（单独 PR，防 diff 噪音淹没行为）。
+
+### 推荐顺序
+
+```text
+S0 → S1 → S2 → S3 → S4 → S5 → S6 → (S7)
+```
+
+S1/S2 可与仓级 contract/catalog path 改名 **同列车**；S3+ 不依赖 web/users 功能。
+
+### 验收（每片）
+
+| 检查 | 标准 |
+|---|---|
+| 测试 | 触及包 `make test` + 相关 integration 绿 |
+| 依赖 | domain 无新出界 import |
+| 主数据 | 无新 upsert；S2 后无 agent 直读 points/bangumi 表 |
+| Session 写 | conversations / messages / session store / quota / usage 仍工作 |
+| 覆盖 | 不靠 noqa；不降 coverage floor |
+| 产品偷渡 | PR 描述声明无 enabler |
+
+---
+
+## 6. Non-goals
+
+| 不做 | 原因 |
+|---|---|
+| edge / web / users **产品** enabler 设计或实现 | SCOPE LOCK |
+| SavedRoute 权威、Share、Check-in、しおり、presign、OSRM 层 2 | Users / Catalog tickets |
+| **match_scene 全管线** 首次实现 | 未写产品 → **ticket only**（挂既有 issue；实现时遵守本文分层，不在本重构 PR 偷渡） |
+| 跨会话 UserMemory 产品 | Users / SD-15 |
+| 重写 PydanticAI 或换 agent 框架 | parent 非目标 |
+| 为未实现用例预建空 domain 模块 / 空表 | greenfield 原则 6 |
+| 长期兼容别名（`Route = Itinerary`） | 无历史用户 |
+| Agent 新增 **数据端点**（catalog 或用户域） | X12 / G4 / A3 |
+| 工具侧随便写库 | SD-19；写 Session 走 application + port |
+| 本文件阶段改生产代码 | DESIGN ONLY |
+| monorepo 其他包目录重构 | 仅 agent |
+
+### 6.1 Ticket 指针（未写能力 · 不实现）
+
+重构列车 **不** 打开下列首次交付；仅要求未来实现遵守 CA + greenfield：
+
+- **match_scene / 场景匹配全管线** — 既有产品 ticket（实现时：Catalog 读 + Session 写边界同上）  
+- Share / Check-in / しおり 等 — Users 设计文 + 对应 issue  
+- 跨会话 memory 唤醒 — Users  
+- 主战场结构债跟踪：#432 · #666（及 agent boy-scout 卡）
+
+---
+
+## 7. 与 parent 文档的映射
+
+| Parent | 本文 |
+|---|---|
+| CA §3 圈层 | §0 依赖规则 + §4 |
+| CA §5 端口 | §4.2（收紧删除主数据 port） |
+| CA §6 用例 | §4.1 + §5 S3–S4 |
+| CA §9 A1–A5 | §5 S0–S7 |
+| CA §9.1 做/不做 | §0 + §6 |
+| Greenfield §0 真结构 | 全文；§2 move table |
+| Greenfield Agent §4.3 删直连写 | §1.8 + S1/S2 |
+
+---
+
+## 8. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿：基于 `src/animichi` 实盘 inventory 的结构重构设计（DESIGN ONLY） |
+| 2026-08-06 | Owner **ACCEPTED**（best-practice 默认）；实现按 §5；§9 实现时微选项用推荐默认 |
+
+---
+
+## 9. Owner 阅读清单（实现前）— 默认已按 best practice
+
+| # | 项 | 默认（ACCEPTED） |
+|---|---|---|
+| 1 | `bangumi` / `search_preview` 双读 | **删 agent 数据端点**；读只经 Catalog |
+| 2 | Session 附属 `routes` 表名 | 结构片先语义切割；DB rename 可并 greenfield |
+| 3 | `plan_route` 工具名字符串 | **类型/内部先 Itinerary**；工具对外名评估 eval 成本后改（可同波或紧后） |
+| 4 | 实现 | 按 §5 切片开 PR |

--- a/docs/superpowers/specs/2026-08-06-catalog-clean-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-06-catalog-clean-architecture-design.md
@@ -1,0 +1,391 @@
+# Catalog 教科书式 DDD + Clean Architecture 设计
+
+- Status: **ACCEPTED** (owner 2026-08-06) — 目标形态与迁移原则已锁定；**实现另开 PR，本文不代替代码**
+- Date: 2026-08-06
+- Package: `workers/catalog`
+- Language: ADR-0002 · `CONTEXT-MAP.md` · `workers/catalog/CONTEXT.md`
+- Parent: `docs/superpowers/specs/2026-08-06-monorepo-target-layout.md`
+- Owner acceptance: C1–C6 全部接受（四圈 CA、目标树、ingest=application、P1→P6 分期）
+- Greenfield: 见 `2026-08-06-greenfield-language-and-data-plane.md`（**语言/契约/表一次最佳，无兼容层**）
+- Refactor train: **已有代码** 真·结构重构（移文件/抽 use case/化简/SOLID），**不止 rename**；未写产品能力归既有 ticket
+
+---
+
+## 0. 目标
+
+把 Catalog 从「能力管道 + 部分纯 kernel + handler 内事务脚本」收成**可教学的**：
+
+1. **DDD**：清晰有界上下文、统一语言、领域不变量在 domain、用例在 application  
+2. **Clean Architecture**：依赖只指向内圈；框架（Hono/oRPC/Drizzle/Neon/fetch）只在最外圈  
+3. **可测**：domain 与 application 可在无 workerd、无真实 Neon 下单测  
+4. **Greenfield 语言**：Point / Bangumi / Itinerary；无 `PilgrimagePoint` / `Route` / `work_id`  
+
+**非目标（本文不直接改代码）：**
+
+- 立刻单 PR 完成全部 `git mv` + 全仓契约（实现见 §10 + greenfield G1）  
+- 保留长期 wire 别名（**已否决**）
+
+---
+
+## 1. 现状诊断（设计基线）
+
+### 1.1 今日目录
+
+```text
+workers/catalog/src/
+  index.ts          # Hono 入口、DB 池、cron、媒体
+  router.ts         # oRPC implement(catalogContract)
+  api/*             # 读 API：用例 + SQL 混写
+  lib/*             # 混杂：纯 kernel（route/clustering/geo）+ 绑框架工具
+  db/               # Neon 客户端
+  ingest|enrich|publish|media/  # 数据平台流水线
+  types.ts          # contract 的 import type 镜像
+```
+
+### 1.2 已有的「正确碎片」
+
+| 碎片 | 评价 |
+|---|---|
+| 包边界：Agent 只读客户端 | BC 清楚 |
+| `packages/contract` + `import type` | 发布语言 / 防腐入口 |
+| `lib/route.ts` + clustering **纯函数** | 已是 domain service 候选 |
+| `CatalogContext` 注入 db/fetch/waitUntil | 有 port 意识 |
+| `api/route` 先 fetch 再 kernel | 接近 application 编排 |
+
+### 1.3 与教科书的差距
+
+| 期望 | 现状 |
+|---|---|
+| `domain/` 无 I/O | 无此目录；规则散在 SQL 与 api |
+| application 不直接写 SQL | 多数 `api/*` 直接 drizzle |
+| 依赖单向内指 | handler 同时依赖 Hono 世界、SQL、ingest |
+| 统一语言 | 代码仍 `Route` / `PilgrimagePoint` / `work_id` |
+
+**结论：** 有 CA 的 kernel 与契约纪律，**尚未**教科书分层。
+
+---
+
+## 2. 领域模型（Catalog BC）
+
+### 2.1 统一语言（LOCKED）
+
+| 词 | 含义 |
+|---|---|
+| **Point** | 可拜访圣地取景点 |
+| **Bangumi** | 一部动画作品/标题 |
+| **Itinerary** | 算出的有序行程 |
+| **Cluster** | 共址点合并为一站 |
+| **Origin / Pacing** | 规划起点与疏密 |
+| **Alias** | 查询串 → Bangumi 的归一化键 |
+
+**不拥有：** SavedRoute、Session、登录身份、Edge 限流。
+
+### 2.2 核心不变量
+
+1. Point 必属一个 Bangumi。  
+2. Itinerary 由 Point 选择生成；空选择无有效行程。  
+3. 规划可对共址 Point 做 Cluster，且有上限。  
+4. Search 可返回 **partial** 预览行；调用方不得当最终全集。  
+5. Catalog 不持久化用户 SavedRoute。
+
+### 2.3 上下文关系
+
+```text
+Agent ──read──▶ Catalog ──SQL──▶ Neon
+Web/Edge ──/v1/catalog*──▶ Catalog
+Users ──仅 point_ids 引用──▶（不写 Catalog 表）
+Ingest upstream (Anitabi 等) ◀── Catalog outbound
+```
+
+---
+
+## 3. Clean Architecture 圈层
+
+```text
+                    ┌─────────────────────────────┐
+                    │  Frameworks & Drivers         │
+                    │  Hono · oRPC · wrangler · R2  │
+                    │  Neon HTTP · fetch · cron     │
+                    └────────────▲────────────────┘
+                                 │ implements
+                    ┌────────────┴────────────────┐
+                    │  Interface Adapters           │
+                    │  inbound: router, api handlers│
+                    │  outbound: db/*, upstream/*   │
+                    │  DTO map ↔ contract types     │
+                    └────────────▲────────────────┘
+                                 │ calls
+                    ┌────────────┴────────────────┐
+                    │  Application (use cases)      │
+                    │  SearchPoints, ResolveBangumi │
+                    │  PlanItinerary, IngestBangumi │
+                    │  ports: PointsRepo, …         │
+                    └────────────▲────────────────┘
+                                 │ uses
+                    ┌────────────┴────────────────┐
+                    │  Domain                       │
+                    │  Point, Bangumi, Cluster      │
+                    │  planItinerary pure rules     │
+                    │  不变量；无 I/O               │
+                    └─────────────────────────────┘
+```
+
+**依赖规则（硬）：**
+
+- Domain **不得** import：hono、@orpc、drizzle、@neondatabase、cloudflare:、ingest 编排  
+- Application **不得** import：hono、drizzle 实现细节；只依赖 **port 接口** 与 domain  
+- Adapters 可以实现 port、调用 application、接触框架  
+- `types.ts` / contract：**仅适配器边界**做 wire 形状；domain 用自己的类型或从 port 返回的已映射结构  
+
+---
+
+## 4. 目标目录树（教科书形态）
+
+```text
+workers/catalog/
+  CONTEXT.md                 # 语言与所有权（已有，随设计加厚）
+  AGENTS.md                  # 命令与陷阱（实现期更新路径）
+  src/
+    domain/
+      README.md              # 本层规则（可选）
+      model/
+        point.ts             # Point 相关纯类型/工厂/守卫
+        bangumi.ts
+        cluster.ts           # Cluster 类型 + clusterByLocation
+      itinerary/
+        plan.ts              # 今 lib/route.ts 纯规划
+        pacing.ts            # 若拆常量
+      geo/
+        haversine.ts         # 今 lib/geo.ts
+      errors.ts              # 领域错误（非 ORPCError）
+    application/
+      ports.ts               # PointsRepo, BangumiRepo, UpstreamPreview, Clock, …
+      search-points.ts
+      resolve-bangumi.ts
+      list-points-for-bangumi.ts
+      get-point.ts           # spots
+      nearby-points.ts
+      geocode-place.ts
+      plan-itinerary.ts      # 内存点集 → Itinerary + 装配策略
+      anime-overview.ts
+      ingest-bangumi.ts      # 编排 ingest（调用 outbound）
+    adapters/
+      inbound/
+        http/
+          app.ts             # 今 index 的 Hono 应用
+          router.ts          # oRPC
+          handlers/          # 薄：parse → app use case → map error
+        cron/
+          seed-and-ttl.ts
+      outbound/
+        neon/
+          client.ts
+          points-repo.ts
+          …
+        upstream/
+          anitabi.ts
+          bangumi-api.ts
+        r2/
+          media.ts
+    # 过渡：流水线可先挂 application 下或 adapters 旁
+    processes/
+      ingest/                # 今 ingest/（实现期迁入 application 或 adapters）
+      enrich/
+      publish/
+    config/
+      cron.ts
+  test/
+    domain/                  # 纯单测（可不进 workerd）
+    application/             # port fake
+    adapters/                # worker / spike 测
+```
+
+**命名说明（Greenfield）：**
+
+- 对外 oRPC：**`planItinerary`** / path **`/catalog/itinerary`**（不再保留 `route` 兼容名）。  
+- Wire 类型：**`Point`**、**`Itinerary`**；输入键 **`bangumi_id`** 而非 `work_id`。  
+- 文件：`lib/route.ts` → `domain/itinerary/plan.ts`。  
+
+### 4.1 数据面（Catalog 表目标）
+
+| 表 | 目标 |
+|---|---|
+| `bangumi`, `points` | 保留；列语言已对齐 |
+| `aliases`, `series_edges`, `cluster_version` | 列 **`work_id` → `bangumi_id`** |
+| `route_snapshots` | **`itinerary_snapshots`** + `bangumi_id` |
+| 用户域 `routes` | **不属 Catalog** → Users `saved_routes` |
+
+细节总表：greenfield 文档 §3.1。
+
+---
+
+## 5. 端口（Application 出站接口）设计
+
+以下为**接口职责**，非代码。
+
+| Port | 职责 |
+|---|---|
+| **PointsRepo** | 按 id 列表取 Point（保序）；按 bangumi 列表；nearby 查询 |
+| **BangumiRepo** | 解析/读取 Bangumi 元数据 |
+| **AliasIndex** | normalize + 精确命中 alias → bangumi id |
+| **UpstreamCatalog** | Anitabi lite / full、必要时 Bangumi 搜索（ingest/search miss） |
+| **IngestQueue / UnitOfWork** | 后台 full ingest（waitUntil 的抽象） |
+| **GazetteerRepo** | geocode 候选 |
+| **MediaStore** | R2 图（若仍属 catalog） |
+| **Clock** | 测 TTL/cron 用 |
+
+**原则：** 一个 use case 只依赖它需要的 port，避免上帝 `CatalogDb`。
+
+---
+
+## 6. 用例切分（Application）
+
+| Use case | 输入（概念） | 输出（概念） | 主要 port |
+|---|---|---|---|
+| SearchPoints | query, Origin? | Point[] + partial? + synced_at | AliasIndex, PointsRepo, Upstream, Ingest |
+| ResolveBangumi | query | 身份结果 | BangumiRepo / Upstream |
+| ListPointsForBangumi | bangumi id | Point[] | PointsRepo, 可触发 ingest |
+| GetPoint | bangumi_id + Origin? | Point + distance? | PointsRepo |
+| NearbyPoints | lat,lng,radius | Point[] | PointsRepo |
+| GeocodePlace | query, limit | candidates | GazetteerRepo |
+| PlanItinerary | point ids, Origin?, Pacing? | Itinerary + ordered Points meta | PointsRepo + **domain itinerary** |
+| AnimeOverview | bangumi 相关 | 公开聚合 | PointsRepo / 只读投影 |
+| IngestBangumi | bangumi id | 任务结果 | Upstream + write side of repos |
+
+**PlanItinerary 分层示例（逻辑，非实现）：**
+
+1. Adapter：HTTP/oRPC → 校验 wire 输入  
+2. Application：PointsRepo.loadByIds → domain.cluster → domain.planTimedItinerary → 装配公开结果  
+3. Domain：clusterByLocation、buildTimedItinerary — **零 I/O**  
+
+Search 必须把「别名命中 / lite 预览 / 后台 ingest」收成 application 策略，而不是单文件事务脚本（设计要求；实现分期）。
+
+---
+
+## 7. 数据平台（Ingest → Enrich → Publish）
+
+| 阶段 | 圈层 | 说明 |
+|---|---|---|
+| Ingest | application 编排 + outbound upstream/db | 拉外部、落原始/工作表 |
+| Enrich | application / domain 规则 | 去重、聚类、城市回填 — **可测纯规则进 domain** |
+| Publish | application + outbound | 发布为可读 Point/Alias 投影 |
+
+这些是 **application 过程名**，不是粉丝域名词（见 CONTEXT）。
+
+---
+
+## 8. 测试策略（设计）
+
+| 层 | 测什么 | 运行时 |
+|---|---|---|
+| domain | 聚类、行程、haversine、不变量 | Node 纯测，快 |
+| application | 用例 + in-memory ports | Node |
+| adapters inbound | oRPC 映射、错误码 | workerd pool（现有） |
+| adapters outbound | SQL/geo 真或 spike | worker/spike 现有分工 |
+| startup smoke | bundle 可启动 | 保留 |
+
+**回归纪律：** 分层 PR 保持规划语义；**greenfield 改名可与 G1 同波破坏性落地**（无用户）。
+
+---
+
+## 9. 与现状映射（迁移地图）
+
+| 今日 | 目标 |
+|---|---|
+| `lib/route.ts` | `domain/itinerary/plan.ts` |
+| `lib/clustering.ts` | `domain/model/cluster.ts`（或 domain/clustering） |
+| `lib/geo.ts` | `domain/geo/haversine.ts` |
+| `api/route.ts` 纯编排部分 | `application/plan-itinerary.ts` |
+| `api/route.ts` SQL | `adapters/outbound/neon/points-repo.ts` |
+| `api/route.ts` oRPC 入口 | `adapters/inbound/http/handlers/plan-itinerary.ts` |
+| `route` contract / path | **`itinerary`** |
+| `PilgrimagePoint` / `work_id` | **`Point` / `bangumi_id`** |
+| `route_snapshots` / 列 `work_id` | **`itinerary_snapshots` / `bangumi_id`** |
+| `api/search.ts` 等 | 同上模式拆 application + outbound |
+| `router.ts` / `index.ts` | `adapters/inbound/http/` |
+| `db/*` | `adapters/outbound/neon/` |
+| `ingest|enrich|publish` | `processes/*` 或 application 子包 |
+| `lib/errors.ts` 的 ORPCError | 留在 inbound adapter；domain 用领域错误再 map |
+
+**迁移策略（Greenfield）：**
+
+- **无**长期 `PilgrimagePoint` 别名 export。  
+- 可选短期 `lib/foo.ts` re-export **仅**为拆 PR 方便，合并前删掉。  
+- 禁止 domain import api。  
+
+---
+
+## 10. 分阶段实施顺序（仅计划，不执行）
+
+| 阶段 | 内容 | 完成判据 |
+|---|---|---|
+| **P0 设计** | 本文 + CONTEXT + greenfield 总表 | ACCEPTED |
+| **P1 语言+数据面** | contract Itinerary/Point；DB `work_id`/`route_snapshots` 改名；path `/catalog/itinerary` | 全仓编译 + catalog 测绿（可并入仓级 G1） |
+| **P2 Itinerary 竖切** | domain 规划 + application PlanItinerary + handler 变薄 | itinerary/clustering 测绿 |
+| **P3 Search 竖切** | SearchPoints use case + ports | search 测绿 |
+| **P4 读模型其余** | nearby/geocode/point/overview 同构 | 读路径无新增「api 内业务规则」 |
+| **P5 流水线归位** | ingest/enrich/publish → application/processes | cron/ingest 测绿 |
+| **P6 目录收敛** | 去掉过时 lib、inbound 最终化 | AGENTS 路径更新 |
+
+每阶段 **一个可审查 PR** 优先；**P1 允许跨包大 PR**（greenfield）。
+
+### 10.1 重构列车里 Catalog **做什么 / 不做什么**
+
+| 做（已有 `workers/catalog` 码） | 不做（留给 ticket） |
+|---|---|
+| 按 §4 树 **移动** `api/*` / `lib/*` → domain/application/adapters | 新建尚未存在的公共 API 产品面 |
+| 抽 **PlanItinerary / Search** 等 **已有路径** 的 use case + port | OSRM/铁道拓扑层2（#292 等）首次实现 |
+| 化简 handler 事务脚本；纯 kernel 进 domain；去掉错误抽象 | 质量门/SEO 新管线（#285 等）若未写则不借 P 阶段偷渡 |
+| greenfield 改名与路径 | ingest 内部入口形态若已有票（#540/#555）则按票改，不另开宇宙 |
+
+**抽象：** 依赖倒置用 **窄 port**；禁止 God `CatalogDb`；1-10-50 与 SOLID 约束已有文件拆分。
+
+---
+
+## 11. 风险与非目标
+
+| 风险 | 缓解 |
+|---|---|
+| 大挪目录 CI 路径钉死 | 先 re-export；CI pin 改目录 seam（monorepo 文档） |
+| workerd + 路径别名 | 与现有 vitest 配置一致，避免花式 paths 直至证明需要 |
+| 过度设计 Thin 路径 | GetPoint 等保持 Thin application，不造空 domain 实体 |
+| 与 Agent Python 镜像类型漂移 | contract 仍为 SoT；domain 映射在边界测 parity |
+
+---
+
+## 12. 验收（设计完成 / 实现完成）
+
+**设计完成（本文）：**
+
+- [x] 圈层、依赖规则、目标树、端口、用例、迁移地图、分期  
+- [x] Owner 标记本文 Status → **ACCEPTED** (2026-08-06)  
+- [x] Greenfield 语言/表目标并入（2026-08-06）  
+
+
+**实现完成（未来）：**
+
+- [ ] domain 无框架 import（可用 lint/边界测试约束）  
+- [ ] PlanItinerary / Search 主路径符合分层  
+- [ ] 测试分层存在且主测绿  
+- [ ] AGENTS.md 描述与树一致  
+
+---
+
+## 13. 相关文档
+
+| 文档 | 角色 |
+|---|---|
+| `workers/catalog/CONTEXT.md` | 语言与所有权 |
+| `docs/adr/0002-published-language-…md` | 跨服务词 |
+| `docs/superpowers/specs/2026-08-06-monorepo-target-layout.md` | 仓级目标与逐包进度 |
+| `workers/catalog/AGENTS.md` | 现行命令与陷阱（实现后改） |
+
+---
+
+## 14. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿：教科书 DDD+CA 目标、圈层、目录、端口、用例、分期；**明确 DESIGN ONLY** |
+| 2026-08-06 | Owner 全盘接受 C1–C6 → Status **ACCEPTED** |
+| 2026-08-06 | §10.1：重构 = 已有码搬家/抽用例/化简/SOLID，不止 rename；未写能力归 ticket |

--- a/docs/superpowers/specs/2026-08-06-catalog-structure-refactor-design.md
+++ b/docs/superpowers/specs/2026-08-06-catalog-structure-refactor-design.md
@@ -1,0 +1,533 @@
+# Catalog structure refactor (existing code only)
+
+- Status: **ACCEPTED** (owner 2026-08-06 — best-practice default; **no implementation in this doc**)
+- Date: 2026-08-06
+- Package: `workers/catalog` (+ rename notes for `packages/contract` types **already consumed**)
+- Parents:
+  - `docs/superpowers/specs/2026-08-06-catalog-clean-architecture-design.md` (ACCEPTED CA target)
+  - `docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md` (Point / Bangumi / Itinerary)
+- Scope lock: **only** catalog internal structure (move files/functions, simplify, SOLID / 1-10-50).  
+  **Not** edge / web / maintenance / monorepo root. **Not** new product features.
+
+---
+
+## 0. Intent
+
+Turn today’s “pipeline folders + `api/*` transaction scripts + grab-bag `lib/*`” into the **existing** CA target tree **by moving and thinning code that already exists**, not by inventing product surfaces.
+
+**Do**
+
+- `git mv` / function extract into `domain/`, `application/`, `adapters/`, `processes/`
+- Collapse duplicate mappers and dual “Origin” shapes where they already exist
+- Prefer **delete** wrong layering over new interface trees
+- Keep narrow ports that already work (`SearchDb`, `RouteDb`, …) — rename/relocate, do not grow a God port
+
+**Do not**
+
+- Rename-only PRs without moves that improve dependency direction
+- Build empty domain entities for thin paths
+- Ship Share / Check-in / しおり / OSRM layer-2 / SEO pipelines under this train  
+  (ticket pointers only — see §6)
+
+---
+
+## 1. Current inventory
+
+Inventory taken from the live tree under `workers/catalog/` (2026-08-06). Line counts are approximate end-of-file anchors from reads (useful for prioritization, not CI pins).
+
+### 1.1 `src/` tree (today)
+
+```text
+workers/catalog/src/
+  index.ts                 # Hono app, DB pool, media route, IngestEntrypoint, cron (~239)
+  router.ts                # oRPC implement(catalogContract) + CatalogContext (~109)
+  types.ts                 # import-type mirror of packages/contract models (~186)
+  cron-config.ts           # seed/TTL cron strings + batch cap
+  api/
+    anime-overview.ts      # SQL + pure overview aggregation (~174)
+    geocode.ts             # SQL exact/fuzzy + collapse (~48)
+    nearby.ts              # geo-query + detail merge (~68)
+    preview.ts             # Anitabi lite + Bangumi search mapping (~93)
+    resolve.ts             # alias hit + Bangumi miss ranking + SQL (~250)
+    route.ts               # load points + cluster + plan + assemble Route (~171)
+    search.ts              # alias hit/miss + SearchDb + SQL (~244)
+    spots.ts               # representative point + distance (~99)
+    work-points.ts         # work-id tiered preview/ingest (~136)
+  lib/
+    alias.ts               # normalizeAlias + rankAliases (pure, ~85)
+    clustering.ts          # clusterByLocation union-find (pure, ~183)
+    errors.ts              # CATALOG_ERRORS + ORPCError factories (~124)
+    geo.ts                 # haversine (pure, ~36)
+    geo-query.ts           # PostGIS nearby SQL (~58)
+    geocode.ts             # collapseGeocodeHits pure collapse (~125)
+    optional.ts            # strip null optionals (~21)
+    route.ts               # orderNearestNeighbor + buildTimedItinerary (pure, ~300)
+    rows.ts                # row coercers (~37)
+    series.ts              # walkSeries pure graph (~100)
+    upstream.ts            # withUpstreamUnavailable → ORPC (~13)
+    transit/               # pure transit kernel + etl/* (already mostly pure)
+      compare.ts, constants.ts, dijkstra.ts, estimate.ts, format.ts,
+      graph.ts, heap.ts, leg.ts, model.ts, nearest.ts, index.ts
+      etl/{build,coverage,csv,ekidata,index,n02}.ts
+  db/
+    client.ts              # makeDb / makeNeonSql / CatalogDb types
+    schema.ts              # drizzle typing-only tables (work_id columns still present)
+  ingest/
+    orchestrator.ts        # singleflight full ingest (~157)
+    jobs.ts                # JobStore / acquire / guard
+    sources.ts             # Anitabi + Bangumi fetch (~240+)
+    retry.ts               # retry helper
+    raw-store.ts           # raw_* upserts
+    cron-queries.ts        # seed/TTL SQL lists
+    seed-works.ts          # checked-in seed list
+  enrich/
+    enrich.ts              # raw → UPSERT bangumi/points/aliases + publish (~176)
+    parse.ts               # parseBangumi / parseAnitabiPoints (pure-ish, ~211)
+  publish/
+    versioning.ts          # cluster_version blue/green
+    snapshots.ts           # route_snapshots R/W (legacy name)
+    gc.ts                  # old version GC
+  media/
+    img.ts                 # lazy R2 image serve (~160)
+    r2.ts                  # put/get image helpers (~23)
+```
+
+Supporting (not moved as “product API”, but part of package layout):
+
+```text
+workers/catalog/
+  test/                    # *.worker.test.ts + *.spike.test.ts + fixtures/
+  scripts/                 # gazetteer + transit ETL CLIs
+  data/                    # gazetteer sources/audit
+  wrangler.toml, vitest*.ts, package.json, AGENTS.md, CONTEXT.md
+```
+
+### 1.2 Hot modules (priority for structure)
+
+| Module | ~LOC | Role today | Structure pressure |
+|---|---:|---|---|
+| `lib/route.ts` | 300 | Pure itinerary kernel | File at 1-10-50 file ceiling; domain home |
+| `api/resolve.ts` | 250 | Use case + SQL + miss ranking | Classic SRP mix; best vertical slice after itinerary |
+| `api/search.ts` | 244 | Use case + SearchDb + SQL + ingest hook | Second vertical slice |
+| `index.ts` | 239 | Framework entry + cron + entrypoint | God boundary file |
+| `ingest/sources.ts` | 240+ | Outbound HTTP | Belongs in adapters/outbound |
+| `enrich/parse.ts` | 211 | Upstream JSON → rows | Domain/parser vs adapter boundary |
+| `lib/clustering.ts` | 183 | Pure cluster | Domain ready |
+| `api/anime-overview.ts` | 174 | SQL + pure aggregation | Split pure scene/circle builders |
+| `api/route.ts` | 171 | Almost textbook app orchestration | Template for PlanItinerary |
+| `enrich/enrich.ts` | 176 | Write batch orchestration | Application process |
+| `media/img.ts` | 160 | R2 + SQL media | Outbound adapter |
+| `api/work-points.ts` | 136 | Ingest claim orchestration | Application |
+| `lib/errors.ts` | 124 | ORPC error registry mirror | **Stay inbound**; not domain |
+| `lib/geocode.ts` | 125 | Pure collapse | Domain |
+
+### 1.3 What is already “correct fragments”
+
+| Fragment | Evidence | Keep / move as-is |
+|---|---|---|
+| Pure itinerary kernel | `lib/route.ts` — no I/O | → `domain/itinerary/` |
+| Pure clustering | `lib/clustering.ts` | → `domain/model/cluster.ts` |
+| Pure haversine | `lib/geo.ts` | → `domain/geo/haversine.ts` |
+| Narrow ports on read paths | `SearchDb`, `RouteDb`, `ResolveDb`, `WorkPointsDb`, `OverviewDb` | → `application/ports` or colocated use-case files |
+| `CatalogContext` injection | `router.ts` | Keep shape; live under inbound |
+| Route handler flow | `api/route.ts`: fetch → cluster → plan → assemble | Template for PlanItinerary use case |
+| Contract `import type` only | `types.ts` + AGENTS discipline | Stay at adapter boundary |
+| Transit pure kernel | `lib/transit/*` (non-etl) | → `domain/transit/` |
+
+### 1.4 Cross-cutting language lag (catalog-local; contract rename notes)
+
+Already present in catalog code / schema typing (greenfield renames ride the structure train, not a separate cosmetic PR):
+
+| Today (catalog) | Target language |
+|---|---|
+| `PilgrimagePoint` (`types.ts`, handlers) | **Point** |
+| `Route` / `route` handler / `POST …/route` | **Itinerary** / `planItinerary` |
+| `work_id` in SQL (`aliases`, `cluster_version`, `route_snapshots`) | **`bangumi_id`** |
+| `pointsByWorkId` / `input.work_id` | **`pointsByBangumiId` / `bangumi_id`** |
+| `route_snapshots` / `saveRouteSnapshot` | **`itinerary_snapshots`** |
+| `AnimeSampleRoute` / `sample_routes` | **AnimeSampleItinerary** / `sample_itineraries` |
+| `lib/route.ts` dual `Origin` (kernel-only lat/lng) vs wire `Origin` | One domain origin coord type + wire map at boundary |
+
+**Contract touch (notes only, same train as greenfield G1):** types and paths catalog already implements — `PilgrimagePoint`, `Route`, `pointsByWorkId`, `work_id`, route procedure — become Point / Itinerary / bangumi_id. No new contract procedures.
+
+---
+
+## 2. File / function move table
+
+Concrete **from → to** for existing code. Intermediate re-exports allowed only inside a PR and **deleted before merge**.
+
+### 2.1 Domain (no I/O, no hono/orpc/drizzle/neon)
+
+| From | To | Symbols / notes |
+|---|---|---|
+| `src/lib/route.ts` | `src/domain/itinerary/plan.ts` | `orderNearestNeighbor`, `buildTimedItinerary`, `computeDwellMinutes`, `MAX_ITINERARY_CLUSTERS`, `ItineraryOptions` |
+| (split if needed) `src/lib/route.ts` pacing tables | `src/domain/itinerary/pacing.ts` | `DWELL_MULTIPLIERS`, `TRANSIT_BUFFERS`, `safePacing` — only if plan.ts stays ≥300 |
+| `src/lib/clustering.ts` | `src/domain/model/cluster.ts` | `ClusterablePoint`, `LocationCluster`, `clusterByLocation` |
+| `src/lib/geo.ts` | `src/domain/geo/haversine.ts` | `haversine` |
+| `src/lib/alias.ts` | `src/domain/model/alias.ts` | `Source`, `normalizeAlias`, `rankAliases`, `RawAlias`, `RankedAlias` |
+| `src/lib/geocode.ts` | `src/domain/geocode/collapse.ts` | `collapseGeocodeHits`, thresholds, hit types used purely |
+| `src/lib/series.ts` | `src/domain/model/series.ts` | `walkSeries`, `SeriesEdge`, `Relation`, `SAME_SERIES_RELATIONS` |
+| `src/lib/transit/*` (except `etl/`) | `src/domain/transit/*` | keep internal relative imports |
+| pure parts of `api/anime-overview.ts` | `src/domain/overview/*` or `application` pure helpers | `buildCircles`, `buildScenes`, `buildSampleRoutes` / `toSampleItinerary` (rename) — **no SQL** |
+| domain errors (new thin types only if needed) | `src/domain/errors.ts` | e.g. too-many-clusters **as data**, not `ORPCError` |
+
+**Do not move into domain:** `lib/errors.ts` (ORPC), `lib/geo-query.ts` (SQL), `lib/rows.ts` / `optional.ts` (boundary mapping — adapters or shared adapter util).
+
+### 2.2 Application (use cases + ports; no hono/drizzle impl)
+
+| From | To | Responsibility |
+|---|---|---|
+| `api/route.ts` orchestration | `application/plan-itinerary.ts` | load points (port) → cluster → plan → assemble Itinerary |
+| `api/route.ts` `fetchPoints` / SQL | **outbound** (below), called via port | |
+| `api/search.ts` `search` / hit / miss | `application/search-points.ts` | alias hit vs partial preview + background ingest |
+| `api/search.ts` `SearchDb` | `application/ports.ts` (or `ports/search.ts`) | keep narrow surface |
+| `api/work-points.ts` | `application/list-points-for-bangumi.ts` | claim/preview/ingest orchestration |
+| `api/work-points.ts` `WorkPointsDb` | ports | |
+| `api/resolve.ts` resolve ranking (no SQL) | `application/resolve-bangumi.ts` | hit rules + miss similarity |
+| `api/resolve.ts` `ResolveDb` | ports | |
+| `api/spots.ts` handler body | `application/get-point.ts` | representative point + optional distance |
+| `api/nearby.ts` merge logic | `application/nearby-points.ts` | geo port + detail port |
+| `api/geocode.ts` lookup orchestration | `application/geocode-place.ts` | exact-first then fuzzy; collapse pure domain |
+| `api/anime-overview.ts` orchestration | `application/anime-overview.ts` | load rows → pure builders |
+| `api/preview.ts` | `application/miss-preview.ts` **or** outbound preview service used by use cases | keep single owner of lite mapping |
+| `ingest/orchestrator.ts` | `application/ingest-bangumi.ts` | singleflight full ingest |
+| `index.ts` `runSeedJob` / `runTtlJob` / `ingestBatch` | `application/cron-ingest.ts` | pure job loop; deps as ports |
+
+### 2.3 Adapters — inbound (framework)
+
+| From | To | Notes |
+|---|---|---|
+| `index.ts` Hono app + `/catalog/*` + healthz + img route | `adapters/inbound/http/app.ts` | thin wiring only |
+| `router.ts` | `adapters/inbound/http/router.ts` | oRPC only |
+| thin handlers wrapping use cases | `adapters/inbound/http/handlers/*.ts` | map errors → ORPC; **no SQL** |
+| `index.ts` `IngestEntrypoint` | `adapters/inbound/rpc/ingest-entrypoint.ts` | service-binding door stays |
+| `index.ts` scheduled export | `adapters/inbound/cron/scheduled.ts` | uses application cron use cases |
+| `cron-config.ts` | `config/cron.ts` | constants only |
+| `lib/errors.ts` | `adapters/inbound/http/errors.ts` | ORPC factories stay outer |
+| `lib/upstream.ts` | next to errors or outbound | maps transport → typed boundary error |
+| `types.ts` | `adapters/inbound/http/wire-types.ts` (or keep `types.ts` at src root briefly) | still `import type` only |
+
+### 2.4 Adapters — outbound
+
+| From | To | Notes |
+|---|---|---|
+| `db/client.ts` | `adapters/outbound/neon/client.ts` | |
+| `db/schema.ts` | `adapters/outbound/neon/schema.ts` | typing only; column renames with greenfield |
+| SQL in `api/search.ts` | `adapters/outbound/neon/alias-index.ts` + `points-repo.ts` | `firstWorkId`, `selectPoints` |
+| SQL in `api/route.ts` | `adapters/outbound/neon/points-repo.ts` | `pointsQuery` by ids |
+| SQL in `api/resolve.ts` | `adapters/outbound/neon/alias-index.ts` + `bangumi-repo.ts` | |
+| SQL in `api/spots.ts` / `nearby.ts` / `anime-overview.ts` / `geocode.ts` | same repos by concern | avoid one God repo |
+| `lib/geo-query.ts` | `adapters/outbound/neon/geo-query.ts` | PostGIS |
+| `lib/rows.ts`, `lib/optional.ts` | `adapters/outbound/neon/row-map.ts` (or `adapters/shared/`) | row → wire/DTO |
+| `ingest/sources.ts` + `retry.ts` | `adapters/outbound/upstream/{anitabi,bangumi,retry}.ts` | |
+| `ingest/raw-store.ts` | `adapters/outbound/neon/raw-store.ts` | |
+| `ingest/jobs.ts` | `adapters/outbound/neon/job-store.ts` | JobStore |
+| `ingest/cron-queries.ts` | `adapters/outbound/neon/cron-queries.ts` | |
+| `publish/*` | `adapters/outbound/neon/publish/*` **or** keep under processes (see §2.5) | versioning is persistence |
+| `media/img.ts`, `media/r2.ts` | `adapters/outbound/r2/media.ts` + img serve adapter | |
+| `enrich/parse.ts` | prefer `adapters/outbound/upstream/parse.ts` **or** `domain` if treated as pure parse of known JSON | pure parse of upstream payloads → stay framework-free; either domain or outbound-without-I/O helper |
+
+### 2.5 Processes (data platform — existing pipeline only)
+
+| From | To | Notes |
+|---|---|---|
+| `ingest/*` (remaining orchestration glue) | `processes/ingest/` **or** fully absorbed into `application/ingest-bangumi` + outbound | Prefer absorb over empty process shell |
+| `enrich/enrich.ts` | `application/enrich-bangumi.ts` or `processes/enrich/enrich.ts` | application orchestration of pure parse + SQL ports |
+| `publish/*` | `processes/publish/` if kept as stage name in CONTEXT | still calls outbound neon |
+
+**Preference (owner principle):** if `processes/` would only re-export application modules, **skip the folder** and put orchestration under `application/`. Delete process indirection rather than add it.
+
+### 2.6 Entry re-exports (temporary)
+
+| From | To | Lifetime |
+|---|---|---|
+| Old paths under `src/api/*`, `src/lib/*` | one-line re-export of new path | **delete in same PR** once tests import new paths |
+
+### 2.7 Test layout (existing tests only)
+
+| From | To (optional, later PR) | Rule |
+|---|---|---|
+| pure kernel tests (`route.worker`, `clustering`, transit-*) | `test/domain/…` when path move lands | keep workerd vs spike split rules from AGENTS |
+| search/resolve/route API tests | `test/application/` + thin adapter tests | do not rewrite scenarios; only update imports |
+| spike / neon | stay spike pool | no structural rewrite required for design |
+
+---
+
+## 3. SOLID / 1-10-50 smells (with evidence)
+
+### 3.1 Single Responsibility
+
+| Smell | Evidence | Fix direction |
+|---|---|---|
+| Handler = use case + SQL + DTO map | `api/search.ts` exports `search`, `searchDb`, SQL `firstWorkId`/`selectPoints`, and `toPoint` | split application vs neon adapter |
+| Same for resolve | `api/resolve.ts` ranking pure logic + `resolveDb` SQL in one file (~250) | same |
+| Entry god-file | `index.ts` Hono + pool + media + IngestEntrypoint + cron jobs | split inbound adapters |
+| `lib/` grab bag | pure kernels next to `errors` (ORPC) and `geo-query` (SQL) | dissolve `lib/` by layer |
+| Enrich stages SQL + domain cluster log | `enrich/enrich.ts` | application orchestration + outbound statements |
+
+### 3.2 Open/Closed & Dependency Inversion
+
+| Smell | Evidence | Fix |
+|---|---|---|
+| Production wiring inside use-case modules | `searchDb(db)`, `workPointsDb(db)`, `resolveDb(db)` defined beside use cases | keep factories, but place them under outbound adapters implementing ports |
+| Application imports orchestrator + JobStore concrete | `api/work-points.ts` imports `./ingest/*` and `JobStore` | depend on port methods already on `WorkPointsDb` only (good) — **delete direct JobStore import from application path** by completing the port |
+| Domain-ish throw becomes framework error mid-stack | `lib/route.ts` throws bare `Error` for too many clusters; `lib/errors.ts` builds ORPC; router maps spots/overview | domain signal → application → inbound map once |
+
+### 3.3 Interface Segregation (keep what works)
+
+| Good | Evidence | Do not “improve” into |
+|---|---|---|
+| Narrow `SearchDb` / `RouteDb` / `ResolveDb` / `WorkPointsDb` / `OverviewDb` | each file defines only methods it needs | **God `CatalogDb` port** wrapping all SQL |
+| `RouteDb` is just `execute` | `api/route.ts` | fine for thin reads; optional later PointsRepo with typed methods |
+
+**Delete:** any impulse to invent `ICatalogService` / base repository class hierarchy.
+
+### 3.4 Liskov / substitution
+
+Ports already use structural typing (`CatalogDb` satisfies `RouteDb` via drizzle `execute`). Keep structural ports; no inheritance trees.
+
+### 3.5 DRY violations (existing duplication)
+
+| Duplication | Paths | Consolidation |
+|---|---|---|
+| Point row → wire Point | `search.toPoint`, `route.toPoint`, `spots.toPoint`, `nearby.merge`, `preview.litePoint` | one `adapters/…/map-point.ts` (or shared mapper); lite path stays separate input shape |
+| Origin: kernel lat/lng vs wire union | `lib/route.ts` `Origin` vs `types.ts` `Origin` | domain `GeoOrigin {lat,lng}`; wire map in plan-itinerary / get-point |
+| Optional null stripping | repeated `optional({…})` | keep `optional` helper once under adapters/shared |
+| Alias SQL `work_id` | `search.ts`, `resolve.ts` | single AliasIndex outbound |
+
+### 3.6 1-10-50 pressure
+
+| Rule | Breaches / near | Action |
+|---|---|---|
+| File ≤300 | `lib/route.ts` ~300 | split pacing/assemble if anything else is added; move first |
+| File ≤300 | `api/resolve.ts` ~250, `api/search.ts` ~244 | drops when SQL extracted |
+| Function ≤10 | generally followed in enrich/route helpers | preserve when moving |
+| Class ≤50 | `JobStore` is a thin class — OK | keep; no new service classes |
+| Indent ≤2 | mostly OK | preserve early-return style in work-points claim flow |
+
+### 3.7 Language / boundary smells (structure-relevant)
+
+| Smell | Paths |
+|---|---|
+| Fan language still `Route` / `PilgrimagePoint` / `work_id` | `types.ts`, handlers, `router.ts` `pointsByWorkId`, `schema.ts` columns, `publish/snapshots.ts` |
+| Overview still builds `sample_routes` | `api/anime-overview.ts` `buildSampleRoutes` |
+| Domain pure code imports wire names from `types` | `lib/route.ts` imports `TimedItinerary` from `../types` | either domain owns plan types, or imports only type-only aliases renamed to Itinerary |
+
+---
+
+## 4. Target patterns — and what NOT to use
+
+### 4.1 Patterns to use (minimal)
+
+1. **Pure domain functions**  
+   Existing kernels stay functions/modules, not entity class hierarchies.  
+   Example spine: `clusterByLocation` → `buildTimedItinerary`.
+
+2. **Use case functions**  
+   `planItinerary(ports, input)`, `searchPoints(ports, input)`, …  
+   One exported async function per use case file; helpers private.
+
+3. **Narrow ports (structural TypeScript interfaces)**  
+   Extend the existing style:
+
+   ```text
+   PointsRepo.loadByIds(ids) → Point[]
+   AliasIndex.bangumiIdForNormalized(alias) → bangumi_id?
+   BangumiRepo.candidatesForIds / metadata
+   GazetteerRepo.exact / fuzzy
+   UpstreamCatalog.lite / search / full
+   IngestGate.claim / guard / runClaimed
+   Clock / WaitUntil (for miss path)
+   ```
+
+   Prefer **several small interfaces** over one catalog façade.
+
+4. **Adapter inbound thin handlers**  
+   parse/validate (oRPC/zod at boundary) → call use case → map domain/application errors to `lib/errors` (relocated) ORPC factories.
+
+5. **Adapter outbound neon**  
+   Raw `sql` tagged templates only (workerd hang rule stays — AGENTS).  
+   No fluent Drizzle query builder.
+
+### 4.2 What NOT to use
+
+| Anti-pattern | Why |
+|---|---|
+| New abstract base classes / DI containers | package is a Worker; structural ports + factories suffice |
+| God `CatalogDb` / `UnitOfWork` mega-port | violates ISP; existing narrow ports already testable |
+| Domain entities with mutators / ORM entities | schema is typing-only; points are values |
+| Hexagonal “port per function” explosion | one port per **concept**, not per SQL string |
+| Long-lived `src/lib` façade re-exports | temporary only |
+| Empty `domain/model/point.ts` with no behavior | only add if a pure invariant needs a home |
+| CQRS/event-sourcing layers | not in current code; out of scope |
+| New middleware frameworks | Hono + oRPC stay |
+
+### 4.3 Target tree (aligned with CA parent; processes optional)
+
+```text
+workers/catalog/src/
+  domain/
+    model/           # cluster, alias, series (+ Point/Bangumi types if needed)
+    itinerary/       # plan, pacing
+    geo/             # haversine
+    geocode/         # collapse pure
+    transit/         # moved pure kernel
+    overview/        # pure circle/scene builders (optional)
+    errors.ts        # non-ORPC signals only if needed
+  application/
+    ports.ts         # or ports/*.ts
+    plan-itinerary.ts
+    search-points.ts
+    list-points-for-bangumi.ts
+    resolve-bangumi.ts
+    get-point.ts
+    nearby-points.ts
+    geocode-place.ts
+    anime-overview.ts
+    miss-preview.ts
+    ingest-bangumi.ts
+    enrich-bangumi.ts   # if not under processes
+    cron-ingest.ts
+  adapters/
+    inbound/
+      http/           # app, router, handlers, errors, wire-types
+      cron/
+      rpc/            # IngestEntrypoint
+    outbound/
+      neon/           # client, schema, repos, job-store, raw-store, geo-query, publish
+      upstream/       # anitabi, bangumi, parse, retry
+      r2/             # media
+  config/
+    cron.ts
+  # NO long-term lib/, api/ after P6
+```
+
+Package root entry for wrangler: keep a **thin** `src/index.ts` that re-exports default fetch/scheduled from inbound adapters (Cloudflare entry path stability).
+
+### 4.4 Dependency rules (hard)
+
+```text
+domain        → (nothing in catalog except other domain)
+application   → domain + ports (interfaces only)
+adapters      → application + domain + frameworks
+config        → nothing
+```
+
+Forbidden: domain/application import `hono`, `@orpc/server` values, `drizzle-orm` SQL builders, `cloudflare:workers`.
+
+---
+
+## 5. PR slices (existing code only, ordered)
+
+Each slice: **one reviewable PR**, green `pnpm test` + typecheck + oxlint in `workers/catalog`. Prefer vertical slices that leave no half-dead `lib/` permanent dual homes.
+
+| # | Slice | Moves / deletes | Done when |
+|---|---|---|---|
+| **S0** | Design docs only | this file + parents already ACCEPTED | no code |
+| **S1** | Greenfield language in catalog + contract types catalog uses | rename Point/Itinerary/bangumi_id in `types.ts`, handlers, router keys, schema column names **as consumed**, snapshots table name alignment with greenfield | compile + catalog tests green; **structure can still be old folders** if needed, but no new old names |
+| **S2** | Domain extract (pure only) | `lib/route|clustering|geo|alias|geocode|series|transit` → `domain/*`; delete `lib` copies | domain imports have zero I/O; itinerary/clustering tests import new paths |
+| **S3** | PlanItinerary vertical | `api/route.ts` → `application/plan-itinerary` + `outbound/neon/points-repo` + thin handler; router calls handler | handler has no SQL; behavior parity on route tests |
+| **S4** | Search + work-points vertical | `search` / `preview` / `work-points` → application + AliasIndex/Points/Ingest ports; outbound SQL + upstream | miss/hit/partial parity; `SearchDb`/`WorkPointsDb` live as ports |
+| **S5** | Resolve vertical | pure ranking → application; SQL → neon; miss upstream → outbound | resolve tests green |
+| **S6** | Remaining reads | spots, nearby, geocode, anime-overview same pattern; pure overview builders out of SQL file | no new business rules inside handlers |
+| **S7** | Ingest/enrich/publish placement | orchestrator/jobs/sources/raw/enrich/publish → application + outbound; delete orphan process shells | cron + ingest entrypoint + worker tests green |
+| **S8** | Inbound finalize + delete husks | split `index.ts`; move errors; **delete** empty `api/`, `lib/`, old re-exports; update `AGENTS.md` paths | tree matches §4.3; startup smoke green |
+
+### 5.1 Slice rules
+
+- **S1 may couple to monorepo contract** (greenfield); still **catalog-first** in this design — web/agent follow outside this doc’s implementation ownership.
+- **S2 before S3** so itinerary domain is free of wire rename thrash mid-move (or S1+S2 combined if PR size acceptable).
+- **Do not** open a “introduce ports only” PR with zero callers moved.
+- **Do not** move tests without code in the same slice.
+
+### 5.2 Suggested first vertical (teaching path)
+
+`PlanItinerary` is already almost correct in `api/route.ts`:
+
+1. Domain: cluster + plan (S2)  
+2. Application: load via port → domain → assemble Itinerary (S3)  
+3. Outbound: one SQL  
+4. Inbound: cap check stays in router/handler (`MAX_ROUTE_POINT_IDS` → itinerary point cap)
+
+Use this as the template for Search (harder: waitUntil + ingest).
+
+---
+
+## 6. Explicit non-goals / out of scope
+
+### 6.1 Other packages / surfaces
+
+- `workers/edge`, `apps/web`, `workers/users`, `workers/maintenance`, monorepo root layout  
+- Agent Python catalog client (except note that contract rename forces follow-up **outside** this structure doc’s catalog PRs)
+- New public HTTP products not already in `catalogContract`
+
+### 6.2 Product / enabler tickets (one-line pointers only)
+
+| Topic | Ticket pointer | Relation to this refactor |
+|---|---|---|
+| OSRM / rail topology layer-2 | #292 (and related) | do not implement under structure PRs |
+| Quality / SEO pipelines | #285 etc. | not created here |
+| Ingest internal entry morph | #540 / #555 | if already code-shaped, only **relocate**; no new universe |
+| Share / Check-in / しおり | #235 / #243 / #249 … | Users/product train — **not** catalog structure |
+| Delete-not-in-set enrich gap | noted in `enrich/enrich.ts` header | product/data quality ticket, not structure |
+| Persist cluster_id / city_backfill | enrich comments | not structure |
+
+### 6.3 Non-structure work this design refuses
+
+- Rewrite transit ETL algorithms or gazetteer scripts (scripts/ stay; optional import path fix only when domain/transit moves)
+- New caching layers, Hyperdrive adoption, Drizzle query-builder revival  
+- Compatibility aliases for old wire names (greenfield: **no**)
+- Coverage theatre / large test rewrites without behavior change  
+- Adding Share/Check-in tables or SavedRoute concepts into catalog
+
+### 6.4 Abstraction non-goals
+
+- Demonstrating OOP for its own sake  
+- Full DDD aggregate/repository textbooks with factories for every row  
+- Micro-package split of catalog into multiple Workers
+
+---
+
+## 7. Risk register (structure)
+
+| Risk | Mitigation |
+|---|---|
+| Import graph thrash breaks vitest workerd pool | move + update tests same PR; avoid path aliases until needed |
+| Dual homes (`lib` re-export forever) | PR checklist: no re-export left at merge |
+| Over-porting thin GetPoint | allow application file that is 20 lines calling one repo method |
+| Contract rename vs folder move conflicts | sequence S1 then S2–S3, or one carefully owned mega-PR with greenfield |
+| Cron / entrypoint export shape (workerd primitive export ban) | keep constants in `config/`; entry only exports handlers/classes |
+
+---
+
+## 8. Acceptance (for future implementation PRs)
+
+Structure refactor is done when:
+
+1. No long-term `src/api/` or `src/lib/` (except temporary deleted in-PR).  
+2. `domain/**` has no framework/SQL imports (lint or boundary test optional).  
+3. PlanItinerary + SearchPoints paths: handlers thin; SQL in outbound; pure plan/cluster in domain.  
+4. Language: Point / Bangumi / Itinerary in catalog-facing names; no new `work_id` / `PilgrimagePoint` / bare `Route`.  
+5. `AGENTS.md` paths match the tree; startup smoke + worker/spike suites green.  
+6. No new product feature landed in the same PRs.
+
+---
+
+## 9. Related docs
+
+| Doc | Role |
+|---|---|
+| `docs/superpowers/specs/2026-08-06-catalog-clean-architecture-design.md` | CA target, ports, P1–P6 |
+| `docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md` | Language + tables |
+| `workers/catalog/CONTEXT.md` | BC language ownership |
+| `workers/catalog/AGENTS.md` | Commands, workerd SQL rules (update after moves) |
+| `packages/contract` | Wire SoT for renames catalog already implements |
+
+---
+
+## 10. Changelog
+
+| Date | Change |
+|---|---|
+| 2026-08-06 | Initial structure-refactor design: inventory, move table, SOLID evidence, patterns, PR slices S0–S8, non-goals |
+| 2026-08-06 | Owner ACCEPTED (best-practice default) |

--- a/docs/superpowers/specs/2026-08-06-ci-cd-refactor-plan.md
+++ b/docs/superpowers/specs/2026-08-06-ci-cd-refactor-plan.md
@@ -1,0 +1,277 @@
+# CI/CD 重构怎么写（基于现方案 · 可执行计划）
+
+- Status: **ACCEPTED (design only)** — owner 2026-08-06；**不实施 YAML**，直至另开实现列车  
+- Aligns: [ci-deploy-architecture](./2026-08-06-ci-deploy-architecture.md)（DIRECTION ACCEPTED）  
+- Date: 2026-08-06  
+- Scope (when implemented): **只改 `.github` 编排与文档**；不改业务包运行时（除非 pin/脚本路径）  
+- Out: Neon DBA N1、catalog ingest 代码、产品 enabler；**本会话不改 workflow 文件**
+
+---
+
+## 0. 先回答：Sonar 接了没？
+
+| 证据 | 含义 |
+|---|---|
+| 根目录 **`.sonarcloud.properties`**（写明 automatic-analysis 唯一配置） | **SonarCloud 已接**，偏 **自动分析 / GitHub App**，不是每条 `pipeline-*.yml` 里手写 `sonar-scanner` job |
+| PR 历史上有 **SonarCloud Quality Gate** 顶层评论 | 门禁在 **GitHub 检查/评论** 侧，不在我们自研 workflow 正文里 |
+| `s0v2/GOAL.md` 仍有「sonar 配置合一且 QG 仍工作」 | 配置曾分叉风险；现文件注释称 twin 已退役 |
+| **工作流内几乎无 `sonar-scanner` step** | 所以你会「有点忘了接没接」——**接了，但是隐形的** |
+
+**重构时怎么写 Sonar：**
+
+- **保留** SonarCloud 为 **仓级 CI 横切门**（Quality Gate = required check 之一，若 branch protection 已勾选）。  
+- **不要** 复制进 9 个 package workflow。  
+- **要做：** 在重构文档/部署 runbook 写清「Sonar = Automatic Analysis + `.sonarcloud.properties`」；验证 **一份配置**；QG 仍绿。  
+- 若以后要 **CI-based analysis**（显式 action），再做成 **一个** `reusable` / 一个 `ci-quality` job，仍不 per-package 抄。
+
+**Codecov：** 已在多条 pipeline 里 OIDC upload — 应 **收进 reusable-package-ci**，flag=`${{ inputs.component }}`。
+
+**Security：** 已有 `reusable-security.yml` + `codeql.yml` — 保持横切；从胖 `ci.yml` 叙事上拆清楚即可。
+
+---
+
+## 1. 目标终态（重构写完后长什么样）
+
+```text
+.github/
+  actions/setup/                    # 已有，继续唯一安装入口
+  workflows/
+    # ── CI：包级（薄调用方，~20–40 行）──
+    ci-contract.yml
+    ci-db.yml
+    ci-catalog.yml
+    ci-users.yml
+    ci-web.yml
+    ci-agent.yml
+    ci-edge.yml
+    ci-jobs.yml                   # 原 pipeline-maintenance
+
+    # ── CI：横切（各 1 个）──
+    ci-security.yml               # 调 reusable-security + 可选 codeql 触发关系写清
+    # Sonar：Automatic Analysis（无 workflow 或将来单一 job）— 见 §0
+
+    # ── 共享实现 ──
+    reusable-package-ci.yml       # NEW：lint/test/build/artifact/codecov
+    reusable-package-ci-python.yml # 或同一文件 matrix language: node|python
+    reusable-deploy-component.yml # 已有，收瘦注释/preflight 若可能
+    reusable-post-deploy-test.yml # 已有
+    reusable-cross-stack-e2e.yml  # 已有
+    reusable-security.yml         # 已有
+
+    # ── CD 编排 ──
+    deploy-staging.yml            # 从 ci.yml 拆出：顺序 deploy + post API/E2E
+    deploy-prod.yml               # 自动晋升 + 与 manual 对齐
+    deploy-manual.yml             # 今日 deploy.yml 改名/收束
+
+    # ── 旁路（不进包部署主路径）──
+    agent-eval-nightly.yml
+    agent-eval-smoke.yml          # 可选：从 ci.yml 挪出
+    neon-test-base.yml
+    dependabot-agent.yml
+    codeql.yml                    # 或并入 ci-security 文档关系
+
+    # 删除/归档
+    # pipeline-*.yml              → 被 ci-*.yml 取代
+    # purge-anonymous-*.yml       → 权威在 workers/jobs
+    # ci.yml 上帝文件             → 拆空或只剩 redirect 注释期
+```
+
+**每包 CI 语义（不变）：** `lint → test → build → (artifact)`  
+**CD 语义（不变）：** migrate(若需) → deploy → smoke → staging API/E2E → tag → prod…
+
+---
+
+## 2. 核心 reusable 合同（重构要先写这个）
+
+### 2.1 `reusable-package-ci.yml` inputs（草案）
+
+| input | 用途 |
+|---|---|
+| `component` | 名字：catalog / web / …（codecov flag、artifact 名） |
+| `language` | `node` \| `python` |
+| `working_directory` | 包根 |
+| `lint_command` | 覆盖默认时用 |
+| `test_command` | |
+| `build_command` | 空 = 跳过 build job |
+| `coverage_file` | 如 `coverage/lcov.info` |
+| `upload_codecov` | bool |
+| `startup_smoke` | bool（catalog 类 wrangler boot） |
+| `node_package_filter` | pnpm filter 名 |
+
+**jobs 固定：** `lint` → `test` → `build`（needs test 或 parallel 策略成文）→ 可选 `smoke`。  
+**禁止：** 在 reusable 里 `wrangler deploy`。
+
+### 2.2 薄调用方示例（目标长度）
+
+```yaml
+# ci-catalog.yml — 目标形态（示意）
+name: ci-catalog
+on:
+  pull_request:
+  merge_group:
+    branches: [main]
+  push:
+    branches: [main]
+    paths: [ 'workers/catalog/**', 'packages/contract/**', ... ]
+jobs:
+  ci:
+    uses: ./.github/workflows/reusable-package-ci.yml
+    with:
+      component: catalog
+      language: node
+      working_directory: workers/catalog
+      test_command: pnpm run test:worker
+      build_command: # or startup_smoke: true
+      coverage_file: workers/catalog/coverage/lcov.info
+      upload_codecov: true
+      startup_smoke: true
+    permissions:
+      contents: read
+      id-token: write
+```
+
+**PR path 策略（实现时二选一，须成文）：**
+
+| 策略 | 说明 |
+|---|---|
+| **A（推荐）** | PR 用 **paths-filter / dorny 在调用方或 reusable 入口** 跳过无关包；`merge_group` **全量** 跑所有 ci-* |
+| **B（现状）** | PR pathless 全跑 — 仅当 branch protection/queue 强制要求且短期不改 |
+
+重构默认按 **A** 写；若 queue 约束暂不能 A，C3 可先薄调用方 + 仍 pathless，C4 再切 A。
+
+---
+
+## 3. 分 PR 怎么拆（推荐顺序）
+
+### PR-C1 — 盘点与门禁表（无行为变化）
+
+**写什么：**
+
+- 表格：今日每个 workflow 的职责、触发、是否 required  
+- Required checks 目标列表（ci-catalog 等新名映射）  
+- Sonar：确认 Automatic Analysis + `.sonarcloud.properties` + QG 是否 required  
+
+**验收：** 文档 PR；CI 行为不变。
+
+### PR-C2 — 引入 `reusable-package-ci`（先迁 1–2 个最简包）
+
+**先迁：** `contract`、`users` 或 `edge`（步骤最像）。  
+**验收：** 原 pipeline 与新 ci-* 可短暂双跑或直接切；测绿；codecov flag 仍在。
+
+### PR-C3 — 全部 `pipeline-*` → 薄 `ci-*`
+
+| 旧 | 新 |
+|---|---|
+| pipeline-web | ci-web |
+| pipeline-agent | ci-agent（python 档） |
+| pipeline-catalog | ci-catalog |
+| pipeline-users | ci-users |
+| pipeline-edge | ci-edge |
+| pipeline-maintenance | **ci-jobs**（与包 rename 可同波或先别名） |
+| pipeline-contract | ci-contract |
+| pipeline-db | ci-db（validate only；无 deploy） |
+| pipeline-infra | ci-infra（特殊可保留更多 steps，但仍尽量 composite） |
+| pipeline-quality | 缩成 `ci-invariants` 或并入 security/docs |
+
+**验收：** 无 `pipeline-*.yml`（或仅 deprecated 空壳一周）；branch protection 更新 required 名。
+
+### PR-C4 — 拆 `ci.yml` 上帝文件
+
+| 挪出 | 去向 |
+|---|---|
+| security job | `ci-security.yml` → reusable-security |
+| agent-eval-smoke | `agent-eval-smoke.yml`（旁路） |
+| python-integration / catalog-spikes | 旁路或 path 触发的 `ci-agent-integration.yml` |
+| deploy-staging/* / post-staging | **`deploy-staging.yml`** |
+| deploy-prod/* / post-prod | **`deploy-prod.yml`** |
+| cross-stack e2e | 由 **deploy-staging 成功** `workflow_run` 或 `needs` 调 reusable-cross-stack-e2e |
+
+**验收：** 不再存在「打开 ci.yml 既有 eval 又有五连 prod deploy」；CD 只读 deploy-* 文件。
+
+### PR-C5 — 清理杂物
+
+- 删除或 archive：`purge-anonymous-sessions.yml`、`purge-anon-quota-counts.yml`（权威 **jobs Worker**）  
+- `deploy.yml` → `deploy-manual.yml`，与 deploy-prod **共用** reusable-deploy  
+- 文档：`docs/ops/deployment.md` 重画「CI 横切 / 包 CI / CD」三层 + Sonar 说明  
+
+### PR-C6 — 策略打磨（可选同波）
+
+- PR path-skip 策略 A  
+- staging 后 API/E2E 触发关系写死  
+- scheduler 健康检查（若需要）独立 `schedule: cron` workflow  
+
+---
+
+## 4. 每层放什么（写进 review 清单）
+
+### 4.1 包 CI（reusable-package-ci）— **该重用却没重用的集中地**
+
+| 步骤 | 重用 |
+|---|---|
+| checkout + setup | `actions/setup` |
+| lint / typecheck | inputs |
+| test + coverage | inputs |
+| codecov | **一处** OIDC |
+| build / emit artifact | inputs |
+| 可选 startup smoke | inputs |
+
+### 4.2 横切 CI — **不进包正文**
+
+| 能力 | 放置 |
+|---|---|
+| gitleaks / 供应链等 | reusable-security / ci-security |
+| CodeQL | codeql.yml 或 security 文档绑定 |
+| **SonarCloud QG** | Automatic Analysis + `.sonarcloud.properties`（现状）；勿 9 份 scanner |
+| 全仓 allowlist / pin 检查 | ci-invariants（原 quality 瘦身） |
+
+### 4.3 CD — **只交付**
+
+| 能力 | 放置 |
+|---|---|
+| Atlas apply | reusable-deploy（已有） |
+| wrangler / pulumi | reusable-deploy |
+| 组件顺序 | deploy-staging / deploy-prod |
+| smoke / post-deploy | reusable-post-deploy-test |
+| E2E / API after staging | deploy-staging 后触发 |
+| tag | deploy 成功后策略（成文） |
+
+---
+
+## 5. 风险与迁移技巧
+
+| 风险 | 缓解 |
+|---|---|
+| Required check 改名导致 merge 卡死 | C3 先 **双写 check 名** 或保护规则预加新名再删旧名 |
+| merge_group 与 path-filter | 策略 A：merge_group 强制 full；PR 可 skip |
+| agent python 特殊 | `language: python` 专用 job 模板，仍一个 reusable 文件内 `if` |
+| Sonar 隐形 | C1 验证 QG；配置只认 `.sonarcloud.properties` |
+| 大 PR 难 review | **严格按 C1→C6**；C2 只迁 2 包做样板 |
+
+---
+
+## 6. 成功标准（重构 Done）
+
+- [ ] 包 CI **无** 大段复制的 checkout/setup/codecov  
+- [ ] 部署编排 **不** 活在「还跑 eval 的 ci.yml」里  
+- [ ] 顶层 workflow 数量明显下降或 **职责一目了然**（名见义）  
+- [ ] Sonar / Security / Codecov 位置成文；Sonar **未** 复制进每包  
+- [ ] purge 双轨消除  
+- [ ] `docs/ops/deployment.md` 与本文一致  
+- [ ] 一次完整 PR：改单包只跑相关 ci（若已上策略 A）或至少 merge_group 行为成文  
+
+---
+
+## 7. 建议的第一行「设计说明」（给将来写 PR 的人）
+
+> 我们不否定「每包一条部署线」。  
+> 本次重构把 **实现** 收成：薄 `ci-<pkg>` + 深 `reusable-package-ci` + 独立 `deploy-*` + 横切 security/sonar。  
+> SonarCloud 已通过 Automatic Analysis 接入；本次只文档化与配置合一验收，不把 scanner 抄进每个包。
+
+---
+
+## 8. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿：如何按已定方向重构现网 CI/CD；Sonar 现状澄清；C1–C6 PR 切片 |
+| 2026-08-06 | Owner **ACCEPTED design only** — 实现后置 |

--- a/docs/superpowers/specs/2026-08-06-ci-deploy-architecture.md
+++ b/docs/superpowers/specs/2026-08-06-ci-deploy-architecture.md
@@ -1,0 +1,172 @@
+# CI / 部署架构（方向）
+
+- Status: **DIRECTION ACCEPTED**（owner 2026-08-06 — 原则如下；**实现未开**；与 Neon DBA / catalog ingest **分轨**）  
+- Executable plan (also design-only until scheduled): [ci-cd-refactor-plan](./2026-08-06-ci-cd-refactor-plan.md)
+- Date: 2026-08-06  
+- Related: `docs/ops/deployment.md` · S0-v2 B4 / CI-1 · 现网 `.github/workflows/*`
+
+---
+
+## 0. Owner 定调（LOCKED 原则）
+
+### 0.1 架构上对的
+
+| 原则 | 含义 |
+|---|---|
+| **Monorepo 下每个可部署小单元一条部署 pipeline** | catalog / users / web / agent(container) / edge(root) / jobs… 各自一条，**不是**错 |
+| **标准阶段** | **lint → test → build → 发布 artifact → deploy**；之后 **打 tag**，再部署、再打 tag（环境递进） |
+| **Staging 后质量** | staging 部署完成后跑 **API 测试 + E2E**；必要时 **scheduler** 定时跑 API/E2E — **合理** |
+| **Shared pipeline as code** | reusable workflow / composite action — **方向对** |
+
+### 0.2 实现上错的（体感「超级乱」）
+
+| 问题 | 现状 |
+|---|---|
+| **顶层 workflow 过多** | ~23 个 yml；10 条 `pipeline-*` + 胖 `ci.yml` + 零散 purge/eval/neon |
+| **Reusable 有，但仍复制粘贴** | 每条 pipeline 各自 checkout/setup/codecov/pin；改 pin 改 N 处 |
+| **关注点混杂** | 包 CI、跨栈 e2e、安全、eval、Neon 集成、**整段 staging→prod 晋升** 挤在叙事不清的文件里 |
+| **PR 行为与「按包」打架** | 多条 lane **PR pathless 全跑**（merge_group 一致），包级隔离的收益被吃掉 |
+| **命名** | `pipeline-*` = 包 CI，又和 **数据 ingest pipeline**、部署 pipeline 口语撞车 |
+| **遗留双轨** | 旧 GHA purge yml 与 `workers/jobs` 并存风险；`ci.yml` 仍 500+ 行上帝工作流 |
+
+**结论：**  
+**「每包一条部署线」保留。**  
+要改的是：**文件编排、复用深度、阶段纯度、命名，以及把乱七八糟的东西移出包部署主路径。**
+
+---
+
+## 1. 目标叙事（一张图）
+
+```text
+                    ┌─────────────────────────────────────┐
+                    │  Package CI (每可部署单元一条「细调用方」)  │
+                    │  lint → test → build → (artifact)     │
+                    │  实现：几乎全是 workflow_call 进 reusable  │
+                    └─────────────────┬───────────────────┘
+                                      │ artifacts / green checks
+                    ┌─────────────────▼───────────────────┐
+                    │  Deploy orchestration（按环境）         │
+                    │  staging: deploy components in order   │
+                    │       → API tests → E2E (or schedule)  │
+                    │  prod: approval → deploy → tag         │
+                    │       → (optional) post checks         │
+                    └─────────────────────────────────────┘
+
+旁路（不进包部署主路径，单独 workflow）:
+  security / CodeQL / dependabot
+  agent-eval nightly|smoke（报告向）
+  neon test-base 维护
+  文档-only quality（可选）
+```
+
+---
+
+## 2. 目标文件形状（比现在少、比现在纯）
+
+### 2.1 建议保留的「种类」（不是再加 20 个文件）
+
+| 种类 | 数量目标 | 职责 |
+|---|---|---|
+| **`reusable-package-ci.yml`**（或 2 个：node-ts / python） | **1–2** | lint/test/build/artifact 的 **唯一实现** |
+| **`ci-<component>.yml` 细调用方** | **≈ 可部署单元数**（~6–8） | 只传 `component`、paths、working-directory、语言；**几乎无步骤正文** |
+| **`reusable-deploy-component.yml`** | **1**（已有，继续收瘦） | 单组件 deploy + 必要 atlas/pulumi/wrangler |
+| **`deploy-staging.yml` / `deploy-prod.yml`（或一个带 environment）** | **1–2** | **只**编排顺序、needs、post API/E2E、tag |
+| **旁路** | 少量 | security、eval、ops 定时；**禁止**再塞进包 CI 正文 |
+
+### 2.2 相对现状的映射
+
+| 今日 | 目标 |
+|---|---|
+| `pipeline-web/agent/catalog/...yml` 各写一遍 steps | **同一 reusable**；调用方 30 行级 |
+| `ci.yml` = 安全 + eval + neon 集成 + **整段 deploy 晋升** | **拆开**：检查旁路 vs **deploy orchestration** |
+| `deploy.yml` 手动 prod | 保留；与自动晋升 **共用** reusable-deploy |
+| `purge-anonymous-*.yml` | **删除或归档**（jobs Worker 为权威） |
+| `pipeline-quality.yml` 大杂烩 | 缩成 invariants **或** 并入 security/docs 旁路 |
+| 名 `pipeline-*` | 建议改为 **`ci-<pkg>`** 或 **`check-<pkg>`**；「pipeline」留给部署叙事/数据面口语 |
+
+### 2.3 每包 CI 阶段（LOCKED 语义）
+
+```text
+lint → test → build → publish artifact
+```
+
+- **不** 在包 CI 里直接 `wrangler deploy`（除非明确 local-only 例外，本项目 **否**）  
+- artifact：web bundle、worker 构建产物、agent 镜像引用等 — 按组件定义 inputs  
+- branch protection：**required checks** = 各包 `ci-<pkg>` 的结论 job（或一个 matrix 汇总 job）
+
+### 2.4 部署阶段（LOCKED 语义）
+
+```text
+(需要时) atlas migrate as migrator
+→ deploy component(s) in dependency order
+→ smoke
+→ (staging) API tests + E2E
+→ tag environment/git as policy defines
+→ next environment …
+```
+
+- Staging 后 API/E2E：**部署编排的一部分**或 **独立 workflow 由 deploy 成功触发** — 都对；不要散落在每个 `pipeline-web` 里复制  
+- **Scheduler** 跑 API/E2E：允许（合成监控）；与 PR 门禁分离配置  
+
+---
+
+## 3. 什么叫「乱」的判定标准（实现验收反例）
+
+实现完成后应 **消除**：
+
+1. 同一套 `actions/checkout@sha` + setup 在 ≥5 个文件全文重复而无 reusable  
+2. PR 上出现 **与 diff 无关** 的全量包编译作为默认（除非 contract/共享触达或 merge_group 全量策略 **成文**）  
+3. `ci.yml` 同时拥有「随机 eval」和「prod 五连 deploy」且无目录/命名分层  
+4. 包 CI 文件 > ~80 行且大部分是可复用 steps  
+5. 两套 purge（GHA + jobs Worker）无「唯一权威」声明  
+
+---
+
+## 4. 与 monorepo 包结构的对齐
+
+| 可部署单元 | CI 调用方（目标名示例） | Deploy 顺序提示 |
+|---|---|---|
+| contract | `ci-contract` | 库；先于消费者 |
+| db (Atlas validate) | `ci-db` | migrate 挂 **deploy** 不是包 lint |
+| catalog | `ci-catalog` | staging 较早 |
+| users | `ci-users` | 依赖 contract；deploy 在 catalog 后或并行（现网顺序可保留） |
+| web | `ci-web` | artifact → CF |
+| agent | `ci-agent` | image/build |
+| edge (root) | `ci-edge` | 路由依赖 users/catalog 已上 |
+| jobs | `ci-jobs` | 原 maintenance |
+
+**db validate** 可以是 `ci-db`；**migrate apply** 只在 deploy reusable 里（已有方向）。
+
+---
+
+## 5. 实施切片（未开做）
+
+**可执行逐步写法见：** [ci-cd-refactor-plan](./2026-08-06-ci-cd-refactor-plan.md)（PR-C1…C6、reusable 合同、Sonar 现状）。
+
+| 切片 | 内容 |
+|---|---|
+| **C0** | 本文方向 ACCEPTED（本会话） |
+| **C1** | 盘点 required checks 清单 + 每文件职责表（只读 PR 说明） |
+| **C2** | 抽/加深 `reusable-package-ci`（node + python 两档） |
+| **C3** | 把现有 `pipeline-*` 收成薄调用方；统一命名 |
+| **C4** | 从 `ci.yml` **拆出** deploy orchestration；`ci.yml` 降级或改名 |
+| **C5** | 删除/归档 purge GHA；scheduler E2E 若需要则独立 workflow |
+| **C6** | branch protection / merge queue 文档更新 |
+
+**不做进本列车：** 改 Neon 角色（DBA 图）；改 catalog ingest 代码结构。
+
+---
+
+## 6. 明确非目标
+
+- 取消「每包一条线」改回巨型单体 job 且无法并行  
+- PR 上永远跑全 monorepo 且无法 path-skip（除非 merge_group 策略显式选择全量）  
+- 在包 CI 里藏生产 deploy  
+
+---
+
+## 7. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | Owner：架构原则对（每包部署线 + lint/test/build/artifact/deploy/tag + staging API/E2E）；乱在实现与杂物；目标形状与切片 |

--- a/docs/superpowers/specs/2026-08-06-config-file-placement.md
+++ b/docs/superpowers/specs/2026-08-06-config-file-placement.md
@@ -1,0 +1,184 @@
+# 小配置文件放哪（Monorepo 放置规则）
+
+- Status: **DESIGN** — 与 monorepo P3「根只做编排」对齐；**不强制一次搬完**  
+- Date: 2026-08-06  
+- Parent: [monorepo-target-layout](./2026-08-06-monorepo-target-layout.md)
+
+---
+
+## 0. 三条总则
+
+1. **谁拥有生命周期，配置就跟谁**  
+   只服务一个 app/worker 的 → 放在该包根下（`apps/web/vitest.config.ts`）。  
+2. **工具强制要求仓库根的 → 留在根**  
+   例如 GitHub、SonarCloud Automatic Analysis、多数 pre-commit、pnpm workspace。  
+3. **根上禁止「假装编排、其实是 edge 运行时」**  
+   已定：`wrangler.toml`、edge 的 hono/jose deps、agent `Dockerfile` → 沉入 `workers/edge` / `apps/agent`。
+
+**不搞** 统一的 `config/` 大筐把所有东西塞进去——会破坏工具发现路径，也违反「跟 owner 走」。
+
+---
+
+## 1. 决策树
+
+```text
+这个文件只影响一个可部署包/库吗？
+  是 → 放 packages|apps|workers/<name>/
+  否 ↓
+工具/平台要求必须在 git 根目录吗？
+  是 → 留根（或 .github/）
+  否 ↓
+是仓级质量/安全/覆盖率策略吗？
+  是 → 根（或 docs/ops 只写说明，可执行配置仍常在根）
+  否 ↓
+是本机/IDE/agent 私货吗？
+  是 → 点目录（.claude/.grok）或 gitignore；不要进业务包
+```
+
+---
+
+## 2. 根上该留什么（编排 + 仓级门禁）
+
+| 文件 | 去留 | 说明 |
+|---|---|---|
+| `package.json` + `pnpm-workspace.yaml` + `pnpm-lock.yaml` | **根** | workspace 编排；**目标：** 无 edge 业务 runtime deps |
+| `.npmrc` · `.nvmrc` | **根** | 全仓 Node/pnpm 约定 |
+| `.gitignore` · `.dockerignore` | **根** | 工具读根 |
+| `Makefile` | **根** | 跨包命令入口（可再薄） |
+| `AGENTS.md` · `CLAUDE.md` · `CONTEXT-MAP.md` · `README*` | **根** | 人/agent 入口 |
+| `.oxlintrc.json`（根） | **根 base** | 共享严格规则；**包内** `.oxlintrc.json` extends 根（现状合理） |
+| `.pre-commit-config.yaml` | **根** | pre-commit 默认根配置 |
+| `.sonarcloud.properties` | **根** | Sonar Automatic Analysis 要求/惯例在根 |
+| `codecov.yml` | **根** | Codecov 仓级 flag/门禁 |
+| `.sqlfluff` · `.semgrepignore` · `.codacy.yml` | **根** | 仓级静态分析入口 |
+| `.env.example` · `.env.test.example` | **根** 或拆 | 跨服务本地变量总表可留根；**单包** 用 `apps/web/.env.example` |
+| `.github/**` | **根下** | CI/CD、模板、actions — 永不沉到 workers |
+
+---
+
+## 3. 应沉入包的（已定目标 · 与 edge package-ize 一致）
+
+| 文件 | 目标位置 |
+|---|---|
+| 根 `wrangler.toml` | `workers/edge/wrangler.toml` |
+| 根 `Dockerfile` | `apps/agent/Dockerfile`（容器定义跟 agent） |
+| 根 `package.json` 的 hono/jose/containers | `workers/edge/package.json` |
+| 各包 `tsconfig` / `vitest.config` / 包级 `.oxlintrc` | **已在包内 · 保持** |
+| `apps/web/vite.config.ts` · `lighthouserc.cjs` · `wrangler.jsonc` | **web 包内 · 保持** |
+| `infra/Pulumi*.yaml` · `infra/tsconfig` | **infra/ · 保持** |
+| `e2e/playwright.config.ts` | 目标 `tests/e2e/`（随 e2e 搬家） |
+| `db` 迁移 + atlas.sum | 目标 `migrations/neon/`（DBA D19） |
+| `supabase/` | 目标 `migrations/supabase/` |
+
+包内配置命名习惯（统一即可，不必再套一层 `config/`）：
+
+```text
+workers/catalog/
+  package.json
+  tsconfig.json
+  vitest.config.ts
+  .oxlintrc.json          # extends ../../../.oxlintrc.json
+  wrangler.toml
+```
+
+---
+
+## 4. 按类型速查
+
+### 4.1 语言 / 构建
+
+| 类型 | 放置 |
+|---|---|
+| `tsconfig.json` | **包内**；根可不设（或仅 `tsconfig.base.json` 被 extends — **可选**，现在没有就别硬加） |
+| `vitest.config.*` | **包内** |
+| `vite.config.ts` | **apps/web** |
+| Python：`pyproject.toml` / `ruff` / `mypy` | **apps/agent**（uv 项目根） |
+| `Dockerfile` | **产生镜像的包**（agent） |
+| `docker/` 测试镜像 | **`docker/` 顶层** 或 `apps/agent/docker/` — 测试基础设施可顶层 |
+
+### 4.2 质量 / 安全 / 覆盖
+
+| 类型 | 放置 |
+|---|---|
+| oxlint 共享规则 | **根** `.oxlintrc.json` + 包 extends |
+| Sonar | **根** `.sonarcloud.properties` |
+| Codecov | **根** `codecov.yml` |
+| Semgrep / Codacy / sqlfluff | **根** 点文件（工具默认） |
+| pre-commit | **根** |
+
+### 4.3 密钥与环境样例
+
+| 类型 | 放置 |
+|---|---|
+| 跨服务「本地要哪些变量」总表 | 根 `.env.example` |
+| 单 Worker secrets 形状 | `workers/<pkg>/.dev.vars.example`（已有 users/maintenance） |
+| Web 仅前端 `VITE_*` | `apps/web/.env.example` |
+| **真实 secret** | 永不入库；CI Environment / `wrangler secret` |
+
+### 4.4 本机 / Agent 工具
+
+| 类型 | 放置 |
+|---|---|
+| `.claude/` · `.grok/` · `.serena/` | 可留根；**不要**塞进 `apps/web/src` |
+| 个人 override | gitignore 或 user-level |
+
+### 4.5 脚本与夹具
+
+| 类型 | 放置 |
+|---|---|
+| 跨包运维脚本 | 根 `scripts/` |
+| 仅 agent 的 | `apps/agent/scripts` 或 `apps/agent/src/.../scripts` |
+| 测试 fixture | 跟测试 owner：`apps/agent` fixtures、`e2e/`、`fixtures/`（少而精；避免根无限涨） |
+
+---
+
+## 5. 目标根目录「点文件 + 编排」清单（干净后）
+
+```text
+.
+├── package.json              # private 编排 ONLY
+├── pnpm-workspace.yaml
+├── pnpm-lock.yaml
+├── Makefile
+├── AGENTS.md · CLAUDE.md · CONTEXT-MAP.md · README*
+├── .gitignore · .dockerignore · .npmrc · .nvmrc
+├── .oxlintrc.json            # base
+├── .pre-commit-config.yaml
+├── .sonarcloud.properties
+├── codecov.yml
+├── .sqlfluff · .semgrepignore · .codacy.yml   # 若仍用这些工具
+├── .env.example · .env.test.example           # 跨服务样例
+├── .github/
+├── apps/ · workers/ · packages/ · migrations/ · infra/ · tests/ · scripts/ · docs/
+└── （可选）docker/   # 仅共享测试镜像
+```
+
+**根上不应再长期存在：** `wrangler.toml`、业务 `Dockerfile`、edge runtime deps、`db/` 名（改为 migrations）、把 e2e 当「随便根目录邻居」而不进 `tests/`（目标态）。
+
+---
+
+## 6. 和已有列车的关系
+
+| 列车 | 会动哪些小配置 |
+|---|---|
+| Edge package-ize (E1) | 根 wrangler + edge deps |
+| Agent 结构 | Dockerfile 路径、容器 image 引用 |
+| DBA D19 | `db/` → `migrations/neon/` |
+| CI C2–C5 | 只动 `.github`；不把 sonar 拆进包 |
+| jobs rename | `pipeline-maintenance` → `ci-jobs` 路径字符串 |
+
+---
+
+## 7. 非目标
+
+- 建 `config/sonar/` `config/lint/` 深层树（除非工具强制）  
+- 每个包复制一份 `.sonarcloud.properties`  
+- 把 `pnpm-workspace` 沉到子目录  
+
+---
+
+## 8. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿：小配置放置决策树 + 根/包对照表 |

--- a/docs/superpowers/specs/2026-08-06-edge-gateway-structure-design.md
+++ b/docs/superpowers/specs/2026-08-06-edge-gateway-structure-design.md
@@ -1,0 +1,232 @@
+# Edge Gateway 结构重构（一次做到位 · 无巡礼 domain）
+
+- Status: **ACCEPTED**（owner 2026-08-06 — Gateway 一次到位；**无**巡礼 domain；**不含实现**）
+- Date: 2026-08-06
+- Package: `workers/edge`（今日大量文件平铺；运行时 deps 仍在**根** `package.json` / `wrangler.toml`）
+- Tier: **Gateway**（monorepo §4.3 LOCKED）
+- Parents: monorepo-target-layout · greenfield-language-and-data-plane · CONTEXT.md
+- Scope: **已有代码** 真结构 + package-ize + greenfield path；**无** 巡礼产品 enabler
+
+---
+
+## 0. 关于「domain model」—— Edge **不用**
+
+| 概念 | Edge 是否用 |
+|---|---|
+| 巡礼 **DDD domain model**（Point / Bangumi / Itinerary / SavedRoute 实体与不变量） | **否** — 那些归 Catalog / Users / Agent |
+| 目录名 `domain/` | **否** — 禁止 mkdir 假 domain |
+| Gateway **关切词汇**（Identity / Forward / Policy / RateLimit） | **是** — 这是网关语言，不是巡礼领域模型 |
+| Clean Architecture 四圈教科书 | **否** — Gateway 用 **关切分包 + 纯 policy 函数 + 薄 adapter** |
+
+一句话：**Edge 没有业务 domain model；有的是网关策略与转发。**  
+若文档出现 “policy / identity”，指 **接入控制**，不是 DDD Aggregate。
+
+---
+
+## 1. 目标（一次最好）
+
+1. **Package-ize 一次到位**：edge 运行时依赖、wrangler、测试入口全部在 `workers/edge`；根只编排。  
+2. **目录一次到位**：按关切进 `src/`，测试进 `test/`（或 `__tests__`），禁止再扁平堆根。  
+3. **策略可单测**：path allowlist / public catalog / rate-limit 范围 = **纯函数**，零 CF 绑定。  
+4. **Greenfield path 一次对齐**：`/catalog/itinerary`、`/v1/users/saved-routes` 等随 contract 改（与 G1 同波或紧后）。  
+5. **不半吊子**：不做「先只 rename 文件名、目录下个迭代再说」。
+
+---
+
+## 2. 现状 inventory（实盘）
+
+### 2.1 生产模块（`workers/edge/*.ts`，排除 `*.test.ts`）
+
+| 模块 | 角色 |
+|---|---|
+| `entry.ts` | Worker default export；Container 类；`outboundByHost` |
+| `app.ts` | Hono 组装、路由挂载、容器冷启动重试 |
+| `env.ts` / `entry-env.ts` | Env 类型与校验 |
+| `auth.ts` | JWT / API key 身份 |
+| `anonymous-flow.ts` / `anonymous-id.ts` | 匿名 /v1 流 |
+| `turnstile.ts` | Turnstile 门 |
+| `forward.ts` | 转发 Catalog / Users / 容器 + identity 头 |
+| `routing-policy.ts` | 公网 v1 / 鉴权限流路径谓词 |
+| `catalog-policy.ts` | 匿名 catalog GET allowlist |
+| `rate-limiter.ts` / `cost-breaker.ts` | 限流与成本闸 |
+| `edge-guard.ts` / `guard-store.ts` | DO 护栏存储 |
+| `image-proxy.ts` / `tiles.ts` / `showcase.ts` | 资产 proxy |
+| `container-env.ts` | 容器 env / egress denylist 数据 |
+| `session-migrate.ts` | 会话迁移边车路径 |
+| `responses.ts` | 标准 JSON 体 |
+| `*-doubles.ts` | 测试 double（应离开生产树） |
+
+**痛点：** 包根 = 生产 + 测试 + doubles 混放；根 monorepo 持 hono/jose/containers 依赖；`package.json` name 仍像「整仓 worker」。
+
+### 2.2 正确碎片（保留语义）
+
+- Identity 注入后转发（不预鉴权 Users 的二次模型 — Users 自验签）  
+- Public catalog / public v1 与 authenticated 分轨  
+- Percent-decode 后做限流匹配（防编码绕过）  
+- Container → `catalog.internal` 私有 binding  
+- 非 HTML：未匹配 → JSON 404（页面归 web）
+
+---
+
+## 3. 目标树（一次最好 · 无 `domain/`）
+
+```text
+workers/edge/
+  package.json              # 运行时 deps 全部在此（自根迁入）
+  wrangler.toml             # 自根迁入；entry = src/entry.ts
+  tsconfig.json
+  AGENTS.md
+  CONTEXT.md
+  src/
+    entry.ts                # default export + RuntimeContainer
+    app.ts                  # createWorkerApp — 只组装
+    env.ts
+    identity/
+      auth.ts
+      anonymous-flow.ts
+      anonymous-id.ts
+      turnstile.ts
+    gateway/
+      forward.ts
+      routing-policy.ts     # 纯函数
+      catalog-policy.ts     # 纯函数
+      responses.ts
+      session-migrate.ts
+    protect/
+      rate-limiter.ts
+      cost-breaker.ts
+      edge-guard.ts
+      guard-store.ts
+    proxy/
+      image-proxy.ts
+      tiles.ts
+      showcase.ts
+    container/
+      container-env.ts
+      # outbound host table 可留 entry 旁或 container/outbound.ts
+  test/
+    *.test.ts
+    doubles/                # guard-doubles, turnstile-doubles
+```
+
+**禁止：**
+
+```text
+src/domain/                 # 不要
+src/application/plan-itinerary.ts
+entities/Point.ts
+```
+
+---
+
+## 4. 文件搬家表（from → to）
+
+| 今日 | 目标 |
+|---|---|
+| `workers/edge/entry.ts` | `src/entry.ts` |
+| `workers/edge/app.ts` | `src/app.ts` |
+| `workers/edge/env.ts` · `entry-env.ts` | `src/env.ts`（合并若重复） |
+| `auth.ts` | `src/identity/auth.ts` |
+| `anonymous-flow.ts` · `anonymous-id.ts` | `src/identity/` |
+| `turnstile.ts` | `src/identity/turnstile.ts` |
+| `forward.ts` | `src/gateway/forward.ts` |
+| `routing-policy.ts` · `catalog-policy.ts` | `src/gateway/` |
+| `responses.ts` · `session-migrate.ts` | `src/gateway/` |
+| `rate-limiter.ts` · `cost-breaker.ts` | `src/protect/` |
+| `edge-guard.ts` · `guard-store.ts` | `src/protect/` |
+| `image-proxy.ts` · `tiles.ts` · `showcase.ts` | `src/proxy/` |
+| `container-env.ts` | `src/container/container-env.ts` |
+| `*-doubles.ts` | `test/doubles/` |
+| `*.test.ts`（包根） | `test/*.test.ts` |
+| 根 `package.json` edge runtime deps | `workers/edge/package.json` |
+| 根 `wrangler.toml` | `workers/edge/wrangler.toml` |
+| 根 `pnpm test:worker` 路径 | `pnpm --filter edge-worker test`（或等价） |
+
+**化简（同列车，非半吊子）：**
+
+| 化简 | 做法 |
+|---|---|
+| Path 规范化 + decode | 单一 `gateway/path.ts`：normalize trailing slash + decodeURIComponent；routing 与 rate-limit **共用** |
+| Public path 表 | `routing-policy` / `catalog-policy` 常量一处导出；app 不散落魔法字符串 |
+| Env 双文件 | `env.ts` 合并类型与解析，删冗余 `entry-env` 若可 |
+| Doubles 污染生产 import | 测试只从 `test/doubles` 引 |
+
+---
+
+## 5. Pattern（Gateway · 非 DDD domain）
+
+| 用 | 含义 | 不用 |
+|---|---|---|
+| **Identity resolution** | Request → AuthResult | User Aggregate |
+| **Routing policy** | 纯 pathname → 分支 | 业务规则引擎 |
+| **Forward** | binding.fetch + 头清理/注入 | 在 edge 重写 body 业务字段 |
+| **Protect** | rate limit / cost / DO guard | 计费 domain 服务 |
+| **Proxy** | 图/瓦片/R2 | 在 edge 实现 catalog SQL |
+| **Container adapter** | 启动/env/egress | 把 agent 逻辑搬进 worker |
+
+**SOLID 在 Gateway 的落点：**
+
+- **S：** `app.ts` 只组装；policy 与 forward 分离  
+- **O：** 新公网 path = 改 policy 表，不改 Container 类  
+- **I：** 不要求 forward 依赖整包 Env 的每个字段（可收窄参数类型）  
+- **D：** 测试注入 `authenticate` / `fetch` / clock（已有 seam 则保留并统一）
+
+**1-10-50：** 继续拆 >10 行函数；`app.ts` / `auth.ts` / `tiles.ts` 超标则按关切再拆文件，**不** 引入无意义 base class。
+
+---
+
+## 6. Greenfield（path · 一次对齐）
+
+| 区域 | 动作 |
+|---|---|
+| `catalog-policy` allowlist | 路径随 catalog contract（如 itinerary 取代 route） |
+| `routing-policy` public/auth 表 | 与 agent/users 公网 path 同步；**不**发明业务语义 |
+| Users 转发 | `/v1/users/*` 保持；子 path `saved-routes` 由 Users 契约定，edge 只前缀转发 |
+| 响应体 | edge **不** 定义 Point/Itinerary 类型；透传或固定 gateway 错误 envelope |
+
+---
+
+## 7. PR 切片（已有代码 · 建议仍可审查，但目标态完整）
+
+| 切片 | 内容 | 完成判据 |
+|---|---|---|
+| **E0** | 本文 ACCEPTED | 文档 |
+| **E1** | Package-ize：deps + wrangler + CI scripts 迁入 `workers/edge`；根变编排 | deploy/test 绿；根无 hono 业务 deps |
+| **E2** | `src/` + `test/` 搬家（上表）；更新 imports | typecheck + `test:worker` 绿 |
+| **E3** | path 工具合并 + policy 常量收敛 | 限流/公网测不回归 |
+| **E4** | Greenfield path 字符串（与 contract G1 同波） | allowlist 测更新 |
+| **E5** | AGENTS.md / CONTEXT 路径；删空 husk | 文档与树一致 |
+
+**允许 E1+E2 合并为一大 PR**（「一次最好」）若 CI 扛得住；**禁止** 只改名不搬家、或只搬家不 package-ize 却宣称完成。
+
+---
+
+## 8. Non-goals
+
+| 不做 | 去向 |
+|---|---|
+| 巡礼 domain / itinerary 规划 | Catalog |
+| SavedRoute / Share / Check-in 业务 | Users + tickets |
+| CF Images 替换整条图链 | #682 等 |
+| DO 限流换 native binding 大改 | #680 |
+| HTML 页面 | apps/web |
+| monorepo 其他包目录 | 各包自己的结构文 |
+
+---
+
+## 9. 验收（实现后）
+
+- [ ] 无 `workers/edge/src/domain`  
+- [ ] 根 `package.json` 无 edge 运行时业务依赖  
+- [ ] 生产 ts 均在 `src/**`；测试在 `test/**`  
+- [ ] policy 纯函数可在 node:test 无 binding 跑  
+- [ ] 公网/鉴权/容器/proxy 既有测绿  
+
+---
+
+## 10. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿：Gateway 一次到位；明确 **无** 巡礼 domain model |
+| 2026-08-06 | Owner **ACCEPTED**（routes/features 方案一并确认会话） |

--- a/docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md
+++ b/docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md
@@ -1,0 +1,194 @@
+# Greenfield：全仓发布语言 + 数据面目标态
+
+- Status: **DESIGN ONLY** — owner 方向 2026-08-06（无历史用户 / 无生产包袱 → **一次最佳，无兼容层**）
+- Parent: `2026-08-06-monorepo-target-layout.md`
+- Supersedes lag language in ADR-0002「wire 可滞后」— 见下文修订意图
+- Per-package detail: Catalog / Agent / Users CA 设计文；本文是 **跨包总表**
+
+---
+
+## 0. 原则（LOCKED）
+
+1. **无历史用户** → 契约、HTTP path、表名、Python/TS 内部类型 **直接最佳名**，不做双写/别名窗。  
+2. **一词一主**：`Route` 不再作跨包名词（拆成 **Itinerary** / **SavedRoute**）。  
+3. **同表 ≠ 同 BC**：写权威见各包；Users 列表投影不拥有 Conversation。  
+4. **无跨 BC FK**：Users 不 REFERENCES `points`/`bangumi`；只存 TEXT id。Catalog 内部 FK 可保留。  
+5. **实现按包分期 PR**，但 **目标态已定**；禁止新代码再引入旧名。  
+6. **重构范围 = 已有代码的真·结构重构**（owner 2026-08-06），**不是**「只 rename」：  
+   - **做：** 按 CA/DDD 目标 **移动文件与函数**、抽出 use case / port、**化简**多余抽象、对齐 **SOLID** 与既有 1-10-50、依赖单向、可测 seam  
+   - **顺带：** greenfield **语言/契约/表名** 与结构重构同列车或紧前/紧后，避免半旧半新  
+   - **不做：** 为 **尚未实现** 的产品能力新造 runtime / 空 domain / 抢先建表；那些能力的设计指引挂 **既有 ticket**，随 ticket 做  
+7. **抽象纪律：** 优先 **删掉** 错误分层与上帝对象，再谈「加 pattern」；禁止为演示 OOP 而堆 interface/base class。SOLID 是约束，不是装饰。
+
+### 0.1 重构列车 vs 产品 ticket（全仓）
+
+| 列车 | 包含 | 排除 |
+|---|---|---|
+| **Refactor train** | 今日仓库里 **已存在** 的 catalog / agent / users / edge / contract / web 调用点：分层、搬家、化简、命名、删死路径 | Share/Check-in/しおり/presign/OSRM 层2… **未写完的 enabler** 的首次实现 |
+| **Product / enabler tickets** | 首次交付未写能力；实现时遵守 CA + greenfield + ticket 上的 design comment | 不借重构 PR 偷渡大功能 |
+
+**主战场 ticket（已有代码）：** #432 · #666（及各包 debt/boy-scout 卡）  
+**产品票（只挂指引，不随重构实现）：** #235 #243 #249 #212… 等
+
+### 0.2 结构细化范围（讨论中锁定）
+
+| 现在做结构细化（搬家表 / SOLID / pattern） | 以后再讨论 |
+|---|---|
+| **catalog** · **agent** · **users** | edge · web · maintenance · monorepo 第一层路径搬迁 |
+
+Workflow: `.grok/workflows/structure-design-three-packages.rhai`  
+产出：`2026-08-06-{catalog,agent,users}-structure-refactor-design.md` + index
+
+---
+
+## 1. 发布语言（全仓）
+
+| 规范名 | 含义 | 禁止（新代码） |
+|---|---|---|
+| **Point** | 圣地取景点 | `PilgrimagePoint`、`Spot`（契约） |
+| **Bangumi** | 作品 | `Work`、`work_id` 字段名 |
+| **Itinerary** | Catalog 算出的有序行程 | 裸 `Route`、`RouteModel`（此义） |
+| **SavedRoute** | 用户保存文档 | `UserRoute`、表 `routes`（用户义） |
+| **Session** | Agent 对话上下文 | 与 auth session 混用且不限定 |
+| **Claim** | 匿名文档 → 登录用户 | `Migrate`（平台迁移义） |
+| **RouteShare** / **WalkCheckin** | 分享 / 打卡 | 模糊 `share` 无所有者 |
+
+---
+
+## 2. 契约 / HTTP 目标（`packages/contract`）
+
+| 今日 | 目标 |
+|---|---|
+| `PilgrimagePoint` | **`Point`** |
+| `Route`（规划结果） | **`Itinerary`** |
+| `work_id` | **`bangumi_id`**（仍为数字字符串时用 regex 约束，名改正） |
+| `pointsByWorkId` | **`pointsByBangumiId`** |
+| `POST /catalog/route` | **`POST /catalog/itinerary`** |
+| `POST /catalog/spots` | **`POST /catalog/point`**（或 `/catalog/points/get`；实现选定一，文档锁定） |
+| `UserRoute` / `/v1/users/routes` | **`SavedRoute` / `/v1/users/saved-routes`** |
+| share/checkin `route_id` | **`saved_route_id`** |
+| `AnimeSampleRoute` / `sample_routes` | **`AnimeSampleItinerary` / `sample_itineraries`** |
+| Agent Python 镜像类型 | 与 contract **同词**（Point / Itinerary / …） |
+
+**兼容：** 无。Web、MSW、eval fixture、Agent `CatalogClient` **同波或紧后 PR 改完**。
+
+---
+
+## 3. 数据面：表归属与改名
+
+### 3.1 Catalog 写权威
+
+| 今日 | 目标 | 说明 |
+|---|---|---|
+| `bangumi` | **保留** | 已佳 |
+| `points` | **保留** | 已佳；`bangumi_id` 列已对 |
+| `aliases` | **`work_id` → `bangumi_id`** | 列改名 |
+| `series_edges` | 若有 `work_id` → **`bangumi_id`** | 同 |
+| `cluster_version` | **`work_id` → `bangumi_id`** | 同 |
+| `route_snapshots` | **`itinerary_snapshots`**；键列 `bangumi_id` | 缓存/发布快照，非 SavedRoute |
+| `leg_cache` | 评估保留或改 `transit_leg_cache` | 实现时定，避免 `route` 歧义 |
+| `ingest_jobs` / `raw_*` / `media_assets` | **保留**（平台表） | 非粉丝语言 |
+| `locations`（gazetteer） | **保留** | 非 Point |
+
+### 3.2 Users 写权威
+
+| 今日 | 目标 |
+|---|---|
+| `routes`（用户保存） | **`saved_routes`**（见 Users §2.5） |
+| （无） | **`route_shares`**、`walk_checkins` |
+| `user_memory` | 休眠预留形状见 Users 设计 |
+
+### 3.3 Agent 写权威
+
+| 今日 | 目标 | 说明 |
+|---|---|---|
+| `conversations` | **保留** | 佳 |
+| `conversation_messages` | **保留** | 佳 |
+| `sessions` | **保留**或与 conversation 收敛 | 实现审计：是否双轨；目标 **一个 Session 权威存储** |
+| `agent_memory*` | **保留**（会话/agent 内） | 非跨会话 UserMemory |
+| `anon_daily_message_count` / `daily_usage` | **保留** | 配额/计量 |
+| `feedback` / `request_log` / `api_keys` | 评估是否仍要；要则归 Agent 或 Edge | 另卡 |
+
+### 3.4 禁止
+
+- Users / Agent **新表**再叫 `routes`。  
+- Catalog **新列**再叫 `work_id`。  
+- 跨 BC `REFERENCES points(id)` 从用户表发出。
+
+---
+
+## 4. 分包装改清单
+
+### 4.1 Contract（先或与第一消费方同 PR）
+
+- models + catalog contract + users/share/checkin 全量改名  
+- OpenAPI / 生成物若有则重生  
+
+### 4.2 Catalog
+
+- oRPC path + handler 名 `planItinerary`  
+- SQL/`schema.ts`：`work_id`→`bangumi_id`；`route_snapshots`→`itinerary_snapshots`  
+- `lib/route.ts` → domain `itinerary`（可同 PR 或 P1）  
+- CONTEXT / AGENTS 去「wire legacy」措辞  
+
+### 4.3 Agent
+
+- 实体/工具/客户端：`Route`→`Itinerary`，`PilgrimagePoint`→`Point`  
+- `CatalogClient` 跟新 path  
+- **删除或冻结** 直连主数据写（PointsRepo upsert）— 无包袱则 **删** 优先于标债  
+- Session/Conversation 表纪律不变（写权威）  
+
+### 4.4 Users
+
+- 已定 §2.5 greenfield（`saved_routes` 等）  
+
+### 4.5 Web
+
+- 类型从 contract 导入；MSW path；UI 文案可不改日文/中文产品词  
+
+### 4.6 Edge
+
+- 路由表 path 字符串；**无**领域模型改名（Gateway）  
+- outbound allowlist 随 catalog path 更新  
+
+### 4.7 Maintenance
+
+- 只碰 agent 匿名 retention 表名；确认不扫 `saved_routes`  
+
+### 4.8 Migrations
+
+- 单一 Atlas 史：可 **破坏性** rename/drop（无用户）  
+- 建议顺序：contract 类型 PR 可与 DB rename 同列车；禁止半截 `work_id` 混列长期存在  
+
+---
+
+## 5. 与既有 CA 设计的关系
+
+| 包 | 设计文 | Greenfield 增量 |
+|---|---|---|
+| Catalog | ACCEPTED CA | P6 升格为 **必做**；与分层 PR 可合并「无兼容」 |
+| Agent | ACCEPTED CA | A4 升格为 **全量语言**；A3 直连写 **优先删除** |
+| Users | ACCEPTED core | §2.5 greenfield；§0.4 真结构重构 |
+| Edge / Web / Maintenance | 未单开 Full CA | 本总表 + Gateway/UI 规则足够 |
+
+---
+
+## 6. 分期建议（仓级）
+
+| 波次 | 内容 |
+|---|---|
+| **G0** | 文档：CA + greenfield + **重构范围（真结构，非只 rename）** |
+| **G1** | **已有代码** 上：语言/契约/表 rename **+** 必要的调用点搬家，全仓编译/测绿 |
+| **G2** | **已有代码** 上：Catalog/Agent/Users **CA 竖切** — 移文件、抽 use case/port、化简、SOLID/1-10-50（可多 PR） |
+| **G3** | 产品 ticket 各自实现未写能力（Share/Check-in…）— **不** 并进 G1/G2 |
+
+**G0 无代码。G1–G2 = 重构列车。G3 = 产品列车。**
+
+---
+
+## 7. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿：全仓 greenfield 语言 + 表/契约总表 |
+| 2026-08-06 | §0 原则 6–7：重构 = 搬家/化简/SOLID，不只 rename；未写能力归 ticket |

--- a/docs/superpowers/specs/2026-08-06-jobs-worker-structure-design.md
+++ b/docs/superpowers/specs/2026-08-06-jobs-worker-structure-design.md
@@ -1,0 +1,136 @@
+# Jobs Worker 结构（原 maintenance · 定时任务 · 无巡礼 domain）
+
+- Status: **ACCEPTED**（owner 2026-08-06 — 包名 **`workers/jobs`**；内部分 **jobs/**）
+- Date: 2026-08-06
+- **Package (target):** `workers/jobs`  
+- **Package (today):** `workers/maintenance` → 实现时 `git mv` 改名  
+- Tier: **Thin** · scheduled-only · **无 HTTP**
+- Supersedes naming: `2026-08-06-maintenance-thin-structure-design.md`（见文末）
+
+---
+
+## 0. 为什么不叫 maintenance / 为何选 jobs
+
+| 名 | 评价 |
+|---|---|
+| **maintenance** | 像「运维杂项」，看不出跑什么 |
+| **scheduler** | 像平台调度器 / 编排；和 CF `scheduled`、各类 agent scheduler 易混 |
+| **`jobs`** | **推荐**：包内就是一条条 **job**；cron 只是触发器 |
+
+**LOCKED：** 目标包名 **`workers/jobs`**（pnpm name / wrangler name 同步，如 `animichi-jobs` 或 `jobs`）。  
+对外说明：Cloudflare **Scheduled Worker** that runs retention **jobs**.
+
+---
+
+## 1. Domain model？
+
+**无巡礼 `domain/`。** 只有：
+
+- **Job** = 一次可调度的工作单元（输入：clock + db；输出：report/log）  
+- **Schedule** = cron 表达式 → 选哪个 job  
+
+Session 表权威仍在 **Agent**；本包是 **执行删除的定时作业**。
+
+---
+
+## 2. 职责（不变，只改名）
+
+| Job | Cron（保持字节一致） | 作用 |
+|---|---|---|
+| `purge-anonymous-sessions` | `37 18 * * *` | 过期匿名会话（无关联 saved_route） |
+| `purge-anon-quota` | `37 19 * * *` | 过期 `anon_daily_message_count` |
+
+- Secret：`AGENT_DATABASE_URL`  
+- 不碰 Catalog；不删 Users 已归属文档  
+- SQL 谓词与历史 Python port 对齐；表 rename 同波  
+
+---
+
+## 3. 目标树（一次最好）
+
+```text
+workers/jobs/                    # 原 workers/maintenance
+  package.json                   # name: "jobs"（或 @animichi/jobs）
+  wrangler.toml                  # name = "jobs" / "jobs-staging"
+  AGENTS.md
+  CONTEXT.md
+  src/
+    index.ts                     # scheduled export；组装 only
+    database.ts                  # DatabaseClient + neon 工厂
+    schedule.ts                  # CRON 常量 + dispatch(cron) → job
+    jobs/
+      cutoff.ts                  # retentionCutoff / quotaCutoff 纯函数
+      purge-anonymous-sessions.ts
+      purge-anon-quota.ts
+      types.ts                   # PurgeReport 等
+  test/
+    jobs/
+    schedule.worker.test.ts
+    …
+```
+
+**今日 → 目标**
+
+| 今日 `workers/maintenance` | 目标 `workers/jobs` |
+|---|---|
+| 包目录 maintenance | **`jobs`** |
+| `src/purge.ts`（双 job） | `src/jobs/purge-*.ts` + `cutoff.ts` |
+| `src/index.ts` 内 cron 字符串 | `src/schedule.ts`（与 wrangler 双写注释钉死） |
+| `src/database.ts` | 同路径语义 |
+| wrangler `name = "maintenance"` | **`jobs`** / `jobs-staging` |
+| CI paths `workers/maintenance` | `workers/jobs` |
+| 根 AGENTS / CONTEXT-MAP 表述 | maintenance → **jobs** |
+
+---
+
+## 4. Pattern
+
+| 用 | 不用 |
+|---|---|
+| **Job module**（一文件一作业） | 巡礼 domain / use case 深树 |
+| **Schedule dispatch** | HTTP router |
+| **Injected clock + DatabaseClient** | 散落 `new Date()` 难测 |
+| 作业名 = 文件名 = 日志 event 前缀 | 模糊 `maintenance_run` |
+
+---
+
+## 5. PR 切片
+
+| 切片 | 内容 |
+|---|---|
+| **J0** | 本文 ACCEPTED；文档全局 `maintenance`→`jobs` 用语 |
+| **J1** | `git mv workers/maintenance workers/jobs`；package/wrangler/CI/filter 改名；测绿 |
+| **J2** | 拆 `src/jobs/*` + `schedule.ts`；删上帝 `purge.ts` |
+| **J3** | Greenfield：SQL `routes`→`saved_routes`（与 users 表 rename **同波**） |
+| **J4** | Agent Python `purge_*.py` deprecate/删除；只认 jobs Worker |
+
+**一次最好：** J1+J2 可合并；**J3 不可与 users rename 脱节**。
+
+---
+
+## 6. 与邻包
+
+| 邻居 | 关系 |
+|---|---|
+| Agent | 表/匿名语义权威；jobs 执行 purge |
+| Users | EXISTS 哨兵表 `saved_routes`（原 `routes`） |
+| Edge | 无公网路径 |
+| Catalog | 无 |
+
+---
+
+## 7. 验收
+
+- [ ] 仓库路径为 `workers/jobs`  
+- [ ] 无 `workers/maintenance`（或仅 re-export 过渡 **零** 终态）  
+- [ ] `src/jobs/` 下每 job 可单测  
+- [ ] wrangler crons 与 `schedule.ts` 一致  
+- [ ] 无 `domain/`、无 public fetch  
+
+---
+
+## 8. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 由 maintenance Thin 稿更名：**包 `workers/jobs`** + 内部分 `jobs/`；弃用 scheduler 作包名 |

--- a/docs/superpowers/specs/2026-08-06-monorepo-target-layout.md
+++ b/docs/superpowers/specs/2026-08-06-monorepo-target-layout.md
@@ -1,0 +1,240 @@
+# Animichi monorepo 目标形态（活文档）
+
+- Status: DRAFT — 讨论中，逐段锁定
+- Date: 2026-08-06
+- Working copy: `~/work/animichi`（Documents 原仓 agent 侧曾 TCC 不可读）
+- Method: 结构/架构讨论优先；路径搬迁与实施后置。Matt wayfinder / improve-codebase-architecture / domain-modeling 结论并入本文。
+
+**怎么用这份文档**
+
+1. 已锁定的段落标 `LOCKED`，改它们要显式翻案。  
+2. 进行中的段落标 `OPEN`，讨论结果直接往文档里追加/改写。  
+3. 实施时另开 PR；本文是 **目标态 + 决策记录**，不是 git mv 脚本。
+
+---
+
+## 0. 原则（LOCKED）
+
+| # | 原则 |
+|---|---|
+| P1 | **第一层 = 部署与平台**，不是 Bounded Context 名录 |
+| P2 | **DDD 主要落在包内部**（domain / application / adapters），靠 `CONTEXT-MAP` + `packages/contract` 画 context map |
+| P3 | **根只做编排**：无业务 runtime 依赖；可部署单元自持配置 |
+| P4 | **一张 Neon 数据面 → 一份 Atlas 迁移史**（服务内 Drizzle schema 仅打字） |
+| P5 | **单测在包内**；**跨包真环境测在 `tests/`**；**CI 只在 `.github/`** |
+| P6 | Supabase 是 **过渡**，cutover 完成后删除；在此之前可挪位置但不假装已下线 |
+
+**不是目标的：** 把 `apps/` 与 `workers/` 揉成一个「按领域命名」的根目录。
+
+---
+
+## 1. 第一层目录与根文件（LOCKED）
+
+### 1.1 目标树
+
+```text
+.
+├── apps/
+│   ├── agent/                 # Python FastAPI 容器
+│   └── web/                   # TanStack Start，唯一浏览器面
+├── workers/
+│   ├── edge/                  # 网关 + auth + container 编排
+│   ├── catalog/               # Bangumi / Point / Itinerary 数据与规划
+│   ├── users/                 # SavedRoute 等用户文档
+│   └── jobs/                  # 定时 retention jobs（原 maintenance；无 HTTP）
+├── packages/
+│   └── contract/              # 发布语言（oRPC/zod 等）
+├── migrations/
+│   ├── neon/                  # 原 db/migrations — Atlas
+│   ├── supabase/              # 原根 supabase/ — 过渡
+│   └── AGENTS.md
+├── infra/
+├── tests/
+│   └── e2e/                   # 原 e2e/
+├── scripts/
+├── docs/
+├── .github/
+├── package.json               # private 编排 ONLY
+├── pnpm-workspace.yaml
+├── pnpm-lock.yaml
+├── Makefile
+├── AGENTS.md · CLAUDE.md
+├── CONTEXT-MAP.md
+├── README.md (+ i18n)
+└── 必要点文件
+```
+
+### 1.2 根上明确移除（目标态）
+
+| 现状 | 去向 |
+|---|---|
+| 根上 edge 运行时 deps | `workers/edge/package.json` |
+| 根 `wrangler.toml` | `workers/edge/` |
+| 根 `Dockerfile` | `apps/agent/` |
+| 根 `db/` | `migrations/neon/` |
+| 根 `supabase/` | `migrations/supabase/` |
+| 根 `e2e/` | `tests/e2e/` |
+| `fixtures/` / 仅 agent 的 `docker/` | 沉入 `apps/agent/`（实施时核实） |
+
+### 1.3 决策明细
+
+| 议题 | 决定 |
+|---|---|
+| apps + workers | 保持双顶栏 |
+| packages | 保留 `packages/contract`，不改顶层名为 contract |
+| migrations | `neon/` + `supabase/` 并列 |
+| **jobs**（原 maintenance） | 定时 retention Worker；包名 **`workers/jobs`**，不用 scheduler |
+| infra | 顶层保留 |
+| 系统测 | `tests/e2e/` |
+| CI | 仅 `.github/` |
+
+### 1.4 jobs（原 maintenance）
+
+Cron 清理 agent 域匿名 Session / 配额行。包名 **`workers/jobs`**（比 maintenance 好懂；不用 scheduler 以免和编排混淆）。  
+非 catalog/users 职责；非 lib（需可部署 cron 单元）。结构：[jobs-worker-structure-design](./2026-08-06-jobs-worker-structure-design.md)。
+
+### 1.5 Supabase
+
+**未 cutover 完**：可挪到 `migrations/supabase/`，不能删。删除条件：edge 只信 Neon、api_keys 迁出、E2E 脱钩。
+
+### 1.6 工具
+
+Supabase CLI 需 `--workdir migrations/supabase`；Atlas `file://migrations/neon`；workspace 成员 `tests/e2e`。
+
+---
+
+## 2. 测试分层（LOCKED 方向）
+
+| 层 | 位置 |
+|---|---|
+| 包内单测/集成 | 各包内 |
+| 跨包真环境 | `tests/e2e/`（可扩展 smoke） |
+| CI 编排 | `.github/` only |
+
+---
+
+## 3. Monorepo / DDD 立场（LOCKED）
+
+第一层 = 部署与平台；DDD = 包内模型 + CONTEXT 地图。  
+Arch review 候选见会话记录（Edge package-ize 等）——实施顺序另议。
+
+---
+
+## 4. 领域语言与包内 domain model
+
+### 4.0 跨上下文词汇（LOCKED — 2026-08-06）
+
+权威：`CONTEXT-MAP.md` + 各包 `CONTEXT.md`。
+
+| 规范词 | 含义 | Avoid |
+|---|---|---|
+| **Point** | 可拜访的圣地取景点 | PilgrimagePoint（旧名）、契约里的 Spot |
+| **Bangumi** | 一部动画作品/标题 | Work、用 Anime 指一部片 |
+| **Itinerary** | catalog **算出**的有序行程 | 单独 Route |
+| **SavedRoute** | 用户**保存**的路线（point_ids + 元数据） | 单独 Route |
+| **Session** | 用户与 agent 的对话上下文 | 未限定的 auth session |
+
+**保存语义（LOCKED）：** SavedRoute = point_ids + 元数据；打开可再算 Itinerary。  
+**代码债：** 契约里或仍见 `Route` / `PilgrimagePoint` / `UserRoute`——先锁语言，改名另 PR。
+
+### 4.1 分层词（LOCKED 方向）
+
+Domain / Application / Adapters / Infrastructure；依赖 adapters → application → domain。
+
+### 4.2 怎么做 DDD（LOCKED — 逐包）
+
+**对：一个包一个包做。** 不是全仓同一天铺空 `domain/`。
+
+| 阶段 | 做什么 | 状态 |
+|---|---|---|
+| **A. 跨包语言** | CONTEXT-MAP + 共享词 | **已做** |
+| **B. 逐包深入** | 一次只做一个 deployable：所有权、不变量、用例、ports、目标内部树 | **进行中** |
+
+**每个包的固定议程：**
+
+1. 拥有 / 不拥有哪些概念  
+2. 核心不变量与边界场景  
+3. 入站用例（application）  
+4. 出站 port  
+5. 目标内部目录  
+6. 与 contract 的映射  
+7. 测试 seam  
+
+**推荐顺序：** catalog → agent → users → edge → web → jobs  
+（contract 不单独「实现 DDD」，只随前几包收紧发布语言。）
+
+**明确不做：** 无场景地给每个包 mkdir 空 domain。
+
+### 4.3 分级默认（可在逐包时推翻）
+
+- **Full**：catalog、agent  
+- **Gateway**：edge  
+- **Thin**：users、**jobs**  
+- **UI**：web features  
+
+全局 D1/D3 不再空转：以 **catalog 第一包** 实装选择为准再回写。
+
+### 4.4 逐包进度
+
+| 包 | 状态 |
+|---|---|
+| catalog | **ACCEPTED** + greenfield 语言/表目标 — [CA](./2026-08-06-catalog-clean-architecture-design.md) · [总表](./2026-08-06-greenfield-language-and-data-plane.md) |
+| agent | **ACCEPTED** + greenfield — [CA](./2026-08-06-agent-clean-architecture-design.md) · [总表](./2026-08-06-greenfield-language-and-data-plane.md) |
+| users | **ACCEPTED (core BC)** — [CA](./2026-08-06-users-clean-architecture-design.md)（§0.3 大量 OPEN 产品面）· [总表](./2026-08-06-greenfield-language-and-data-plane.md) |
+| edge | **ACCEPTED** — [Gateway 结构](./2026-08-06-edge-gateway-structure-design.md) |
+| web | **ACCEPTED** — [UI 结构](./2026-08-06-web-ui-structure-design.md)（routes≈pages + features） |
+| jobs（原 maintenance） | **ACCEPTED 命名+结构** — [jobs-worker-structure](./2026-08-06-jobs-worker-structure-design.md)；代码仍在 `workers/maintenance` 直至 J1 |
+
+### 4.5 Catalog 摘要
+
+- **拥有 / 语言 / 用例：** `workers/catalog/CONTEXT.md`  
+- **CA 设计：** `2026-08-06-catalog-clean-architecture-design.md`（ACCEPTED + greenfield）  
+- **待实现：** 分层目录；G1 去掉 `route` / `PilgrimagePoint` / `work_id`
+
+### 4.6 结构 best practice（LOCKED 默认）
+
+| 规则 | 选择 |
+|---|---|
+| 统一程度 | **分级**（Full / Gateway / Thin / UI），非全员硬套四层 |
+| edge | **无**巡礼 `domain/`；用 identity/gateway/proxy/container |
+| ingest 流水线 | **application** |
+| domain vs contract | 边界 DTO 可用 contract；包内 domain map 进出 |
+
+---
+
+## 5. 文档变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿：第一层树 LOCKED |
+| 2026-08-06 | domain-modeling：Point / Bangumi / Itinerary / SavedRoute / Session；CONTEXT* 落盘 |
+| 2026-08-06 | LOCKED：DDD **逐包**；序 catalog → agent → … |
+| 2026-08-06 | ADR-0002 发布语言；catalog 包议程完成；结构 best practice LOCKED |
+| 2026-08-06 | Catalog 教科书 CA/DDD **仅设计**文：`2026-08-06-catalog-clean-architecture-design.md` |
+| 2026-08-06 | Catalog 设计 **ACCEPTED**；Agent 设计稿 `2026-08-06-agent-clean-architecture-design.md`（待确认） |
+| 2026-08-06 | Agent 设计 **ACCEPTED**（A1–A5；§0.1 catalog 只读 / Session 可写） |
+| 2026-08-06 | Users 设计稿 `2026-08-06-users-clean-architecture-design.md`（Thin；待确认） |
+| 2026-08-06 | **全仓 greenfield** 总表 `2026-08-06-greenfield-language-and-data-plane.md`；ADR-0002 取消 wire 滞后默认 |
+| 2026-08-06 | Users **core BC ACCEPTED**；OPEN backlog O1–O12 显式列出 |
+| 2026-08-06 | 全仓：重构列车 = 真结构（SOLID/搬家/化简）+ greenfield，不止 rename |
+| 2026-08-06 | 三包 structure-refactor 设计 **ACCEPTED**（best practice）；edge/web 未设计 |
+| 2026-08-06 | Edge Gateway + Web UI 结构设计稿（无 domain model；一次到位） |
+| 2026-08-06 | Edge/Web 结构 **ACCEPTED**；Maintenance Thin 设计稿 |
+| 2026-08-06 | **maintenance → workers/jobs**（包名+jobs/ 目录）；scheduler 不作包名 |
+| 2026-08-06 | Neon DBA 能力图（缺口 D0–D21；#685 对齐） |
+| 2026-08-06 | Neon DBA 图 **ACCEPTED**；CI pipeline 布局明确另议 |
+| 2026-08-06 | CI/部署架构方向文：每包线对、实现乱、目标形状（DIRECTION ACCEPTED） |
+| 2026-08-06 | CI/CD 重构计划 ACCEPTED design only（C1–C6；Sonar 澄清） |
+| 2026-08-06 | Pulumi/infra 设计 **ACCEPTED design only**（边界对；结构/ESC 后置） |
+| 2026-08-06 | 骨架重构 GOAL：`docs/iterations/refactor-skeleton-2026-08/GOAL.md` |
+
+---
+
+## 6. 下一步
+
+1. **可部署包结构设计已齐**；索引：[structure-refactor-index](./2026-08-06-structure-refactor-index.md)。  
+2. **Neon DBA 能力图 ACCEPTED**（best practice）：[neon-dba-capability-map](./2026-08-06-neon-dba-capability-map.md) — 优先 **N1 角色矩阵 + staging DSN**（#685）。  
+3. **CI/部署**：**方向 + 重构计划均 design ACCEPTED** — [architecture](./2026-08-06-ci-deploy-architecture.md) · [refactor plan C1–C6](./2026-08-06-ci-cd-refactor-plan.md)；**YAML 未改**。  
+4. **Pulumi/infra**：[pulumi-infra-review](./2026-08-06-pulumi-infra-review.md) **ACCEPTED design only**（P1 拆 index 等后置）。  
+5. **重构 GOAL（只骨架）：** [docs/iterations/refactor-skeleton-2026-08/GOAL.md](../../iterations/refactor-skeleton-2026-08/GOAL.md) — 无新功能；未做 `TODO(refactor-skeleton)`；Matt `/to-issues`→`/implement`（+/tdd）→`/code-review`。  
+6. **实现列车**（按 GOAL 出票）：包结构 · jobs rename · DBA 文档骨架 · CI 设计已定实现后置 · 产品 ticket 另线。

--- a/docs/superpowers/specs/2026-08-06-pulumi-infra-review.md
+++ b/docs/superpowers/specs/2026-08-06-pulumi-infra-review.md
@@ -1,0 +1,190 @@
+# Pulumi / `infra/` 现状与目标（设计）
+
+- Status: **ACCEPTED (design only)** — owner 2026-08-06；边界 + best-practice 对照已定；**不含实现**  
+- Date: 2026-08-06  
+- Package: `infra/`（独立 pnpm 项目，**不在** workspace 成员里）  
+- Stacks: `staging` · `prod`（`Pulumi.staging.yaml` / `Pulumi.prod.yaml`）  
+- Aligns: monorepo 目标树、`docs/ops/deployment.md`、edge「routes ∈ Pulumi / code ∈ Wrangler」
+
+---
+
+## 0. 一句话
+
+**职责切得对**：Cloudflare **共享平台**（R2、hostname/routes、staging WAF、zone 硬化）归 Pulumi；**Worker 代码与 service binding** 归 Wrangler。  
+**结构还薄**：几乎全部在 **单文件 `index.ts`（~458 行）**；测试有 topology  harness，但无 ComponentResource 分层；**Neon 项目/分支不在 Pulumi 里**（连接串当 secret 注入）。
+
+---
+
+## 1. 所有权边界（LOCKED · 保持）
+
+| 归 Pulumi (`infra/`) | 归 Wrangler / 各 Worker | 归 Atlas / Neon |
+|---|---|---|
+| R2 buckets（media、tiles） | Worker 脚本内容、bindings 声明 | schema / GRANT / 迁移 |
+| Custom Domain + **edge 路径 routes**（`/v1/*` `/img/*` `/tiles/*` `/healthz`） | `wrangler deploy` | 分支 connstr 内容 |
+| www 占位与 redirect（prod） | secrets **推送**到 Worker（CI `wrangler secret put`） | |
+| Staging WAF gate（cookie/header/IP） | 容器 image 构建 | |
+| Zone DNSSEC / CAA / HSTS / zone rate-limit（prod zone） | | |
+| 导出 `catalogDatabaseUrl` 给 CI（config secret，非 CF WorkersSecret 资源） | | |
+
+**铁律（已验证、AGENTS 写明）：**  
+`wrangler deploy` **不** 覆盖 Pulumi 管的 routes → **routes 只在 Pulumi 改**。
+
+---
+
+## 2. 现状 inventory
+
+```text
+infra/
+  Pulumi.yaml                 # project: seichijunrei-infra, runtime nodejs
+  Pulumi.staging.yaml         # webRoutes + stagingGate + secrets
+  Pulumi.prod.yaml            # webRoutes 默认关；catalogDatabaseUrl secret
+  index.ts                    # 全部资源 + 导出 validate* 纯函数
+  testing/harness.ts          # topology 测
+  topology-*.test.ts          # node:test
+  package.json                # 独立 lockfile；--ignore-workspace 安装
+  AGENTS.md
+```
+
+### 2.1 资源块（`index.ts`）
+
+| 块 | 内容 |
+|---|---|
+| R2 | `catalog-media*`、`map-tiles*`（protect + deleteBeforeReplace） |
+| 可选拓扑 | `webRoutesEnabled`：web Custom Domain + 4 条 edge route；prod 另有 www |
+| Zone 硬化 | 仅 **prod + zoneId**：DNSSEC、CAA、/v1 rate limit、HSTS |
+| Staging gate | WAF custom rule + IP allowlist + token（secret） |
+| Export | `catalogDatabaseUrl`、`catalogBucketName`、`tilesBucketName` |
+
+### 2.2 正确碎片
+
+- Stack 分名：prod 稳定名，非 prod 后缀  
+- 未知 stack **禁止** 误吃 `stagingDomain`  
+- Staging gate 表达式与 token 校验可测（export 纯函数）  
+- 每次 `up` 前 stack export → R2 rollback-backups（**非** 公开 GH artifact）  
+- 无 Hyperdrive（catalog = neon-http）— 有意简化  
+
+### 2.3 债 / 缺口
+
+| ID | 问题 | 建议方向 |
+|---|---|---|
+| **I1** | **单文件上帝 `index.ts`** | 拆 `src/{r2,topology,hardening,staging-gate}.ts` 或 ComponentResource |
+| **I2** | **不在 pnpm workspace** | 可保持（隔离 deps）或可选接入 workspace；二选一成文 |
+| **I3** | **Neon 不在 IaC** | 可接受（分支手建 + secret）；或日后 `pulumi-neon` / ESC 只管引用 |
+| **I4** | **Workers 脚本名硬编码** | `animichi` / `animichi-web` 与 wrangler name 双源；应用 config 或共享常量文档钉死 |
+| **I5** | **rollback-backups 无 lifecycle** | #521；R2 生命周期规则应在 Pulumi |
+| **I6** | **ESC / 中央 secrets** | #674 方向；避免更多 secret 只活在 stack yaml |
+| **I7** | **preview 栈** | 无第三 hostname 映射；PR preview 若要上需显式加 stack 策略 |
+| **I8** | **users/agent/jobs 的 CF 资源** | 多半仅 wrangler；确认是否缺 R2/队列等应进 Pulumi 的共享物 |
+| **I9** | **TypeScript 5 vs 仓 TS 7** | 对齐大版本减少双轨（小） |
+
+---
+
+## 3. 目标结构（best practice · 一次说清）
+
+```text
+infra/
+  Pulumi.yaml
+  Pulumi.staging.yaml
+  Pulumi.prod.yaml
+  package.json
+  AGENTS.md · CONTEXT.md
+  src/
+    index.ts                 # 只组装 + export
+    config.ts                # stack/config 解析
+    r2.ts                    # media + tiles buckets
+    topology.ts              # Custom Domain + routes + www
+    hardening.ts             # DNSSEC/CAA/HSTS/rate-limit（prod zone）
+    staging-gate.ts          # WAF + IP helpers
+    names.ts                 # script/bucket 命名与 wrangler 对齐表
+  test/                      # topology-* 迁入
+  testing/harness.ts
+```
+
+**不** 引入巡礼 `domain/`。  
+**可** 用 Pulumi **ComponentResource**（`AnimichiWebTopology`、`StagingAccessGate`）——这是 IaC 组件，不是 DDD。
+
+---
+
+## 4. 与 CI/CD、配置放置
+
+| 项 | 放置 |
+|---|---|
+| `pulumi preview` | `ci-infra` / 今日 `pipeline-infra`（凭证 preview） |
+| `pulumi up` | **仅 CD** `reusable-deploy-component`（staging/prod） |
+| Stack yaml | **`infra/` 内**（已正确） |
+| 状态后端 | R2 + `PULUMI_BACKEND_URL`（secret/env，不进公开 repo 明文） |
+
+配置放置文：`infra/` 的 Pulumi* **属于包内配置**，不要搬到根。
+
+---
+
+## 5. 与 Neon DBA 的边界
+
+| Neon | Pulumi |
+|---|---|
+| 库内角色、迁移、分支内容 | **不** 管 |
+| 连接串作为 **secret 配置** | 可存 stack secret / 将来 ESC；**apply 后** CI 注入 Worker |
+| 分支创建 | 人/neonctl/API；可选未来 IaC |
+
+DBA 图 N1 换 app DSN **不** 要求先大改 Pulumi；最多更新 `catalogDatabaseUrl` 指向与角色匹配的 URL。
+
+---
+
+## 6. PR 切片（实现时）
+
+| 切片 | 内容 |
+|---|---|
+| **P0** | 本文 ACCEPTED design only — **DONE 2026-08-06** |
+| **P1** | `index.ts` → `src/*` 无行为拆分 + 测绿 |
+| **P2** | #521 R2 lifecycle on rollback-backups |
+| **P3** | `names.ts` 与 wrangler 脚本名单一来源文档/常量 |
+| **P4** | ESC/中央 secret（跟 #674）可选 |
+| **P5** | preview stack 策略（若产品要 PR 域名） |
+
+---
+
+## 7. 非目标
+
+- 用 Pulumi 部署 Worker **源码**（继续 wrangler）  
+- 把 Atlas 迁移搬进 Pulumi  
+- 在 `infra/` 写巡礼业务  
+
+---
+
+## 8. 与业界 / 官方 best practice 对照（2026-08 检索）
+
+来源摘要：Pulumi 文档（[Secrets](https://www.pulumi.com/docs/iac/concepts/secrets/)、[ESC](https://www.pulumi.com/docs/esc/)、[Config](https://www.pulumi.com/docs/iac/concepts/config/)）、Pulumi Components 产品文、社区/技能库对 **ComponentResource** 的强调、CF 生态「routes vs wrangler」实践。
+
+| 实践 | 官方/社区说法 | 我们现状 | 结论 |
+|---|---|---|---|
+| **Stack = 环境** | 每环境一 stack + `Pulumi.<stack>.yaml` | staging / prod | ✅ 符合 |
+| **Config / secrets** | 敏感值用 `requireSecret`/`getSecret`；勿明文 | gate token、DB URL、allowed IPs 用 secret；AGENTS 强调 export 不带 show-secrets | ✅ 符合 |
+| **跨栈/跨项目共享 secret** | 栈内 secret 够单栈用；**多栈共用 → ESC** 中央化 | 多在 stack yaml + GH secrets；#674 指向 ESC | ⚠️ 方向对，未做满 — 符合「下一步」而非做错 |
+| **ComponentResource / Components** | 把相关资源打成可复用逻辑单元，避免扁平巨图 | 全在 `index.ts` 顶层 `new` | ⚠️ **结构上落后于 best practice**；拆分/组件化合理 |
+| **项目结构** | 代码与配置分离、可按 repo 对齐 GitOps | `infra/` 独立、stack yaml 在旁 | ✅ 小项目可接受；大了应 `src/` |
+| **多栈拆分** | 超大时 network/apps 分 project + StackReference | 单 project 两 stack，体量尚小 | ✅ 暂不必拆 project |
+| **Cloudflare Workers** | 可用 Pulumi 管 Script+Route；也有 **Wrangler 管代码、IaC 管周边** | **routes/DNS/R2 ∈ Pulumi，code ∈ wrangler** | ✅ 常见、合理混合；不是「必须全在 Pulumi」 |
+| **Worker secrets** | CF secret 常用 wrangler put；ESC 可与 CF/wrangler 集成 | CI `wrangler secret put` + 部分 Pulumi config 导出 | ✅ 可接受；ESC 统一是增强项 |
+| **State 与备份** | 远端 state + 访问控制 | R2 backend + export 备份到同桶 | ✅；缺 lifecycle 是运营债不是架构错 |
+| **prod 人工门** | 生产变更要控 | GitHub `production` environment | ✅ |
+
+**总评：**
+
+- **所有权与 secrets 用法**：与官方/最佳实践 **大体一致**，不是野路子。  
+- **「最佳」还差的主要是结构（组件化）与 secret 中央化（ESC）**，不是「routes 不该在 Pulumi」。  
+- 我们文档里建议的 `src/` 拆分 + ComponentResource + ESC + lifecycle，**对齐** 业界写法，不是自创洁癖。
+
+**不必照抄的：**
+
+- 为洁癖把 **Worker 源码** 也改成纯 Pulumi `WorkersScript` 管理（会与现 wrangler 工作流打架；CF 官方也同时支持两边）。  
+- 立刻把 Neon 全建成 Pulumi 资源（DBA/分支生命周期可继续 neonctl + Atlas）。
+
+---
+
+## 9. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿：所有权、inventory、债、目标树、切片 |
+| 2026-08-06 | §8 对照官方/社区 best practice（检索） |
+| 2026-08-06 | Owner **ACCEPTED design only** |

--- a/docs/superpowers/specs/2026-08-06-structure-refactor-index.md
+++ b/docs/superpowers/specs/2026-08-06-structure-refactor-index.md
@@ -1,0 +1,80 @@
+# 结构重构索引（三包 only）
+
+- Status: **六包结构 ACCEPTED**（含 **jobs**，原 maintenance）
+- Date: 2026-08-06
+- Workflow (three packages): `.grok/workflows/structure-design-three-packages.rhai`
+- Parent: greenfield · monorepo-target-layout
+
+---
+
+## 0. 范围
+
+| 包 | 状态 |
+|---|---|
+| catalog · agent · users | ACCEPTED |
+| edge · web | ACCEPTED（无巡礼 domain） |
+| **jobs**（原 maintenance） | ACCEPTED — 包名 `workers/jobs` + `src/jobs/*` |
+
+**Domain model 用法：**
+
+| 包 | 巡礼 DDD `domain/` |
+|---|---|
+| catalog / agent | **有** |
+| users | **浅** |
+| edge / web | **无** |
+| **jobs** | **无** — Job + Schedule only |
+
+---
+
+## 1. 结构设计一览
+
+| 包 | 结构设计 | PR 切片（摘要） |
+|---|---|---|
+| Catalog | [catalog-structure…](./2026-08-06-catalog-structure-refactor-design.md) **ACCEPTED** | S0–S8 |
+| Agent | [agent-structure…](./2026-08-06-agent-structure-refactor-design.md) **ACCEPTED** | S0–S7 |
+| Users | [users-structure…](./2026-08-06-users-structure-refactor-design.md) **ACCEPTED** | U-S1–S5 |
+| Edge | [edge-gateway-structure…](./2026-08-06-edge-gateway-structure-design.md) **ACCEPTED** | E1–E5 package-ize + src 关切分包 |
+| Web | [web-ui-structure…](./2026-08-06-web-ui-structure-design.md) **ACCEPTED** | W1–W6 routes≈pages + features + platform |
+| **Jobs** | [jobs-worker-structure…](./2026-08-06-jobs-worker-structure-design.md) **ACCEPTED** | J1 `git mv` maintenance→jobs → J2 `src/jobs/*` → J3 saved_routes SQL → J4 弃 Python 双源 |
+
+---
+
+## 2. 跨包顺序建议（仍仅三包）
+
+1. **Contract 语言**（Point / Itinerary / SavedRoute / bangumi_id）— 三包消费，宜先或与 Catalog S1 / Users U-S5 同波。  
+2. **Catalog** 纯 domain 抽出（S2）与 **Agent** 删双写/双读（S1–S2）可并行（不同树）。  
+3. **Users** U-S1–S4 小，可与上并行。  
+4. 竖切（Catalog S3+、Agent S3+）按包内依赖推进；测绿再合。
+
+**不做：** 为 edge/web 开结构切片，直到单独讨论。
+
+---
+
+## 3. 共同 pattern 纪律（三包）
+
+| 用 | 不用 |
+|---|---|
+| Use case 函数 / 薄 application | 空 domain entity、演示用 OOP 树 |
+| 窄 Port（Protocol / 结构类型） | God `Db` / 万能 container |
+| 纯 domain 函数（尤其 itinerary/cluster） | Domain 进 Hono / PydanticAI |
+| 删死路径优先 | 长期兼容 re-export 双名 |
+
+---
+
+## 4. 相对「之前缺什么」
+
+此前只有 CA 目标树与分期口号。  
+现已补齐：**实盘 inventory · from→to · smell 证据路径 · pattern 取舍 · 按包 PR 切片**。  
+仍缺：**你拍板切片优先级**、以及 **edge/web 是否同一套规则**（未讨论）。
+
+---
+
+## 5. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 三包 structure design 由 subagent 产出；本索引锁定范围 |
+| 2026-08-06 | Owner ACCEPTED 三包结构（best practice）；实现按各包切片；edge/web 另议 |
+| 2026-08-06 | Edge Gateway + Web UI 结构文（一次到位、**无**巡礼 domain）；待确认 |
+| 2026-08-06 | Edge/Web **ACCEPTED**；Maintenance Thin 结构稿 |
+| 2026-08-06 | **maintenance → jobs** 包名与 `src/jobs/`；结构 ACCEPTED |

--- a/docs/superpowers/specs/2026-08-06-users-clean-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-06-users-clean-architecture-design.md
@@ -1,0 +1,542 @@
+# Users 教科书式 DDD + Clean Architecture 设计（Thin 分级）
+
+- Status: **ACCEPTED (core BC)** — owner 收口 2026-08-06；**不含实现**
+- Scope note: 下文 **§0.2 LOCKED** vs **§0.3 OPEN** — 核心边界已锁；产品面大量能力仍待单独设计，**不得假装整包已设计完**
+- Date: 2026-08-06
+- Package: `workers/users`（TS Cloudflare Worker · Hono · oRPC · Neon）
+- Language: ADR-0002 · greenfield 总表 · `workers/users/CONTEXT.md`
+- Parent: `docs/superpowers/specs/2026-08-06-monorepo-target-layout.md`
+- Siblings: [Catalog ACCEPTED](./2026-08-06-catalog-clean-architecture-design.md) · [Agent ACCEPTED](./2026-08-06-agent-clean-architecture-design.md) · [Greenfield 总表](./2026-08-06-greenfield-language-and-data-plane.md)
+- Tier: **Thin**（monorepo §4.3 LOCKED 默认）— 不硬套 Full 四层空壳
+- Accepted: U1–U7（核心）；§0.3 仍为后续设计队列
+
+---
+
+## 0. 目标
+
+把 Users 从「已能跑的 SavedRoute CRUD + JWT 门」收成**可教学且与分级一致**的：
+
+1. **DDD**：SavedRoute / Claim / Share / Check-in 语言清晰；**不**拥有 Point 几何与 Itinerary 算法  
+2. **Clean Architecture（Thin 版）**：所有权与生命周期规则可抽测；SQL / jose / Hono 在外圈  
+3. **信任模型可叙述**：Bearer JWT 自验签、跨用户 403、分享 resolve 匿名只读 — 与 AGENTS 一致  
+
+**非目标（本文仍不直接改生产代码；实现按 §9 分期 PR）：**
+
+- 立刻 mkdir 空 domain 深树  
+- 本文阶段不部署 Share/Check-in runtime（表与契约目标已在 §2.5 定好）  
+
+**Greenfield 前提（owner 2026-08-06）：** 无历史用户 / 无生产包袱 → **语言、契约、表名一次到位最佳形态**，不保留 `UserRoute` / `routes` 作为长期别名。
+
+### 0.1 与 Full 包（catalog / agent）的差别（LOCKED 默认）
+
+| | Full（catalog / agent） | **Thin（users）** |
+|---|---|---|
+| 领域厚度 | 规划 kernel、会话策略、多 port | **所有权 + 生命周期 + 幂等** 为主 |
+| 目录 | 目标有完整 domain/application/adapters | **可先逻辑分层**；物理目录可浅 |
+| 强制 | 禁止 handler 内堆业务 | 禁止「所有 SQL + 规则糊在一个文件」无限膨胀；**允许**小包单文件用例 |
+| 空 domain/ | 有场景再 mkdir | **无场景不 mkdir**（monorepo 明确不做） |
+
+**一句话：** Users 要的是 **清晰边界与不变量**，不是 catalog 规模的目录树。
+
+### 0.2 本次收口 — LOCKED（可据此实现 G1 / 分层）
+
+| # | 锁定内容 |
+|---|---|
+| L1 | **Thin CA**：浅 domain + 用例/port；不硬套 Full 深树（§0.1 / §3） |
+| L2 | **语言 greenfield**：SavedRoute / SavedRouteStatus / Claim / RouteShare / WalkCheckin；禁 `UserRoute`/`routes` 用户义（§2.1） |
+| L3 | **表目标**：`saved_routes`、`route_shares`、`walk_checkins`；无跨 BC FK（§2.5） |
+| L4 | **不变量**：JWT 门、所有权 403/404、Claim 规则、status/`saved_at`、Share hash+快照、Check-in 幂等、G4（§2.3） |
+| L5 | **Conversation / 会话内 memory → Agent 写权威**；`listSessions` = 只读投影；跨会话 UserMemory 醒后 → Users（§2.1.1） |
+| L6 | **Share / Check-in 属于 Users BC**（契约已有）；runtime 分期 U5/U6，表可 G1 先建 |
+| L7 | **Catalog 关系**：只持 `point_ids` 引用；Itinerary 不在本包算；Share 创建时固化 `public_snapshot` |
+
+### 0.3 明确尚未设计好 — OPEN（禁止当已定案实现）
+
+下列来自 rebuild 产品环与既有契约/iter，**不在本次 ACCEPTED core 内**。需要时 **另开短设计卡** 再写进本文或子文。
+
+| ID | 主题 | 为何仍 OPEN | 建议何时设计 |
+|---|---|---|---|
+| **O1** | **しおり（keepsake）持久化 / 生成元数据** | 产品 iter-4 重面；版式/完走态/对比図枚数；是否只存 R2 key + SavedRoute 引用未定 | Share 前或并 Share |
+| **O2** | **R2 presign（#249）归属** | 契约曾挂 users 周边；edge/root 也出现过；路径、TTL、`sub` 前缀、谁验 JWT | しおり / 对比図上传前 |
+| **O3** | **対比図 / image-merge 记录** | 挂在 cut 还是 check-in 还是独立表；与 Walk 机位关系 | iter-4 数据卡 |
+| **O4** | **匿名产出 SavedRoute 的写路径** | 今日 claim 假设行已存在；**谁在匿名时 INSERT**（Agent？临时 Users 匿名？）未钉 | G1 SavedRoute 前必须钉 |
+| **O5** | **Claim 与 conversation.user_id 编排** | SavedRoute claim 在 Users；conversation claim 在 Agent；Web 一次登录是否两调用 / 顺序 / 失败补偿 | Claim 产品化前 |
+| **O6** | **SessionSummary API 最终挂谁** | 可挂 Users 投影或 Agent；影响 Edge 路由与 web client | 続きから / 历史页前 |
+| **O7** | **UserMemory 字段模型** | SD-15 休眠；payload 形状、可见可编辑、GEM 语义 | 解冻 SD-15 时 |
+| **O8** | **catalog_suggestions / UGC 飞轮** | 打卡纠偏信号进 suggestions；审核流；绝不自动写 catalog | 飞轮3 工程卡 |
+| **O9** | **SavedRoute 与 Agent 产出同步** | chat 出行程后如何落 `saved_routes`（自动 draft？用户点保存？） | 与 O4 一起 |
+| **O10** | **错误码与 OpenAPI 最终集** | `SAVED_ROUTE_*` 全量、share/checkin 已有；しおり/presign 未有 | 各能力设计时 |
+| **O11** | **删除级联与 GDPR/注销** | 删用户时 saved_routes/shares/checkins 顺序；anon purge 边界 | 有真实用户前 |
+| **O12** | **RLS 是否补策略** | 今应用层裁决；Neon RLS 是否纵深防御 | 安全卡可选 |
+
+**纪律：** 实现 PR 只允许碰 **§0.2 LOCKED** + 已单独 ACCEPTED 的 O* 卡。遇到 O* 未决就停并开设计，不靠「先写着再说」。
+
+### 0.4 重构范围（LOCKED — owner 2026-08-06）
+
+**全仓同一原则**（见 greenfield §0 原则 6–7）：重构列车 = **已有代码的真·结构工作**，**不止 rename**。
+
+| | 做什么 | 不做什么 |
+|---|---|---|
+| **本重构列车（Users 已有码）** | **移动** handler/SQL/规则文件；抽出 ownership/claim **纯函数** 与 SavedRouteRepo port；**化简** 事务脚本；JWT/adapter 边界清晰；greenfield 命名对齐；SOLID / 1-10-50 | 为演示堆 interface；把 Thin 硬升 Full 空树 |
+| **未写代码** | 设计指引 **comment → 既有 ticket**；ticket 开工时再实现 | 在重构 PR 里实现 Share/Check-in/しおり/presign |
+| **表** | rename/收紧 **现有** `routes`→`saved_routes`（代码已写） | 未开工 enabler **抢先建空表**（除非该 ticket 自己建） |
+
+**O\* → 既有 ticket 挂载（设计指引写 issue comment，不新开 epic 除非缺票）：**
+
+| OPEN | 既有 ticket（主） | 重构侧只做 |
+|---|---|---|
+| O1 しおり | #212 #215 #219 | 无 |
+| O2 R2 presign | #249 | 无 |
+| O3 対比図记录 | #249 / #215 系 | 无 |
+| O4/O9 匿名/chat 落 SavedRoute | #289 #333 #432 | 仅当现码已有路径则整理命名 |
+| O5 双 claim 编排 | #333 #386 | 现有 claim 端点可 greenfield 改名 |
+| O6 SessionSummary 挂谁 | #526 #386 | 现有 `listSessions` 可改名/投影注释 |
+| O7 UserMemory | SD-15 / 无硬票则 ticket 自建时引用本文 | 无 |
+| O8 catalog_suggestions | 飞轮工程卡（未绑则 backlog） | 无 |
+| Share runtime | **#235** | 无实现；指引见 comment |
+| Check-in runtime | **#243** | 无实现；指引见 comment |
+| 分层/会话不变量 | **#432** #666 | **本重构可做的主战场（已有代码）** |
+
+---
+
+## 1. 现状诊断（设计基线）
+
+### 1.1 今日目录（~700 行量级）
+
+```text
+workers/users/src/
+  index.ts          # Hono 入口、DI、JWT 门、oRPC OpenAPIHandler
+  router.ts         # implement(usersContract) + UsersContext
+  api/routes.ts     # list/save/delete/claim + listSessions（SQL + 映射）
+  auth/jwt.ts       # jose 远程 JWKS 验签
+  db/schema.ts      # Drizzle 仅 typing（routes 表）
+  db/client.ts      # DbExecutor（raw sql）
+  lib/errors.ts     # ROUTE_NOT_* 镜像
+```
+
+### 1.2 已有正确碎片
+
+| 碎片 | 评价 |
+|---|---|
+| BC：用户域数据服务，binding-only `/v1/users/*` | G4 / SD-2 对齐 |
+| 契约 `packages/contract/src/users-contract.ts` | 发布语言入口 |
+| JWT 自验签 + `sub` → `user_id` | 信任边界清晰（≠ Edge 预鉴权） |
+| `assertOwner` → 404 / 403 分型 | 所有权在应用边界，不静默靠 RLS |
+| claim：`session_id` 且 `user_id IS NULL` | Claim 语义已在 SQL 里 |
+| 测试 seam：`createUsersApp({ getKey, makeDb })` | 可替 port 意识 |
+| workerd 纪律：raw `sql`、数组 `sql.param`、timestamptz normalize | 运维债写进 AGENTS |
+
+### 1.3 与目标态差距（greenfield 可一次清）
+
+| 期望 | 现状（待迁） |
+|---|---|
+| 表 `saved_routes` + 契约 `SavedRoute` | 表 `routes` + 类型 `UserRoute`；混有旧规划列 |
+| 无跨 BC 的 FK 到 `bangumi` | `routes.bangumi_id` 曾 REFERENCES catalog |
+| Share / Check-in 表就绪 | 契约有、表与 Worker 无 |
+| Conversation 写权威文档化 | 已 LOCK §2.1.1；列表投影仍可读 |
+| 领域规则可单测 | 规则嵌在 SQL / `api/routes.ts` |
+
+**结论：** 运行时 Thin 服务已能用；**命名与表形状按 §2.5 直接迁到最佳**，不做兼容层。
+
+---
+
+## 2. 领域模型（Users BC）
+
+### 2.1 统一语言（LOCKED — greenfield，无遗留别名）
+
+| 词 | 含义 |
+|---|---|
+| **SavedRoute** | 用户文档：title、`point_ids[]`、`SavedRouteStatus`、时间戳；可尚未 claim（`user_id` 空 + `claim_session_id`） |
+| **SavedRouteStatus** | `draft` \| `saved` \| `completed` |
+| **Claim** | 将仍匿名的 SavedRoute（`user_id IS NULL` 且 `claim_session_id` 匹配）归属到 JWT `sub` |
+| **SessionSummary** | 历史列表用的对话摘要投影 — 非 auth session；非 Conversation 所有权 |
+| **RouteShare** | 一条 SavedRoute 的公开分享记录（token、过期、吊销、公开快照） |
+| **ShareToken** | 分享用高熵 token（库内只存 **hash**） |
+| **WalkCheckin** | Walk 打卡；`client_id` 离线幂等键 |
+| **point_ids** | Catalog **Point** 的 id 引用列表，非几何权威 |
+| **UserMemory** | 跨会话 profile（SD-15 休眠；表形状预留见 §2.5.4） |
+
+**禁止在新代码/新契约中使用：** `UserRoute`、`Route`（裸词）、`routes` 表名（用户域）。  
+Catalog 的计算结果继续叫 **Itinerary**，与 SavedRoute 严格二分。
+
+**不拥有：**
+
+| 概念 | 拥有方 |
+|---|---|
+| Point 几何 / Bangumi 主数据 / Itinerary 算法 | Catalog |
+| **Conversation / 消息 / 会话运行时 / 会话内 memory**（fact ledger、tool_state、`agent_memory*`、`conversation_messages`） | **Agent**（写权威） |
+| JWT 签发 / magic-link UI | Neon Auth · apps/web |
+| Edge 限流 / 路由 | Edge |
+| 匿名 Session retention cron | Maintenance（对象仍是 agent 域数据） |
+
+### 2.1.1 Conversation / Memory 归属（LOCKED — owner 2026-08-06）
+
+| 概念 | 拥有方 | Users 角色 |
+|---|---|---|
+| Conversation + messages + Session 运行时 + 会话内 memory | **Agent** | **无写权威** |
+| `listSessions` / 历史列表 API | API 可挂 Users | **只读投影**（读 agent 域表或只读视图）；不因列表在 Users 而转移所有权 |
+| Claim SavedRoute（`saved_routes.user_id`） | **Users** | 写 |
+| Claim / 迁移 conversation 的 `user_id` | **Agent 域规则**（今 session migration 等） | Users 至多编排调用，不双写消息 |
+| 跨会话 `user_memory`（唤醒后） | **Users** | 读写；Agent 只读消费 |
+
+**原则：** 同一张 Neon 表 ≠ 同一 BC。写方 = 语义权威；只读投影 ≠ 拥有。
+
+### 2.2 拥有 / 不拥有（行为）
+
+| 拥有 | 不拥有 |
+|---|---|
+| SavedRoute 持久化与所有权裁决 | 根据 point_ids 重算 Itinerary（调 Catalog 或由 Web 调） |
+| Claim 归属语义 | 改写 Catalog 点位 |
+| Share 签发 / 吊销 / 公开投影（目标） | 完整 GPS 出现在公开投影 |
+| Check-in 写入与幂等（目标） | photo 上传/presign 实现细节可另卡，但 ref 归用户域 |
+| 对 JWT `sub` 的行级 scoping | 匿名 Chat 配额（Agent 域） |
+| SessionSummary 只读列表（可选 API 面） | Conversation 消息正文的写与 compaction |
+| 跨会话 UserMemory（唤醒后） | 会话内 fact ledger / agent_memory 写 |
+
+### 2.3 核心不变量（草案，确认后 LOCK）
+
+1. **身份：** 除 **Share resolve** 外，Users 过程一律要求有效 Neon Auth JWT；`sub` = 行级 `user_id`。  
+2. **所有权：** 对已归属用户的 SavedRoute，非 owner → **403 `ROUTE_NOT_OWNED`**；不存在 → **404 `ROUTE_NOT_FOUND`**（先存在性再所有权的现序可保留，但不得把跨用户静默当 404 掩盖审计需求时需文档化）。  
+3. **引用而非复制：** SavedRoute 只存 `point_ids`（及元数据）；**不**复制 Point 坐标为权威源。  
+4. **Claim：** 仅 `user_id IS NULL` 且 `claim_session_id` 匹配的 SavedRoute 可被 claim；已有 `user_id` 的行不可被他人 claim。  
+5. **Status / saved_at：** `draft` → `saved_at` IS NULL；进入 `saved`/`completed` 时建立或保留 `saved_at`。  
+6. **Share：** 库内只存 token **hash**；过期/吊销终态；resolve 返回 **创建时固化的 public_snapshot**（无全精度 GPS、无内部 user id — 契约）。  
+7. **Check-in：** 同 `(user_id, client_id)` 同 payload 幂等；payload 变更 → 冲突；观测 GPS 截断 ~100 m。  
+8. **G4：** 用户域能力进本服务；**禁止**再往 Agent 加用户数据端点。  
+9. **Conversation 写权威在 Agent**（§2.1.1）；Users 不得写 messages / 会话内 memory。  
+10. **SessionSummary 列表 = 只读投影**。  
+11. **无跨 BC 外键：** `point_ids` / `primary_bangumi_id` 为 **TEXT 引用**，不 REFERENCES catalog 表。
+
+### 2.4 上下文关系
+
+```text
+Web / Edge ── Bearer ──▶ Users ──SQL──▶ Neon
+                │              │  saved_routes · route_shares · walk_checkins · user_memory?
+                │              ├── point_ids 文本引用 ──▶ Catalog（无 FK）
+                │              └── SessionSummary ──只读──▶ conversations（Agent 写）
+Chat ──▶ Agent ──写──▶ conversations / messages / session runtime
+Claim SavedRoute ──▶ Users 写 saved_routes.user_id
+Claim conversation.user_id ──▶ Agent
+Share resolve（匿名）──▶ Users（hash 查 token → public_snapshot）
+```
+
+**表纪律（LOCKED）：**  
+- Users 写权威：`saved_routes`、`route_shares`、`walk_checkins`、（未来）`user_memory`  
+- Agent 写权威：`conversations`、`conversation_messages`、会话内 memory 表  
+- 禁止无协调双写同一语义列  
+
+### 2.5 目标数据模型（Greenfield LOCKED）
+
+**前提：** 无生产用户 → Atlas 迁移可 **DROP/RENAME 到位**，不做双写兼容窗。  
+**权威迁移史：** `db/migrations`（目标路径 `migrations/neon/`）；Drizzle `schema.ts` 仅 typing。
+
+#### 2.5.1 退役（用户域相关）
+
+| 现状 | 处理 |
+|---|---|
+| 表 `routes` | **替换为** `saved_routes`（见下）；实现 PR 中 migrate + 改 Worker/测试 |
+| 列 `bangumi_id` FK、`origin_location` geography、`total_distance`、`total_duration`、`route_data` | **不迁入**权威列；需要展示时打开再算 Itinerary 或 Share 用快照 |
+| 契约 `UserRoute`、错误码文案里的含糊 “Route” | **改为** `SavedRoute` / `SAVED_ROUTE_*`（与 ADR-0002 一致） |
+| HTTP path `/v1/users/routes` | **改为** `/v1/users/saved-routes`（及 claim 子路径） |
+
+Catalog 的 `route_snapshots` / `catalog/route` API **不动**（那是 Itinerary，不是 SavedRoute）。
+
+#### 2.5.2 `saved_routes`
+
+```sql
+-- 设计规格（实现时落入 timestamped Atlas 文件；以下为规范形状）
+CREATE TABLE saved_routes (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           TEXT,                    -- JWT sub；未 claim 时 NULL
+  claim_session_id  TEXT,                    -- 匿名产出时的 agent session；claim 键
+  title             TEXT NOT NULL DEFAULT '',
+  point_ids         TEXT[] NOT NULL,         -- Catalog Point id 引用
+  status            TEXT NOT NULL DEFAULT 'draft'
+                      CHECK (status IN ('draft', 'saved', 'completed')),
+  -- 可选规划提示（非几何权威；打开时可喂回 Catalog plan）
+  origin_label      TEXT,
+  origin_lat        DOUBLE PRECISION,
+  origin_lng        DOUBLE PRECISION,
+  pacing            TEXT CHECK (pacing IS NULL OR pacing IN ('chill', 'normal', 'packed')),
+  primary_bangumi_id TEXT,                   -- 软引用，无 FK
+  saved_at          TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT saved_routes_owner_or_claim CHECK (
+    user_id IS NOT NULL OR claim_session_id IS NOT NULL
+  ),
+  CONSTRAINT saved_routes_origin_pair CHECK (
+    (origin_lat IS NULL) = (origin_lng IS NULL)
+  )
+);
+
+CREATE INDEX idx_saved_routes_user_updated
+  ON saved_routes (user_id, updated_at DESC)
+  WHERE user_id IS NOT NULL;
+
+CREATE INDEX idx_saved_routes_claim_session
+  ON saved_routes (claim_session_id)
+  WHERE user_id IS NULL;
+
+-- updated_at trigger：复用既有 update_updated_at()
+```
+
+**行语义：**
+
+| 状态 | `user_id` | `claim_session_id` |
+|---|---|---|
+| 登录用户保存 | 有 | 可选（溯源） |
+| 匿名会话产出、待 claim | NULL | **必有** |
+| claim 后 | 写入 sub | 可保留溯源 |
+
+#### 2.5.3 `route_shares`（Share 目标表）
+
+```sql
+CREATE TABLE route_shares (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  saved_route_id  UUID NOT NULL REFERENCES saved_routes(id) ON DELETE CASCADE,
+  created_by      TEXT NOT NULL,             -- owner user_id
+  token_hash      TEXT NOT NULL UNIQUE,      -- SHA-256(token) 等；永不存明文
+  public_snapshot JSONB NOT NULL,            -- 创建时 PublicSharedItinerary 固化
+  expires_at      TIMESTAMPTZ NOT NULL,      -- 签发时不可变
+  revoked_at      TIMESTAMPTZ,
+  view_count      INTEGER NOT NULL DEFAULT 0,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_route_shares_route ON route_shares (saved_route_id);
+CREATE INDEX idx_route_shares_creator ON route_shares (created_by);
+```
+
+**resolve：** 入参 token → hash 查找 → 校验未过期且 `revoked_at IS NULL` → 返回 `public_snapshot`（不再实时拼内部 id）。  
+**快照策略（LOCKED）：** 创建时固化公开投影，避免 Users 运行时强依赖 Catalog；点名/帧图在创建瞬间从 Catalog 读入快照。
+
+#### 2.5.4 `walk_checkins`
+
+```sql
+CREATE TABLE walk_checkins (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         TEXT NOT NULL,
+  saved_route_id  UUID NOT NULL REFERENCES saved_routes(id) ON DELETE CASCADE,
+  point_id        TEXT NOT NULL,             -- Catalog Point 软引用
+  client_id       UUID NOT NULL,             -- 离线幂等键
+  latitude        DOUBLE PRECISION NOT NULL,
+  longitude       DOUBLE PRECISION NOT NULL, -- 存储全精度；日志另截断
+  checked_in_at   TIMESTAMPTZ NOT NULL,
+  synced_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  photo_ref       TEXT,
+  CONSTRAINT walk_checkins_client_idempotent UNIQUE (user_id, client_id)
+);
+
+CREATE INDEX idx_walk_checkins_user_route
+  ON walk_checkins (user_id, saved_route_id);
+```
+
+#### 2.5.5 `user_memory`（休眠预留；SD-15）
+
+已有迁移曾 `DROP user_memory`。唤醒时 **新建**（不复活旧 JSON 形状 unless 产品需要）：
+
+```sql
+-- 仅规格预留；U 分期不默认建表，除非产品解冻 SD-15
+CREATE TABLE user_memory (
+  user_id     TEXT PRIMARY KEY,
+  payload     JSONB NOT NULL DEFAULT '{}'::jsonb,  -- 版本化 profile；字段治理另卡
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+#### 2.5.6 契约目标形状（与表对齐）
+
+| 今日 | 目标 |
+|---|---|
+| `UserRoute` | `SavedRoute` |
+| `RouteStatus` | `SavedRouteStatus` |
+| `ROUTE_NOT_FOUND` / `ROUTE_NOT_OWNED` | `SAVED_ROUTE_NOT_FOUND` / `SAVED_ROUTE_NOT_OWNED`（或保留 code、改 message/类型名 — 实现时统一一种，推荐 **码与类型一并新名**） |
+| `ListRoutesResult.routes` | `ListSavedRoutesResult.saved_routes` |
+| paths `/v1/users/routes` | `/v1/users/saved-routes` |
+| share 输入 `route_id` | `saved_route_id`（契约字段同步） |
+| checkin `route_id` | `saved_route_id` |
+
+**兼容：** 无。Web / 测试 / MSW 与实现 PR **同 PR 或紧后 PR** 改完。
+
+---
+
+## 3. Clean Architecture（Thin 圈层）
+
+```text
+Hono · oRPC · jose · neon-http · wrangler
+        ▲
+adapters: index（入站 HTTP/JWT）· db（出站 SQL）· errors map
+        ▲
+application: 用例（SaveSavedRoute, ClaimRoutes, …）
+        ▲
+domain（浅）: SavedRoute 不变量、Status 规则、Claim 资格、所有权结果类型
+```
+
+**依赖硬规则（Thin 版）：**
+
+- 领域规则（状态机、claim 资格、所有权结果）**不** import Hono / jose / drizzle schema 类  
+- 用例依赖 **port**（`SavedRouteRepo`、`SessionSummaryReader`、可选 `Clock`）  
+- `auth/jwt` = 入站 identity adapter，不是 domain  
+- **允许** 初期：domain 以纯函数模块存在（`domain/saved-route-rules.ts`），不必强制 class / 聚合根脚手架  
+
+### 3.1 与现状命名对齐
+
+| 教科书 | 今日可对应 |
+|---|---|
+| domain（浅） | 从 `api/routes.ts` 抽出的纯规则 + 行映射校验 |
+| application | `listRoutes` / `saveRoute` / … 编排 |
+| inbound | `index.ts` + `router.ts` + `auth/jwt.ts` |
+| outbound | `db/*`、未来 share/checkin 仓储 |
+| DTO | `@animichi/contract`（目标 `SavedRoute` 等） |
+
+---
+
+## 4. 目标职责树（设计；物理 mkdir 可选）
+
+```text
+workers/users/src/
+  domain/                 # 可选物理目录；逻辑必须先有
+    saved-route.ts        # 状态、saved_at、标题/点位数守卫（与契约对齐的内规则）
+    ownership.ts          # found | not_found | not_owned
+    claim.ts              # claim 资格语义（测的是规则，不是 SQL 串）
+  application/
+    list-saved-routes.ts
+    save-saved-route.ts
+    delete-saved-route.ts
+    claim-routes.ts
+    list-session-summaries.ts
+    # 后续：create-share, revoke-share, resolve-share, submit-checkin, list-checkins
+  adapters/
+    inbound/              # 今日 index + router + auth
+    outbound/             # 今日 db + errors
+  # 近端可不改路径：继续 api/* 但文件内分「规则 / 仓储 / handler」三段注释边界
+```
+
+**近端推荐：** 在 **实现 Share/Check-in 之前** 完成规则抽取 + port，避免第三个 400 行事务脚本文件。  
+**不强制** 与 catalog 同构的深树。
+
+---
+
+## 5. 端口（出站）
+
+| Port | 职责 | 备注 |
+|---|---|---|
+| **SavedRouteRepo** | 对 `saved_routes` 列表/插入/更新/删除/claim | 替换今日 `routes` SQL |
+| **SessionSummaryReader** | 分页读 Session 摘要 | 只读投影；写权威在 Agent |
+| **ShareRepo** | `route_shares`：签发、吊销、按 token_hash 解析 | §2.5.3 |
+| **CheckinRepo** | `walk_checkins` 幂等写与列表 | §2.5.4 |
+| **Identity**（入站） | Bearer → `userId` | 今 `verifyBearer`；非出站 port |
+
+**禁止的 port：** `PointsRepo` 写、Catalog 主数据写、Agent tool 循环。
+
+**Catalog 关系：** Share **创建时** 读 Catalog 填入 `public_snapshot`；之后 resolve **不**依赖 Catalog 实时性。SavedRoute 打开重算 Itinerary → Web/Agent 调 Catalog，Users 不内嵌规划 kernel。
+
+---
+
+## 6. 主要用例
+
+### 6.1 已实现（应对齐命名）
+
+| Use case | 今日函数 | 说明 |
+|---|---|---|
+| ListSavedRoutes | `listRoutes` | owner 范围 |
+| SaveSavedRoute | `saveRoute` | create / update + 所有权 |
+| DeleteSavedRoute | `deleteRoute` | 所有权后删 |
+| ClaimRoutes | `claimRoutes` | 匿名 session → 用户 |
+| ListSessionSummaries | `listSessions` | 分页摘要（**只读投影**，非 Conversation 拥有） |
+
+### 6.2 契约已有、Worker 未实现（设计纳入边界）
+
+| Use case | 契约 | 说明 |
+|---|---|---|
+| CreateShare / RevokeShare / ResolveShare | `share-contract` | resolve **匿名**；create/revoke Bearer |
+| SubmitCheckin / ListCheckins | `checkin-contract` | 全程 Bearer；幂等 `client_id` |
+
+实施顺序建议：SavedRoute 分层收紧 → Share → Check-in（与产品 iter 对齐即可，不绑死）。
+
+---
+
+## 7. 与 Catalog / Agent / Edge / Web
+
+| 邻居 | 关系 |
+|---|---|
+| **Catalog** | 供应商（Point 详情 / Itinerary 重算）；Users 只持 id 引用 |
+| **Agent** | Conversation / 会话内 memory **写权威**；Users 只读列表投影 + Claim SavedRoute；**不**在 Agent 新增用户文档 CRUD（G4）；**不**在 Users 写消息 |
+| **Edge** | 透传 `Authorization`；**不**替代 Users 验签 |
+| **Web** | 经 `/v1/users/*`；Share 页可匿名 resolve |
+| **Contract** | `users-contract` + share + checkin 为发布面 |
+| **Maintenance** | 不清理用户已归属文档（除非另有产品规则）；匿名 agent 域 retention 不归 Users |
+
+---
+
+## 8. 测试策略（设计）
+
+| 层 | 内容 |
+|---|---|
+| domain | ownership 结果、status/`saved_at`、claim 资格、check-in 幂等键冲突 — **无 DB** |
+| application | fake repos + 用例 |
+| adapters | 现有 `vitest-pool-workers`（JWT 本地 JWKS、fake `DbExecutor`） |
+| 契约 | share/checkin 实现时锁形 + 错误码与 registry 一致 |
+
+保留：≤200 行/测试文件、可注入 `getKey` / `makeDb`。
+
+---
+
+## 9. 分阶段（仅计划）
+
+| 阶段 | 内容 |
+|---|---|
+| **U0** | 本文 core DESIGN → owner ACCEPTED | **DONE 2026-08-06** |
+| **U1** | AGENTS/CONTEXT 与 §0.2 对齐 | 文档 |
+| **U2** | Greenfield 数据面 + 契约（`saved_routes` 等）+ Worker/测试改名 | **须先决 O4/O9**（匿名谁写 SavedRoute）再动刀，或 G1 只做已登录路径 |
+| **U3** | ownership / status / claim 纯规则 + 单测 | 代码 |
+| **U4** | SavedRouteRepo port | 代码 |
+| **U5** | Share runtime | 宜先有 O1 边界（しおり vs share） |
+| **U6** | Check-in runtime | 契约较齐；O8 另卡 |
+| **U7** | UserMemory | 仅 O7 解冻后 |
+
+每阶段独立 PR 优先。**实现不得吞掉 §0.3 OPEN。**
+
+---
+
+## 10. Owner 确认（Users 核心）— **ACCEPTED 2026-08-06**
+
+| # | 议题 | 决议 |
+|---|---|---|
+| **U1** | Thin 分级：浅 domain + 用例/port | **ACCEPTED** — §0.1 / §3 |
+| **U2** | Greenfield 语言 + 表 + 契约（§2.1 / §2.5） | **ACCEPTED** |
+| **U3** | 不变量 §2.3 | **ACCEPTED** |
+| **U4** | Share / Check-in 进 BC；runtime 分期 U5/U6 | **ACCEPTED**（表形状锁；行为细节可随实现卡补 AC） |
+| **U5** | Conversation/Memory 归属 §2.1.1 | **ACCEPTED** |
+| **U6** | 分期 §9 | **ACCEPTED** |
+| **U7** | Status → **ACCEPTED (core BC)** | **ACCEPTED**；§0.3 OPEN 不阻塞 core |
+
+**未接受为定案：** §0.3 全部 O1–O12（仍是设计队列）。
+
+---
+
+## 11. 相关文档
+
+| 文档 | 角色 |
+|---|---|
+| `workers/users/CONTEXT.md` · `AGENTS.md` | 语言；JWT 信任模型 |
+| ADR-0002 | SavedRoute 发布语言 |
+| rebuild **G4 / SD-2** | 用户域 → workers/users；禁止 agent 新数据端点 |
+| `packages/contract` users / share / checkin | 发布面 |
+| Catalog / Agent CA（ACCEPTED） | 邻居边界 |
+| monorepo-target-layout | Thin 分级与逐包进度 |
+
+---
+
+## 12. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿 DESIGN ONLY；Thin 分级；对齐 X12/G4 与既有契约面 |
+| 2026-08-06 | LOCK §2.1.1 Conversation/Memory 归属；U5 提前 ACCEPTED |
+| 2026-08-06 | Greenfield：§2.5 目标表 `saved_routes`/`route_shares`/`walk_checkins`；契约去 `UserRoute`；无兼容层 |
+| 2026-08-06 | 并入仓级总表 `2026-08-06-greenfield-language-and-data-plane.md`（全包同原则） |
+| 2026-08-06 | **Core BC ACCEPTED**（U1–U7）；§0.2 LOCKED / §0.3 OPEN  backlog（O1–O12） |
+| 2026-08-06 | §0.4 重构只动已有代码；O* 指引 comment 挂 #235 #243 #249 #333 #526 #432 #289 |
+| 2026-08-06 | §0.4 明确：真·结构重构（搬家/化简/SOLID），不止 rename；全仓同原则 |

--- a/docs/superpowers/specs/2026-08-06-users-structure-refactor-design.md
+++ b/docs/superpowers/specs/2026-08-06-users-structure-refactor-design.md
@@ -1,0 +1,573 @@
+# Users 结构重构设计（Thin CA — 已有代码 only）
+
+- Status: **ACCEPTED**（owner 2026-08-06 — best-practice 默认；**不含实现**）
+- Date: 2026-08-06
+- Package: `workers/users`（~700 行；Hono · oRPC · jose · Neon raw SQL）
+- Parent: [`2026-08-06-users-clean-architecture-design.md`](./2026-08-06-users-clean-architecture-design.md)（§0.2 LOCKED · §0.4 重构范围）
+- Greenfield: [`2026-08-06-greenfield-language-and-data-plane.md`](./2026-08-06-greenfield-language-and-data-plane.md)（原则 6–7：真·结构，不止 rename）
+- Tier: **Thin** — 浅 domain + use case + port；**禁止** Full catalog 深树
+
+---
+
+## 0. 范围锁（读此节再动手）
+
+### 0.1 在本设计内
+
+| 项 | 说明 |
+|---|---|
+| **已有 HTTP 面** | `listRoutes` · `saveRoute` · `deleteRoute` · `claimRoutes` · `listSessions` + JWT 门（`/v1/users/*`） |
+| **真·结构** | 移动/拆分函数；抽出 ownership / claim / status 纯规则；`SavedRouteRepo` + `SessionSummaryReader` port；化简事务脚本；SOLID / 1-10-50 |
+| **语言对齐（可同列车）** | `UserRoute`→`SavedRoute`；`session_id` 列语义→`claim_session_id`；`listSessions` 注释/类型为 **SessionSummary 只读投影**（Conversation 写权威在 Agent） |
+| **测试** | 跟搬家改 import；域规则加无 DB 单测；fake repo 替 SQL 串匹配（逐步） |
+
+### 0.2 明确不在本设计 / 本重构列车
+
+| 项 | 去向 |
+|---|---|
+| Share runtime | **#235** — 本文件不展开 |
+| Check-in runtime | **#243** — 本文件不展开 |
+| しおり / R2 presign / 対比図 | **#249**（及相关 #212/#215）— 本文件不展开 |
+| Edge path 表、Web MSW、contract 全仓 rename 的**跨包**编排 | greenfield G1 他包 PR；本设计只定 users 内部切法 |
+| 空 `domain/application/adapters` 脚手架、ShareRepo/CheckinRepo 空壳 | 无场景不 mkdir；product ticket 开工时再建 |
+
+**纪律（parent §0.4）：** 重构 PR = 今日仓库里已存在的 handler/SQL/规则。未写能力只挂 ticket comment，不在重构里实现。
+
+---
+
+## 1. Current inventory
+
+### 1.1 物理树与体量（实测基线 2026-08-06）
+
+```text
+workers/users/
+  package.json · wrangler.toml · vitest.config.ts · tsconfig.json
+  AGENTS.md · CONTEXT.md · CLAUDE.md
+  src/
+    index.ts           ~117 行  Hono 入口 · DI · JWT 门 · OpenAPIHandler · db 池
+    router.ts          ~37 行   implement(usersContract) → 调 api handlers
+    api/
+      routes.ts        ~237 行  ★ 上帝文件：映射 + SQL + 所有权 + 5 用例
+    auth/
+      jwt.ts           ~51 行   jose JWKS · verifyBearer
+    db/
+      client.ts        ~17 行   DbExecutor + makeDb
+      schema.ts        ~41 行   Drizzle typing only（表名 routes + 遗留规划列）
+    lib/
+      errors.ts        ~38 行   ROUTE_NOT_FOUND / ROUTE_NOT_OWNED 镜像
+  test/
+    in-memory-routes-db.ts     fake DbExecutor（按 SQL 文本分派）
+    neon-auth-fixture.ts       本地 Ed25519 JWT
+    auth.worker.test.ts
+    eddsa-shared-primitive.worker.test.ts
+    routes-api.worker.test.ts  直调 list/save/delete/listSessions
+    route-mutations.worker.test.ts  HTTP delete/claim + 403/404
+    row-validation.worker.test.ts   坏行 / 空 title
+    worker.worker.test.ts      契约 smoke
+```
+
+**合计 src ~540 行 + test ~700 行量级** — Thin 包，**不需要** catalog 式多层目录。
+
+### 1.2 导出表面（现函数 → 角色）
+
+| 路径 | 符号 | 今日角色 | 目标层 |
+|---|---|---|---|
+| `src/index.ts` | `createUsersApp`, `Env`, `UsersAppDeps`, `closeDbPools` | 入站 composition root | **adapters/inbound**（可保持路径） |
+| `src/index.ts` | `guardUsersV1`, `requireUser`, `requestService` | JWT + 配置守卫 | inbound（可留 index 或抽 `auth-middleware`） |
+| `src/router.ts` | `usersRouter`, `UsersContext` | oRPC wiring | inbound |
+| `src/auth/jwt.ts` | `verifyBearer`, `issuerFromJwksUrl` | Identity adapter | inbound identity |
+| `src/api/routes.ts` | `listRoutes` | List SavedRoutes | **application** |
+| `src/api/routes.ts` | `saveRoute` / create+update 私有链 | Save SavedRoute | **application** |
+| `src/api/routes.ts` | `deleteRoute` | Delete SavedRoute | **application** |
+| `src/api/routes.ts` | `claimRoutes` | Claim by session | **application** |
+| `src/api/routes.ts` | `listSessions` | SessionSummary 投影（误像「拥有会话」） | **application**（只读） |
+| `src/api/routes.ts` | `assertOwner`, `ownerFrom` | 所有权裁决（嵌 SQL） | **domain 规则 + repo 读** |
+| `src/api/routes.ts` | `toUserRoute`, `toSession`, `iso`, `isStatus`… | 行映射 / 校验 | **adapters/outbound map** 或 domain parse |
+| `src/api/routes.ts` | `*Sql` / `*Row` helpers | 出站 SQL | **SavedRouteRepo / SessionSummaryReader** |
+| `src/db/client.ts` | `DbExecutor`, `makeDb` | 出站执行器 | outbound infra |
+| `src/db/schema.ts` | `routes` table typing | 遗留形状 | 目标 `savedRoutes` typing（G1 语言） |
+| `src/lib/errors.ts` | `routeNotFound`, `routeNotOwned` | oRPC 错误构造 | adapter error map（应用抛 domain 结果） |
+
+### 1.3 数据与契约现状（与目标差）
+
+| 层 | 今日 | Greenfield 目标（parent §2.5；可与结构 PR 同波或紧前） |
+|---|---|---|
+| 表 | `routes`；claim 键列名 **`session_id`** | `saved_routes`；**`claim_session_id`** |
+| 契约模型 | `UserRoute`, `RouteStatus` | `SavedRoute`, `SavedRouteStatus` |
+| 列表结果 | `ListRoutesResult.routes` | `ListSavedRoutesResult.saved_routes` |
+| 会话列表 | `UserSession` / `listSessions` | **SessionSummary** 投影；写权威仍在 Agent `conversations` |
+| 错误码 | `ROUTE_NOT_*` | 推荐 `SAVED_ROUTE_NOT_*`（实现时与 contract 一次对齐） |
+| schema 遗留列 | `bangumi_id` FK 语义、`origin_location` geography、`total_*`、`route_data` | **不进** SavedRoute 权威模型；schema typing 收成目标列 |
+
+### 1.4 已有正确碎片（保留，勿拆坏）
+
+1. **BC 边界**：binding-only `/v1/users/*`；JWT 自验签；`sub` → `user_id`。  
+2. **信任序**：无 JWT → 401；跨用户 → 403 `ROUTE_NOT_OWNED`；不存在 → 404（`assertOwner` 先查存在性）。  
+3. **Claim SQL 语义**：`user_id IS NULL` + session 匹配才更新（正确；列名待 greenfield）。  
+4. **status / saved_at**：insert 时 draft→NULL；update 时 draft 清 NULL，非 draft `COALESCE(saved_at, NOW())`。  
+5. **可测 seam**：`createUsersApp({ getKey, makeDb })` + `DbExecutor`。  
+6. **workerd 纪律**：raw `sql`、数组 `sql.param`、timestamptz `toISOString()`。  
+7. **数组绑定**：`${sql.param(input.point_ids)}::text[]` — 搬家时必须原样保留。
+
+### 1.5 核心问题（为何要结构重构，而不只 rename）
+
+`src/api/routes.ts` 是 **单一事务脚本文件**，混有：
+
+- 领域规则（所有权、claim 资格、status→saved_at）  
+- 应用编排（create vs update 分支、删前 assert）  
+- 出站 SQL 与行映射  
+- 与 Agent 域表 `conversations` 的只读查询（未标明「投影、非拥有」）
+
+结果：
+
+- 规则无法无 DB 单测（只能走 fake SQL 文本匹配）。  
+- 新增第三段能力时会再长一截 400 行脚本。  
+- 命名仍是 `UserRoute` / `routes` / `session_id`，与 CONTEXT / parent LOCKED 语言冲突。  
+- `UsersContext` 直接持 `DbExecutor`，用例无法依赖抽象 port。
+
+---
+
+## 2. File / function move-split table（from → to）
+
+### 2.1 目标逻辑树（Thin — 物理可浅）
+
+**推荐物理布局（够用即止；文件数 ≈ 今日 + 少量，不是 catalog 镜像）：**
+
+```text
+workers/users/src/
+  domain/
+    ownership.ts          # 纯：OwnerLookup → found | not_found | not_owned
+    claim.ts              # 纯：行是否可 claim（user_id null + claim_session_id 匹配）
+    saved-route-status.ts # 纯：status → saved_at 规则
+  application/
+    ports.ts              # SavedRouteRepo · SessionSummaryReader（interface only）
+    list-saved-routes.ts
+    save-saved-route.ts
+    delete-saved-route.ts
+    claim-saved-routes.ts
+    list-session-summaries.ts
+  adapters/
+    outbound/
+      saved-route-repo.ts     # SQL 实现 SavedRouteRepo
+      session-summary-reader.ts
+      row-map.ts              # toSavedRoute / toSessionSummary / iso / isStatus
+      errors.ts               # 今 lib/errors（或保留 lib/ 路径）
+    inbound/
+      # 近端可继续：index.ts · router.ts · auth/jwt.ts 不强制搬目录
+  db/
+    client.ts · schema.ts     # 保留；schema 对齐 saved_routes
+  # 删除或变空：api/routes.ts（拆光后删）
+```
+
+**允许的更浅变体（若 PR 想少 mkdir）：**
+
+```text
+src/
+  domain/{ownership,claim,saved-route-status}.ts
+  application/{ports,list-*,save-*,delete-*,claim-*,list-session-*}.ts
+  db/{client,schema,saved-route-repo,session-summary-reader,row-map}.ts
+  lib/errors.ts
+  auth/jwt.ts · router.ts · index.ts
+```
+
+两种变体 **逻辑边界相同**；选一种写进实现 PR 的 description，不要两种半截。
+
+### 2.2 函数级 from → to
+
+| From（今日） | To（目标） | 动作 | 备注 |
+|---|---|---|---|
+| `api/routes.ts` `isRecord` | `adapters/.../row-map.ts` 或 `domain/parse.ts` | **move** | 共享 narrow |
+| `api/routes.ts` `isStatus` | `domain/saved-route-status.ts` `isSavedRouteStatus` | **move + rename** | 纯类型守卫 |
+| `api/routes.ts` `strings` | `row-map.ts` | **move** | point_ids 窄化 |
+| `api/routes.ts` `iso` / `nullableIso` | `row-map.ts` | **move** | workerd timestamptz 边界 |
+| `api/routes.ts` `requireRouteRow` / `toUserRoute` | `row-map.ts` `toSavedRoute` | **move + rename** | 输出契约 SavedRoute |
+| `api/routes.ts` `requireSessionRow` / `toSession` | `row-map.ts` `toSessionSummary` | **move + rename** | 投影 DTO；注释写清非 Conversation 写 |
+| `api/routes.ts` `sessionPage` / `MAX_LIST_OFFSET` | `application/list-session-summaries.ts` 或 domain `paginate` | **move** | 分页截断规则可纯测 |
+| `api/routes.ts` `ownerFrom` | `domain/ownership.ts` `ownerIdFromRow` | **move** | 纯 |
+| `api/routes.ts` `assertOwner` | **拆** | **split** | 见下节 |
+| `api/routes.ts` insert/update/delete/claim `*Sql` + `*Row` | `SavedRouteRepo` 实现 | **move** | 唯一持 SQL 处 |
+| `api/routes.ts` `sessionSql` + listSessions body | `SessionSummaryReader` + use case | **split** | 读 `conversations` 只在 reader |
+| `api/routes.ts` `listRoutes` | `application/list-saved-routes.ts` | **move** | 依赖 `SavedRouteRepo.listByUser` |
+| `api/routes.ts` `saveRoute` / `createRoute` / `updateRoute` | `application/save-saved-route.ts` | **move + simplify** | 见 §2.4 |
+| `api/routes.ts` `deleteRoute` | `application/delete-saved-route.ts` | **move** | assert + delete |
+| `api/routes.ts` `claimRoutes` / `claimRouteRows` | `application/claim-saved-routes.ts` + repo | **move** | 规则可在 domain 文档化；原子性仍在 SQL UPDATE |
+| `api/routes.ts`（文件） | **删除** | 拆完后无 re-export 上帝桶 | 测试改 import |
+| `lib/errors.ts` | `adapters/outbound/errors.ts` **或** 保留路径 | optional move | 应用层返回 domain 结果后由 handler/map 抛 ORPCError 更干净；**最小改动可先保留** |
+| `db/schema.ts` `routes` | `savedRoutes` / 表 `saved_routes` | rename + **drop 遗留列 typing** | 与迁移同 PR 或紧邻 |
+| `router.ts` handlers | 仍薄：调 application 函数 | **edit** | `UsersContext` 注入 port 实现，**不**直接暴露 `DbExecutor` 给用例（见 §2.3） |
+| `index.ts` composition | `makeDb` → 构造 `createSavedRouteRepo(db)` 等 | **edit** | 仍是 DI 根；测试注入 fake ports **或** 继续 fake `DbExecutor` 进真实 repo |
+| `test/in-memory-routes-db.ts` | 保留一段时间 **或** 升 `FakeSavedRouteRepo` | 渐进 | 见 §5 |
+| 无 | `domain/*.test.ts` 或 `test/domain-*.worker.test.ts` | **new tests only** | 纯函数；无 SQL |
+
+### 2.3 `assertOwner` 拆分（关键结构点）
+
+今日（嵌在 routes.ts）：
+
+```text
+assertOwner(db, userId, routeId)
+  → SQL SELECT user_id
+  → rows empty → routeNotFound
+  → owner !== userId → routeNotOwned
+```
+
+目标：
+
+| 片段 | 位置 | 形态 |
+|---|---|---|
+| `type Ownership = { kind: "found"; ownerId: string \| null } \| { kind: "not_found" }` | domain | 数据 |
+| `decideOwnership(lookup, actorUserId): "ok" \| "not_found" \| "not_owned"` | `domain/ownership.ts` | **纯函数** |
+| `SavedRouteRepo.findOwner(id): Promise<string \| null \| undefined>`（undefined = missing） | port | 出站 |
+| use case: `const o = decideOwnership(...); if o !== "ok" throw mapError(o)` | application | 编排 |
+| `mapError` → `routeNotFound` / `routeNotOwned` | errors adapter | 边界 |
+
+**简化：** update/delete 的「先 assert 再写」可收敛为 **一次** repo 方法（`updateIfOwned` 返回 affected），但 **403 vs 404 语义必须保留**（parent 不变量 2）。推荐：
+
+1. `findOwner` → domain decide → 非 ok 则错；  
+2. 再 `update`/`delete` 带 `user_id` 条件；  
+3. 若 2 返回 0 行 → 仍 `not_owned`（竞态）。  
+
+不要为了少一次 round-trip 把 404 静默成 403 或反之。
+
+### 2.4 `saveRoute` 化简
+
+今日链：`saveRoute` → `createRoute`/`updateRoute` → `insertRoute`/`updateRouteRow` + 内联 CASE SQL。
+
+目标：
+
+| 步骤 | 谁 |
+|---|---|
+| 若 `input.id` 缺失 → create | application |
+| 若有 id → ownership 裁决 | application + domain |
+| `savedAtForStatus(status, previousSavedAt)` | **domain 纯函数**（draft→null；else previous ?? now） |
+| `repo.insert` / `repo.update` | port；SQL 可继续用 CASE 或把 timestamp 从纯函数注入（**优先纯函数 + 参数化 NOW()** 以便测） |
+
+**Clock port（可选）：** 仅当要把 `NOW()` 从 SQL 挪到 TS 时引入 `() => Date`；否则 **不** 为演示加 Clock — Thin 允许 SQL `NOW()`，domain 单测用固定 `previousSavedAt` 测规则表即可。
+
+### 2.5 Port 形状（最小，禁止堆 interface）
+
+```ts
+// application/ports.ts — 示意，非实现
+
+/** Users 写权威：saved_routes */
+export interface SavedRouteRepo {
+  listByUser(userId: string): Promise<unknown[]>; // 或已 map 的 SavedRoute[]
+  findOwner(id: string): Promise<string | null | undefined>;
+  insert(userId: string, input: SaveSavedRouteInput): Promise<unknown>;
+  updateOwned(userId: string, input: SaveSavedRouteInput & { id: string }): Promise<unknown[]>;
+  deleteOwned(userId: string, id: string): Promise<unknown[]>;
+  /** Atomic claim: user_id IS NULL AND claim_session_id = ? */
+  claimBySession(userId: string, claimSessionId: string): Promise<number>;
+}
+
+/** Agent 写权威表的只读投影 — 不是 Conversation 仓储 */
+export interface SessionSummaryReader {
+  pageByUser(
+    userId: string,
+    input: { limit: number; offset: number },
+  ): Promise<unknown[]>;
+}
+```
+
+**禁止的 port：** PointsRepo、Catalog 写、ShareRepo/CheckinRepo（无 runtime）、Agent message 写。
+
+**DbExecutor：** 留在 adapter 构造函数内；**application 不 import** `drizzle-orm` / `sql`。
+
+### 2.6 `UsersContext` 演化
+
+| 阶段 | Context 内容 |
+|---|---|
+| 今日 | `{ db: DbExecutor; userId: string }` |
+| 结构重构后 | `{ userId: string; savedRoutes: SavedRouteRepo; sessions: SessionSummaryReader }` |
+| index 装配 | `db = makeDb(...)` → `savedRoutes = createSqlSavedRouteRepo(db)` 等 |
+
+测试：
+
+- **单元（application）：** 手写 fake repo（内存 Map）— 不解析 SQL。  
+- **适配器：** 可保留 `fakeDb` SQL 分派测 repo 实现。  
+- **HTTP：** `createUsersApp` 仍可 `makeDb` 注入；或新增 `makeRepos` 覆盖（可选，勿过度）。
+
+### 2.7 语言对照（结构 PR 内命名）
+
+| 旧（代码/SQL） | 新 |
+|---|---|
+| `UserRoute` / `toUserRoute` | `SavedRoute` / `toSavedRoute` |
+| `listRoutes` / `saveRoute` / … | 用例文件名 `list-saved-routes` 等；**HTTP/oRPC 过程名**随 contract G1 |
+| `session_id` 在 **routes 行**（claim 键） | **`claim_session_id`** |
+| `listSessions` / `UserSession` | `listSessionSummaries` / **SessionSummary**（契约可分波） |
+| `conversations` 查询 | 保留表名（Agent 权威）；代码注释：`// SessionSummary projection — Agent owns writes` |
+
+---
+
+## 3. SOLID smells with paths
+
+| 原则 | 症状 | 路径 | 重构动作 |
+|---|---|---|---|
+| **S** Single Responsibility | 一个文件同时：行校验、所有权、CRUD SQL、会话分页、claim | `src/api/routes.ts`（整文件） | 拆 domain / application / repo（§2） |
+| **S** | `index.ts` 配置、鉴权、oRPC handle、db 池 | `src/index.ts` | **可接受 Thin 根**；仅当再涨时抽 `guardUsersV1` → `inbound/users-v1-guard.ts`，**非必须** |
+| **O** Open/Closed | 新用例只能往 `routes.ts` 加 export | `api/routes.ts` + `router.ts` | 新文件 + router 一行 wiring |
+| **L** Liskov | `DbExecutor` 被当万能仓储；fake 靠 SQL 字符串 LSP 脆弱 | `test/in-memory-routes-db.ts` 对 `src/api/routes.ts` | port + fake 实现同一 interface |
+| **I** Interface Segregation | 用例拿完整 `DbExecutor`（可执行任意 SQL） | `router.ts` `UsersContext.db`；所有 handler 签名 | 收成 `SavedRouteRepo` / `SessionSummaryReader` |
+| **D** Dependency Inversion | application 直接依赖 drizzle `sql` 与表名 | `api/routes.ts` import `drizzle-orm` | 用例只依赖 port；SQL 仅 adapter |
+| **D** | 错误类型在应用中心直接 `new ORPCError` | `assertOwner` → `lib/errors.ts` | domain 返回结果码；边界 map（可分期） |
+| God function | `saveRoute` 创建/更新/所有权/时间戳一体 | `saveRoute` / `updateRoute` ~L183–200 | 编排薄 + `savedAtForStatus` 纯 |
+| 重复 | update 与 delete 各写 assert + 0 行再判 | `updateRoute`, `deleteRoute` | 共用 `requireOwned` 应用 helper |
+| 泄漏 BC | Users 文件内写「拥有会话」语义的命名/缺注释 | `listSessions` L116–121 | 改名/注释 SessionSummary；**不**迁写权威 |
+| 遗留模型 | schema 含规划几何与 `route_data` | `src/db/schema.ts` L24–40 | 收成 SavedRoute 列；删 typing 死列 |
+| 测试双关 | `FakeRouteRow` 兼 routes 与 conversations 行 | `test/in-memory-routes-db.ts` | 拆 `FakeSavedRouteRow` / 会话 seed，或 fake port |
+| 命名债 | `session_id` 作 claim 键 vs 会话 `session_id` | SQL claim L222–225；schema L26 | greenfield `claim_session_id` |
+
+**非 smell（勿过度修）：**
+
+- `auth/jwt.ts` 短且单一 — 保持。  
+- `DbExecutor` 作为 workerd 出站最小面 — 保留在 adapter。  
+- oRPC `implement` 薄 handler — 正确；不要再包一层「UseCase class」。
+
+---
+
+## 4. Patterns for Thin package + what NOT to use
+
+### 4.1 采用（Thin CA 工具箱）
+
+| 模式 | 在本包的用法 |
+|---|---|
+| **纯函数 domain** | ownership / claim 资格文档化 / status→saved_at；**无 class 聚合根** |
+| **Use case 函数** | `export async function saveSavedRoute(ports, userId, input)` — 模块级函数即可 |
+| **Port interface** | 仅 2 个出站（SavedRouteRepo、SessionSummaryReader） |
+| **Composition root** | `createUsersApp` 装配 repo；测试替换 `makeDb` 或 ports |
+| **Result / 判别联合** | `OwnershipDecision` 代替抛异常驱动控制流（边界再转 ORPCError） |
+| **Row mapper 在 adapter** | `toSavedRoute` 不进 domain 核心规则 |
+| **1-10-50** | 拆文件后单函数 ≤10 行目标；超则再提纯，禁止为凑数再抽象 |
+| **注释边界** | 若暂缓物理 `domain/` 目录，文件顶部分段 `// --- domain ---` **不可**代替长期拆分 — 本列车要真搬家 |
+
+### 4.2 明确不采用（Full / 演示 OOP 禁区）
+
+| 禁止 | 原因 |
+|---|---|
+| catalog 式深树：`domain/model/aggregates/...`、`application/services/...`、多层 `index.ts` barrel | 包体 ~700 行；空树违反 monorepo Thin 与 parent §0.1 |
+| `SavedRoute` **class** + 私有字段 + 工厂仪式 | 无复杂不变式需要封装；zod/契约已是边界 |
+| Repository **基类** / Unit of Work / Generic `CrudRepo<T>` | 仅一张主表 + 一个投影读 |
+| Domain Event 总线、MediatR、CQRS 读写模型分离 | 无订阅方 |
+| 为 Share/Check-in **预建** `ShareRepo` 空实现 | product #235/#243 开工再建 |
+| DI 容器（tsyringe 等） | 手动构造足够 |
+| `Either`/`fp-ts` 全盘 | 可选简单 union；不引入新运行时依赖 |
+| 把 JWT 验签放进 domain | identity 是 inbound adapter |
+| 在 Users 内「封装」Conversation 写 API | 违反 LOCKED §2.1.1 |
+| 双写 `routes` + `saved_routes` 兼容层 | greenfield 无用户；一次迁到位 |
+
+### 4.3 依赖方向（硬规则）
+
+```text
+index / router / auth/jwt
+        ↓
+application/*  (use cases)
+        ↓
+domain/*       (pure)
+        ↑
+adapters/outbound/*  implements ports（application 定义 port）
+```
+
+- `domain/*` **不得** import：`hono`、`jose`、`drizzle-orm`、`@orpc/*`、`./db/*`。  
+- `application/*` **不得** import：`sql` 模板、表名字符串（经 port）。  
+- 允许 `application` import `type` 自 `@animichi/contract`。  
+- `adapters` 可 import domain 纯函数做映射辅助。
+
+### 4.4 与 Full 包（catalog）对照
+
+| | Catalog（Full） | Users（本列车） |
+|---|---|---|
+| 领域厚度 | 规划 kernel、多聚合 | 所有权 + 生命周期 + claim 幂等 SQL |
+| 目录 | 完整 domain/application/adapters 合理 | **浅**；5 用例 + 2 port |
+| 测试 | 大量 domain 单测 | domain 薄测 + 现有 worker 测保留 |
+| 成功标准 | 规则可单测、handler 无 SQL | **同左**，但文件总数不必膨胀 |
+
+---
+
+## 5. PR slices（existing code only）
+
+原则：**每 PR 可独立绿**（`pnpm test` / typecheck / lint in `workers/users`）；优先可审 diff；**不**夹带 Share/Check-in。
+
+### Slice U-S0 — 文档对齐（可选，可已做）
+
+- CONTEXT / AGENTS 已指向 parent CA：确认「SessionSummary 只读」「claim_session_id」用语。  
+- **无生产代码。**
+
+### Slice U-S1 — 纯规则抽出 + 无 DB 测试
+
+**动：**
+
+| 新增 | 内容 |
+|---|---|
+| `domain/ownership.ts` | `decideOwnership` |
+| `domain/saved-route-status.ts` | `isSavedRouteStatus`, `savedAtForStatus` |
+| `domain/claim.ts` | `isClaimable({ userId, claimSessionId }, sessionKey)` 文档化规则（与 SQL WHERE 同语义） |
+| `test/domain-rules.worker.test.ts` 或 vitest 普通测 | 表驱动：404/403/ok；draft/saved_at |
+
+**暂不动：** SQL 仍可在 `api/routes.ts`；`assertOwner` 可先 **调用** `decideOwnership` 再抛错（半对接）。
+
+**验收：** 新测全绿；既有 worker 测绿；`routes.ts` 行数下降。
+
+### Slice U-S2 — SavedRouteRepo port + SQL 搬家
+
+**动：**
+
+- `application/ports.ts` + `adapters/.../saved-route-repo.ts`（或 `db/saved-route-repo.ts`）。  
+- 迁移 list/insert/update/delete/claim/findOwner SQL。  
+- `listRoutes` / `saveRoute` / `deleteRoute` / `claimRoutes` 改为调 repo（可仍住 `api/routes.ts` 短暂，或已拆 application 文件）。  
+- `row-map.ts`：`toSavedRoute`（名可先 `toUserRoute` 若 contract 未改）。  
+- 更新 `in-memory-routes-db` **或** 测 repo 的 SQL fake。
+
+**验收：** 行为不变（403/404/claim 计数/saved_at）；无 contract 强制改名亦可本 slice 只做结构。
+
+### Slice U-S3 — SessionSummaryReader + 投影语义
+
+**动：**
+
+- 抽出 `listSessions` SQL → `SessionSummaryReader`。  
+- 应用函数命名/注释：**SessionSummary projection；Agent owns Conversation writes**。  
+- `UsersContext` 去掉裸 `db`（若 U-S2 已换 SavedRoute，本 slice 换掉剩余 db）。  
+- router / index 装配两 port。
+
+**验收：** 分页 `next_offset` 与 `MAX_LIST_OFFSET` 行为不变；row-validation 会话测绿。
+
+### Slice U-S4 — 拆 application 文件 + 删 `api/routes.ts`
+
+**动：**
+
+- 五文件 use case；router 改 import。  
+- 删除 `api/routes.ts`；必要时删空 `api/`。  
+- 测试 import 路径全量更新。  
+- 跑 1-10-50 目视：过长函数再抽。
+
+**验收：** 包内无「上帝 routes 文件」；目录符合 §2.1 选定变体。
+
+### Slice U-S5 — Greenfield 语言 / 表（可与 U-S2 合并，勿无结构只 rename）
+
+**动（仍限 users 包 + 其测试 + 约定的 contract/migration 邻 PR）：**
+
+- 表 `routes`→`saved_routes`；列 claim 键→`claim_session_id`。  
+- schema.ts 收列。  
+- 类型/函数名 SavedRoute；错误码与 contract 对齐。  
+- fake SQL 文本 `insert into saved_routes` 等。
+
+**跨包 path**（`/v1/users/saved-routes`）若 contract 同改：edge/web 跟车 — **不算本结构文档展开**，但 PR 描述须链 greenfield G1。
+
+**验收：** users 测绿；无双写。
+
+### Slice 顺序建议
+
+```text
+U-S1（纯规则） → U-S2（SavedRouteRepo） → U-S3（SessionSummary） → U-S4（删上帝文件）
+                 ↘ U-S5 语言/表 可与 U-S2 或 U-S4 合并，但禁止「只改名不搬家」
+```
+
+主战场 ticket 引用：parent §0.4 → **#432** · **#666**（分层/会话不变量）。
+
+### 每 slice 不做
+
+- Share / Check-in / しおり / presign 实现。  
+- 新建空表 `route_shares` / `walk_checkins`（除非独立 product PR）。  
+- Edge/Web 大范围 UI。  
+- 覆盖率用 `skip` / `eslint-disable` 糊弄。
+
+---
+
+## 6. Non-goals
+
+### 6.1 包外系统（本设计不规定实现）
+
+| 系统 | 为何 out |
+|---|---|
+| **workers/edge** | 仅透传 `Authorization` 与 path；path 字符串跟 G1 contract，无 Users domain |
+| **apps/web** | 客户端改 import/path；非 users 结构 |
+| **apps/agent** | Conversation 写权威已 LOCKED；本重构 **不** 把消息写入 Users，也 **不** 在 Agent 加 SavedRoute CRUD（G4） |
+| **workers/catalog** | 无 FK、无 Itinerary 内嵌 |
+| **workers/maintenance** | 不扫 `saved_routes` 的 retention 策略另议（O11） |
+| **packages/contract 全仓** | 仅 users 相关符号在 U-S5 邻接；catalog `Itinerary` 改名属 catalog 列车 |
+
+### 6.2 产品 enabler（设计指引 → ticket，本列车零实现）
+
+| 能力 | Ticket | 本文件 |
+|---|---|---|
+| RouteShare runtime | **#235** | 一行：实现时遵守 parent §2.5.3 + Thin port，**不**预建 |
+| WalkCheckin runtime | **#243** | 一行：实现时遵守 §2.5.4 幂等，**不**预建 |
+| しおり / presign / 対比図 | **#249** | 一行：归属 OPEN O1/O2；**不**在 users 结构 PR 做 |
+| 匿名谁 INSERT SavedRoute | O4 / #289 #333 | 现码 claim 假设行已在；结构只整理 claim 读改路径 |
+| 双 claim 编排（route + conversation） | O5 / #333 #386 | 只整理现有 claim **端点** 边界 |
+| SessionSummary 最终挂谁 | O6 / #526 | 现 `listSessions` 可投影注释/改名；**不**迁服务 |
+| UserMemory | O7 / SD-15 | 无 |
+| GDPR 级联 / RLS | O11 / O12 | 无 |
+
+### 6.3 结构上的非目标
+
+- 为「将来 Share」先铺 `application/create-share.ts` 空文件。  
+- 统一全仓同一目录深度。  
+- 把 `listSessions` 从 Users **删掉**（产品未定 O6；现面保留为只读投影）。  
+- 性能项目（Hyperdrive 调优、缓存）— 非结构债。  
+- 替换 oRPC/Hono/Neon 栈。
+
+---
+
+## 7. 测试策略（结构重构配套）
+
+| 层 | 今日 | 重构后 |
+|---|---|---|
+| domain | 几乎无 | ownership / saved_at / claimable / sessionPage 边界 — **无 DB** |
+| application | 经 SQL fake 间接 | fake ports 直接（U-S2+） |
+| adapter SQL | `in-memory-routes-db` | 可保留测 repo；或缩小为关键 SQL 快照 |
+| HTTP / JWT | `route-mutations` · `auth` · `worker` | **保留**；只改装配 |
+| 行校验 | `row-validation` | 跟 `row-map` / use case import |
+
+纪律（仓级）：≤200 行/测试文件；≤5 mocks/测；不靠真实时钟断言。
+
+---
+
+## 8. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| 只 rename 交差 | Reviewer 对照 §2 表：须见 **新文件 + routes.ts 删除/瘦身** |
+| 拆太细导致 20 个 5 行文件 | 上限：domain ≤3 文件、application ≤5、repo ≤2；禁止空 barrel |
+| fake SQL 与真实 SQL 漂移 | U-S2 后优先 fake port；adapter 测关键查询文本 |
+| claim 列改名漏测 | U-S5 显式测 `claim_session_id`；mutation 测 claimed_count |
+| Context 同时持 db 与 port 半迁 | U-S3 结束前允许过渡；U-S4 禁止 `UsersContext.db` |
+| 误把 Conversation 写入 Users | 代码审：无 `INSERT/UPDATE conversations`；仅 SELECT |
+
+---
+
+## 9. 完成定义（Definition of Done — 结构列车）
+
+当且仅当：
+
+1. **`src/api/routes.ts` 已删除**（或 ≤50 行 re-export 过渡且下一 PR 必删 — 推荐直接删）。  
+2. Domain 纯规则可单测且 **不** import drizzle/hono/jose。  
+3. Application 用例只依赖 **SavedRouteRepo + SessionSummaryReader**（+ userId）。  
+4. SQL 仅出现在 outbound adapter。  
+5. Claim 语义与 status/saved_at 行为与重构前一致（测锁定）。  
+6. SessionSummary 路径有「Agent 写权威 / Users 只读投影」注释或类型名。  
+7. **无** Share/Check-in/しおり/presign 新 runtime。  
+8. `pnpm test` + typecheck + lint 在 `workers/users` 绿。  
+
+**非 DoD：** 目录「看起来像 textbook」；interface 数量最大化。
+
+---
+
+## 10. 与 parent 文档映射
+
+| Parent | 本结构文 |
+|---|---|
+| §0.2 L1 Thin CA | §4 模式；§2 浅树 |
+| §0.2 L5 Conversation / listSessions | §2.5 SessionSummaryReader；§6.2 O6 |
+| §0.4 真结构非只 rename | 全文；§5 U-S*；§9 DoD |
+| §3 圈层 | §2.1–2.3 |
+| §5 ports | §2.5（仅已实现两 port） |
+| §6.1 五用例 | §2.2 表 |
+| §9 U3/U4 | ≈ U-S1 / U-S2–S4 |
+| Greenfield 原则 6–7 | §0 · §5 U-S5 · §6 |
+
+---
+
+## 11. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿：workers/users 已有码结构重构设计；inventory / move 表 / SOLID / Thin 模式 / PR slices / non-goals；Share·Check-in·presign 仅挂 #235 #243 #249 |
+| 2026-08-06 | Owner **ACCEPTED**（best-practice 默认） |

--- a/docs/superpowers/specs/2026-08-06-web-ui-structure-design.md
+++ b/docs/superpowers/specs/2026-08-06-web-ui-structure-design.md
@@ -1,0 +1,214 @@
+# Web UI 结构重构（一次做到位 · 无巡礼 domain）
+
+- Status: **ACCEPTED**（owner 2026-08-06 — `routes`≈pages + `features` + platform；**无**巡礼 domain；**不含实现**）
+- Date: 2026-08-06
+- Package: `apps/web`（TanStack Start · Cloudflare）
+- Tier: **UI**（monorepo §4.3 LOCKED）
+- Parents: monorepo-target-layout · greenfield · `apps/web/AGENTS.md`
+- Scope: **已有代码** 边界收敛 + api 纪律 + greenfield 跟车；**无** 假 domain 层
+
+---
+
+## 0. 关于「domain model」—— Web **不用**
+
+| 概念 | Web 是否用 |
+|---|---|
+| 巡礼 **DDD domain model**（实体不变量、仓储） | **否** — 权威在 Catalog / Users / Agent |
+| 目录 `src/domain/` | **否** — 禁止为「像样」mkdir |
+| **Contract DTO**（`@animichi/contract` 的 Point / Itinerary / SavedRoute） | **是** — **边界类型**，不是包内 domain 再建模 |
+| Feature 内 **view-model / UI state** | **是** — 仅 UI 状态（chat draft、panel open），不复制主数据权威 |
+| Clean Architecture 四圈 | **否** — UI 用 **Feature module + Route + API hook** |
+
+一句话：**Web 消费发布语言（contract），不拥有领域模型。**  
+组件里的 `Point` 类型 = **wire/view 形状**，规则以服务端与 contract 为准。
+
+---
+
+## 1. 目标（一次最好）
+
+1. **依赖方向一次钉死（已有好基础，写成硬规则）：**  
+   `routes / components → features → api/hooks → api clients → 公网 /v1`  
+   UI **永不** 手写 JSON 旁路 contract。  
+2. **Feature 边界一次理清：** 跨 feature 共享进 `platform/` 或极薄 `components/`；feature 私货不进 `lib/` 黑洞。  
+3. **`lib/` 降级为 platform 工具：** auth / byok / turnstile 等跨面能力；chat/route-detail **迁回或明确归属 feature**。  
+4. **Greenfield 一次跟车：** contract 改名/path 时 hooks + MSW + 类型 import 全改，无长期 `UserRoute` 别名。  
+5. **不半吊子：** 不做「文档写 feature-first、仓库继续双堆 components+lib 无时间表」。
+
+---
+
+## 2. 现状 inventory（实盘）
+
+```text
+apps/web/src/
+  api/           # clients, orpc, hooks, config, query-client — 正确
+  routes/        # TanStack file routes
+  features/      # chat, shiori, map-*, anime, seo, bubble-map, config
+  components/    # landing, auth, home, legal, route-detail, …
+  lib/           # auth, byok, turnstile, chat, route-detail
+  platform/      # theme-bootstrap, geo
+  i18n/ server/ styles/
+```
+
+### 2.1 正确碎片
+
+- oRPC OpenAPILink + 分 service client（catalog / users）  
+- hooks 前缀 key 分离；SSR QueryClient per request  
+- MSW 用 contract zod parse，不手写 envelope  
+- features 已按产品面切开  
+- 1-10-50 / coverage floors 已在 AGENTS
+
+### 2.2 结构债
+
+| 债 | 说明 |
+|---|---|
+| `components/route-detail` vs `lib/route-detail` vs 未来 feature | 三处风险 |
+| `lib/chat` vs `features/chat` | 双栖 |
+| `components/*` 与 `features/*` 标准不清 | 新人不知放哪 |
+| 无 CONTEXT.md | 语言/边界靠 AGENTS 散落 |
+| Greenfield 未做 | 仍消费旧 wire 名（随 contract 列车） |
+
+---
+
+## 3. 目标树（一次最好 · 无 `domain/`）
+
+```text
+apps/web/src/
+  app/                         # 可选：router.tsx、全局 provider（若从根迁入）
+  routes/                      # 只负责 URL ↔ 组合 features（薄）
+  features/
+    chat/                      # UI + hooks 私有 + 原 lib/chat
+    route-detail/              # 合并 components/route-detail + lib/route-detail
+    shiori/
+    anime/
+    maps/                      # 收敛 map-spike + maplibre + bubble-map（见下）
+    seo/
+    auth/                      # 登录 UI（原 components/auth）+ 与 lib/auth 的边界
+    landing/                   # landing / home / splash
+    legal/
+  api/                         # 保持：唯一 HTTP 出口
+    clients.ts
+    orpc.ts
+    hooks/                     # 可按 service 分子目录 catalog/ users/ agent/
+    config.ts
+    query-client.ts
+  platform/                    # 跨 feature 真共享
+    auth/                      # session/token 获取（非业务）
+    byok/
+    turnstile/
+    i18n/                      # 或保持 src/i18n 顶层
+    styles/
+    geo.ts
+    theme-bootstrap.ts
+  components/                  # 仅真正无业务的 primitive / 壳（或最终清空并入 platform/ui）
+  server/                      # SSR 仅有逻辑
+  # 禁止：domain/
+```
+
+### 3.1 Maps 收敛（一次说清）
+
+今日 `map-spike` / `maplibre` / `bubble-map` 并存。目标：
+
+- **`features/maps/`** 统一出口；spike 中已生产化的代码并入，死 spike **删除**（已有码清理，不是新功能）。  
+- 若某文件仍是实验且无路由引用 → 删或移 `_dev`，不留三套真源。
+
+---
+
+## 4. 搬家表（from → to，已有码）
+
+| 今日 | 目标 |
+|---|---|
+| `lib/chat/*` | `features/chat/*`（或 `features/chat/lib/*` 若需子层） |
+| `lib/route-detail/*` | `features/route-detail/*` |
+| `components/route-detail/*` | `features/route-detail/ui/*` |
+| `components/auth/*` | `features/auth/ui/*` |
+| `components/landing|home|Splash|Landing` | `features/landing/*` |
+| `components/legal/*` | `features/legal/*` |
+| `lib/auth|byok|turnstile` | `platform/auth|byok|turnstile` |
+| `platform/geo.ts` · `theme-bootstrap.ts` | 保留 `platform/` |
+| `features/map-spike` + `maplibre` + `bubble-map` | `features/maps/*` + 删死代码 |
+| `api/hooks/*` | 可按 `hooks/catalog` `hooks/users` 分子夹（同 PR 或紧后） |
+| 无 `CONTEXT.md` | 新增 `apps/web/CONTEXT.md`（UI 语言 + 无 domain 声明） |
+
+**路由层：** `routes/*.tsx` 只 import features 的 page 入口，避免 route 文件堆业务。
+
+---
+
+## 5. Pattern（UI · 非 DDD）
+
+| 用 | 不用 |
+|---|---|
+| **Feature module** | 包级 `domain/entities` |
+| **Route as composition root** | Route 内巨型业务函数 |
+| **Query/Mutation hooks** | 组件内直接 `createCatalogClient` 散落 |
+| **Contract DTO at boundary** | 手写平行 interface 与 contract 漂移 |
+| **MSW = contract parse** | 手写 JSON fixture 旁路 zod |
+| **View state in feature** | 全局 store 镜像整份 Catalog |
+
+**SOLID 在 UI 的落点：**
+
+- **S：** 一个 feature 一个产品面；hook 不渲染  
+- **O：** 新卡片/流式 part → registry 扩展（既有 generative 纪律）  
+- **D：** UI 依赖 hook 抽象，不依赖 OpenAPILink 细节  
+
+**1-10-50 / coverage：** 搬家不降 floor；超标组件拆，不靠 disable。
+
+---
+
+## 6. Greenfield（一次跟车）
+
+| 项 | 动作 |
+|---|---|
+| 类型名 | `PilgrimagePoint`→`Point`，`Route`→`Itinerary`，`UserRoute`→`SavedRoute` |
+| Client path | catalog itinerary；users `saved-routes` |
+| MSW handlers | 同步 path + schema |
+| i18n / 文案 | 产品词可保留日文「ルート」；**代码标识符** 用 SavedRoute/Itinerary |
+| 禁止 | `export type Route = Itinerary` 长期别名 |
+
+与 catalog/users G1 **同波或紧后**；web 单独半截旧类型 = 不允许作为终态。
+
+---
+
+## 7. PR 切片
+
+| 切片 | 内容 | 完成判据 |
+|---|---|---|
+| **W0** | 本文 + CONTEXT.md ACCEPTED | 文档 |
+| **W1** | 钉死 api 层纪律（eslint/path 或 AGENTS 硬句 + 违反例清理） | 无 UI 直连乱 fetch |
+| **W2** | `lib/chat` + route-detail → features；删双栖 | import 单向；测绿 |
+| **W3** | landing/auth/legal 进 features；components 只留 primitive 或清空 | 树符合 §3 |
+| **W4** | maps 三源收敛 + 删死 spike | 单 features/maps |
+| **W5** | platform 收 auth/byok/turnstile | lib/ 可删或空 |
+| **W6** | Greenfield 类型/path/MSW | typecheck + unit 绿 |
+
+**允许 W2–W5 合并** 若团队接受大 PR；**目标态必须完整**，禁止「maps 永远 spike」。
+
+---
+
+## 8. Non-goals
+
+| 不做 | 去向 |
+|---|---|
+| `src/domain` 巡礼模型 | Catalog/Users/Agent |
+| Share/Check-in/しおり **后端** | tickets #235 #243 #212… |
+| 实现新页面产品 | 各 story |
+| Edge package-ize | edge 结构文 |
+| 放宽 coverage / 1-10-50 | 禁止 |
+
+---
+
+## 9. 验收（实现后）
+
+- [ ] 无 `apps/web/src/domain`  
+- [ ] UI → hooks → clients 单向；无组件手写业务 URL 散落  
+- [ ] `lib/chat`、`lib/route-detail` 不存在或仅 re-export 过渡 **零**（终态无 re-export）  
+- [ ] maps 单一 feature 入口  
+- [ ] contract 新名全站编译通过  
+
+---
+
+## 10. 变更日志
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-06 | 初稿：UI 一次到位；明确 **无** 巡礼 domain model；feature/platform 终态 |
+| 2026-08-06 | Owner **ACCEPTED**（`routes`≈pages + `features` + platform） |

--- a/packages/contract/CONTEXT.md
+++ b/packages/contract/CONTEXT.md
@@ -1,0 +1,44 @@
+# Shared contract (published language)
+
+Types and error codes exchanged across deployable units. Not a full bounded context — a **published language** so Agent, Catalog, Users, Edge, and Web do not invent parallel words for the same wire shapes.
+
+Greenfield rename train:  
+`docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md`
+
+## Language
+
+**Point**:
+A single visitable place tied to anime media. Atomic seichi stop on the wire.
+_Avoid_: PilgrimagePoint, Spot, Location
+
+**Bangumi**:
+One anime title / work as identified in our catalog (`bangumi_id`).
+_Avoid_: Work, work_id field name
+
+**Itinerary**:
+A computed, ordered plan over Points. Produced by Catalog; not a long-lived user document.
+_Avoid_: Route (ambiguous), Plan (product sense)
+
+**SavedRoute**:
+User-owned record: title, ordered point ids, status. May recompute Itinerary when opened.
+_Avoid_: UserRoute, bare Route
+
+**Session**:
+User–agent dialogue context. Distinct from auth tokens.
+_Avoid_: Conversation as the cross-service noun (Agent may still say Conversation for message log)
+
+**Origin** · **Pacing**:
+Planning start and packing preference (chill | normal | packed).
+
+## Greenfield wire targets
+
+| Old | New |
+|---|---|
+| `PilgrimagePoint` | `Point` |
+| `Route` (plan result) | `Itinerary` |
+| `work_id` | `bangumi_id` |
+| `/catalog/route` | `/catalog/itinerary` |
+| `UserRoute`, `/v1/users/routes` | `SavedRoute`, `/v1/users/saved-routes` |
+| share/checkin `route_id` | `saved_route_id` |
+
+No long-lived dual exports.

--- a/scripts/check-skeleton-w0-docs.sh
+++ b/scripts/check-skeleton-w0-docs.sh
@@ -6,23 +6,38 @@ cd "$ROOT"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
-test -f CONTEXT-MAP.md || fail "CONTEXT-MAP.md missing"
-grep -q 'Domain model presence' CONTEXT-MAP.md || fail "CONTEXT-MAP missing domain presence table"
-grep -q 'workers/catalog' CONTEXT-MAP.md || fail "CONTEXT-MAP missing catalog"
+require_file() { test -f "$1" || fail "missing file: $1"; }
+require_grep() { grep -qE "$2" "$1" || fail "missing pattern in $1: $2"; }
 
-test -f docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md || fail "PATH-DELTA missing"
-grep -q 'workers/jobs' docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md || fail "PATH-DELTA missing jobs row"
+require_file CONTEXT-MAP.md
+require_grep CONTEXT-MAP.md 'Domain model presence'
+require_grep CONTEXT-MAP.md 'workers/catalog'
+require_grep CONTEXT-MAP.md 'No.*pilgrimage|Gateway only|\*\*No\*\*'
 
-for f in workers/catalog/CONTEXT.md workers/users/CONTEXT.md apps/agent/CONTEXT.md \
-  workers/edge/CONTEXT.md apps/web/CONTEXT.md packages/contract/CONTEXT.md \
-  workers/maintenance/CONTEXT.md; do
-  test -f "$f" || fail "missing $f"
+require_file docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md
+require_grep docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md 'workers/jobs'
+require_grep docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md 'migrations/neon'
+require_file docs/iterations/refactor-skeleton-2026-08/GOAL.md
+require_file docs/iterations/refactor-skeleton-2026-08/README.md
+
+for f in \
+  workers/catalog/CONTEXT.md \
+  workers/users/CONTEXT.md \
+  apps/agent/CONTEXT.md \
+  workers/edge/CONTEXT.md \
+  apps/web/CONTEXT.md \
+  packages/contract/CONTEXT.md \
+  workers/maintenance/CONTEXT.md
+do
+  require_file "$f"
 done
 
-grep -q 'no pilgrimage domain' workers/edge/CONTEXT.md || grep -qi 'Does not own' workers/edge/CONTEXT.md \
-  || fail "edge CONTEXT must deny pilgrimage domain ownership"
+require_grep workers/edge/CONTEXT.md 'no pilgrimage domain|Does not own|Gateway'
+require_grep apps/web/CONTEXT.md 'no.*src/domain|Does not own|no.*domain'
 
-test -f docs/superpowers/specs/2026-08-06-monorepo-target-layout.md || fail "monorepo-target-layout missing"
-test -f docs/superpowers/specs/2026-08-06-structure-refactor-index.md || fail "structure-refactor-index missing"
+require_file docs/superpowers/specs/2026-08-06-monorepo-target-layout.md
+require_file docs/superpowers/specs/2026-08-06-structure-refactor-index.md
+require_file docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md
+require_file docs/adr/0002-published-language-point-bangumi-itinerary.md
 
 echo "OK: skeleton W0 doc structure"

--- a/scripts/check-skeleton-w0-docs.sh
+++ b/scripts/check-skeleton-w0-docs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Structural checks for skeleton campaign W0 docs (no runtime behaviour).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+test -f CONTEXT-MAP.md || fail "CONTEXT-MAP.md missing"
+grep -q 'Domain model presence' CONTEXT-MAP.md || fail "CONTEXT-MAP missing domain presence table"
+grep -q 'workers/catalog' CONTEXT-MAP.md || fail "CONTEXT-MAP missing catalog"
+
+test -f docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md || fail "PATH-DELTA missing"
+grep -q 'workers/jobs' docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md || fail "PATH-DELTA missing jobs row"
+
+for f in workers/catalog/CONTEXT.md workers/users/CONTEXT.md apps/agent/CONTEXT.md \
+  workers/edge/CONTEXT.md apps/web/CONTEXT.md packages/contract/CONTEXT.md \
+  workers/maintenance/CONTEXT.md; do
+  test -f "$f" || fail "missing $f"
+done
+
+grep -q 'no pilgrimage domain' workers/edge/CONTEXT.md || grep -qi 'Does not own' workers/edge/CONTEXT.md \
+  || fail "edge CONTEXT must deny pilgrimage domain ownership"
+
+test -f docs/superpowers/specs/2026-08-06-monorepo-target-layout.md || fail "monorepo-target-layout missing"
+test -f docs/superpowers/specs/2026-08-06-structure-refactor-index.md || fail "structure-refactor-index missing"
+
+echo "OK: skeleton W0 doc structure"

--- a/workers/catalog/CONTEXT.md
+++ b/workers/catalog/CONTEXT.md
@@ -1,0 +1,44 @@
+# Catalog
+
+Owns seichi **master data** and **planning algorithms**: Bangumi, Points, search/nearby/geocode, and Itinerary computation. Read-mostly for the Agent; public anonymous reads for some overview/search surfaces. Does **not** own login identity, SavedRoute documents, or Agent Session state.
+
+Published language: ADR-0002 · greenfield: `docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md`.
+
+## Language
+
+**Point**:
+A visitable seichi stop Catalog stores and returns (coordinates, screenshot, bangumi link, optional episode/time).
+_Avoid_: Spot in contracts, PilgrimagePoint
+
+**Bangumi**:
+A cataloged anime title (typically `bangumi_id` digit string on the wire).
+_Avoid_: Work, work_id
+
+**Itinerary**:
+Catalog's computed ordered plan over selected Points (cluster → order → optional timing/pacing).
+_Avoid_: SavedRoute, bare Route
+
+**Cluster** · **Origin** · **Pacing** · **Alias** · **Ingest/Enrich/Publish** · **Gazetteer entry**:
+As in prior glossary; pipeline stages are not fan-facing nouns.
+
+## Owns / does not own
+
+| Owns | Does not own |
+|---|---|
+| Point rows, Bangumi identity | User identity / JWT |
+| Itinerary computation | SavedRoute persistence (Users) |
+| Search, nearby, geocode, anime overview | Agent Session / messages |
+| Ingest→enrich→publish | Edge rate limits |
+
+## Wire / tables (greenfield target)
+
+| Avoid (today) | Target |
+|---|---|
+| `PilgrimagePoint`, `Route` | `Point`, `Itinerary` |
+| `work_id`, `pointsByWorkId` | `bangumi_id`, `pointsByBangumiId` |
+| `POST /catalog/route` | `POST /catalog/itinerary` |
+| `route_snapshots`, column `work_id` | `itinerary_snapshots`, `bangumi_id` |
+
+## Design
+
+`docs/superpowers/specs/2026-08-06-catalog-clean-architecture-design.md` (ACCEPTED + greenfield).

--- a/workers/edge/CONTEXT.md
+++ b/workers/edge/CONTEXT.md
@@ -1,0 +1,30 @@
+# Edge
+
+Request gateway: identity, rate limits, routing to Catalog / Users / Agent container, image and tile proxies. **Does not own** Point, Bangumi, Itinerary, or SavedRoute models — only forwards and enforces access policy.
+
+**Tier:** Gateway — **no pilgrimage domain model**, **no `src/domain/`**.
+
+Structure target (one-shot best):  
+`docs/superpowers/specs/2026-08-06-edge-gateway-structure-design.md`
+
+Greenfield path strings:  
+`docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md`
+
+## Domain model?
+
+**No.** Gateway vocabulary only:
+
+| Term | Means |
+|---|---|
+| **Identity** | Who is calling (anon / JWT sub / API key) — not Agent Session |
+| **Forward** | Pass /v1 to Catalog, Users, or Agent container with injected headers |
+| **Policy** | Pure path allowlists / rate-limit scope — not business rules |
+| **Proxy** | Image / tiles / R2 — not catalog SQL |
+| **Container** | Agent runtime lifecycle — not a pilgrimage entity |
+
+## Owns / does not own
+
+| Owns | Does not own |
+|---|---|
+| Authn at edge, rate limits, turnstile, forwarding | Itinerary planning, SavedRoute CRUD |
+| Container env / egress denylist config | HTML pages (apps/web) |

--- a/workers/maintenance/CONTEXT.md
+++ b/workers/maintenance/CONTEXT.md
@@ -1,0 +1,19 @@
+# Maintenance → Jobs (rename pending)
+
+**Target package path:** `workers/jobs` (not `maintenance`, not `scheduler`).
+
+This folder will be `git mv`'d in the jobs structure train. Until then, runtime code still lives here.
+
+Design: `docs/superpowers/specs/2026-08-06-jobs-worker-structure-design.md`
+
+## Domain model?
+
+No. Scheduled **jobs** only (purge anonymous sessions, purge anon quota).
+
+## Language
+
+| Prefer | Avoid |
+|---|---|
+| **Job** | maintenance task (vague) |
+| **Schedule / cron** | calling the whole package "scheduler" |
+| `workers/jobs` | `workers/maintenance` (legacy path) |

--- a/workers/users/CONTEXT.md
+++ b/workers/users/CONTEXT.md
@@ -1,0 +1,41 @@
+# Users
+
+Owns authenticated-user documents and claims of anonymous work after login. Does not own Point geometry or Itinerary algorithms — only references (e.g. point ids).
+
+Design (Thin CA + greenfield schema):  
+`docs/superpowers/specs/2026-08-06-users-clean-architecture-design.md`  
+**Status:** ACCEPTED core BC (§0.2). Product surfaces still OPEN (§0.3 O1–O12) — do not implement those as if designed.
+
+## Language
+
+**SavedRoute**:
+A user document: title, ordered `point_ids`, status (`draft` | `saved` | `completed`), optional planning hints. Table: `saved_routes`. May be unclaimed (`user_id` null + `claim_session_id` set).
+_Avoid_: Route, Itinerary, UserRoute, table name `routes`
+
+**SavedRouteStatus**:
+`draft` | `saved` | `completed`.
+
+**Claim**:
+Assign unclaimed SavedRoutes (`user_id` IS NULL, matching `claim_session_id`) to the authenticated user after login.
+_Avoid_: Migrate (reserved for schema/auth platform moves)
+
+**SessionSummary**:
+Read-only list projection of an agent Conversation for “history” UI. Not auth session; not ownership of messages.
+_Avoid_: Calling this Conversation ownership
+
+**RouteShare** / **ShareToken**:
+Public share of a SavedRoute; store token hash; freeze `public_snapshot` at create. Table: `route_shares`.
+
+**WalkCheckin**:
+Walk check-in with offline idempotency via `client_id`. Table: `walk_checkins`.
+
+**UserMemory**:
+Cross-session profile (SD-15 dormant). Session-scoped memory stays with Agent.
+
+## Ownership (summary)
+
+| Concept | Owner |
+| --- | --- |
+| SavedRoute, RouteShare, WalkCheckin, UserMemory (when awake) | **Users** |
+| Conversation, messages, in-session memory | **Agent** |
+| Point / Bangumi / Itinerary computation | **Catalog** |


### PR DESCRIPTION
## Parent
#829 · Closes #833

## What
W0 navigation docs for skeleton refactor: PATH-DELTA, CONTEXT-MAP (domain presence table), per-package CONTEXT.md, ACCEPTED structure design specs, ADR-0002, GOAL/README, structural check `scripts/check-skeleton-w0-docs.sh`.

## Verify
```bash
bash scripts/check-skeleton-w0-docs.sh
```

## Matt code-review (pre-merge)

### Spec
- AC: PATH-DELTA present and linked; CONTEXT-MAP + package CONTEXT; domain has/no table; links #829 / structure index — **met** by added files.
- No product behaviour — docs only.

### Standards
- Docs only; no runtime code; check script is bash structural gate.
- No 1-10-50 violations in application code (none shipped).

## Non-goals
No renames of workers/maintenance, no CI required-check renames.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added monorepo context maps for Agent, Catalog, Edge, Users, Web, Jobs, and shared contracts.
  - Added architecture and restructuring specifications covering service boundaries, terminology, data ownership, target layouts, and CI/CD direction.
  - Added refactor campaign goals, migration tracking, implementation guidance, and related ADRs.
  - Documented canonical product language and the planned maintenance-to-Jobs rename.

- **Tests**
  - Added structural validation for required skeleton and architecture documentation.

- **Chores**
  - Updated repository hygiene checks to recognize the new root documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->