### PR TITLE
refactor(#838): Catalog PlanItinerary application use case

### DIFF
--- a/workers/catalog/src/adapters/outbound/route-points.ts
+++ b/workers/catalog/src/adapters/outbound/route-points.ts
@@ -1,0 +1,94 @@
+/**
+ * Outbound adapter for the `PointsForRoutePort`: fetch the points for a route
+ * from Postgres (joined to bangumi for the anime title) and map the rows to
+ * `RoutePoint`s, preserving the requested `ids` order. This adapter owns the
+ * only SQL on the plan-itinerary path.
+ */
+
+import { sql } from "drizzle-orm";
+import type { PointsForRoutePort, RoutePoint } from "../../application/plan-itinerary";
+import { optional } from "../../lib/optional";
+import type { PilgrimagePoint } from "../../types";
+
+/** The one DB capability this adapter needs: run a query, get back `{ rows }`. */
+export interface RouteDb {
+  execute(query: ReturnType<typeof sql>): Promise<{ rows: unknown[] }>;
+}
+
+/** One joined points+bangumi row, as selected by {@link pointsQuery}. */
+interface PointRow {
+  id: string;
+  name: string;
+  name_cn: string | null;
+  bangumi_id: string;
+  episode: number | null;
+  time_seconds: number | null;
+  image: string | null;
+  latitude: number;
+  longitude: number;
+  origin: string | null;
+  title: string | null;
+  title_cn: string | null;
+  cover_url: string | null;
+  city?: string | null;
+}
+
+/** Build the `PointsForRoutePort` backed by `db` (a single SELECT, no writes). */
+export function pointsForRoute(db: RouteDb): PointsForRoutePort {
+  return { loadPoints: (ids) => fetchPoints(db, ids) };
+}
+
+/** SELECT the points for `ids` joined to their bangumi, preserving `ids` order. */
+async function fetchPoints(db: RouteDb, ids: string[]): Promise<RoutePoint[]> {
+  if (ids.length === 0) return [];
+  const result = await db.execute(pointsQuery(ids));
+  const byId = indexRows(result.rows as PointRow[]);
+  return ids.flatMap((id) => {
+    const val = byId.get(id);
+    return val ? [val] : [];
+  });
+}
+
+/** Index fetched rows by `id` (mapped to points), for ordered reassembly. */
+function indexRows(rows: PointRow[]): Map<string, RoutePoint> {
+  return new Map(rows.map((r) => [r.id, toPoint(r)]));
+}
+
+/** The points+bangumi SELECT for `ids` (parameterised via `inArray`-style IN). */
+function pointsQuery(ids: string[]) {
+  return sql`
+    SELECT p.id, p.name, p.name_cn, p.bangumi_id, p.episode, p.time_seconds,
+           p.image, p.latitude, p.longitude, p.origin, p.city,
+           b.title, b.title_cn, b.cover_url
+    FROM points p
+    LEFT JOIN bangumi b ON b.id = p.bangumi_id
+    WHERE p.id IN (${sql.join(ids, sql`, `)})
+  `;
+}
+
+/** Map a joined DB row to a contract `PilgrimagePoint` (+ clustering geo). */
+function toPoint(r: PointRow): RoutePoint {
+  return { ...scalarFields(r), latitude: r.latitude, longitude: r.longitude };
+}
+
+/** The non-coordinate `PilgrimagePoint` fields, dropping null optionals. */
+function scalarFields(r: PointRow): Omit<PilgrimagePoint, "latitude" | "longitude"> {
+  return { ...scalarBase(r), ...optional(scalarOptionals(r)) };
+}
+
+function scalarBase(r: PointRow): Omit<PilgrimagePoint, "latitude" | "longitude"> {
+  return {
+    id: r.id,
+    name: r.name,
+    bangumi_id: r.bangumi_id,
+    screenshot_url: r.image ?? "",
+  };
+}
+
+function scalarOptionals(r: PointRow): Record<string, unknown> {
+  return {
+    name_cn: r.name_cn, episode: r.episode, time_seconds: r.time_seconds,
+    origin: r.origin, title: r.title, title_cn: r.title_cn,
+    cover_url: r.cover_url, city: r.city,
+  };
+}

--- a/workers/catalog/src/api/route.ts
+++ b/workers/catalog/src/api/route.ts
@@ -1,172 +1,29 @@
 // TODO(refactor-skeleton): vertical slice — structure design catalog #837/#838
 /**
  * The `route` read API handler: plan an ordered, timed route over selected
- * points. Composes the data layer (fetch points + bangumi) with the pure W2-1
- * kernel (`catalog/src/domain/itinerary/plan.ts`: cluster -> nearest-neighbor order ->
- * timed itinerary) and assembles the contract `Route`
- * (`packages/contract/src/models.ts`).
+ * points. Handler orchestration only — the SQL fetch lives in the outbound
+ * adapter `adapters/outbound/route-points.ts` and the planning orchestration in
+ * the use case `application/plan-itinerary.ts` (load points via port ->
+ * cluster -> nearest-neighbor order -> timed itinerary -> contract `Route`).
  *
- * Flow: fetch points for `point_ids` (joined to bangumi for the anime title) ->
- * `clusterByLocation` (50m) -> deterministic 50-cluster cap ->
- * `buildTimedItinerary` -> expand the ordered clusters back to their member
- * points (= `ordered_points`) -> `Route`.
- *
- * Read-only: a single SELECT, no writes. Origin is forwarded to the kernel only
- * in `{lat,lng}` form; the contract's named-place string Origin would need
- * geocoding first (a follow-up, alongside the `leg_cache` pre-warmed walk
- * durations the kernel currently derives from haversine).
+ * Read-only: a single SELECT, no writes.
  */
 
-import { sql } from "drizzle-orm";
-import type { ClusterablePoint, LocationCluster } from "../domain/clustering/cluster";
-import { clusterByLocation } from "../domain/clustering/cluster";
-import { optional } from "../lib/optional";
-import type { Origin as KernelOrigin, Pacing, TimedItinerary } from "../domain/itinerary/plan";
-import { buildTimedItinerary, MAX_ITINERARY_CLUSTERS } from "../domain/itinerary/plan";
+import { pointsForRoute, type RouteDb } from "../adapters/outbound/route-points";
+import { planItinerary, type RouteInput } from "../application/plan-itinerary";
 import type { Origin, PilgrimagePoint, Route } from "../types";
 
 /**
- * Output types (`PilgrimagePoint` / `Route`) and the `Origin` / `Pacing` inputs
- * come from `../types` — the single in-Worker mirror of
- * `packages/contract/src/models.ts`. `import type` erases at compile time, so the
- * contract's zod runtime stays out of the Worker bundle. Re-exported here so
- * existing consumers keep importing them from this handler.
+ * Output types (`PilgrimagePoint` / `Route`) and the `Origin` input come from
+ * `../types` — the single in-Worker mirror of `packages/contract/src/models.ts`.
+ * `import type` erases at compile time, so the contract's zod runtime stays out
+ * of the Worker bundle. Re-exported here so existing consumers keep importing
+ * them from this handler.
  */
 export type { Origin, PilgrimagePoint, Route };
-
-/** Inputs for {@link route} — mirrors `RouteInput` in the contract. */
-export interface RouteInput {
-  point_ids: string[];
-  origin?: Origin;
-  pacing?: Pacing;
-}
-
-/** The one DB capability `route` needs: run a query, get back `{ rows }`. */
-export interface RouteDb {
-  execute(query: ReturnType<typeof sql>): Promise<{ rows: unknown[] }>;
-}
-
-/** One joined points+bangumi row, as selected by {@link fetchPoints}. */
-interface PointRow {
-  id: string;
-  name: string;
-  name_cn: string | null;
-  bangumi_id: string;
-  episode: number | null;
-  time_seconds: number | null;
-  image: string | null;
-  latitude: number;
-  longitude: number;
-  origin: string | null;
-  title: string | null;
-  title_cn: string | null;
-  cover_url: string | null;
-  city?: string | null;
-}
-
-/** A `PilgrimagePoint` carrying the geo fields {@link clusterByLocation} needs. */
-type ClusterablePilgrimagePoint = PilgrimagePoint & ClusterablePoint;
-
-/** A cluster whose members are full pilgrimage points (for `ordered_points`). */
-type PointCluster = LocationCluster<ClusterablePilgrimagePoint>;
+export type { RouteDb, RouteInput };
 
 /** Plan an ordered, timed route over `point_ids`. Empty/unknown ids -> count 0. */
-export async function route(db: RouteDb, input: RouteInput): Promise<Route> {
-  const points = await fetchPoints(db, input.point_ids);
-  const allClusters = clusterByLocation(points, 50);
-  const clusters = allClusters.slice(0, MAX_ITINERARY_CLUSTERS);
-  const itinerary = buildTimedItinerary(clusters, kernelOpts(input));
-  return assembleRoute(clusters, itinerary, allClusters.length);
-}
-
-/** SELECT the points for `ids` joined to their bangumi, preserving `ids` order. */
-async function fetchPoints(db: RouteDb, ids: string[]): Promise<ClusterablePilgrimagePoint[]> {
-  if (ids.length === 0) return [];
-  const result = await db.execute(pointsQuery(ids));
-  const byId = indexRows(result.rows as PointRow[]);
-  return ids.flatMap((id) => {
-    const val = byId.get(id);
-    return val ? [val] : [];
-  });
-}
-
-/** Index fetched rows by `id` (mapped to points), for ordered reassembly. */
-function indexRows(rows: PointRow[]): Map<string, ClusterablePilgrimagePoint> {
-  return new Map(rows.map((r) => [r.id, toPoint(r)]));
-}
-
-/** The points+bangumi SELECT for `ids` (parameterised via `inArray`-style IN). */
-function pointsQuery(ids: string[]) {
-  return sql`
-    SELECT p.id, p.name, p.name_cn, p.bangumi_id, p.episode, p.time_seconds,
-           p.image, p.latitude, p.longitude, p.origin, p.city,
-           b.title, b.title_cn, b.cover_url
-    FROM points p
-    LEFT JOIN bangumi b ON b.id = p.bangumi_id
-    WHERE p.id IN (${sql.join(ids, sql`, `)})
-  `;
-}
-
-/** Map a joined DB row to a contract `PilgrimagePoint` (+ clustering geo). */
-function toPoint(r: PointRow): ClusterablePilgrimagePoint {
-  return {
-    ...scalarFields(r),
-    latitude: r.latitude,
-    longitude: r.longitude,
-  };
-}
-
-/** The non-coordinate `PilgrimagePoint` fields, dropping null optionals. */
-function scalarFields(r: PointRow): Omit<PilgrimagePoint, "latitude" | "longitude"> {
-  return { ...scalarBase(r), ...optional(scalarOptionals(r)) };
-}
-
-function scalarBase(r: PointRow): Omit<PilgrimagePoint, "latitude" | "longitude"> {
-  return {
-    id: r.id,
-    name: r.name,
-    bangumi_id: r.bangumi_id,
-    screenshot_url: r.image ?? "",
-  };
-}
-
-function scalarOptionals(r: PointRow): Record<string, unknown> {
-  return {
-    name_cn: r.name_cn, episode: r.episode, time_seconds: r.time_seconds,
-    origin: r.origin, title: r.title, title_cn: r.title_cn,
-    cover_url: r.cover_url, city: r.city,
-  };
-}
-
-/** Kernel itinerary options: pacing + the coordinate form of Origin only. */
-function kernelOpts(input: RouteInput): { pacing?: Pacing; origin?: KernelOrigin } {
-  const origin = typeof input.origin === "object" ? input.origin : undefined;
-  return { pacing: input.pacing, origin };
-}
-
-/** Assemble the contract `Route` from the ordered clusters and the itinerary. */
-function assembleRoute(clusters: PointCluster[], itinerary: TimedItinerary, totalClusters: number): Route {
-  const ordered = orderPoints(clusters, itinerary);
-  return { ...animeMeta(ordered[0]), ...truncationMeta(clusters.length, totalClusters), ordered_points: ordered, point_count: ordered.length, timed_itinerary: itinerary };
-}
-
-/** Add disclosure fields only when the deterministic cluster cap was applied. */
-function truncationMeta(shown: number, total: number): Partial<Pick<Route, "truncated" | "shown_cluster_count" | "total_cluster_count">> {
-  if (shown === total) return {};
-  return { truncated: true, shown_cluster_count: shown, total_cluster_count: total };
-}
-
-/** Expand the itinerary's ordered stops back to their member points, in order. */
-function orderPoints(clusters: PointCluster[], itinerary: TimedItinerary): PilgrimagePoint[] {
-  const byCluster = new Map(clusters.map((c) => [c.clusterId, c]));
-  return itinerary.stops.flatMap((s) => byCluster.get(s.cluster_id)?.points ?? []);
-}
-
-/** The anime-title metadata carried on the Route, taken from the lead point. */
-function animeMeta(lead?: PilgrimagePoint): Pick<Route, "anime_title" | "anime_title_cn" | "cover_url"> {
-  return optional({
-    anime_title: lead?.title,
-    anime_title_cn: lead?.title_cn,
-    cover_url: lead?.cover_url,
-  });
+export function route(db: RouteDb, input: RouteInput): Promise<Route> {
+  return planItinerary(pointsForRoute(db), input);
 }

--- a/workers/catalog/src/application/README.md
+++ b/workers/catalog/src/application/README.md
@@ -2,6 +2,8 @@
 
 Application use-case layer (Clean Architecture).
 
-Empty by design at #837: the first vertical slice (PlanItinerary application
-use case) lands in #838. Inbound adapters (`src/api/*`) call use cases here;
-use cases orchestrate domain kernels without knowing about I/O.
+First vertical slice lands here at #838: `plan-itinerary.ts` (the PlanItinerary
+use case). Inbound adapters (`src/api/*`) call use cases here; use cases
+orchestrate domain kernels without knowing about I/O — data arrives through
+ports (e.g. `PointsForRoutePort`), implemented by outbound adapters under
+`src/adapters/outbound/`.

