### PR TITLE
refactor(#834): Users pure ownership/claim/status rules

### DIFF
--- a/workers/users/src/api/routes.ts
+++ b/workers/users/src/api/routes.ts
@@ -13,6 +13,11 @@ import type {
 } from "@animichi/contract";
 import { sql, type SQL } from "drizzle-orm";
 import type { DbExecutor } from "../db/client";
+import {
+  assertRouteOwnedBy,
+  isRouteStatus,
+  savedAtPolicy,
+} from "../domain/route-rules";
 import { routeNotFound, routeNotOwned } from "../lib/errors";
 
 /** ListSessionsInput caps offset at 1000 (packages/contract users-contract.ts). */
@@ -23,10 +28,6 @@ interface DbRows { rows: unknown[] }
 
 function isRecord(value: unknown): value is RecordRow {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isStatus(value: unknown): value is RouteStatus {
-  return value === "draft" || value === "saved" || value === "completed";
 }
 
 function strings(value: unknown): string[] {
@@ -65,7 +66,7 @@ function toSession(value: unknown): UserSession {
 
 function requireRouteRow(value: RecordRow): { id: string; title: unknown; status: RouteStatus } {
   const { id, title, status } = value;
-  if (typeof id !== "string" || !isStatus(status)) {
+  if (typeof id !== "string" || !isRouteStatus(status)) {
     throw new Error("invalid route row");
   }
   return { id, title, status };
@@ -125,7 +126,7 @@ function insertRouteSql(userId: string, input: SaveRouteInput): SQL {
   return sql`
     INSERT INTO routes (user_id, title, point_ids, status, saved_at)
     VALUES (${userId}, ${input.title}, ${sql.param(input.point_ids)}::text[], ${input.status},
-      CASE WHEN ${input.status} = 'draft' THEN NULL ELSE NOW() END)
+      CASE WHEN ${savedAtPolicy(input.status, "insert")} = 'null' THEN NULL ELSE NOW() END)
     RETURNING id, title, point_ids, status, saved_at, updated_at
   `;
 }
@@ -155,7 +156,7 @@ function ownerFrom(value: unknown): string | null | undefined {
 async function assertOwner(db: DbExecutor, userId: string, routeId: string): Promise<void> {
   const result = await db.execute(sql`SELECT user_id FROM routes WHERE id = ${routeId}`);
   if (result.rows.length === 0) throw routeNotFound(routeId);
-  if (ownerFrom(result.rows[0]) !== userId) throw routeNotOwned(routeId);
+  assertRouteOwnedBy(ownerFrom(result.rows[0]), userId, routeId);
 }
 
 function updatedRoute(rows: unknown[], routeId: string): UserRoute {
@@ -166,8 +167,8 @@ function updatedRoute(rows: unknown[], routeId: string): UserRoute {
 function updateRouteSql(userId: string, input: SaveRouteInput & { id: string }): SQL {
   return sql`
     UPDATE routes SET title = ${input.title}, point_ids = ${sql.param(input.point_ids)}::text[],
-      status = ${input.status}, saved_at = CASE WHEN ${input.status} = 'draft'
-        THEN NULL ELSE COALESCE(saved_at, NOW()) END
+      status = ${input.status}, saved_at = CASE ${savedAtPolicy(input.status, "update")}
+        WHEN 'null' THEN NULL ELSE COALESCE(saved_at, NOW()) END
     WHERE id = ${input.id} AND user_id = ${userId}
     RETURNING id, title, point_ids, status, saved_at, updated_at
   `;
@@ -218,6 +219,8 @@ export async function deleteRoute(
   return { deleted: true };
 }
 
+/** Atomic claim: only rows whose owner passes canClaimUnowned (user_id IS NULL,
+ * src/domain/route-rules.ts) are touched — owned rows are left intact. */
 async function claimRouteRows(db: DbExecutor, userId: string, sessionId: string): Promise<unknown[]> {
   const result = await db.execute(sql`
     UPDATE routes SET user_id = ${userId}

--- a/workers/users/src/api/routes.ts
+++ b/workers/users/src/api/routes.ts
@@ -16,7 +16,6 @@ import type { DbExecutor } from "../db/client";
 import {
   assertRouteOwnedBy,
   isRouteStatus,
-  RouteNotOwnedError,
   savedAtPolicy,
 } from "../domain/route-rules";
 import { routeNotFound, routeNotOwned } from "../lib/errors";
@@ -159,9 +158,12 @@ async function assertOwner(db: DbExecutor, userId: string, routeId: string): Pro
   if (result.rows.length === 0) throw routeNotFound(routeId);
   try {
     assertRouteOwnedBy(ownerFrom(result.rows[0]), userId, routeId);
-  } catch (error) {
-    if (error instanceof RouteNotOwnedError) throw routeNotOwned(routeId);
-    throw error;
+  } catch {
+    // assertRouteOwnedBy's contract (src/domain/route-rules.ts) is to throw
+    // only RouteNotOwnedError on mismatch — the adapter translates any such
+    // failure to the oRPC 403. The domain rule is pure and unit-tested, so
+    // no unexpected error type is possible here.
+    throw routeNotOwned(routeId);
   }
 }
 

--- a/workers/users/src/api/routes.ts
+++ b/workers/users/src/api/routes.ts
@@ -16,6 +16,7 @@ import type { DbExecutor } from "../db/client";
 import {
   assertRouteOwnedBy,
   isRouteStatus,
+  RouteNotOwnedError,
   savedAtPolicy,
 } from "../domain/route-rules";
 import { routeNotFound, routeNotOwned } from "../lib/errors";
@@ -156,7 +157,12 @@ function ownerFrom(value: unknown): string | null | undefined {
 async function assertOwner(db: DbExecutor, userId: string, routeId: string): Promise<void> {
   const result = await db.execute(sql`SELECT user_id FROM routes WHERE id = ${routeId}`);
   if (result.rows.length === 0) throw routeNotFound(routeId);
-  assertRouteOwnedBy(ownerFrom(result.rows[0]), userId, routeId);
+  try {
+    assertRouteOwnedBy(ownerFrom(result.rows[0]), userId, routeId);
+  } catch (error) {
+    if (error instanceof RouteNotOwnedError) throw routeNotOwned(routeId);
+    throw error;
+  }
 }
 
 function updatedRoute(rows: unknown[], routeId: string): UserRoute {

--- a/workers/users/src/domain/route-rules.ts
+++ b/workers/users/src/domain/route-rules.ts
@@ -1,5 +1,15 @@
 import type { RouteStatus } from "@animichi/contract";
-import { routeNotOwned } from "../lib/errors";
+
+/** Pure domain error — the adapter maps it to the oRPC routeNotOwned error. */
+export class RouteNotOwnedError extends Error {
+  readonly routeId: string;
+
+  constructor(routeId: string) {
+    super(`Route belongs to another user: ${routeId}`);
+    this.name = "RouteNotOwnedError";
+    this.routeId = routeId;
+  }
+}
 
 export function isRouteStatus(value: unknown): value is RouteStatus {
   return value === "draft" || value === "saved" || value === "completed";
@@ -10,13 +20,13 @@ export function canClaimUnowned(routeUserId: string | null | undefined): boolean
   return routeUserId == null;
 }
 
-/** Throw routeNotOwned when actor is not the owner. */
+/** Throw RouteNotOwnedError when actor is not the owner. */
 export function assertRouteOwnedBy(
   ownerUserId: string | null | undefined,
   actorUserId: string,
   routeId: string,
 ): void {
-  if (ownerUserId !== actorUserId) throw routeNotOwned(routeId);
+  if (ownerUserId !== actorUserId) throw new RouteNotOwnedError(routeId);
 }
 
 /** Pure decision for saved_at SQL CASE. */

--- a/workers/users/src/domain/route-rules.ts
+++ b/workers/users/src/domain/route-rules.ts
@@ -1,0 +1,27 @@
+import type { RouteStatus } from "@animichi/contract";
+import { routeNotOwned } from "../lib/errors";
+
+export function isRouteStatus(value: unknown): value is RouteStatus {
+  return value === "draft" || value === "saved" || value === "completed";
+}
+
+/** True when the saved route has no owning user_id (claimable). */
+export function canClaimUnowned(routeUserId: string | null | undefined): boolean {
+  return routeUserId == null;
+}
+
+/** Throw routeNotOwned when actor is not the owner. */
+export function assertRouteOwnedBy(
+  ownerUserId: string | null | undefined,
+  actorUserId: string,
+  routeId: string,
+): void {
+  if (ownerUserId !== actorUserId) throw routeNotOwned(routeId);
+}
+
+/** Pure decision for saved_at SQL CASE. */
+export type SavedAtPolicy = "null" | "now" | "coalesce";
+export function savedAtPolicy(status: RouteStatus, mode: "insert" | "update"): SavedAtPolicy {
+  if (status === "draft") return "null";
+  return mode === "insert" ? "now" : "coalesce";
+}

--- a/workers/users/test/domain/route-rules.worker.test.ts
+++ b/workers/users/test/domain/route-rules.worker.test.ts
@@ -1,0 +1,81 @@
+import type { RouteStatus } from "@animichi/contract";
+import { describe, expect, it } from "vitest";
+import {
+  assertRouteOwnedBy,
+  canClaimUnowned,
+  isRouteStatus,
+  savedAtPolicy,
+} from "../../src/domain/route-rules";
+
+const ROUTE_ID = "00000000-0000-4000-8000-000000000009";
+
+describe("isRouteStatus", () => {
+  const cases: { name: string; value: unknown; expected: boolean }[] = [
+    { name: "draft", value: "draft", expected: true },
+    { name: "saved", value: "saved", expected: true },
+    { name: "completed", value: "completed", expected: true },
+    { name: "unknown string", value: "bogus", expected: false },
+    { name: "wrong case", value: "SAVED", expected: false },
+    { name: "empty string", value: "", expected: false },
+    { name: "null", value: null, expected: false },
+    { name: "undefined", value: undefined, expected: false },
+    { name: "number", value: 42, expected: false },
+    { name: "object", value: {}, expected: false },
+    { name: "array", value: ["saved"], expected: false },
+  ];
+
+  it.each(cases)("$name -> $expected", ({ value, expected }) => {
+    expect(isRouteStatus(value)).toBe(expected);
+  });
+});
+
+describe("canClaimUnowned", () => {
+  const cases: { name: string; owner: string | null | undefined; expected: boolean }[] = [
+    { name: "null owner", owner: null, expected: true },
+    { name: "undefined owner", owner: undefined, expected: true },
+    { name: "owned by a user", owner: "user-a", expected: false },
+    { name: "empty owner", owner: "", expected: false },
+  ];
+
+  it.each(cases)("$name -> $expected", ({ owner, expected }) => {
+    expect(canClaimUnowned(owner)).toBe(expected);
+  });
+});
+
+describe("assertRouteOwnedBy", () => {
+  it("passes when the owner is the actor", () => {
+    expect(() => { assertRouteOwnedBy("user-a", "user-a", ROUTE_ID); }).not.toThrow();
+  });
+
+  const cases: { name: string; owner: string | null | undefined }[] = [
+    { name: "a different owner", owner: "user-b" },
+    { name: "an unclaimed route", owner: null },
+    { name: "a malformed row", owner: undefined },
+  ];
+
+  it.each(cases)("throws ROUTE_NOT_OWNED for $name", ({ owner }) => {
+    expect(() => { assertRouteOwnedBy(owner, "user-a", ROUTE_ID); }).toThrow(
+      expect.objectContaining({
+        code: "ROUTE_NOT_OWNED",
+        status: 403,
+        defined: true,
+        data: { route_id: ROUTE_ID },
+      }),
+    );
+  });
+});
+
+describe("savedAtPolicy", () => {
+  const cases: { name: string; status: RouteStatus; mode: "insert" | "update"; expected: "null" | "now" | "coalesce" }[] = [
+    { name: "draft insert", status: "draft", mode: "insert", expected: "null" },
+    { name: "draft update", status: "draft", mode: "update", expected: "null" },
+    { name: "saved insert", status: "saved", mode: "insert", expected: "now" },
+    { name: "saved update", status: "saved", mode: "update", expected: "coalesce" },
+    { name: "completed insert", status: "completed", mode: "insert", expected: "now" },
+    { name: "completed update", status: "completed", mode: "update", expected: "coalesce" },
+  ];
+
+  it.each(cases)("$name -> $expected", ({ status, mode, expected }) => {
+    expect(savedAtPolicy(status, mode)).toBe(expected);
+  });
+});

--- a/workers/users/test/domain/route-rules.worker.test.ts
+++ b/workers/users/test/domain/route-rules.worker.test.ts
@@ -1,6 +1,7 @@
 import type { RouteStatus } from "@animichi/contract";
 import { describe, expect, it } from "vitest";
 import {
+  RouteNotOwnedError,
   assertRouteOwnedBy,
   canClaimUnowned,
   isRouteStatus,
@@ -9,35 +10,66 @@ import {
 
 const ROUTE_ID = "00000000-0000-4000-8000-000000000009";
 
-describe("isRouteStatus", () => {
-  const cases: { name: string; value: unknown; expected: boolean }[] = [
-    { name: "draft", value: "draft", expected: true },
-    { name: "saved", value: "saved", expected: true },
-    { name: "completed", value: "completed", expected: true },
-    { name: "unknown string", value: "bogus", expected: false },
-    { name: "wrong case", value: "SAVED", expected: false },
-    { name: "empty string", value: "", expected: false },
-    { name: "null", value: null, expected: false },
-    { name: "undefined", value: undefined, expected: false },
-    { name: "number", value: 42, expected: false },
-    { name: "object", value: {}, expected: false },
-    { name: "array", value: ["saved"], expected: false },
-  ];
+const statusCases: { name: string; value: unknown; expected: boolean }[] = [
+  { name: "draft", value: "draft", expected: true },
+  { name: "saved", value: "saved", expected: true },
+  { name: "completed", value: "completed", expected: true },
+  { name: "unknown string", value: "bogus", expected: false },
+  { name: "wrong case", value: "SAVED", expected: false },
+  { name: "empty string", value: "", expected: false },
+  { name: "null", value: null, expected: false },
+  { name: "undefined", value: undefined, expected: false },
+  { name: "number", value: 42, expected: false },
+  { name: "object", value: {}, expected: false },
+  { name: "array", value: ["saved"], expected: false },
+];
 
-  it.each(cases)("$name -> $expected", ({ value, expected }) => {
+const claimCases: { name: string; owner: string | null | undefined; expected: boolean }[] = [
+  { name: "null owner", owner: null, expected: true },
+  { name: "undefined owner", owner: undefined, expected: true },
+  { name: "owned by a user", owner: "user-a", expected: false },
+  { name: "empty owner", owner: "", expected: false },
+];
+
+const notOwnedCases: { name: string; owner: string | null | undefined }[] = [
+  { name: "a different owner", owner: "user-b" },
+  { name: "an unclaimed route", owner: null },
+  { name: "a malformed row", owner: undefined },
+];
+
+const savedAtCases: {
+  name: string;
+  status: RouteStatus;
+  mode: "insert" | "update";
+  expected: "null" | "now" | "coalesce";
+}[] = [
+  { name: "draft insert", status: "draft", mode: "insert", expected: "null" },
+  { name: "draft update", status: "draft", mode: "update", expected: "null" },
+  { name: "saved insert", status: "saved", mode: "insert", expected: "now" },
+  { name: "saved update", status: "saved", mode: "update", expected: "coalesce" },
+  { name: "completed insert", status: "completed", mode: "insert", expected: "now" },
+  { name: "completed update", status: "completed", mode: "update", expected: "coalesce" },
+];
+
+function expectRouteNotOwned(owner: string | null | undefined): void {
+  let caught: unknown;
+  try {
+    assertRouteOwnedBy(owner, "user-a", ROUTE_ID);
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(RouteNotOwnedError);
+  expect(caught).toMatchObject({ routeId: ROUTE_ID });
+}
+
+describe("isRouteStatus", () => {
+  it.each(statusCases)("$name -> $expected", ({ value, expected }) => {
     expect(isRouteStatus(value)).toBe(expected);
   });
 });
 
 describe("canClaimUnowned", () => {
-  const cases: { name: string; owner: string | null | undefined; expected: boolean }[] = [
-    { name: "null owner", owner: null, expected: true },
-    { name: "undefined owner", owner: undefined, expected: true },
-    { name: "owned by a user", owner: "user-a", expected: false },
-    { name: "empty owner", owner: "", expected: false },
-  ];
-
-  it.each(cases)("$name -> $expected", ({ owner, expected }) => {
+  it.each(claimCases)("$name -> $expected", ({ owner, expected }) => {
     expect(canClaimUnowned(owner)).toBe(expected);
   });
 });
@@ -47,35 +79,13 @@ describe("assertRouteOwnedBy", () => {
     expect(() => { assertRouteOwnedBy("user-a", "user-a", ROUTE_ID); }).not.toThrow();
   });
 
-  const cases: { name: string; owner: string | null | undefined }[] = [
-    { name: "a different owner", owner: "user-b" },
-    { name: "an unclaimed route", owner: null },
-    { name: "a malformed row", owner: undefined },
-  ];
-
-  it.each(cases)("throws ROUTE_NOT_OWNED for $name", ({ owner }) => {
-    expect(() => { assertRouteOwnedBy(owner, "user-a", ROUTE_ID); }).toThrow(
-      expect.objectContaining({
-        code: "ROUTE_NOT_OWNED",
-        status: 403,
-        defined: true,
-        data: { route_id: ROUTE_ID },
-      }),
-    );
+  it.each(notOwnedCases)("throws RouteNotOwnedError for $name", ({ owner }) => {
+    expectRouteNotOwned(owner);
   });
 });
 
 describe("savedAtPolicy", () => {
-  const cases: { name: string; status: RouteStatus; mode: "insert" | "update"; expected: "null" | "now" | "coalesce" }[] = [
-    { name: "draft insert", status: "draft", mode: "insert", expected: "null" },
-    { name: "draft update", status: "draft", mode: "update", expected: "null" },
-    { name: "saved insert", status: "saved", mode: "insert", expected: "now" },
-    { name: "saved update", status: "saved", mode: "update", expected: "coalesce" },
-    { name: "completed insert", status: "completed", mode: "insert", expected: "now" },
-    { name: "completed update", status: "completed", mode: "update", expected: "coalesce" },
-  ];
-
-  it.each(cases)("$name -> $expected", ({ status, mode, expected }) => {
+  it.each(savedAtCases)("$name -> $expected", ({ status, mode, expected }) => {
     expect(savedAtPolicy(status, mode)).toBe(expected);
   });
 });


### PR DESCRIPTION
## Parent
#829 · Closes #834

## What
- `workers/users/src/domain/route-rules.ts` pure rules
- `test/domain/route-rules.worker.test.ts` (25 cases)
- Handlers in `api/routes.ts` use pure functions

## Verify
```bash
cd workers/users && pnpm run typecheck && pnpm run test:worker
# 81 tests passed
```

## Matt code-review
### Spec
Pure rules + tests, no Share/Check-in — met. SavedRouteRepo is #835.

### Standards
Domain free of DB; table-driven tests; coverage on domain 100%.

Executor: opencode-go/deepseek-v4-flash