### PR TITLE
docs(#856): HY-1 repo hygiene inventory + path drift fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ edge tokens today and backs local-dev/E2E (#561). **Do not add new Supabase-auth
   `noqa` / `pragma: no cover` / `continue-on-error` / `skip`. Fix the code; don't silence the rule.
 - **TypeScript gate** — TypeScript 7.0.2 direct + type-aware oxlint/tsgolint with
   `--deny-warnings` across every package. ESLint left the repo with `frontend/` (#537).
-- **Coverage floors ratchet UP only** — backend ≥82; `apps/web` floors live in `apps/web/AGENTS.md`.
+- **Coverage floors ratchet UP only** — `apps/agent` ≥87 (`pyproject.toml` `--cov-fail-under`); `apps/web` floors live in `apps/web/vitest.config.ts` (mirrored in `apps/web/AGENTS.md`).
 - **Test quality**: mock the clock (no timing-dependent asserts); no conditional logic in tests
   (split them); ≤200 lines per test file; ≤5 mocks per test.
 - **No local deploy** (hook `block-local-deploy`) — CI/CD only: staging = merge to `main`; prod =

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/lifeodyssey/animichi/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/lifeodyssey/animichi/actions/workflows/ci.yml?query=branch%3Amain)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg)](https://www.python.org)
-[![Next.js](https://img.shields.io/badge/Next.js-16-000000.svg?logo=nextdotjs)](https://nextjs.org)
+[![TanStack Start](https://img.shields.io/badge/TanStack_Start-SSR-FF4154.svg)](https://tanstack.com/start)
 [![Cloudflare Workers](https://img.shields.io/badge/deploy-Cloudflare_Workers-f38020.svg?logo=cloudflare)](https://developers.cloudflare.com/workers/)
 [![Supabase](https://img.shields.io/badge/Supabase-Postgres-3ecf8e.svg?logo=supabase)](https://supabase.com)
 [![GitHub last commit](https://img.shields.io/github/last-commit/lifeodyssey/animichi)](https://github.com/lifeodyssey/animichi/commits/main)
@@ -26,11 +26,11 @@
 
 ```
 ユーザー入力 → PydanticAI Agent（animichi_agent）
-                 ├── resolve_anime  → DB優先のタイトル検索; ミス時は Bangumi.tv API
-                 ├── search_bangumi → パラメータ化 SQL → Supabase ポイント
-                 ├── search_nearby  → PostGIS 地理検索
-                 ├── plan_route     → 最近傍法によるルート最適化
-                 └── answer_question → QA パススルー
+                 ├── resolve_anime  → catalog Worker のタイトル解決; ミス時は Bangumi 取り込み
+                 ├── search_bangumi → 解決済み bangumi_id の catalog ポイント
+                 ├── search_nearby  → catalog 地理検索（Neon 上の PostGIS）
+                 ├── plan_route     → catalog ルート並び替え
+                 └── web_search / translate → 出典付き調査 / タイトル翻訳
               → AgentResult（型付き出力 + ツール呼び出し記録）
 ```
 
@@ -85,15 +85,17 @@ make db-push           # NEON_DATABASE_URL に適用
 
 ## 環境変数
 
-**必須：**
+**必須（agent コンテナ / ローカル serve）：**
 | 変数名 | 用途 |
 |---|---|
-| `SUPABASE_DB_URL` | Postgres 接続文字列 |
-| `SUPABASE_URL` | Supabase プロジェクト URL |
-| `SUPABASE_SERVICE_ROLE_KEY` | サーバーサイド Supabase 認証 |
-| `SUPABASE_ANON_KEY` | Worker エッジでの JWT 検証 |
+| `SUPABASE_DB_URL` | agent ドメインの Postgres 接続文字列 |
+| `SUPABASE_URL` | Supabase プロジェクト URL（auth + API キー照会） |
+| `SUPABASE_SERVICE_ROLE_KEY` | サーバーサイド Supabase 認証 / `api_keys` 照会 |
+| `MIMO_API_KEY` | 主モデルプロバイダキー |
 
-**オプション：** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`
+**Worker エッジ:** `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`（JWT は公開 JWKS で検証 — エッジに `SUPABASE_ANON_KEY` は不要）。catalog/users/maintenance は各 Neon DSN も必要 — [`docs/ops/deployment.md`](docs/ops/deployment.md)。
+
+**オプション：** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`, `DEEPSEEK_API_KEY`
 
 詳細は [`apps/agent/src/animichi/config/settings.py`](apps/agent/src/animichi/config/settings.py) と [`.env.example`](.env.example) を参照してください。
 
@@ -118,21 +120,15 @@ curl -X POST https://seichijunrei.zhenjia.org/v1/runtime \
   -d '{"text":"吹響の聖地","locale":"ja"}'
 ```
 
-**Python クライアント：**
-```python
-from animichi.clients.python.seichijunrei_client import SeichijunreiClient
-
-client = SeichijunreiClient(api_key="sk_your_key_here")
-result = client.search("Hibike Euphonium locations", locale="en")
-```
-
 ## リポジトリ構成マップ
 
 - `apps/agent/` — Python ランタイム本体。agents、interfaces、infrastructure、tests、tools を含む
-- `workers/catalog/` — アニメ聖地カタログ REST API を提供する Cloudflare Worker（TypeScript）
-- `packages/contract/` — catalog ↔ agent 間で共有する oRPC contract 型定義
-- `apps/web/` — TanStack Start SSR の Web アプリと UI コンポーネント
-- `workers/edge/` — 認証とリクエストルーティングを担う Cloudflare Worker
+- `workers/catalog/` — アニメカタログ API + データ基盤の Cloudflare Worker（TypeScript）
+- `workers/users/` — ユーザー領域データ Worker（`/v1/users/*`）
+- `workers/maintenance/` — スケジュール Neon 保持 Worker（公開ルートなし）
+- `packages/contract/` — 共有 oRPC/zod 契約（catalog ↔ agent ↔ users）
+- `apps/web/` — TanStack Start SSR Web アプリ（**唯一のブラウザ面**）
+- `workers/edge/` — 認証と `/v1` ルーティングの Cloudflare Worker 入口
 - `db/migrations/` — Neon データ面の Atlas マイグレーションと生成 checksum
 - `supabase/` — auth/旧版互換マイグレーションと Supabase プロジェクト資産
 - `docs/` — アーキテクチャ、運用手順、イテレーション資料、実装計画
@@ -145,5 +141,6 @@ result = client.search("Hibike Euphonium locations", locale="en")
 - [マイグレーション境界](docs/ops/migrations.md) — Atlas authority と Drizzle のクエリ/型境界
 - [運用ドキュメント](docs/ops/README.md) — 運用手順と環境向けランブック
 - [イテレーション資料](docs/iterations/README.md) — task plan、progress、findings の保存場所
-- [実装計画](docs/superpowers/plans/) — 既存位置を維持する実装計画の履歴
-- [設計仕様](docs/superpowers/specs/) — プロダクト仕様
+- [実装計画（アーカイブ）](docs/superpowers/plans/archive/) — 過去の実行計画（平層 `plans/` には新規を置かない）
+- [設計仕様](docs/superpowers/specs/) — 現行のプロダクト/アーキテクチャ仕様
+- [エージェントガイド](AGENTS.md) — monorepo 構成・コマンド・横断ガードレール

--- a/README.ja.md
+++ b/README.ja.md
@@ -92,10 +92,11 @@ make db-push           # NEON_DATABASE_URL に適用
 | `SUPABASE_URL` | Supabase プロジェクト URL（auth + API キー照会） |
 | `SUPABASE_SERVICE_ROLE_KEY` | サーバーサイド Supabase 認証 / `api_keys` 照会 |
 | `MIMO_API_KEY` | 主モデルプロバイダキー |
+| `DEEPSEEK_API_KEY` | エッジ container-env がコンテナ起動時に要求（コンテナへ転送） |
 
 **Worker エッジ:** `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`（JWT は公開 JWKS で検証 — エッジに `SUPABASE_ANON_KEY` は不要）。catalog/users/maintenance は各 Neon DSN も必要 — [`docs/ops/deployment.md`](docs/ops/deployment.md)。
 
-**オプション：** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`, `DEEPSEEK_API_KEY`
+**オプション：** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`
 
 詳細は [`apps/agent/src/animichi/config/settings.py`](apps/agent/src/animichi/config/settings.py) と [`.env.example`](.env.example) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ order. Apply migrations in a dedicated deploy step, not at application startup.
 | `SUPABASE_URL` | Supabase project URL (auth + API-key lookup plane) |
 | `SUPABASE_SERVICE_ROLE_KEY` | Server-side Supabase auth / `api_keys` lookup |
 | `MIMO_API_KEY` | Primary model provider key |
+| `DEEPSEEK_API_KEY` | Required by edge container-env for agent boot (forwarded into the container) |
 
 **Worker edge:** `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (JWT verifies public JWKS — `SUPABASE_ANON_KEY` is not required at the edge). Catalog/users/maintenance also need their Neon DSNs — see [`docs/ops/deployment.md`](docs/ops/deployment.md).
 
-**Optional:** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`, `DEEPSEEK_API_KEY`
+**Optional:** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`
 
 See [`apps/agent/src/animichi/config/settings.py`](apps/agent/src/animichi/config/settings.py) for full reference and [`.env.example`](.env.example) for defaults.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/lifeodyssey/animichi/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/lifeodyssey/animichi/actions/workflows/ci.yml?query=branch%3Amain)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg)](https://www.python.org)
-[![Next.js](https://img.shields.io/badge/Next.js-16-000000.svg?logo=nextdotjs)](https://nextjs.org)
+[![TanStack Start](https://img.shields.io/badge/TanStack_Start-SSR-FF4154.svg)](https://tanstack.com/start)
 [![Cloudflare Workers](https://img.shields.io/badge/deploy-Cloudflare_Workers-f38020.svg?logo=cloudflare)](https://developers.cloudflare.com/workers/)
 [![Supabase](https://img.shields.io/badge/Supabase-Postgres-3ecf8e.svg?logo=supabase)](https://supabase.com)
 [![GitHub last commit](https://img.shields.io/github/last-commit/lifeodyssey/animichi)](https://github.com/lifeodyssey/animichi/commits/main)
@@ -26,11 +26,11 @@ Tell the agent an anime title or a location in natural language. It finds real-w
 
 ```
 User text  →  PydanticAI Agent (animichi_agent)
-                 ├── resolve_anime  → DB-first title lookup; Bangumi.tv API on miss
-                 ├── search_bangumi → parameterized SQL → Supabase points
-                 ├── search_nearby  → PostGIS geo retrieval
-                 ├── plan_route     → nearest-neighbor route ordering
-                 └── answer_question → QA pass-through
+                 ├── resolve_anime  → catalog Worker title resolve; Bangumi ingest on miss
+                 ├── search_bangumi → catalog points for resolved bangumi_id
+                 ├── search_nearby  → catalog geo retrieval (PostGIS on Neon)
+                 ├── plan_route     → catalog route ordering
+                 └── web_search / translate → attributed research / title translation
               → AgentResult (typed output + tool call records)
 ```
 
@@ -86,15 +86,17 @@ order. Apply migrations in a dedicated deploy step, not at application startup.
 
 ## Environment
 
-**Required:**
+**Required (agent container / local serve):**
 | Variable | Purpose |
 |---|---|
-| `SUPABASE_DB_URL` | Postgres connection string |
-| `SUPABASE_URL` | Supabase project URL |
-| `SUPABASE_SERVICE_ROLE_KEY` | Server-side Supabase auth |
-| `SUPABASE_ANON_KEY` | JWT validation at Worker edge |
+| `SUPABASE_DB_URL` | Agent-domain Postgres connection string |
+| `SUPABASE_URL` | Supabase project URL (auth + API-key lookup plane) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server-side Supabase auth / `api_keys` lookup |
+| `MIMO_API_KEY` | Primary model provider key |
 
-**Optional:** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`
+**Worker edge:** `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (JWT verifies public JWKS — `SUPABASE_ANON_KEY` is not required at the edge). Catalog/users/maintenance also need their Neon DSNs — see [`docs/ops/deployment.md`](docs/ops/deployment.md).
+
+**Optional:** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`, `DEEPSEEK_API_KEY`
 
 See [`apps/agent/src/animichi/config/settings.py`](apps/agent/src/animichi/config/settings.py) for full reference and [`.env.example`](.env.example) for defaults.
 
@@ -119,21 +121,15 @@ curl -X POST https://seichijunrei.zhenjia.org/v1/runtime \
   -d '{"text":"吹響の聖地","locale":"ja"}'
 ```
 
-**Python client:**
-```python
-from animichi.clients.python.seichijunrei_client import SeichijunreiClient
-
-client = SeichijunreiClient(api_key="sk_your_key_here")
-result = client.search("Hibike Euphonium locations", locale="en")
-```
-
 ## Repository Map
 
 - `apps/agent/` — Python runtime: agents, interfaces, infrastructure, tests, and tools
-- `workers/catalog/` — Cloudflare Worker: anime catalog REST API (TypeScript)
-- `packages/contract/` — shared oRPC contract types (catalog ↔ agent)
-- `apps/web/` — TanStack Start SSR web app and UI components
-- `workers/edge/` — Cloudflare Worker entrypoint for auth and request routing
+- `workers/catalog/` — Cloudflare Worker: anime catalog API + data platform (TypeScript)
+- `workers/users/` — Cloudflare Worker: user-domain data service (`/v1/users/*`)
+- `workers/maintenance/` — Scheduled Neon retention Worker (no public route)
+- `packages/contract/` — shared oRPC/zod contract (catalog ↔ agent ↔ users)
+- `apps/web/` — TanStack Start SSR web app (**the only browser surface**)
+- `workers/edge/` — Cloudflare Worker entrypoint for auth and `/v1` routing
 - `db/migrations/` — Atlas migrations and generated checksum for the Neon data plane
 - `supabase/` — auth/legacy compatibility migrations and Supabase project assets
 - `docs/` — architecture, ops runbooks, iteration artifacts, and implementation plans
@@ -146,5 +142,6 @@ result = client.search("Hibike Euphonium locations", locale="en")
 - [Migrations](docs/ops/migrations.md) — Atlas authority and Drizzle query/type boundary
 - [Ops docs](docs/ops/README.md) — operational runbooks and environment procedures
 - [Iteration artifacts](docs/iterations/README.md) — task plans, progress logs, and findings by iteration
-- [Implementation plans](docs/superpowers/plans/) — implementation plans kept in place for execution history
-- [Design spec](docs/superpowers/specs/) — product specification
+- [Implementation plans (archive)](docs/superpowers/plans/archive/) — historical execution plans (flat `plans/` no longer accepts new files)
+- [Design specs](docs/superpowers/specs/) — active product/architecture specifications
+- [Agent guide](AGENTS.md) — monorepo layout, commands, and cross-stack guardrails

--- a/README.zh.md
+++ b/README.zh.md
@@ -91,10 +91,11 @@ make db-push           # 对 NEON_DATABASE_URL 应用迁移
 | `SUPABASE_URL` | Supabase 项目 URL（auth + API key 查询面） |
 | `SUPABASE_SERVICE_ROLE_KEY` | 服务端 Supabase 认证 / `api_keys` 查询 |
 | `MIMO_API_KEY` | 主模型供应商密钥 |
+| `DEEPSEEK_API_KEY` | 边缘 container-env 容器启动必填（转发进容器） |
 
 **Worker 边缘：** `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`（JWT 用公开 JWKS 校验 — 边缘不需要 `SUPABASE_ANON_KEY`）。catalog/users/maintenance 还需各自 Neon DSN — 见 [`docs/ops/deployment.md`](docs/ops/deployment.md)。
 
-**可选：** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`, `DEEPSEEK_API_KEY`
+**可选：** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`
 
 详见 [`apps/agent/src/animichi/config/settings.py`](apps/agent/src/animichi/config/settings.py) 和 [`.env.example`](.env.example)。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/lifeodyssey/animichi/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/lifeodyssey/animichi/actions/workflows/ci.yml?query=branch%3Amain)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg)](https://www.python.org)
-[![Next.js](https://img.shields.io/badge/Next.js-16-000000.svg?logo=nextdotjs)](https://nextjs.org)
+[![TanStack Start](https://img.shields.io/badge/TanStack_Start-SSR-FF4154.svg)](https://tanstack.com/start)
 [![Cloudflare Workers](https://img.shields.io/badge/deploy-Cloudflare_Workers-f38020.svg?logo=cloudflare)](https://developers.cloudflare.com/workers/)
 [![Supabase](https://img.shields.io/badge/Supabase-Postgres-3ecf8e.svg?logo=supabase)](https://supabase.com)
 [![GitHub last commit](https://img.shields.io/github/last-commit/lifeodyssey/animichi)](https://github.com/lifeodyssey/animichi/commits/main)
@@ -26,11 +26,11 @@
 
 ```
 用户输入 → PydanticAI Agent（animichi_agent）
-              ├── resolve_anime  → DB 优先的标题查找; 未命中时调用 Bangumi.tv API
-              ├── search_bangumi → 参数化 SQL → Supabase 数据点
-              ├── search_nearby  → PostGIS 地理检索
-              ├── plan_route     → 最近邻路线排序
-              └── answer_question → QA 直通
+              ├── resolve_anime  → catalog Worker 标题解析; 未命中时 Bangumi 入库
+              ├── search_bangumi → 已解析 bangumi_id 的 catalog 点位
+              ├── search_nearby  → catalog 地理检索（Neon 上的 PostGIS）
+              ├── plan_route     → catalog 路线排序
+              └── web_search / translate → 带出处调研 / 标题翻译
            → AgentResult（类型化输出 + 工具调用记录）
 ```
 
@@ -84,15 +84,17 @@ make db-push           # 对 NEON_DATABASE_URL 应用迁移
 
 ## 环境变量
 
-**必需：**
+**必需（agent 容器 / 本地 serve）：**
 | 变量 | 用途 |
 |---|---|
-| `SUPABASE_DB_URL` | Postgres 连接字符串 |
-| `SUPABASE_URL` | Supabase 项目 URL |
-| `SUPABASE_SERVICE_ROLE_KEY` | 服务端 Supabase 认证 |
-| `SUPABASE_ANON_KEY` | Worker 边缘 JWT 验证 |
+| `SUPABASE_DB_URL` | agent 域 Postgres 连接字符串 |
+| `SUPABASE_URL` | Supabase 项目 URL（auth + API key 查询面） |
+| `SUPABASE_SERVICE_ROLE_KEY` | 服务端 Supabase 认证 / `api_keys` 查询 |
+| `MIMO_API_KEY` | 主模型供应商密钥 |
 
-**可选：** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`
+**Worker 边缘：** `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`（JWT 用公开 JWKS 校验 — 边缘不需要 `SUPABASE_ANON_KEY`）。catalog/users/maintenance 还需各自 Neon DSN — 见 [`docs/ops/deployment.md`](docs/ops/deployment.md)。
+
+**可选：** `SERVICE_HOST`, `SERVICE_PORT`, `OBSERVABILITY_*`, `DEFAULT_AGENT_MODEL`, `DEEPSEEK_API_KEY`
 
 详见 [`apps/agent/src/animichi/config/settings.py`](apps/agent/src/animichi/config/settings.py) 和 [`.env.example`](.env.example)。
 
@@ -117,21 +119,15 @@ curl -X POST https://seichijunrei.zhenjia.org/v1/runtime \
   -d '{"text":"吹響の聖地","locale":"ja"}'
 ```
 
-**Python 客户端：**
-```python
-from animichi.clients.python.seichijunrei_client import SeichijunreiClient
-
-client = SeichijunreiClient(api_key="sk_your_key_here")
-result = client.search("Hibike Euphonium locations", locale="en")
-```
-
 ## 仓库结构地图
 
 - `apps/agent/` — Python 运行时：agents、interfaces、infrastructure、tests、tools
-- `workers/catalog/` — 动漫圣地目录 REST API 的 Cloudflare Worker（TypeScript）
-- `packages/contract/` — catalog 与 agent 之间共享的 oRPC contract 类型
-- `apps/web/` — TanStack Start SSR Web 应用与 UI 组件
-- `workers/edge/` — Cloudflare Worker 入口，负责认证与请求路由
+- `workers/catalog/` — 动漫目录 API + 数据平台 Cloudflare Worker（TypeScript）
+- `workers/users/` — 用户域数据 Worker（`/v1/users/*`）
+- `workers/maintenance/` — 定时 Neon 保留 Worker（无公网路由）
+- `packages/contract/` — 共享 oRPC/zod 契约（catalog ↔ agent ↔ users）
+- `apps/web/` — TanStack Start SSR Web 应用（**唯一浏览器面**）
+- `workers/edge/` — Cloudflare Worker 入口：认证与 `/v1` 路由
 - `db/migrations/` — Neon 数据面的 Atlas 迁移与生成的 checksum
 - `supabase/` — auth/旧版兼容迁移与 Supabase 项目资产
 - `docs/` — 架构文档、运维文档、迭代资料与实现计划
@@ -144,5 +140,6 @@ result = client.search("Hibike Euphonium locations", locale="en")
 - [迁移边界](docs/ops/migrations.md) — Atlas authority 与 Drizzle 查询/类型边界
 - [运维文档](docs/ops/README.md) — 运维手册与环境流程
 - [迭代资料](docs/iterations/README.md) — 按迭代归档的 task plan、progress、findings
-- [实现计划](docs/superpowers/plans/) — 保持原位的实现计划历史
-- [设计规格](docs/superpowers/specs/) — 产品规格说明
+- [实现计划（归档）](docs/superpowers/plans/archive/) — 历史执行计划（平层 `plans/` 不再新增）
+- [设计规格](docs/superpowers/specs/) — 现行产品/架构规格
+- [Agent 指南](AGENTS.md) — monorepo 布局、命令与跨栈护栏

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -56,7 +56,7 @@ landing page and branded 404 through a Cloudflare SSR bundle. Root guide: `../..
   pool runs without the TanStack Start vite plugin, so `tests/setup/generate-route-tree.ts`
   (vitest `globalSetup`) emits it before the suite; a normal build regenerates it otherwise.
 - Coverage sweeps `src/**` (routes + `router.tsx` included, per campaign plan §0.6); the enforced
-  floor is `statements 95 / branches 94 / functions 95 / lines 95`, read from `vitest.config.ts`,
+  floor is `statements 98 / branches 95 / functions 98 / lines 99`, read from `vitest.config.ts`,
   which is the authority — ratchet UP only. `routeTree.gen.ts` is the only exclusion (plus the
   WebGL map glue listed in the config's exclude ledger).
 - `OpenAPILink` captures `globalThis.fetch` at construction: build clients at call time (the lazy

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -210,10 +210,10 @@ Its layout, routing, design tokens, and auth wiring are documented in `apps/web/
 that package is the source of truth, not this file.
 
 <!-- historical: retired in #537 -->
-Issue #537 deleted the legacy `frontend/` Next.js package and the root Worker's OpenNext
-fallback with it. The root Worker (`workers/edge/app.ts`) is now an API gateway only: `/v1/*`,
-`/v1/users/*`, `/healthz`, `/img/*`, one allowlisted public catalog read, and a JSON
-`404 not_found` for everything else. It serves no HTML.
+Issue #537 deleted the legacy `frontend/` package and the root Worker's static-asset fallback
+with it. The root Worker (`workers/edge/app.ts`) is now an API gateway only: `/v1/*`,
+`/v1/users/*`, `/healthz`, `/img/*`, `/tiles/*`, one allowlisted public catalog read, and a JSON
+`404 not_found` for everything else. It serves no HTML; `apps/web` owns every page.
 
 ## Eval Infrastructure
 

--- a/docs/iterations/README.md
+++ b/docs/iterations/README.md
@@ -12,6 +12,8 @@ Current active iteration artifacts:
 - `docs/iterations/iter6/README.md` — iter6 cleanup campaign index + Wave 3 design docs
   (`design-C2-app-ts-split.md` / `design-C4-type-convergence.md` /
   `design-C5-clean-arch-both-sides.md` / `design-L1-lint-enforcement.md`)
+- `docs/iterations/s0v2/` — S0-v2 launch GOAL + ruleset target snapshot
+- `docs/iterations/refactor-skeleton-2026-08/HYGIENE-INVENTORY.md` — #856 HY-1 root/docs hygiene inventory
 
 Previous iteration (iter5):
 - `docs/iterations/iter5/task_plan.md`

--- a/docs/iterations/refactor-skeleton-2026-08/HYGIENE-INVENTORY.md
+++ b/docs/iterations/refactor-skeleton-2026-08/HYGIENE-INVENTORY.md
@@ -1,0 +1,101 @@
+# HY-1 Hygiene Inventory — refactor-skeleton 2026-08
+
+Issue: #856 HY-1. Worktree-only inventory of root/docs drift after the monorepo
+skeleton (apps/agent · workers/* · apps/web). Path renames (PATH-DELTA) follow
+`docs/DOCS_POLICY.md` Single Sources of Truth: `backend/` → `apps/agent/`,
+`worker/` / `worker/worker.js` → `workers/edge/`, `frontend/` → retired (#537) /
+`apps/web/`. No git history rewrite; no mass tag/branch deletes.
+
+## Decision rules
+
+| Class | Action |
+|---|---|
+| Active runbook with wrong path | Fix path in place |
+| Root README stale badge / env / example | Surgical rewrite |
+| Historical review / archived plan citing old paths | Leave (archive is read-only history) |
+| Tracked file with no consumers + strong evidence dead | Delete or archive under `docs/archive/` |
+| Uncertain / still referenced by cutover runbook | Keep; list under Deferred |
+
+## Root README fragments (en / ja / zh)
+
+| Item | Evidence | Action |
+|---|---|---|
+| Next.js 16 badge | Legacy `frontend/` retired #537; browser surface is TanStack Start `apps/web/` | **Fixed** — badge → TanStack Start |
+| Required `SUPABASE_ANON_KEY` "JWT validation at Worker edge" | `docs/ops/deployment.md`: edge JWT verifies public JWKS; anon key not required | **Fixed** — removed from required table |
+| Python client example `animichi.clients.python.seichijunrei_client` | No such module under `apps/agent/src/animichi/clients/` (only catalog/geocode) | **Fixed** — example removed; SDK still Iteration-7 |
+| How-it-works "Supabase points" | Catalog/user data plane is Neon; Supabase auth-only | **Fixed** — wording → catalog/Neon |
+| Repo map missing `workers/users/`, `workers/maintenance/` | Live Workers per root `AGENTS.md` / `docs/ops/deployment.md` | **Fixed** — map rows added |
+| Docs link "Implementation plans" → `docs/superpowers/plans/` | Flat plans empty; live history is `plans/archive/` (DOCS_POLICY A6) | **Fixed** — link to `plans/archive/` |
+| Live demo host `seichijunrei.zhenjia.org` | Still the pre-apex public origin until domain cutover (#541 family) | **Keep** (ops fact, not path drift) |
+
+## Deployment notes (duplicate / path drift)
+
+| Location | Stale claim | Canonical | Action |
+|---|---|---|---|
+| `docs/ops/deployment.md` | `catalog/wrangler.toml` | `workers/catalog/wrangler.toml` | **Fixed** |
+| `docs/ops/deployment.md` | bare `interfaces/fastapi_service.py` | `apps/agent/src/animichi/interfaces/fastapi_service.py` | **Fixed** |
+| `docs/ops/deployment.md` | "Next.js app" in #537 note | HTML surface moved to `apps/web` (no Next.js residual for hygiene grep) | **Fixed** wording |
+| `docs/ops/deployment.md` HISTORICAL `backend.scripts.backfill_city` | Pre-monorepo module path | Section already labeled historical-only | **Keep** (historical) |
+| `docs/ops/cloudflare-hardening.md` | `worker/worker.js`, `frontend/out/`, `NEXT_PUBLIC_*` | `workers/edge/entry.ts` + `container-env.ts`; web = `apps/web` | **Fixed** topology + env table |
+| `docs/ops/README.md` | Listed 4 of many live runbooks | Directory has maintenance, secrets, integration, … | **Fixed** — index expanded |
+| `wrangler.toml` header | `SUPABASE_ANON_KEY` as edge JWT secret | Matches Env type leftover; runtime auth uses JWKS | **Fixed** comment (optional/legacy binding) |
+| Root `DEPLOYMENT.md` | Already removed iter6 A6 (#640) | `docs/ops/deployment.md` only | No action |
+
+## Dead links to retired `frontend/` / wrong paths (active surfaces)
+
+| Surface | Finding | Action |
+|---|---|---|
+| Root `AGENTS.md` monorepo map | All package `AGENTS.md` targets exist; paths current | Verified OK |
+| Root `AGENTS.md` "backend ≥82" | Live floor is 87 (`apps/agent/pyproject.toml` `--cov-fail-under`) | **Fixed** → `apps/agent ≥87` |
+| `docs/ARCHITECTURE.md` #537 note | Mentions Next.js/OpenNext (S0.9 wants zero hits) | **Fixed** wording |
+| `docs/testing-strategy.md` stack line | "Next.js + React (frontend)" | **Fixed** stack line + E2E ports note |
+| `docs/testing-strategy.md` body | Many `frontend/` MSW path examples, `make test-frontend`, React/Next section | **Deferred** — full rewrite is S0.9/E1 (#262); not mass-edit this card |
+| `apps/web/AGENTS.md` coverage floors | Claimed 95/94/95/95; config is 98/95/98/99 | **Fixed** to match `vitest.config.ts` |
+| Archived reviews under `docs/superpowers/reviews/` | Full of `backend/` + `frontend/` | **Keep** (historical) |
+| `docs/archive/frontend-*.md` | Intentional archive of retired frontend design | **Keep** |
+
+## Candidate deletions (strong-evidence only)
+
+| Candidate | Evidence | Decision |
+|---|---|---|
+| Root `DEPLOYMENT.md` / `docs/todo.md` / `CHANGELOG` / `VERSION` / `atlas.hcl` / `deno.lock` / skills-lock | Already absent from tree (S0-v2 GOAL A partial) | N/A |
+| `scripts/qa_login.sh` hardcodes foreign venv path | Still referenced by `docs/ops/auth-migration-neon.md` until Neon Auth cutover | **Keep** — cutover ticket retires it |
+| `apps/agent/.../spikes/codemode/` | Spike residual; S0-v2 GOAL A lists spikes cleanup | **Deferred** (behavior-adjacent; not pure docs HY-1) |
+| Historical `docs/superpowers/reviews/*` | Pre-rename eng reviews | **Keep** in place (history) |
+
+**No tracked file deleted in this card** — evidence for pure dead files was weak or cutover-blocked; prefer docs path fixes.
+
+## AGENTS.md top-level map check
+
+| Link / path | Status |
+|---|---|
+| `apps/agent/AGENTS.md` … `infra/AGENTS.md` (layout bullets) | OK |
+| `docs/testing-strategy.md` | OK (exists; body partially stale — deferred) |
+| `docs/ops/deployment.md` | OK |
+| `docs/ARCHITECTURE.md` | OK |
+| `docs/DOCS_POLICY.md` | OK |
+| `docs/workflow.md` | OK |
+| `docs/superpowers/specs/2026-06-13-architecture-adr.md` | OK |
+| `docs/superpowers/specs/2026-07-06-frontend-rebuild-spec.md` | OK |
+| `.claude/rules/` | OK (directory present) |
+
+## Deferred (out of HY-1 surgical scope)
+
+1. Full `docs/testing-strategy.md` rewrite (S0.9 / #262 E1) — coverage table already correct; body still uses legacy `frontend/` examples.
+2. S0-v2 root allowlist hygiene test + dead-file script lock (launch spec Track A).
+3. Spike / orphan script purge under `apps/agent` spikes.
+4. Domain cutover copy (live demo URL → `animichi.com`) after #541 DNS/route ownership.
+5. Archive-only reviews still citing `backend/`/`frontend/` — leave unless filter-repo (iter6 C3) rewrites history (explicitly out of scope for HY-1).
+
+## PR-ready change set (this card)
+
+- `docs/iterations/refactor-skeleton-2026-08/HYGIENE-INVENTORY.md` (this file)
+- `README.md` · `README.ja.md` · `README.zh.md`
+- `AGENTS.md`
+- `docs/ops/deployment.md`
+- `docs/ops/cloudflare-hardening.md`
+- `docs/ops/README.md`
+- `docs/ARCHITECTURE.md` (historical wording only)
+- `docs/testing-strategy.md` (stack + E2E env lines only)
+- `apps/web/AGENTS.md` (coverage floor mirror)
+- `wrangler.toml` (header comment only)

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -13,6 +13,12 @@ Current canonical docs:
 - `migrations.md` — Neon Atlas migration authority, Drizzle query/type boundary, CI, and deployment order
 - `neon-backup-rpo.md` — Neon PITR placement, RPO/RTO targets, HITL monitor checklist, failed-migrate + bad-migration recovery (N5 / #860)
 - `cloudflare-hardening.md` — WAF rate limiting, prompt-injection filtering, rollback for edge rules, container-level egress network policy (#284 Task 7)
+- `secrets.md` — repository/environment secret inventory, consumers, rotation impact
+- `integration.md` — single source for env/secrets layout, domain topology, data path, deploy chain, local dev
+- `maintenance-worker.md` — scheduled maintenance Worker schedules and cutover checks
 - `anonymous-session-purge.md` — scheduled anonymous-session retention sweep (cron cadence, required secret, reading a run)
+- `auth-migration-neon.md` — Neon Auth (Better Auth) cutover runbook (flag-gated; Supabase still verifies today)
+- `neon-test-infra.md` · `neon-local-spike-findings.md` — Neon test-base / local proxy operator notes
+- `indexnow.md` · `privacy.md` — SEO push and privacy ops notes
 
 Keep iteration task trackers, progress logs, and findings under `docs/iterations/`.

--- a/docs/ops/cloudflare-hardening.md
+++ b/docs/ops/cloudflare-hardening.md
@@ -17,15 +17,18 @@ For the full deployment topology, auth flow, and env-var boundaries see `deploym
 Browser / API client
   │
   ▼
-Cloudflare Edge (Worker: worker/worker.js)
-  ├─ static paths (/, /about, *.js, *.css, …) ──▶ ASSETS binding (frontend/out/)
+Cloudflare Edge (Worker: workers/edge/entry.ts)
+  ├─ page HTML ──────────────────────────────────▶ apps/web Worker (TanStack Start; not this Worker)
   ├─ /img/* ─────────────────────────────────────▶ Worker image proxy → Anitabi CDN (cached)
+  ├─ /tiles/* ───────────────────────────────────▶ private R2 tile proxy
   ├─ /healthz ───────────────────────────────────▶ RuntimeContainer (no auth)
+  ├─ /v1/users/* ────────────────────────────────▶ USERS service binding
+  ├─ /catalog/* ─────────────────────────────────▶ CATALOG service binding
   └─ /v1/* ── authenticate ── strip Authorization
        │        inject X-User-Id, X-User-Type
        ▼
      RuntimeContainer (Durable Object → Python FastAPI on port 8080)
-       ├─ Supabase Postgres (SUPABASE_DB_URL)
+       ├─ agent-domain Postgres (SUPABASE_DB_URL)
        └─ MiMo/DeepSeek model provider (MIMO_API_KEY / DEEPSEEK_API_KEY) —
           photo-search recognition rides this same chat model (#656)
 ```
@@ -49,20 +52,20 @@ On success the Worker sets `X-User-Id` and `X-User-Type`, deletes the `Authoriza
 | `SUPABASE_SERVICE_ROLE_KEY` | Worker-only | Used for `api_keys` table lookup |
 | `NEON_AUTH_ENABLED` / `NEON_AUTH_JWKS_URL` / `NEON_AUTH_ISSUER` | Worker-only (optional) | Dual-issuer readiness — Neon Auth EdDSA JWKS verification; absent or `false` ⇒ Neon path off (default) |
 | `SUPABASE_DB_URL` | Container-only | Direct Postgres connection for asyncpg |
-| `CORS_ALLOWED_ORIGIN` | Container-only | Backend CORS allowlist |
+| `CORS_ALLOWED_ORIGIN` | Container-only | Agent CORS allowlist |
 | `GOOGLE_MAPS_API_KEY` | Container-only (optional) | Geocoding |
 | `LOGFIRE_TOKEN` | Container-only (optional) | Observability |
-| `NEXT_PUBLIC_SUPABASE_URL` | Frontend build-time only | Injected by CI, not a runtime secret |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Frontend build-time only | Injected by CI, not a runtime secret |
+| `VITE_*` (web build) | `apps/web` build-time only | Injected by CI into the web Worker; not root-Worker secrets |
 
-The full container env allowlist is defined in `worker/worker.js` as `CONTAINER_REQUIRED_ENV_KEYS`, `CONTAINER_RUNTIME_ENV_KEYS`, and `CONTAINER_OPTIONAL_ENV_KEYS`.
+The full container env allowlist is `CONTAINER_ENV_KEYS` / `CONTAINER_REQUIRED_KEYS` in
+`workers/edge/container-env.ts` (consumed by `workers/edge/entry.ts`).
 
 ## Current Trust Boundary
 
-- Browser and API clients talk only to the Worker hostname
+- Browser clients hit `apps/web`; API clients hit the root edge Worker hostname
 - Worker-only auth secrets stay at the edge: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` (+ optional `NEON_AUTH_*`); the edge JWT path verifies against the public Supabase JWKS, so no `SUPABASE_ANON_KEY` is needed there
-- Container runtime receives only its explicit allowlist from `worker/worker.js`
-- Backend auth trust starts from `X-User-Id` and `X-User-Type`, not from raw bearer tokens
+- Container runtime receives only its explicit allowlist from `workers/edge/container-env.ts`
+- Agent auth trust starts from `X-User-Id` and `X-User-Type`, not from raw bearer tokens
 
 ## 1. `/v1/*` Rate Limit Rule
 
@@ -128,7 +131,7 @@ Operational guidance:
 
 If AI Gateway is enabled later:
 
-- place it between the container and Gemini
+- place it between the container and the upstream model provider (MiMo / DeepSeek)
 - do not place it in the browser
 - do not place it in the Worker
 
@@ -164,8 +167,8 @@ After manual dashboard changes:
 
 - confirm `/healthz` still succeeds without auth
 - confirm `/v1/runtime` still requires auth and returns `401` when missing credentials
-- confirm a valid authenticated `/v1/runtime` request still reaches the backend
-- confirm static frontend assets remain unaffected
+- confirm a valid authenticated `/v1/runtime` request still reaches the agent container
+- confirm `apps/web` page routes are unaffected (they are a separate Worker)
 - inspect Worker logs for unexpected spikes in blocked traffic or auth failures
 
 ## 6. Egress Network Policy (container-level defense-in-depth — #284 Task 7)

--- a/docs/ops/cloudflare-hardening.md
+++ b/docs/ops/cloudflare-hardening.md
@@ -23,12 +23,13 @@ Cloudflare Edge (Worker: workers/edge/entry.ts)
   ├─ /tiles/* ───────────────────────────────────▶ private R2 tile proxy
   ├─ /healthz ───────────────────────────────────▶ RuntimeContainer (no auth)
   ├─ /v1/users/* ────────────────────────────────▶ USERS service binding
-  ├─ /catalog/* ─────────────────────────────────▶ CATALOG service binding
   └─ /v1/* ── authenticate ── strip Authorization
        │        inject X-User-Id, X-User-Type
        ▼
      RuntimeContainer (Durable Object → Python FastAPI on port 8080)
        ├─ agent-domain Postgres (SUPABASE_DB_URL)
+       ├─ catalog.internal (private) ─────────────▶ CATALOG service binding
+       │    (no public /catalog/* browser route)
        └─ MiMo/DeepSeek model provider (MIMO_API_KEY / DEEPSEEK_API_KEY) —
           photo-search recognition rides this same chat model (#656)
 ```

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -28,7 +28,7 @@ Cloudflare Cron Triggers ──────────────────�
 
 The hybrid topology runs the edge Worker plus the catalog, users, and scheduled maintenance Workers. The main `seichijunrei` Worker
 (`workers/edge/entry.ts`) routes `/catalog/*` to the separate `catalog` Worker
-(`catalog/wrangler.toml`) via a wrangler service binding (`env.CATALOG.fetch`).
+(`workers/catalog/wrangler.toml`) via a wrangler service binding (`env.CATALOG.fetch`).
 The Python agent in the container cannot use that JS-only binding, so it reaches
 the catalog over the public origin: `CATALOG_API_URL` (forwarded into the
 container as a plain var) points at the deployed host, and `CatalogClient` POSTs
@@ -42,13 +42,14 @@ runtime query/type metadata. The maintenance Worker has no ORM: it calls `neon()
 The checked-in Atlas directory is the only Neon schema authority for all three. See
 [`migrations.md`](./migrations.md) before changing a table or deploy step.
 
-- `interfaces/fastapi_service.py` exposes `GET /healthz`
-- `interfaces/fastapi_service.py` exposes `POST /v1/runtime`
-- `interfaces/fastapi_service.py` exposes `POST /v1/runtime/stream` (SSE)
-- `interfaces/fastapi_service.py` exposes `POST /v1/feedback`
-- `Dockerfile` packages the runtime into a single container image
+Agent HTTP surface (paths relative to `apps/agent/src/animichi/`):
 
-The deployment target stays intentionally thin. The Worker owns routing and edge auth; the container runs the backend service and stays unaware of raw end-user credentials.
+- `interfaces/fastapi_service.py` / `interfaces/routes/health.py` — `GET /healthz`
+- `interfaces/routes/runtime.py` — `POST /v1/runtime` and `POST /v1/runtime/stream` (SSE)
+- `interfaces/routes/feedback.py` — `POST /v1/feedback`
+- root `Dockerfile` packages the agent into a single container image
+
+The deployment target stays intentionally thin. The Worker owns routing and edge auth; the container runs the agent service and stays unaware of raw end-user credentials.
 
 ## Trust Boundaries
 
@@ -250,12 +251,12 @@ Routing defined by `wrangler.toml`:
 - everything else answers a JSON `404 not_found`
 
 <!-- historical: retired in #537 -->
-Issue #537 removed the bundled Next.js app and with it the `[assets]` binding: this Worker
-has **no** HTML surface. `apps/web` deploys as its own Worker and owns every page. The root
-Worker's `routes` still claim `animichi.com/*`, so the apex has not yet been cut over to the
-web Worker. Until issue #541 changes the DNS and route ownership, the root Worker owns the
-apex request but returns its JSON 404 for page paths; `apps/web` owns HTML only on its own
-Worker hostname. That cutover must land before `animichi.com` gets a DNS record.
+Issue #537 removed the bundled legacy static frontend and with it the `[assets]` binding: this
+Worker has **no** HTML surface. `apps/web` (TanStack Start) deploys as its own Worker and owns
+every page. Route ownership for the apex is declared in Pulumi (`infra/index.ts`, #541): until
+`webRoutesEnabled` is on, the root Worker may have no public hostname at all
+(`workers_dev = false`). `apps/web` owns HTML on its Worker hostname; the root Worker is API +
+proxy only (`/v1/*`, `/healthz`, `/img/*`, `/tiles/*`, one public catalog read).
 
 ## Deploy Sequence
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -3,7 +3,7 @@
 Date: 2026-07-18
 Status: CURRENT
 Repo: lifeodyssey/animichi
-Stack: FastAPI + asyncpg + Pydantic AI (backend), Next.js + React (frontend), Cloudflare Workers (deploy)
+Stack: FastAPI + asyncpg + PydanticAI (`apps/agent`), TanStack Start + React (`apps/web`), Cloudflare Workers (`workers/edge` · `catalog` · `users` · `maintenance`)
 
 ## Table of Contents
 
@@ -475,9 +475,9 @@ Weekly CI run without cassettes verifies APIs haven't changed.
 
 ### Test Environment
 
-- Backend: `localhost:8080` (FastAPI; choose its DB arm separately)
-- Frontend: `localhost:3000` (Next.js dev server)
-- Auth: local Supabase GoTrue + `send-auth-email` + Mailpit
+- Agent: `localhost:8080` (FastAPI container/service; choose its DB arm separately)
+- Web: `apps/web` Vite dev / Wrangler preview (default `E2E_WEB_BASE_URL=http://localhost:3000`)
+- Auth: local Supabase GoTrue + `send-auth-email` + Mailpit (until Neon Auth cutover)
 - **Nothing is mocked**
 
 `make e2e-setup` starts the retained auth appliance and seeds its compatibility database. That
@@ -670,15 +670,15 @@ The following is embedded directly in Executor and Reviewer prompts. No runtime 
 - Assert agent-model exchange with `capture_run_messages()`
 - Global `models.ALLOW_MODEL_REQUESTS = False` prevents accidental real calls
 
-### React / Next.js
+### React / TanStack Start (`apps/web`)
 
-- Server Components by default, `"use client"` only when interaction/state needed
-- Minimize `"use client"` — only on components that truly need client state
+- Prefer server loaders and route-level data; mark client components only when interaction/state needs the browser
 - Hook rules: no hooks in conditionals/loops
 - key prop with stable IDs (e.g. `message.id`), not array index
 - `useCallback` for event handlers to prevent unnecessary child re-renders
-- CSS via Tailwind utility + `globals.css` design tokens
+- CSS via Tailwind utility + `apps/web/src/styles/globals.css` design tokens
 - `useEffect` cleanup: return cleanup function to prevent memory leaks
+- Package conventions and coverage floors: `apps/web/AGENTS.md` + `apps/web/vitest.config.ts`
 
 ### testcontainers
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -25,8 +25,9 @@
 #
 # Edge runtime secrets (used by workers/edge/auth.ts for /v1 auth):
 #   SUPABASE_URL               — https://<project>.supabase.co (set via wrangler secret put)
-#   SUPABASE_ANON_KEY          — Public anon key for JWT validation (set via wrangler secret put)
 #   SUPABASE_SERVICE_ROLE_KEY  — Service role for sk_ API key lookup (set via wrangler secret put)
+#   SUPABASE_ANON_KEY          — optional/legacy Env binding; edge JWT verifies public JWKS
+#                                and does not require the anon key (see docs/ops/deployment.md)
 #   NEON_AUTH_ISSUER           — public Neon Auth base URL (set in [vars] when cutover is approved)
 #
 # Container runtime secrets (forwarded to Python backend). Production model


### PR DESCRIPTION
## Summary
Add HYGIENE-INVENTORY.md. Fix root README en/ja/zh, AGENTS coverage floors, deployment/cloudflare-hardening path drift (frontend/backend → apps/web · apps/agent · workers/*). No force-push, no mass deletes.

Closes #856
Parent: #829

## Test plan
- [x] Docs-only review of paths vs monorepo layout
- [ ] CI after Actions recovery
- [ ] Matt code-review + 两路评论闸 before merge