--- a/workers/catalog/src/application/plan-itinerary.ts
+++ b/workers/catalog/src/application/plan-itinerary.ts
@@ -1,0 +1,83 @@
+/**
+ * `planItinerary` application use case: plan an ordered, timed route over
+ * selected points. Orchestration only — the pure W2-1 kernel
+ * (`domain/itinerary/plan.ts`: cluster -> nearest-neighbor order -> timed
+ * itinerary) does the planning; points arrive through the `PointsForRoutePort`
+ * outbound port, adapted to the data layer by the caller. No I/O, no SQL here.
+ *
+ * Flow: `port.loadPoints(point_ids)` -> `clusterByLocation` (50m) ->
+ * deterministic 50-cluster cap -> `buildTimedItinerary` -> expand the ordered
+ * clusters back to their member points (= `ordered_points`) -> `Route`.
+ *
+ * Origin is forwarded to the kernel only in `{lat,lng}` form; the contract's
+ * named-place string Origin would need geocoding first (a follow-up, alongside
+ * the `leg_cache` pre-warmed walk durations the kernel currently derives from
+ * haversine).
+ */
+
+import type { ClusterablePoint, LocationCluster } from "../domain/clustering/cluster";
+import { clusterByLocation } from "../domain/clustering/cluster";
+import type { Origin as KernelOrigin, TimedItinerary } from "../domain/itinerary/plan";
+import { buildTimedItinerary, MAX_ITINERARY_CLUSTERS } from "../domain/itinerary/plan";
+import { optional } from "../lib/optional";
+import type { Origin, Pacing, PilgrimagePoint, Route } from "../types";
+
+/** A route point: the contract `PilgrimagePoint` + the geo fields clustering needs. */
+export type RoutePoint = PilgrimagePoint & ClusterablePoint;
+
+/** A cluster whose members are full route points (for `ordered_points`). */
+type PointCluster = LocationCluster<RoutePoint>;
+
+/** Outbound capability the use case needs: load the points for route `ids`. */
+export interface PointsForRoutePort {
+  loadPoints(ids: string[]): Promise<RoutePoint[]>;
+}
+
+/** Inputs for {@link planItinerary} — mirrors `RouteInput` in the contract. */
+export interface RouteInput {
+  point_ids: string[];
+  origin?: Origin;
+  pacing?: Pacing;
+}
+
+/** Plan an ordered, timed route over `point_ids`. Empty/unknown ids -> count 0. */
+export async function planItinerary(port: PointsForRoutePort, input: RouteInput): Promise<Route> {
+  const points = await port.loadPoints(input.point_ids);
+  const allClusters = clusterByLocation(points, 50);
+  const clusters = allClusters.slice(0, MAX_ITINERARY_CLUSTERS);
+  const itinerary = buildTimedItinerary(clusters, kernelOpts(input));
+  return assembleRoute(clusters, itinerary, allClusters.length);
+}
+
+/** Kernel itinerary options: pacing + the coordinate form of Origin only. */
+function kernelOpts(input: RouteInput): { pacing?: Pacing; origin?: KernelOrigin } {
+  const origin = typeof input.origin === "object" ? input.origin : undefined;
+  return { pacing: input.pacing, origin };
+}
+
+/** Assemble the contract `Route` from the ordered clusters and the itinerary. */
+function assembleRoute(clusters: PointCluster[], itinerary: TimedItinerary, totalClusters: number): Route {
+  const ordered = orderPoints(clusters, itinerary);
+  return { ...animeMeta(ordered[0]), ...truncationMeta(clusters.length, totalClusters), ordered_points: ordered, point_count: ordered.length, timed_itinerary: itinerary };
+}
+
+/** Add disclosure fields only when the deterministic cluster cap was applied. */
+function truncationMeta(shown: number, total: number): Partial<Pick<Route, "truncated" | "shown_cluster_count" | "total_cluster_count">> {
+  if (shown === total) return {};
+  return { truncated: true, shown_cluster_count: shown, total_cluster_count: total };
+}
+
+/** Expand the itinerary's ordered stops back to their member points, in order. */
+function orderPoints(clusters: PointCluster[], itinerary: TimedItinerary): PilgrimagePoint[] {
+  const byCluster = new Map(clusters.map((c) => [c.clusterId, c]));
+  return itinerary.stops.flatMap((s) => byCluster.get(s.cluster_id)?.points ?? []);
+}
+
+/** The anime-title metadata carried on the Route, taken from the lead point. */
+function animeMeta(lead?: PilgrimagePoint): Pick<Route, "anime_title" | "anime_title_cn" | "cover_url"> {
+  return optional({
+    anime_title: lead?.title,
+    anime_title_cn: lead?.title_cn,
+    cover_url: lead?.cover_url,
+  });
+}

