### PR TITLE
refactor(#839): Agent CatalogReadGateway (read-only)

### DIFF
--- a/apps/agent/src/animichi/application/catalog_read_gateway.py
+++ b/apps/agent/src/animichi/application/catalog_read_gateway.py
@@ -1,0 +1,62 @@
+"""Read-only gateway protocol for catalog access (application layer).
+
+Layering rule: ``agents/`` is the PydanticAI/FastAPI **framework adapter** —
+nothing in ``domain/`` or ``application/`` may import the FastAPI /
+pydantic_ai runtime (or the httpx adapter in ``clients/``). This module is
+the application-layer seam: it declares the catalog surface the agent
+domain needs, read-only, with zero runtime imports beyond the stdlib.
+
+Single production implementation: :class:`animichi.clients.catalog_client.CatalogClient`
+(the catalog Worker RPC client). It satisfies this protocol structurally
+(PEP 544); ``CatalogClientProtocol`` in ``clients/`` subclasses it so the
+adapter layer inherits the same read-only contract.
+
+#839: the agent must never write catalog master data. Writes used to exist
+on the direct SQL path (``upsert_bangumi`` / ``upsert_point`` repos) and have
+been deleted; this protocol is the enforcement point — a write method added
+here is a review blocker.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from animichi.clients.catalog_client import (
+        GeocodeCandidate,
+        PilgrimagePoint,
+        ResolveOutcome,
+        Route,
+        SearchResult,
+    )
+
+
+@runtime_checkable
+class CatalogReadGateway(Protocol):
+    """Read-only catalog surface used by the agent domain.
+
+    Mirrors the catalog Worker RPCs the agent consumes today (search, points,
+    geocode, route planning). It deliberately declares no write/upsert/ingest
+    method: ingestion is the catalog Worker's job and any SQL write path in
+    the agent is a regression (see module docstring).
+    """
+
+    async def resolve(self, query: str) -> ResolveOutcome: ...
+
+    async def points_by_work_id(self, work_id: str) -> SearchResult: ...
+
+    async def nearby(
+        self, lat: float, lng: float, *, radius_m: int = 2000
+    ) -> list[PilgrimagePoint]: ...
+
+    async def geocode(
+        self, query: str, *, limit: int = 5
+    ) -> list[GeocodeCandidate]: ...
+
+    async def route(
+        self,
+        point_ids: list[str],
+        *,
+        origin: tuple[float, float] | None = None,
+        pacing: Literal["chill", "normal", "packed"] | None = None,
+    ) -> Route: ...

--- a/apps/agent/src/animichi/clients/__init__.py
+++ b/apps/agent/src/animichi/clients/__init__.py
@@ -5,9 +5,11 @@ service through :mod:`animichi.clients.catalog_client` (httpx). Seed scripts
 use their own scripts-local helpers under ``agent/scripts/``.
 """
 
+from animichi.application.catalog_read_gateway import CatalogReadGateway
 from animichi.clients.catalog_client import CatalogClient, CatalogClientProtocol
 
 __all__ = [
     "CatalogClient",
     "CatalogClientProtocol",
+    "CatalogReadGateway",
 ]

--- a/apps/agent/src/animichi/clients/catalog_client.py
+++ b/apps/agent/src/animichi/clients/catalog_client.py
@@ -32,6 +32,7 @@ from tenacity import (
 )
 
 from animichi.agents.models import TimedItinerary, TimedStop, TransitLeg
+from animichi.application.catalog_read_gateway import CatalogReadGateway
 from animichi.clients.catalog_errors import parse_catalog_error
 from animichi.clients.errors import APIError, TransientAPIError
 from animichi.clients.geocode import GeocodeCandidate, GeocodeKind, GeocodeSource
@@ -59,6 +60,7 @@ __all__ = [
     "TransitLeg",
     "CatalogClient",
     "CatalogClientProtocol",
+    "CatalogReadGateway",
     "GeocodeCandidate",
     "GeocodeKind",
     "GeocodeSource",
@@ -151,7 +153,14 @@ class Route(BaseModel):
 
 
 @runtime_checkable
-class CatalogClientProtocol(Protocol):
+class CatalogClientProtocol(CatalogReadGateway, Protocol):
+    """Read-only catalog protocol: the adapter-level mirror of the gateway.
+
+    Extends :class:`animichi.application.catalog_read_gateway.CatalogReadGateway`
+    so the adapter inherits the same read-only contract; ``CatalogClient``
+    satisfies it structurally.
+    """
+
     async def resolve(self, query: str) -> ResolveOutcome: ...
 
     async def points_by_work_id(self, work_id: str) -> SearchResult: ...

--- a/apps/agent/src/animichi/clients/catalog_client.py
+++ b/apps/agent/src/animichi/clients/catalog_client.py
@@ -161,26 +161,6 @@ class CatalogClientProtocol(CatalogReadGateway, Protocol):
     satisfies it structurally.
     """
 
-    async def resolve(self, query: str) -> ResolveOutcome: ...
-
-    async def points_by_work_id(self, work_id: str) -> SearchResult: ...
-
-    async def nearby(
-        self, lat: float, lng: float, *, radius_m: int = 2000
-    ) -> list[PilgrimagePoint]: ...
-
-    async def geocode(
-        self, query: str, *, limit: int = 5
-    ) -> list[GeocodeCandidate]: ...
-
-    async def route(
-        self,
-        point_ids: list[str],
-        *,
-        origin: tuple[float, float] | None = None,
-        pacing: Literal["chill", "normal", "packed"] | None = None,
-    ) -> Route: ...
-
 
 class CatalogClient:
     """Async client for the Catalog RPC methods over a shared httpx client.

--- a/apps/agent/src/animichi/domain/ports.py
+++ b/apps/agent/src/animichi/domain/ports.py
@@ -34,22 +34,16 @@ from typing import Protocol, runtime_checkable
 
 
 class BangumiRepo(Protocol):
-    """Bangumi-related DB operations used by handlers."""
+    """Bangumi-related DB operations used by handlers (read-only, #839).
+
+    Writes to catalog master data were deleted: the agent is a read-only
+    consumer and ingestion is the catalog Worker's job. Any write method
+    added back here is a review blocker.
+    """
 
     async def find_bangumi_by_title(self, title: str) -> str | None: ...
 
     async def find_all_by_title(self, title: str) -> list[dict[str, object]]: ...
-
-    async def upsert_bangumi_title(self, title: str, bangumi_id: str) -> None: ...
-
-    async def upsert_bangumi(
-        self,
-        bangumi_id: str,
-        *,
-        title: str | None = None,
-        cover_url: str | None = None,
-        points_count: int | None = None,
-    ) -> None: ...
 
     async def find_candidate_details_by_titles(
         self, titles: list[str]
@@ -59,7 +53,7 @@ class BangumiRepo(Protocol):
 
 
 class PointsRepo(Protocol):
-    """Pilgrimage point DB operations used by handlers."""
+    """Pilgrimage point DB operations used by handlers (read-only, #839)."""
 
     async def search_points_by_location(
         self,
@@ -73,8 +67,6 @@ class PointsRepo(Protocol):
     async def get_points_by_ids(
         self, point_ids: list[str]
     ) -> list[dict[str, object]]: ...
-
-    async def upsert_points_batch(self, rows: list[dict[str, object]]) -> None: ...
 
 
 @runtime_checkable

--- a/apps/agent/src/animichi/infrastructure/supabase/helpers.py
+++ b/apps/agent/src/animichi/infrastructure/supabase/helpers.py
@@ -1,106 +1,14 @@
 """Shared helpers for Supabase repository modules.
 
-Column allowlists, validation, and utility functions used across repositories.
+#839: the catalog write helpers (column allowlists, ``upsert`` SQL builders)
+were removed with the dual SQL write path — the agent is a read-only
+consumer of catalog master data. Remaining helpers serve the read and
+operational (session/route/feedback) repositories only.
 """
 
 from __future__ import annotations
 
-import json
-from collections.abc import Mapping, Sequence
-from numbers import Real
-
 from animichi.infrastructure.supabase.client_types import Row
-
-_BANGUMI_COLUMNS = frozenset(
-    {
-        "title",
-        "title_cn",
-        "cover_url",
-        "air_date",
-        "summary",
-        "eps_count",
-        "rating",
-        "points_count",
-        "primary_color",
-        "city",
-        "platform",
-    }
-)
-_POINT_COLUMNS = frozenset(
-    {
-        "bangumi_id",
-        "name",
-        "name_cn",
-        "latitude",
-        "longitude",
-        "episode",
-        "time_seconds",
-        "image",
-        "scene_desc",
-        "embedding",
-        "origin",
-        "origin_url",
-        "location",
-        "city",
-    }
-)
-
-
-def _validate_columns(columns: frozenset[str], fields: Mapping[str, object]) -> None:
-    """Raise ValueError if any field key is not in the allowlist."""
-    bad = set(fields.keys()) - columns
-    if bad:
-        raise ValueError(f"Invalid column names: {bad}")
-
-
-def _vector_literal(value: object) -> str:
-    """Normalize a vector value into pgvector's text literal format."""
-    if isinstance(value, str):
-        return value
-
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        items: list[str] = []
-        for item in value:
-            if not isinstance(item, Real):
-                raise TypeError("Embedding values must be numeric")
-            items.append(f"{float(item):g}")
-        return f"[{','.join(items)}]"
-
-    raise TypeError("Embedding must be a vector literal string or numeric sequence")
-
-
-def _prepare_point_fields(fields: dict[str, object]) -> dict[str, object]:
-    """Normalize point payloads before building dynamic SQL."""
-    prepared = dict(fields)
-    if "embedding" in prepared and prepared["embedding"] is not None:
-        prepared["embedding"] = _vector_literal(prepared["embedding"])
-    return prepared
-
-
-def _decode_json_list(raw: object) -> list[dict[str, object]]:
-    """Decode a JSON/JSONB payload into a list of dicts."""
-    if raw is None:
-        return []
-    if isinstance(raw, str):
-        decoded = json.loads(raw)
-    elif isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
-        decoded = raw
-    else:
-        return []
-
-    if not isinstance(decoded, Sequence):
-        return []
-
-    return [dict(item) for item in decoded if isinstance(item, Mapping)]
-
-
-def _point_placeholder(column: str, position: int) -> str:
-    """Return the SQL placeholder for a point column."""
-    if column == "location":
-        return f"ST_GeogFromText(${position})"
-    if column == "embedding":
-        return f"${position}::vector"
-    return f"${position}"
 
 
 def _require_row(row: Row | None, *, operation: str) -> Row:

--- a/apps/agent/src/animichi/infrastructure/supabase/repositories/bangumi.py
+++ b/apps/agent/src/animichi/infrastructure/supabase/repositories/bangumi.py
@@ -1,12 +1,8 @@
-"""Bangumi table operations."""
+"""Bangumi table operations (read-only, #839 — no writes to catalog master data)."""
 
 from __future__ import annotations
 
 from animichi.infrastructure.supabase.client_types import AsyncPGPool, Row
-from animichi.infrastructure.supabase.helpers import (
-    _BANGUMI_COLUMNS,
-    _validate_columns,
-)
 
 
 def _escape_ilike(value: str) -> str:
@@ -42,18 +38,6 @@ class BangumiRepository:
             "SELECT * FROM bangumi ORDER BY rating DESC NULLS LAST LIMIT $1",
             limit,
         )
-
-    async def upsert_bangumi(self, bangumi_id: str, **fields: object) -> None:
-        """Insert or update a bangumi record."""
-        _validate_columns(_BANGUMI_COLUMNS, fields)
-        columns = ["id"] + list(fields.keys())
-        placeholders = ", ".join(f"${i + 1}" for i in range(len(columns)))
-        update_set = ", ".join(f"{col} = EXCLUDED.{col}" for col in fields.keys())
-        sql = (
-            f"INSERT INTO bangumi ({', '.join(columns)}) VALUES ({placeholders}) "  # noqa: S608 — columns validated against _BANGUMI_COLUMNS allowlist, not user input
-            f"ON CONFLICT (id) DO UPDATE SET {update_set}"
-        )
-        await self._pool.execute(sql, bangumi_id, *fields.values())
 
     async def list_popular(self, *, limit: int = 8) -> list[dict[str, object]]:
         """List popular bangumi by rating, only those with points."""
@@ -126,18 +110,6 @@ class BangumiRepository:
             pattern,
         )
         return [dict(r) for r in rows]
-
-    async def upsert_bangumi_title(self, title: str, bangumi_id: str) -> None:
-        """Insert a bangumi title if the bangumi row does not already exist."""
-        await self._pool.execute(
-            """
-            INSERT INTO bangumi (id, title)
-            VALUES ($1, $2)
-            ON CONFLICT (id) DO NOTHING
-            """,
-            bangumi_id,
-            title,
-        )
 
     async def find_candidate_details_by_titles(
         self, titles: list[str]

--- a/apps/agent/src/animichi/infrastructure/supabase/repositories/points.py
+++ b/apps/agent/src/animichi/infrastructure/supabase/repositories/points.py
@@ -1,14 +1,8 @@
-"""Points table operations."""
+"""Points table operations (read-only, #839 — no writes to catalog master data)."""
 
 from __future__ import annotations
 
 from animichi.infrastructure.supabase.client_types import AsyncPGPool, Row
-from animichi.infrastructure.supabase.helpers import (
-    _POINT_COLUMNS,
-    _point_placeholder,
-    _prepare_point_fields,
-    _validate_columns,
-)
 
 
 class PointsRepository:
@@ -90,52 +84,3 @@ class PointsRepository:
             radius_m,
             limit,
         )
-
-    async def upsert_point(self, point_id: str, **fields: object) -> None:
-        """Insert or update a point record."""
-        _validate_columns(_POINT_COLUMNS, fields)
-        point_fields = _prepare_point_fields(fields)
-
-        columns = ["id"] + list(point_fields.keys())
-        values: list[object] = [point_id] + list(point_fields.values())
-        placeholders = [
-            _point_placeholder(column, i + 1) for i, column in enumerate(columns)
-        ]
-
-        update_columns = list(point_fields.keys())
-        update_set = ", ".join(f"{col} = EXCLUDED.{col}" for col in update_columns)
-
-        sql = (
-            f"INSERT INTO points ({', '.join(columns)}) VALUES ({', '.join(placeholders)}) "  # noqa: S608 — columns validated against _POINT_COLUMNS allowlist, not user input
-            f"ON CONFLICT (id) DO UPDATE SET {update_set}"
-        )
-        await self._pool.execute(sql, *values)
-
-    async def upsert_points_batch(self, rows: list[dict[str, object]]) -> int:
-        """Batch upsert points. Returns the number of rows upserted."""
-        if not rows:
-            return 0
-
-        prepared_rows = [_prepare_point_fields(row) for row in rows]
-        first = prepared_rows[0]
-        fields_sample = {k: v for k, v in first.items() if k != "id"}
-        _validate_columns(_POINT_COLUMNS, fields_sample)
-
-        columns = ["id"] + list(fields_sample.keys())
-        placeholders = [
-            _point_placeholder(column, i + 1) for i, column in enumerate(columns)
-        ]
-        update_set = ", ".join(f"{col} = EXCLUDED.{col}" for col in fields_sample)
-
-        sql = (
-            f"INSERT INTO points ({', '.join(columns)}) VALUES ({', '.join(placeholders)}) "  # noqa: S608 — columns validated against _POINT_COLUMNS allowlist, not user input
-            f"ON CONFLICT (id) DO UPDATE SET {update_set}"
-        )
-
-        args = [tuple(row.get(col) for col in columns) for row in prepared_rows]
-
-        async with self._pool.acquire() as conn:
-            async with conn.transaction():
-                await conn.executemany(sql, args)
-
-        return len(rows)

--- a/apps/agent/src/animichi/tests/eval/null_database.py
+++ b/apps/agent/src/animichi/tests/eval/null_database.py
@@ -20,19 +20,6 @@ class _NullBangumiRepo:
     async def find_all_by_title(self, title: str) -> NoReturn:
         _raise_access("bangumi", "find_all_by_title")
 
-    async def upsert_bangumi_title(self, title: str, bangumi_id: str) -> NoReturn:
-        _raise_access("bangumi", "upsert_bangumi_title")
-
-    async def upsert_bangumi(
-        self,
-        bangumi_id: str,
-        *,
-        title: str | None = None,
-        cover_url: str | None = None,
-        points_count: int | None = None,
-    ) -> NoReturn:
-        _raise_access("bangumi", "upsert_bangumi")
-
     async def find_candidate_details_by_titles(self, titles: list[str]) -> NoReturn:
         _raise_access("bangumi", "find_candidate_details_by_titles")
 
@@ -53,9 +40,6 @@ class _NullPointsRepo:
 
     async def get_points_by_ids(self, point_ids: list[str]) -> NoReturn:
         _raise_access("points", "get_points_by_ids")
-
-    async def upsert_points_batch(self, rows: object) -> NoReturn:
-        _raise_access("points", "upsert_points_batch")
 
 
 _BANGUMI_REPO: BangumiRepo = _NullBangumiRepo()

--- a/apps/agent/src/animichi/tests/unit/repositories/test_bangumi_repo.py
+++ b/apps/agent/src/animichi/tests/unit/repositories/test_bangumi_repo.py
@@ -72,17 +72,6 @@ async def test_list_bangumi_returns_list(
     pool.fetch.assert_awaited_once()
 
 
-async def test_upsert_bangumi_calls_execute(
-    repo: BangumiRepository, pool: AsyncMock
-) -> None:
-    pool.execute.return_value = None
-    await repo.upsert_bangumi("115908", title="Liz")
-    pool.execute.assert_awaited_once()
-    sql = pool.execute.await_args.args[0]
-    assert "INSERT INTO bangumi" in sql
-    assert "ON CONFLICT (id)" in sql
-
-
 async def test_find_bangumi_by_title_returns_id(
     repo: BangumiRepository, pool: AsyncMock
 ) -> None:

--- a/apps/agent/src/animichi/tests/unit/repositories/test_points_repo.py
+++ b/apps/agent/src/animichi/tests/unit/repositories/test_points_repo.py
@@ -67,14 +67,3 @@ async def test_search_points_by_location_returns_rows(
     result = await repo.search_points_by_location(34.88, 135.80, 5000)
     assert len(result) == 1
     pool.fetch.assert_awaited_once()
-
-
-async def test_upsert_point_calls_execute(
-    repo: PointsRepository, pool: AsyncMock
-) -> None:
-    pool.execute.return_value = None
-    await repo.upsert_point("p1", bangumi_id="115908", name="Uji")
-    pool.execute.assert_awaited_once()
-    sql = pool.execute.await_args.args[0]
-    assert "INSERT INTO points" in sql
-    assert "ON CONFLICT (id)" in sql

--- a/apps/agent/src/animichi/tests/unit/test_catalog_read_gateway.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_read_gateway.py
@@ -39,6 +39,43 @@ def _gateway_methods() -> set[str]:
     }
 
 
+def _imported_module_names(module: ast.Module) -> list[str]:
+    names: list[str] = []
+    for node in ast.walk(module):
+        if isinstance(node, ast.ImportFrom):
+            names.append(node.module or "")
+        elif isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+    return names
+
+
+class _FakeReadGateway:
+    """Structural stand-in for CatalogClient; never touches the network."""
+
+    async def resolve(self, query: str) -> object:
+        return object()
+
+    async def points_by_work_id(self, work_id: str) -> object:
+        return object()
+
+    async def nearby(
+        self, lat: float, lng: float, *, radius_m: int = 2000
+    ) -> list[object]:
+        return []
+
+    async def geocode(self, query: str, *, limit: int = 5) -> list[object]:
+        return []
+
+    async def route(
+        self,
+        point_ids: list[str],
+        *,
+        origin: object | None = None,
+        pacing: object | None = None,
+    ) -> object:
+        return object()
+
+
 def test_gateway_protocol_is_read_only() -> None:
     assert _gateway_methods() == _ALLOWED_READ_METHODS
     for name in _gateway_methods():
@@ -55,12 +92,19 @@ def test_catalog_client_protocol_extends_gateway() -> None:
 
 
 def test_gateway_has_no_framework_runtime_imports() -> None:
-    source = Path(inspect.getfile(CatalogReadGateway)).read_text()
-    module = ast.parse(source)
-    imports = [
-        node.module or ""
-        for node in ast.walk(module)
-        if isinstance(node, ast.ImportFrom)
-    ]
+    source = Path(inspect.getfile(CatalogReadGateway)).read_text(encoding="utf-8")
+    imports = _imported_module_names(ast.parse(source))
     for name in _FORBIDDEN_RUNTIME_IMPORTS:
         assert not any(item.startswith(name) for item in imports)
+
+
+def test_fake_gateway_satisfies_read_protocol() -> None:
+    fake = _FakeReadGateway()
+    assert isinstance(fake, CatalogReadGateway)
+    for name in _ALLOWED_READ_METHODS:
+        assert inspect.iscoroutinefunction(getattr(fake, name))
+
+
+def test_gateway_methods_are_awaitable_contracts() -> None:
+    for name in _ALLOWED_READ_METHODS:
+        assert inspect.iscoroutinefunction(getattr(CatalogReadGateway, name))

--- a/apps/agent/src/animichi/tests/unit/test_catalog_read_gateway.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_read_gateway.py
@@ -1,0 +1,66 @@
+"""Read-only contract tests for the catalog read gateway (#839)."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+from animichi.application.catalog_read_gateway import CatalogReadGateway
+from animichi.clients.catalog_client import (
+    CatalogClient,
+    CatalogClientProtocol,
+)
+
+_ALLOWED_READ_METHODS = frozenset(
+    {"resolve", "points_by_work_id", "nearby", "geocode", "route"}
+)
+_WRITE_VERBS = frozenset(
+    {
+        "upsert",
+        "insert",
+        "write",
+        "update",
+        "ingest",
+        "save",
+        "create",
+        "delete",
+        "post",
+    }
+)
+_FORBIDDEN_RUNTIME_IMPORTS = ("fastapi", "pydantic_ai", "httpx")
+
+
+def _gateway_methods() -> set[str]:
+    return {
+        name
+        for name, member in inspect.getmembers(CatalogReadGateway, inspect.isfunction)
+        if not name.startswith("_")
+    }
+
+
+def test_gateway_protocol_is_read_only() -> None:
+    assert _gateway_methods() == _ALLOWED_READ_METHODS
+    for name in _gateway_methods():
+        assert not any(verb in name for verb in _WRITE_VERBS)
+
+
+def test_catalog_client_satisfies_gateway_structural() -> None:
+    client = CatalogClient("https://catalog.test")
+    assert isinstance(client, CatalogReadGateway)
+
+
+def test_catalog_client_protocol_extends_gateway() -> None:
+    assert issubclass(CatalogClientProtocol, CatalogReadGateway)
+
+
+def test_gateway_has_no_framework_runtime_imports() -> None:
+    source = Path(inspect.getfile(CatalogReadGateway)).read_text()
+    module = ast.parse(source)
+    imports = [
+        node.module or ""
+        for node in ast.walk(module)
+        if isinstance(node, ast.ImportFrom)
+    ]
+    for name in _FORBIDDEN_RUNTIME_IMPORTS:
+        assert not any(item.startswith(name) for item in imports)

--- a/apps/agent/src/animichi/tests/unit/test_catalog_read_gateway.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_read_gateway.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import inspect
 from pathlib import Path
+from typing import cast
 
 from animichi.application.catalog_read_gateway import CatalogReadGateway
 from animichi.clients.catalog_client import (
@@ -52,19 +53,22 @@ def _imported_module_names(module: ast.Module) -> list[str]:
 class _FakeReadGateway:
     """Structural stand-in for CatalogClient; never touches the network."""
 
-    async def resolve(self, query: str) -> object:
+    async def _noop(self, *args: object, **kwargs: object) -> object:
         return object()
 
+    async def resolve(self, query: str) -> object:
+        return await self._noop(query)
+
     async def points_by_work_id(self, work_id: str) -> object:
-        return object()
+        return await self._noop(work_id)
 
     async def nearby(
         self, lat: float, lng: float, *, radius_m: int = 2000
     ) -> list[object]:
-        return []
+        return cast(list[object], await self._noop(lat, lng, radius_m=radius_m))
 
     async def geocode(self, query: str, *, limit: int = 5) -> list[object]:
-        return []
+        return cast(list[object], await self._noop(query, limit=limit))
 
     async def route(
         self,
@@ -73,7 +77,7 @@ class _FakeReadGateway:
         origin: object | None = None,
         pacing: object | None = None,
     ) -> object:
-        return object()
+        return await self._noop(point_ids, origin=origin, pacing=pacing)
 
 
 def test_gateway_protocol_is_read_only() -> None:

--- a/apps/agent/src/animichi/tests/unit/test_eval_null_database.py
+++ b/apps/agent/src/animichi/tests/unit/test_eval_null_database.py
@@ -21,14 +21,6 @@ async def _find_all_by_title(db: NullDatabase) -> object:
     return await db.bangumi.find_all_by_title("title")
 
 
-async def _upsert_bangumi_title(db: NullDatabase) -> object:
-    return await db.bangumi.upsert_bangumi_title("title", "bgm-1")
-
-
-async def _upsert_bangumi(db: NullDatabase) -> object:
-    return await db.bangumi.upsert_bangumi("bgm-1", title="title")
-
-
 async def _find_candidate_details_by_titles(db: NullDatabase) -> object:
     return await db.bangumi.find_candidate_details_by_titles(["title"])
 
@@ -41,10 +33,6 @@ async def _get_points_by_ids(db: NullDatabase) -> object:
     return await db.points.get_points_by_ids(["point-1"])
 
 
-async def _upsert_points_batch(db: NullDatabase) -> object:
-    return await db.points.upsert_points_batch([])
-
-
 def test_null_database_satisfies_database_port() -> None:
     assert isinstance(NullDatabase(), CatalogLookup)
 
@@ -54,12 +42,9 @@ def test_null_database_satisfies_database_port() -> None:
     [
         ("bangumi.find_bangumi_by_title", _find_bangumi_by_title),
         ("bangumi.find_all_by_title", _find_all_by_title),
-        ("bangumi.upsert_bangumi_title", _upsert_bangumi_title),
-        ("bangumi.upsert_bangumi", _upsert_bangumi),
         ("bangumi.find_candidate_details_by_titles", _find_candidate_details_by_titles),
         ("points.search_points_by_location", _search_points_by_location),
         ("points.get_points_by_ids", _get_points_by_ids),
-        ("points.upsert_points_batch", _upsert_points_batch),
     ],
 )
 async def test_repo_methods_raise(method_name: str, call: RepoCall) -> None:

--- a/apps/agent/src/animichi/tests/unit/test_supabase_client.py
+++ b/apps/agent/src/animichi/tests/unit/test_supabase_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -29,103 +29,6 @@ def _make_client(pool: AsyncMock) -> SupabaseClient:
     client._messages = None
     client._init_repos(pool)
     return client
-
-
-@pytest.mark.asyncio
-async def test_upsert_point_uses_geography_cast_for_location() -> None:
-    pool = AsyncMock()
-    client = _make_client(pool)
-
-    await client.points.upsert_point(
-        "p1",
-        bangumi_id="115908",
-        name="宇治桥",
-        name_cn="宇治桥",
-        episode=1,
-        time_seconds=42,
-        image="https://example.com/point.jpg",
-        location="POINT(135.7997 34.8843)",
-    )
-
-    sql = pool.execute.await_args.args[0]
-    assert "ST_GeogFromText" in sql
-    assert pool.execute.await_args.args[-1] == "POINT(135.7997 34.8843)"
-
-
-@pytest.mark.asyncio
-async def test_upsert_points_batch_accepts_latitude_and_longitude() -> None:
-    conn = MagicMock()
-    conn.executemany = AsyncMock()
-    tx = AsyncMock()
-    tx.__aenter__.return_value = tx
-    tx.__aexit__.return_value = None
-    conn.transaction.return_value = tx
-
-    acquire_ctx = AsyncMock()
-    acquire_ctx.__aenter__.return_value = conn
-    acquire_ctx.__aexit__.return_value = None
-
-    pool = MagicMock()
-    pool.acquire.return_value = acquire_ctx
-    client = _make_client(pool)
-
-    await client.points.upsert_points_batch(
-        [
-            {
-                "id": "p1",
-                "bangumi_id": "115908",
-                "name": "宇治桥",
-                "name_cn": "宇治桥",
-                "latitude": 34.8843,
-                "longitude": 135.7997,
-                "episode": 1,
-                "time_seconds": 42,
-                "image": "https://example.com/point.jpg",
-                "location": "POINT(135.7997 34.8843)",
-            }
-        ]
-    )
-
-    sql = conn.executemany.await_args.args[0]
-    args = conn.executemany.await_args.args[1]
-    assert "latitude" in sql
-    assert "longitude" in sql
-    assert "ST_GeogFromText" in sql
-    assert args == [
-        (
-            "p1",
-            "115908",
-            "宇治桥",
-            "宇治桥",
-            34.8843,
-            135.7997,
-            1,
-            42,
-            "https://example.com/point.jpg",
-            "POINT(135.7997 34.8843)",
-        )
-    ]
-
-
-@pytest.mark.asyncio
-async def test_upsert_point_casts_embedding_to_vector() -> None:
-    pool = AsyncMock()
-    client = _make_client(pool)
-
-    await client.points.upsert_point(
-        "p1",
-        bangumi_id="115908",
-        name="宇治桥",
-        latitude=34.8843,
-        longitude=135.7997,
-        embedding=[0.1, 0.2, 0.3],
-    )
-
-    sql = pool.execute.await_args.args[0]
-    args = pool.execute.await_args.args[1:]
-    assert "embedding" in sql
-    assert "::vector" in sql
-    assert args[-1] == "[0.1,0.2,0.3]"
 
 
 @pytest.mark.asyncio
@@ -185,16 +88,6 @@ class TestGetPointsByIds:
         ]
         sql = mock_pool.fetch.await_args.args[0]
         assert "WITH ORDINALITY" in sql
-
-
-class TestUpsertBangumiTitle:
-    async def test_upserts_title(self, mock_pool):
-        mock_pool.execute.return_value = None
-        client = _make_client(mock_pool)
-        await client.bangumi.upsert_bangumi_title("進撃の巨人", "6718")
-        mock_pool.execute.assert_awaited_once()
-        sql, *args = mock_pool.execute.call_args[0]
-        assert "6718" in args or "進撃の巨人" in args
 
 
 @pytest.fixture


### PR DESCRIPTION
## Parent
#829 · Closes #839

## What
- `CatalogReadGateway` protocol (read-only catalog RPCs)
- Remove dual master-data write paths from agent bangumi/points SQL repos
- Layering note: agents/ = framework adapter

## Verify
```bash
cd apps/agent && uv run pytest src/animichi/tests/unit/repositories \
  src/animichi/tests/unit/test_catalog_read_gateway.py \
  src/animichi/tests/unit/test_supabase_client.py -q --cov-fail-under=0
# 78+ related tests pass
```

## Matt code-review
### Spec
Single read gateway + kill dual write — met. HandleUserMessage is #840.

### Standards
Protocol seam; no FastAPI import in application gateway.

Executor: opencode-go/deepseek-v4-flash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only catalog access contract supporting search, location lookup, geocoding, and route planning.
  * Exposed the catalog access contract through the client package.
* **Changes**
  * Catalog and repository interfaces are now explicitly read-only.
  * Removed catalog and point data write operations.
* **Tests**
  * Added coverage validating the read-only contract and compatibility with existing catalog clients.
  * Updated tests to reflect the removal of write functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->