### PR TITLE
fix(scripts): validate --ref format before passing to git (S8705, #871)

### DIFF
--- a/scripts/git-squash-daily.py
+++ b/scripts/git-squash-daily.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import time
 from collections import OrderedDict
@@ -194,6 +195,8 @@ def main() -> int:
     if not os.path.isdir(args.repo):
         raise RuntimeError(f"--repo must be an existing directory: {args.repo}")
     ref = args.ref or default_ref(args.repo)
+    if ref.startswith("-") or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]*", ref):
+        raise SystemExit(f"invalid ref: {ref!r}")
     commits = walk_commits(args.repo, ref)
     if not commits:
         print(f"no commits on {ref}")


### PR DESCRIPTION
Closes SonarCloud S8705 (argument injection) in `scripts/git-squash-daily.py`.

## Problem
`--ref` comes from argparse user input and is passed positionally into `["git", ...]` subprocess calls (git() helper, trees_identical()). No shell=True, but S8705 flags the unvalidated injection surface.

## Fix
Validate the ref after parsing (and after `ref = args.ref or default_ref(...)`): reject refs starting with `-` (option-like) or failing the git-ref charset pattern `[A-Za-z0-9][A-Za-z0-9._/-]*`.

## Local verification
```
$ python3 scripts/git-squash-daily.py --repo /Users/lumimamini/work/animichi-wts/fix-s8705 --ref='-bad'
invalid ref: '-bad'
exit=1

$ python3 scripts/git-squash-daily.py --repo /Users/lumimamini/work/animichi-wts/fix-s8705 --ref origin/main
ref: origin/main
days: 98
new commits: 98
densest days (original commit count):
  2026-07-19: 94 commits
  2026-08-05: 93 commits
  2026-08-04: 87 commits
  2026-07-29: 76 commits
  2026-08-03: 75 commits
OK: diff origin/main dry-run/daily-squash-... empty — trees identical
exit=0
```

## Ruff
```
$ uv run --with ruff ruff check scripts/git-squash-daily.py
All checks passed!
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for selected Git references.
  * Rejects invalid or potentially unsafe reference names before processing commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->