--- a/workers/catalog/test/plan-itinerary.worker.test.ts
+++ b/workers/catalog/test/plan-itinerary.worker.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { planItinerary, type PointsForRoutePort, type RoutePoint } from "../src/application/plan-itinerary";
+import { pointsForRoute, type RouteDb } from "../src/adapters/outbound/route-points";
+
+/**
+ * Tests at the use-case seam: `planItinerary` receives points through a fake
+ * `PointsForRoutePort` — no DB, no SQL on this side. Verifies the
+ * load -> cluster -> plan -> assemble orchestration and the contract `Route`
+ * assembly. A small adapter check covers the port wiring (ids order preserved,
+ * unknown ids dropped) against a fake `RouteDb`.
+ *
+ * Fixture (3 points on a meridian, > 50m apart so each is its own cluster;
+ * gaps a-b == b-c == 111.19 m, mirroring the kernel parity fixture):
+ *   a (35.0000) bangumi "k" "Lucky Star"  image "a.jpg"
+ *   b (35.0010) bangumi "k" "Lucky Star"
+ *   c (35.0020) bangumi "k" "Lucky Star"
+ */
+
+function point(id: string, lat: number, image = ""): RoutePoint {
+  return {
+    id, name: id.toUpperCase(), bangumi_id: "k", screenshot_url: image,
+    latitude: lat, longitude: 135.0,
+    title: "Lucky Star", title_cn: "幸运星", cover_url: "cover.jpg", city: "Tokyo",
+  };
+}
+
+const POINTS = [point("a", 35.0, "a.jpg"), point("b", 35.001), point("c", 35.002)];
+const MANY_POINTS: RoutePoint[] = Array.from({ length: 51 }, (_, i) =>
+  point(`p${String(i).padStart(3, "0")}`, 35 + i * 0.001),
+);
+
+/** A fake `PointsForRoutePort` returning only the requested ids, in ids order. */
+function fakePort(points: RoutePoint[]): PointsForRoutePort {
+  const byId = new Map(points.map((p) => [p.id, p]));
+  return {
+    loadPoints: (ids) =>
+      Promise.resolve(ids.flatMap((id) => {
+        const val = byId.get(id);
+        return val ? [val] : [];
+      })),
+  };
+}
+
+const ids = (ps: RoutePoint[]): string[] => ps.map((p) => p.id);
+
+describe("planItinerary use case — port load -> cluster -> plan -> Route", () => {
+  it("plans a timed route with a stop+leg itinerary for the selected ids", async () => {
+    const r = await planItinerary(fakePort(POINTS), { point_ids: ["a", "b", "c"], pacing: "normal" });
+    expect(r.point_count).toBe(3);
+    expect(r.timed_itinerary.stops.map((s) => s.cluster_id)).toEqual(["a", "b", "c"]);
+    expect(r.timed_itinerary.legs.map((l) => [l.from_id, l.to_id])).toEqual([["a", "b"], ["b", "c"]]);
+    expect(r.timed_itinerary.total_minutes).toBe(28);
+    expect(r.timed_itinerary.total_distance_m).toBe(222.4);
+  });
+
+  it("ordered_points follow itinerary order (NN from origin near c -> c,b,a)", async () => {
+    const r = await planItinerary(fakePort(POINTS), { point_ids: ["a", "b", "c"], origin: { lat: 35.0025, lng: 135.0 } });
+    expect(ids(r.ordered_points)).toEqual(["c", "b", "a"]);
+    expect(r.timed_itinerary.stops.map((s) => s.cluster_id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("carries anime title + cover metadata and point fields from the lead point", async () => {
+    const r = await planItinerary(fakePort(POINTS), { point_ids: ["a", "b", "c"] });
+    expect(r.anime_title).toBe("Lucky Star");
+    expect(r.anime_title_cn).toBe("幸运星");
+    expect(r.cover_url).toBe("cover.jpg");
+    const [a] = r.ordered_points;
+    expect(a?.screenshot_url).toBe("a.jpg");
+    expect(a?.city).toBe("Tokyo");
+    expect(a?.latitude).toBe(35.0);
+  });
+
+  it("unknown ids -> point_count 0 with an empty itinerary", async () => {
+    const r = await planItinerary(fakePort(POINTS), { point_ids: ["nope", "missing"] });
+    expect(r.point_count).toBe(0);
+    expect(r.ordered_points).toEqual([]);
+    expect(r.timed_itinerary.stops).toEqual([]);
+    expect(r.timed_itinerary.total_minutes).toBe(0);
+  });
+
+  it("caps 51 clusters and discloses the successful truncation", async () => {
+    const r = await planItinerary(fakePort(MANY_POINTS), { point_ids: ids(MANY_POINTS) });
+    expect(r.point_count).toBe(50);
+    expect(r.timed_itinerary.stops).toHaveLength(50);
+    expect(ids(r.ordered_points)).not.toContain("p050");
+    expect(r).toMatchObject({ truncated: true, shown_cluster_count: 50, total_cluster_count: 51 });
+  });
+});
+
+describe("pointsForRoute outbound adapter — SQL fetch wired to the port", () => {
+  it("loads requested ids in ids order and drops unknown ids", async () => {
+    const fakeDb: RouteDb = {
+      execute: (query) => {
+        const text = JSON.stringify(query);
+        const matched = POINTS.filter((p) => text.includes(`"${p.id}"`));
+        return Promise.resolve({ rows: matched });
+      },
+    };
+    const port = pointsForRoute(fakeDb);
+    const loaded = await port.loadPoints(["c", "nope", "a"]);
+    expect(ids(loaded)).toEqual(["c", "a"]);
+  });
+
+  it("empty ids -> no query, no rows", async () => {
+    let executed = false;
+    const fakeDb: RouteDb = {
+      execute: () => {
+        executed = true;
+        return Promise.resolve({ rows: [] });
+      },
+    };
+    const port = pointsForRoute(fakeDb);
+    expect(await port.loadPoints([])).toEqual([]);
+    expect(executed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Extract planItinerary use case + PointsForRoutePort outbound adapter; thin api/route.ts. No new public API. Tests green.

Closes #838
Parent: #829

## Test plan
- [x] Package local gates run by opencode (see card log)
- [ ] CI green after Actions recovery
- [ ] Matt code-review + 两路评论闸 before merge

Written by opencode-go/deepseek-v4-flash (variant max)