### PR TITLE
fix(#826): edge containers to instance_type basic — cold-start OOM guard

### DIFF
--- a/workers/edge/wrangler.toml
+++ b/workers/edge/wrangler.toml
@@ -153,6 +153,9 @@ class_name = "RuntimeContainer"
 image = "../../apps/agent/Dockerfile"
 image_build_context = "../../"
 max_instances = 3
+# lite (0.0625 vCPU / 256 MiB) is below this service's import peak (~273 MiB,
+# cold-start audit 2026-08-07) — OOM risk during boot. basic: 1/4 vCPU / 1 GiB.
+instance_type = "basic"
 
 [[durable_objects.bindings]]
 name = "CONTAINER"
@@ -248,6 +251,9 @@ class_name = "RuntimeContainer"
 image = "../../apps/agent/Dockerfile"
 image_build_context = "../../"
 max_instances = 3
+# lite (0.0625 vCPU / 256 MiB) is below this service's import peak (~273 MiB,
+# cold-start audit 2026-08-07) — OOM risk during boot. basic: 1/4 vCPU / 1 GiB.
+instance_type = "basic"
 
 [[env.production.durable_objects.bindings]]
 name = "CONTAINER"
@@ -372,6 +378,9 @@ class_name = "RuntimeContainer"
 image = "../../apps/agent/Dockerfile"
 image_build_context = "../../"
 max_instances = 3
+# lite (0.0625 vCPU / 256 MiB) is below this service's import peak (~273 MiB,
+# cold-start audit 2026-08-07) — OOM risk during boot. basic: 1/4 vCPU / 1 GiB.
+instance_type = "basic"
 
 [[env.staging.durable_objects.bindings]]
 name = "CONTAINER"


### PR DESCRIPTION
Cold-start audit (2026-08-07): the agent container's Python import peak is ~273 MiB, above the lite instance cap (0.0625 vCPU / 256 MiB). A cold boot can be OOM-killed before uvicorn binds 8080 — the exact #826 failure shape.

Change: `instance_type = \"basic\"` (1/4 vCPU / 1 GiB / 4 GB) on all three [[containers]] blocks (default / production / staging) in workers/edge/wrangler.toml. Verified: edge node:test 286/286 pass; schema enum confirmed in wrangler config-schema.json. Owner decision 2026-08-07.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RuntimeContainer deployment settings to use the basic instance tier across root, production, and staging environments.
  * Improves available container capacity and consistency between environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->