### PR TITLE
feat(#852): catalog greenfield rename — itinerary_snapshots + bangumi_id (PR-2)

### DIFF
--- a/apps/agent/src/animichi/agents/catalog_adapter.py
+++ b/apps/agent/src/animichi/agents/catalog_adapter.py
@@ -20,22 +20,22 @@ from animichi.agents.session_state import (
     SearchPayloadState,
     TimedItineraryState,
 )
-from animichi.clients.catalog_client import PilgrimagePoint, Route
+from animichi.clients.catalog_client import Itinerary, Point
 
 SearchTool = Literal["search_bangumi", "search_nearby"]
 
 
-def _point_to_row(point: PilgrimagePoint) -> dict[str, object]:
+def _point_to_row(point: Point) -> dict[str, object]:
     """Serialize a typed point to the flat row dict the frontend contract uses."""
     return point.model_dump(mode="json")
 
 
-def _rows_from_points(points: list[PilgrimagePoint]) -> list[dict[str, object]]:
+def _rows_from_points(points: list[Point]) -> list[dict[str, object]]:
     """Serialize points to proxy-rewritten row dicts (shared search/route shape)."""
     return rewrite_image_urls([_point_to_row(p) for p in points])
 
 
-def _search_metadata(points: list[PilgrimagePoint]) -> dict[str, object]:
+def _search_metadata(points: list[Point]) -> dict[str, object]:
     """Derive anime title/cover metadata from the first point, if any."""
     if not points:
         return {}
@@ -49,9 +49,7 @@ def _search_metadata(points: list[PilgrimagePoint]) -> dict[str, object]:
     }
 
 
-def build_search_payload(
-    points: list[PilgrimagePoint], *, tool: SearchTool
-) -> dict[str, object]:
+def build_search_payload(points: list[Point], *, tool: SearchTool) -> dict[str, object]:
     """Shape catalog points into the search/nearby tool_state payload."""
     rows = _rows_from_points(points)
     empty = not rows
@@ -68,21 +66,21 @@ def build_search_payload(
     }
 
 
-def build_route_payload(route: Route) -> dict[str, object]:
-    """Shape a catalog Route into the plan_route tool_state payload."""
-    ordered = _rows_from_points(route.ordered_points)
-    itinerary = route.timed_itinerary
+def build_itinerary_payload(itinerary: Itinerary) -> dict[str, object]:
+    """Shape a catalog Itinerary into the plan_route tool_state payload."""
+    ordered = _rows_from_points(itinerary.ordered_points)
+    timed = itinerary.timed_itinerary
     return {
         "ordered_points": ordered,
-        "timed_itinerary": itinerary.model_dump(mode="json"),
-        "point_count": route.point_count,
-        "cover_url": route.cover_url,
+        "timed_itinerary": timed.model_dump(mode="json"),
+        "point_count": itinerary.point_count,
+        "cover_url": itinerary.cover_url,
         "status": "ok",
         "summary": {
-            "point_count": route.point_count,
-            "total_minutes": itinerary.total_minutes,
-            "total_distance_m": itinerary.total_distance_m,
-            "clusters": itinerary.spot_count,
+            "point_count": itinerary.point_count,
+            "total_minutes": timed.total_minutes,
+            "total_distance_m": timed.total_distance_m,
+            "clusters": timed.spot_count,
             "with_coordinates": len(ordered),
             "without_coordinates": 0,
         },
@@ -90,7 +88,7 @@ def build_route_payload(route: Route) -> dict[str, object]:
 
 
 def build_search_state(
-    points: list[PilgrimagePoint],
+    points: list[Point],
     *,
     kind: Literal["bangumi", "nearby"],
     anime_id: str | None = None,
@@ -119,30 +117,30 @@ def build_search_state(
 
 
 def build_route_state(
-    route: Route, source_ref: ResultRef | None, *, locale: str
+    itinerary: Itinerary, source_ref: ResultRef | None, *, locale: str
 ) -> RoutePayloadState:
     """Adapt a non-empty catalog route into the typed route registry."""
-    localized = route.model_copy(
+    localized = itinerary.model_copy(
         update={
             "ordered_points": [
-                _localized_point(point, locale) for point in route.ordered_points
+                _localized_point(point, locale) for point in itinerary.ordered_points
             ]
         }
     )
-    payload = build_route_payload(localized)
+    payload = build_itinerary_payload(localized)
     summary = payload["summary"]
-    itinerary = payload["timed_itinerary"]
+    timed = payload["timed_itinerary"]
     raw_points = payload["ordered_points"]
     points = raw_points if isinstance(raw_points, list) else []
     return RoutePayloadState(
         ordered_points=[PointState.model_validate(row) for row in points],
-        timed_itinerary=TimedItineraryState.model_validate(itinerary),
+        timed_itinerary=TimedItineraryState.model_validate(timed),
         summary=RouteSummaryState.model_validate(summary),
         source_ref=source_ref,
     )
 
 
-def _localized_point(point: PilgrimagePoint, locale: str) -> PilgrimagePoint:
+def _localized_point(point: Point, locale: str) -> Point:
     if point.city is None:
         return point
     return point.model_copy(update={"city": localized_city_name(point.city, locale)})

--- a/apps/agent/src/animichi/agents/catalog_route_tools.py
+++ b/apps/agent/src/animichi/agents/catalog_route_tools.py
@@ -20,7 +20,7 @@ from animichi.agents.tool_outcomes import (
     RouteStaleRef,
     RouteUpstreamDown,
 )
-from animichi.clients.catalog_client import CatalogClientProtocol, Route
+from animichi.clients.catalog_client import CatalogClientProtocol, Itinerary
 
 Pacing = Literal["chill", "normal", "packed"]
 
@@ -59,23 +59,25 @@ async def _route_outcome(
         return RoutePendingSync()
     if not payload.rows:
         return RouteEmpty()
-    route = await catalog.route(
+    itinerary = await catalog.plan_itinerary(
         [point.id for point in payload.rows if point.id], pacing=pacing
     )
-    if route.point_count < 1:
+    if itinerary.point_count < 1:
         return RouteEmpty()
-    return _store_route(ctx, route, ref)
+    return _store_route(ctx, itinerary, ref)
 
 
-def _store_route(ctx: RunContext[RuntimeDeps], route: Route, ref: ResultRef) -> RouteOk:
-    route_ref = RouteRef(ctx.deps.ref_factory("route", route.point_count))
-    state = build_route_state(route, ref, locale=ctx.deps.locale)
+def _store_route(
+    ctx: RunContext[RuntimeDeps], itinerary: Itinerary, ref: ResultRef
+) -> RouteOk:
+    route_ref = RouteRef(ctx.deps.ref_factory("route", itinerary.point_count))
+    state = build_route_state(itinerary, ref, locale=ctx.deps.locale)
     ctx.deps.tool_state.session.store_route(route_ref, state)
     _clear_pending(ctx.deps)
     minutes = state.timed_itinerary.total_minutes if state.timed_itinerary else 0
     return RouteOk(
         route_ref=str(route_ref),
-        point_count=route.point_count,
+        point_count=itinerary.point_count,
         total_minutes=minutes,
     )
 

--- a/apps/agent/src/animichi/agents/catalog_tools.py
+++ b/apps/agent/src/animichi/agents/catalog_tools.py
@@ -147,7 +147,7 @@ async def run_work_search(
 ) -> SearchOk | SearchEmpty | SearchUpstreamDown:
     """Fetch an already-resolved work without repeating free-text resolution."""
     try:
-        result = await catalog.points_by_work_id(bangumi_id)
+        result = await catalog.points_by_bangumi_id(bangumi_id)
     except CATALOG_FAILURES:
         return SearchUpstreamDown()
     payload = build_search_state(

--- a/apps/agent/src/animichi/agents/photo_search.py
+++ b/apps/agent/src/animichi/agents/photo_search.py
@@ -22,7 +22,7 @@ from animichi.agents.photo_vision import RecognizeCall, VisionRecognitionFailed
 from animichi.clients.catalog_client import (
     AnimeCandidate,
     CatalogClientProtocol,
-    PilgrimagePoint,
+    Point,
     ResolveAmbiguous,
     ResolveResolved,
 )
@@ -99,7 +99,7 @@ class PhotoSearchOutcome:
     usage: AttributedUsage | None = None
 
 
-def _point(row: PilgrimagePoint) -> PhotoPoint:
+def _point(row: Point) -> PhotoPoint:
     return PhotoPoint(
         id=row.id,
         name=row.name,
@@ -113,9 +113,7 @@ def _point(row: PilgrimagePoint) -> PhotoPoint:
     )
 
 
-def _search_response(
-    match: AnimeCandidate, rows: list[PilgrimagePoint]
-) -> PhotoSearchResponse:
+def _search_response(match: AnimeCandidate, rows: list[Point]) -> PhotoSearchResponse:
     results = PhotoResults(
         bangumi_id=match.bangumi_id,
         title=match.title or match.title_cn,
@@ -155,7 +153,7 @@ def merge_candidates(
     return merged
 
 
-def _nearby_works(points: list[PilgrimagePoint]) -> list[PhotoCandidate]:
+def _nearby_works(points: list[Point]) -> list[PhotoCandidate]:
     works: dict[str, PhotoCandidate] = {}
     for point in points:
         if point.bangumi_id and point.bangumi_id not in works:
@@ -200,7 +198,7 @@ async def _layer_one(
 async def _resolved_outcome(
     catalog: CatalogClientProtocol, resolved: ResolveResolved, gps: GpsPoint | None
 ) -> PhotoSearchOutcome:
-    rows = (await catalog.points_by_work_id(resolved.match.bangumi_id)).rows
+    rows = (await catalog.points_by_bangumi_id(resolved.match.bangumi_id)).rows
     response = _search_response(resolved.match, rows)
     return PhotoSearchOutcome(
         response, _signals("anime_screenshot", gps, "1", len(rows))

--- a/apps/agent/src/animichi/agents/selected_route.py
+++ b/apps/agent/src/animichi/agents/selected_route.py
@@ -13,7 +13,7 @@ from animichi.agents.agent_result import (
     RouteRejectionStatus,
     StepRecord,
 )
-from animichi.agents.catalog_adapter import build_route_payload, build_route_state
+from animichi.agents.catalog_adapter import build_itinerary_payload, build_route_state
 from animichi.agents.error_messages import (
     CATALOG_ROUTE_UNAVAILABLE_MESSAGE,
     build_error_message,
@@ -22,7 +22,7 @@ from animichi.agents.runtime_deps import OnStep, StepEvent, StepStatus, new_step
 from animichi.agents.runtime_models import RouteResponseModel
 from animichi.agents.selection_messages import selected_route_message
 from animichi.agents.session_state import SessionState
-from animichi.clients.catalog_client import CatalogClientProtocol, Route
+from animichi.clients.catalog_client import CatalogClientProtocol, Itinerary
 from animichi.clients.errors import APIError
 
 logger = structlog.get_logger(__name__)
@@ -49,7 +49,9 @@ async def execute_selected_route(
     await _emit_step(on_step, call_id, "running", {})
 
     try:
-        route = await catalog.route(point_ids, origin=_parse_coordinate_origin(origin))
+        itinerary = await catalog.plan_itinerary(
+            point_ids, origin=_parse_coordinate_origin(origin)
+        )
     except ValidationError:
         logger.error("selected_route_catalog_contract_error")
         await _emit_step(on_step, call_id, "error", {})
@@ -72,12 +74,12 @@ async def execute_selected_route(
             state,
         )
 
-    step, payload = _build_step(route, params)
+    step, payload = _build_step(itinerary, params)
     if not step.is_success:
         await _emit_step(on_step, call_id, "error", {})
         return _error_result("No catalog route data", locale, state)
     await _emit_step(on_step, call_id, "done", payload)
-    return _build_success_result(route, step, locale, state)
+    return _build_success_result(itinerary, step, locale, state)
 
 
 def _build_params(point_ids: list[str], origin: str | None) -> dict[str, object]:
@@ -101,11 +103,11 @@ async def _emit_step(
 
 
 def _build_step(
-    route: Route, params: dict[str, object]
+    itinerary: Itinerary, params: dict[str, object]
 ) -> tuple[StepRecord, dict[str, object]]:
-    """Shape the catalog route into a StepRecord and its tool_state payload."""
-    payload = build_route_payload(route)
-    is_success = route.point_count > 0
+    """Shape the catalog itinerary into a StepRecord and its tool_state payload."""
+    payload = build_itinerary_payload(itinerary)
+    is_success = itinerary.point_count > 0
     step = StepRecord(
         tool="plan_selected",
         is_success=is_success,
@@ -118,7 +120,7 @@ def _build_step(
 
 
 def _build_success_result(
-    route: Route,
+    itinerary: Itinerary,
     step: StepRecord,
     locale: str,
     state: SessionState,
@@ -126,13 +128,13 @@ def _build_success_result(
     """Assemble the AgentResult returned on a successful route lookup."""
     route_ref = state.next_route_ref("selected", 1)
     state.store_route(
-        route_ref, build_route_state(route, source_ref=None, locale=locale)
+        route_ref, build_route_state(itinerary, source_ref=None, locale=locale)
     )
     step.provenance = ProducedRoute(status="ok", route_ref=route_ref)
     state.pending_clarification = None
     state.geocode_staging = None
     output = RouteResponseModel(
-        message=selected_route_message(locale, route.point_count)
+        message=selected_route_message(locale, itinerary.point_count)
     )
     return AgentResult(
         output=output,

--- a/apps/agent/src/animichi/agents/selection.py
+++ b/apps/agent/src/animichi/agents/selection.py
@@ -105,7 +105,7 @@ async def execute_multi_selection(
     call_id = new_step_call_id("plan_multi")
     await _emit(on_step, call_id, "plan_multi", "running", {})
     fetched = await asyncio.gather(
-        *(catalog.points_by_work_id(item) for item in candidate_ids),
+        *(catalog.points_by_bangumi_id(item) for item in candidate_ids),
         return_exceptions=True,
     )
     steps = _fetch_steps(candidate_ids, fetched)
@@ -134,7 +134,9 @@ async def execute_multi_selection(
             state, steps, locale, "too_large", on_step, call_id, search=provenance
         )
     try:
-        route = await catalog.route([point.id for point in merged.rows if point.id])
+        itinerary = await catalog.plan_itinerary(
+            [point.id for point in merged.rows if point.id]
+        )
     except (RouteTooManyClustersError, RouteTooManyPointsError):
         return await _multi_terminal_event(
             state, steps, locale, "too_large", on_step, call_id, search=provenance
@@ -143,12 +145,14 @@ async def execute_multi_selection(
         return await _multi_terminal_event(
             state, steps, locale, "error", on_step, call_id, search=provenance
         )
-    if route.point_count < 1:
+    if itinerary.point_count < 1:
         return await _multi_terminal_event(
             state, steps, locale, "error", on_step, call_id, search=provenance
         )
     route_ref = state.next_route_ref("multi", state.clarification_revision)
-    state.store_route(route_ref, build_route_state(route, result_ref, locale=locale))
+    state.store_route(
+        route_ref, build_route_state(itinerary, result_ref, locale=locale)
+    )
     _set_current_anime(state, candidate_ids)
     omitted = _omitted_titles(state, merged.omitted_work_ids)
     _consume_pending(state)

--- a/apps/agent/src/animichi/application/catalog_read_gateway.py
+++ b/apps/agent/src/animichi/application/catalog_read_gateway.py
@@ -24,9 +24,9 @@ from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 if TYPE_CHECKING:
     from animichi.clients.catalog_client import (
         GeocodeCandidate,
-        PilgrimagePoint,
+        Itinerary,
+        Point,
         ResolveOutcome,
-        Route,
         SearchResult,
     )
 
@@ -43,20 +43,20 @@ class CatalogReadGateway(Protocol):
 
     async def resolve(self, query: str) -> ResolveOutcome: ...
 
-    async def points_by_work_id(self, work_id: str) -> SearchResult: ...
+    async def points_by_bangumi_id(self, bangumi_id: str) -> SearchResult: ...
 
     async def nearby(
         self, lat: float, lng: float, *, radius_m: int = 2000
-    ) -> list[PilgrimagePoint]: ...
+    ) -> list[Point]: ...
 
     async def geocode(
         self, query: str, *, limit: int = 5
     ) -> list[GeocodeCandidate]: ...
 
-    async def route(
+    async def plan_itinerary(
         self,
         point_ids: list[str],
         *,
         origin: tuple[float, float] | None = None,
         pacing: Literal["chill", "normal", "packed"] | None = None,
-    ) -> Route: ...
+    ) -> Itinerary: ...

--- a/apps/agent/src/animichi/clients/catalog_client.py
+++ b/apps/agent/src/animichi/clients/catalog_client.py
@@ -50,11 +50,11 @@ _CATALOG_HTTP_LIMITS = httpx.Limits(
 
 # Re-exported so callers depend on this client, not on agent internals.
 __all__ = [
-    "PilgrimagePoint",
+    "Point",
     "AnimeCandidate",
     "ResolveOutcome",
     "SearchResult",
-    "Route",
+    "Itinerary",
     "TimedItinerary",
     "TimedStop",
     "TransitLeg",
@@ -69,7 +69,7 @@ __all__ = [
 JSONDict = dict[str, object]
 
 
-class PilgrimagePoint(BaseModel):
+class Point(BaseModel):
     """A single pilgrimage point returned by the Catalog service."""
 
     id: str
@@ -128,17 +128,17 @@ ResolveOutcome: TypeAlias = Annotated[
 
 
 class SearchResult(BaseModel):
-    """Published point result returned by search and pointsByWorkId."""
+    """Published point result returned by search and pointsByBangumiId."""
 
-    rows: list[PilgrimagePoint] = Field(default_factory=list)
+    rows: list[Point] = Field(default_factory=list)
     synced_at: str = ""
     partial: bool = False
 
 
-class Route(BaseModel):
-    """An ordered route plus its timed itinerary."""
+class Itinerary(BaseModel):
+    """An ordered itinerary plus its timed itinerary."""
 
-    ordered_points: list[PilgrimagePoint] = Field(default_factory=list)
+    ordered_points: list[Point] = Field(default_factory=list)
     point_count: int = 0
     cover_url: str = ""
     anime_title: str = ""
@@ -189,14 +189,14 @@ class CatalogClient:
         payload = await self._rpc("resolve", {"query": query})
         return TypeAdapter(ResolveOutcome).validate_python(payload)
 
-    async def points_by_work_id(self, work_id: str) -> SearchResult:
-        """Fetch published points for an already-resolved work id."""
-        payload = await self._rpc("points-by-work-id", {"work_id": work_id})
+    async def points_by_bangumi_id(self, bangumi_id: str) -> SearchResult:
+        """Fetch published points for an already-resolved bangumi id."""
+        payload = await self._rpc("points-by-bangumi-id", {"bangumi_id": bangumi_id})
         return SearchResult.model_validate(payload)
 
     async def nearby(
         self, lat: float, lng: float, *, radius_m: int = 2000
-    ) -> list[PilgrimagePoint]:
+    ) -> list[Point]:
         """Return pilgrimage points near a coordinate within ``radius_m``."""
         body = {"lat": lat, "lng": lng, "radius_m": radius_m}
         payload = await self._rpc("nearby", body)
@@ -210,21 +210,21 @@ class CatalogClient:
             raise APIError("Expected 'candidates' to be a JSON array")
         return [GeocodeCandidate.model_validate(item) for item in candidates]
 
-    async def route(
+    async def plan_itinerary(
         self,
         point_ids: list[str],
         *,
         origin: tuple[float, float] | None = None,
         pacing: Literal["chill", "normal", "packed"] | None = None,
-    ) -> Route:
-        """Plan an ordered, timed route across the given points."""
+    ) -> Itinerary:
+        """Plan an ordered, timed itinerary across the given points."""
         body: dict[str, object] = {"point_ids": point_ids}
         if origin is not None:
             body["origin"] = {"lat": origin[0], "lng": origin[1]}
         if pacing is not None:
             body["pacing"] = pacing
-        payload = await self._rpc("route", body)
-        return Route.model_validate(payload)
+        payload = await self._rpc("itinerary", body)
+        return Itinerary.model_validate(payload)
 
     async def aclose(self) -> None:
         """Close the shared HTTP client (idempotent; no-op when never used)."""
@@ -351,9 +351,9 @@ def _expect_object(value: object, *, context: str) -> JSONDict:
     return {str(key): item for key, item in value.items()}
 
 
-def _parse_rows(payload: JSONDict) -> list[PilgrimagePoint]:
+def _parse_rows(payload: JSONDict) -> list[Point]:
     """Validate a ``{"rows": [...]}`` envelope into typed pilgrimage points."""
     rows = payload.get("rows")
     if not isinstance(rows, list):
         raise APIError("Expected 'rows' to be a JSON array of points")
-    return [PilgrimagePoint.model_validate(row) for row in rows]
+    return [Point.model_validate(row) for row in rows]

--- a/apps/agent/src/animichi/interfaces/chat_wire.py
+++ b/apps/agent/src/animichi/interfaces/chat_wire.py
@@ -91,7 +91,7 @@ class TimedItinerary(_WireModel):
     export_ics: str | None = None
 
 
-class StreamRoute(_WireModel):
+class StreamItinerary(_WireModel):
     id: str | None = None
     version: str | None = None
     ordered_points: list[str] | list[StreamPoint] | None = None
@@ -125,7 +125,7 @@ class SearchData(_WireModel):
 
 class RouteData(_WireModel):
     results: SearchResults | None = None
-    route: StreamRoute | None = None
+    itinerary: StreamItinerary | None = None
 
 
 class ClarificationData(_WireModel):
@@ -172,10 +172,10 @@ def _search_results(data: JsonObject) -> SearchResults | None:
     return SearchResults.model_validate(values, extra="ignore")
 
 
-def _route(data: JsonObject) -> StreamRoute | None:
+def _itinerary(data: JsonObject) -> StreamItinerary | None:
     raw = data.get("route")
     return (
-        StreamRoute.model_validate(raw, extra="ignore")
+        StreamItinerary.model_validate(raw, extra="ignore")
         if isinstance(raw, dict)
         else None
     )
@@ -188,7 +188,7 @@ def _wire_data(
         return SearchData(results=_search_results(response.data))
     if response.intent in {"plan_route", "plan_selected", "plan_multi", "partial"}:
         return RouteData(
-            results=_search_results(response.data), route=_route(response.data)
+            results=_search_results(response.data), itinerary=_itinerary(response.data)
         )
     if response.intent == "clarify":
         return ClarificationData.model_validate(response.data, extra="ignore")

--- a/apps/agent/src/animichi/tests/eval/mock_catalog_client.py
+++ b/apps/agent/src/animichi/tests/eval/mock_catalog_client.py
@@ -9,10 +9,10 @@ from animichi.agents.models import TimedItinerary, TimedStop, TransitLeg
 from animichi.agents.title_matching import best_alias_match
 from animichi.clients.catalog_client import (
     AnimeCandidate,
-    PilgrimagePoint,
+    Itinerary,
+    Point,
     ResolveNotFound,
     ResolveResolved,
-    Route,
     SearchResult,
 )
 from animichi.clients.geocode import GeocodeCandidate, GeocodeKind, GeocodeSource
@@ -36,7 +36,7 @@ __all__ = [
 
 _TITLE_ALIASES = TITLE_ALIASES
 _LOCATION_CENTERS = LOCATION_CENTERS
-_POINT_INDEX: dict[str, PilgrimagePoint] = {
+_POINT_INDEX: dict[str, Point] = {
     point.id: point for points in FIXTURE_POINTS.values() for point in points
 }
 
@@ -63,16 +63,16 @@ class MockCatalogClient:
             ),
         )
 
-    async def points_by_work_id(self, work_id: str) -> SearchResult:
-        self.calls.append(("points_by_work_id", (work_id,)))
+    async def points_by_bangumi_id(self, bangumi_id: str) -> SearchResult:
+        self.calls.append(("points_by_bangumi_id", (bangumi_id,)))
         rows = [
-            point.model_copy(deep=True) for point in FIXTURE_POINTS.get(work_id, [])
+            point.model_copy(deep=True) for point in FIXTURE_POINTS.get(bangumi_id, [])
         ]
         return SearchResult(rows=rows, synced_at="fixture")
 
     async def nearby(
         self, lat: float, lng: float, *, radius_m: int = 2000
-    ) -> list[PilgrimagePoint]:
+    ) -> list[Point]:
         self.calls.append(("nearby", (lat, lng, radius_m)))
         scored = self._within_radius(lat, lng, radius_m)
         return [point for _, point in sorted(scored, key=lambda item: item[0])]
@@ -81,14 +81,14 @@ class MockCatalogClient:
         self.calls.append(("geocode", (query, limit)))
         return [candidate.model_copy() for candidate in _geocode_fixture(query)[:limit]]
 
-    async def route(
+    async def plan_itinerary(
         self,
         point_ids: list[str],
         *,
         origin: tuple[float, float] | None = None,
         pacing: Literal["chill", "normal", "packed"] | None = None,
-    ) -> Route:
-        self.calls.append(("route", (tuple(point_ids), origin, pacing)))
+    ) -> Itinerary:
+        self.calls.append(("plan_itinerary", (tuple(point_ids), origin, pacing)))
         ordered = [
             _POINT_INDEX[pid].model_copy(deep=True)
             for pid in point_ids
@@ -96,7 +96,7 @@ class MockCatalogClient:
         ]
         return _build_route(ordered)
 
-    async def near_location(self, name: str) -> list[PilgrimagePoint]:
+    async def near_location(self, name: str) -> list[Point]:
         center = self._match_location(name)
         if center is None:
             return []
@@ -119,8 +119,8 @@ class MockCatalogClient:
     @staticmethod
     def _within_radius(
         lat: float, lng: float, radius_m: int
-    ) -> list[tuple[float, PilgrimagePoint]]:
-        scored: list[tuple[float, PilgrimagePoint]] = []
+    ) -> list[tuple[float, Point]]:
+        scored: list[tuple[float, Point]] = []
         for point in _POINT_INDEX.values():
             dist = haversine_distance(lat, lng, point.latitude, point.longitude)
             if dist <= radius_m:
@@ -130,10 +130,10 @@ class MockCatalogClient:
         return scored
 
 
-def _build_route(ordered: list[PilgrimagePoint]) -> Route:
+def _build_route(ordered: list[Point]) -> Itinerary:
     if not ordered:
-        return Route()
-    return Route(
+        return Itinerary()
+    return Itinerary(
         ordered_points=ordered,
         point_count=len(ordered),
         cover_url=ordered[0].cover_url,
@@ -169,7 +169,7 @@ def _geocode_fixture(query: str) -> list[GeocodeCandidate]:
     ]
 
 
-def _build_itinerary(ordered: list[PilgrimagePoint]) -> TimedItinerary:
+def _build_itinerary(ordered: list[Point]) -> TimedItinerary:
     stops = [_stop(point, index) for index, point in enumerate(ordered)]
     legs = [_leg(ordered[i], ordered[i + 1]) for i in range(len(ordered) - 1)]
     return TimedItinerary(
@@ -181,7 +181,7 @@ def _build_itinerary(ordered: list[PilgrimagePoint]) -> TimedItinerary:
     )
 
 
-def _stop(point: PilgrimagePoint, index: int) -> TimedStop:
+def _stop(point: Point, index: int) -> TimedStop:
     arrive_hour = 9 + index
     return TimedStop(
         cluster_id=point.id,
@@ -195,7 +195,7 @@ def _stop(point: PilgrimagePoint, index: int) -> TimedStop:
     )
 
 
-def _leg(src: PilgrimagePoint, dst: PilgrimagePoint) -> TransitLeg:
+def _leg(src: Point, dst: Point) -> TransitLeg:
     distance = haversine_distance(
         src.latitude, src.longitude, dst.latitude, dst.longitude
     )

--- a/apps/agent/src/animichi/tests/eval/mock_catalog_fixtures.py
+++ b/apps/agent/src/animichi/tests/eval/mock_catalog_fixtures.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from animichi.clients.catalog_client import PilgrimagePoint
+from animichi.clients.catalog_client import Point
 from animichi.clients.geocode import GeocodeKind
 
 
@@ -323,9 +323,9 @@ def _title_aliases() -> dict[str, str]:
     }
 
 
-def _point(seed: PointSeed) -> PilgrimagePoint:
+def _point(seed: PointSeed) -> Point:
     names = TITLE_NAMES[seed.bangumi_id]
-    return PilgrimagePoint(
+    return Point(
         id=seed.pid,
         name=seed.name,
         name_cn=seed.name_cn,
@@ -340,8 +340,8 @@ def _point(seed: PointSeed) -> PilgrimagePoint:
     )
 
 
-def _fixture_points() -> dict[str, list[PilgrimagePoint]]:
-    points: dict[str, list[PilgrimagePoint]] = {}
+def _fixture_points() -> dict[str, list[Point]]:
+    points: dict[str, list[Point]] = {}
     for seed in POINT_SEEDS:
         points.setdefault(seed.bangumi_id, []).append(_point(seed))
     return points

--- a/apps/agent/src/animichi/tests/eval/test_agent_eval_mock.py
+++ b/apps/agent/src/animichi/tests/eval/test_agent_eval_mock.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from animichi.clients.catalog_client import PilgrimagePoint, Route
+from animichi.clients.catalog_client import Itinerary, Point
 from animichi.tests.eval.mock_catalog_client import MockCatalogClient
 
 
@@ -9,17 +9,17 @@ async def test_nearby_returns_sorted_points_within_radius() -> None:
     client = MockCatalogClient()
     points = await client.near_location("宇治")
     assert points, "Uji should resolve to seeded Euphonium points"
-    assert all(isinstance(p, PilgrimagePoint) for p in points)
+    assert all(isinstance(p, Point) for p in points)
     distances = [p.distance_m for p in points]
     assert distances == sorted(distances)
     assert all(d >= 0 for d in distances)
 
 
 async def test_route_builds_valid_timed_itinerary() -> None:
-    """route() (D1-style plan) returns an ordered Route with a timed itinerary."""
+    """plan_itinerary() (D1-style plan) returns an ordered Itinerary with a timed itinerary."""
     client = MockCatalogClient()
-    route = await client.route(["p004", "p005"])
-    assert isinstance(route, Route)
+    route = await client.plan_itinerary(["p004", "p005"])
+    assert isinstance(route, Itinerary)
     assert route.point_count == 2
     assert len(route.ordered_points) == 2
     itinerary = route.timed_itinerary
@@ -33,4 +33,4 @@ async def test_unknown_inputs_yield_no_data() -> None:
     """Unknown title/coord/ids keep DataKeysPresent empty-data semantics stable."""
     client = MockCatalogClient()
     assert await client.nearby(0.0, 0.0, radius_m=1000) == []
-    assert (await client.route(["does-not-exist"])).point_count == 0
+    assert (await client.plan_itinerary(["does-not-exist"])).point_count == 0

--- a/apps/agent/src/animichi/tests/eval/test_agent_eval_mock_runtime.py
+++ b/apps/agent/src/animichi/tests/eval/test_agent_eval_mock_runtime.py
@@ -33,7 +33,7 @@ from animichi.clients.catalog_client import CatalogClientProtocol
 from animichi.tests.eval.mock_catalog_client import MockCatalogClient
 from animichi.tests.streaming_function_model import streaming_function_model
 
-_ALLOWED_CATALOG_METHODS = {"search", "spots", "nearby", "route"}
+_ALLOWED_CATALOG_METHODS = {"search", "spots", "nearby", "plan_itinerary"}
 
 
 def _returned(messages: list[ModelMessage], tool_name: str) -> bool:

--- a/apps/agent/src/animichi/tests/integration/test_frontend_contracts.py
+++ b/apps/agent/src/animichi/tests/integration/test_frontend_contracts.py
@@ -112,7 +112,7 @@ def _parse_sse(raw: str) -> list[dict[str, object]]:
 
 
 class TestAC1SearchBangumi:
-    """Search by anime title returns typed PilgrimagePoint rows."""
+    """Search by anime title returns typed Point rows."""
 
     async def test_returns_200_with_success(self) -> None:
         status, body = await _post(
@@ -136,7 +136,7 @@ class TestAC1SearchBangumi:
         assert len(rows) > 0
 
     async def test_rows_have_required_pilgrimage_point_fields(self) -> None:
-        """Every row must match frontend PilgrimagePoint type."""
+        """Every row must match frontend Point type."""
         rows = await _search_euphonium()
         required = {"id", "name", "latitude", "longitude", "bangumi_id"}
         for row in rows:

--- a/apps/agent/src/animichi/tests/integration/test_selected_route_no_cross_db.py
+++ b/apps/agent/src/animichi/tests/integration/test_selected_route_no_cross_db.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from animichi.agents.catalog_adapter import build_search_payload
-from animichi.clients.catalog_client import PilgrimagePoint
+from animichi.clients.catalog_client import Point
 from animichi.infrastructure.session.memory import InMemorySessionStore
 from animichi.interfaces.public_api import PublicAPIRequest, RuntimeAPI
 from animichi.interfaces.schemas import PublicAPIResponse
@@ -34,7 +34,7 @@ _STALE_SUPABASE_ROWS = [
 ]
 
 
-def _catalog_points() -> list[PilgrimagePoint]:
+def _catalog_points() -> list[Point]:
     return [point.model_copy(deep=True) for point in FIXTURE_POINTS["115908"][:2]]
 
 

--- a/apps/agent/src/animichi/tests/unit/photo_search_fakes.py
+++ b/apps/agent/src/animichi/tests/unit/photo_search_fakes.py
@@ -15,7 +15,7 @@ from animichi.agents.photo_vision import (
 )
 from animichi.clients.catalog_client import (
     AnimeCandidate,
-    PilgrimagePoint,
+    Point,
     ResolveAmbiguous,
     ResolveNotFound,
     ResolveOutcome,
@@ -61,8 +61,8 @@ def recognize_unavailable() -> RecognizeCall:
     return call
 
 
-def suga_shrine_point() -> PilgrimagePoint:
-    return PilgrimagePoint(
+def suga_shrine_point() -> Point:
+    return Point(
         id="p1",
         name="須賀神社",
         bangumi_id=YOURNAME_BANGUMI_ID,
@@ -72,8 +72,8 @@ def suga_shrine_point() -> PilgrimagePoint:
     )
 
 
-def nearby_point() -> PilgrimagePoint:
-    return PilgrimagePoint(
+def nearby_point() -> Point:
+    return Point(
         id="n1",
         name="豊郷小学校",
         bangumi_id=NEARBY_BANGUMI_ID,
@@ -86,7 +86,7 @@ def nearby_point() -> PilgrimagePoint:
 class FakeCatalog:
     """Resolves 君の名は。 to 160209; nearby returns one けいおん! point."""
 
-    def __init__(self, nearby_points: list[PilgrimagePoint] | None = None) -> None:
+    def __init__(self, nearby_points: list[Point] | None = None) -> None:
         self.nearby_points = (
             nearby_points if nearby_points is not None else [nearby_point()]
         )
@@ -100,12 +100,10 @@ class FakeCatalog:
             return ResolveResolved(outcome="resolved", match=match)
         return ResolveNotFound(outcome="not_found", reason="anime_not_found")
 
-    async def points_by_work_id(self, work_id: str) -> SearchResult:
+    async def points_by_bangumi_id(self, bangumi_id: str) -> SearchResult:
         return SearchResult(rows=[suga_shrine_point()])
 
-    async def nearby(
-        self, lat: float, lng: float, radius_m: int = 5000
-    ) -> list[PilgrimagePoint]:
+    async def nearby(self, lat: float, lng: float, radius_m: int = 5000) -> list[Point]:
         self.nearby_calls.append((lat, lng, radius_m))
         return self.nearby_points
 
@@ -127,7 +125,5 @@ class DownCatalog(FakeCatalog):
     async def resolve(self, query: str) -> ResolveOutcome:
         raise APIError("catalog down")
 
-    async def nearby(
-        self, lat: float, lng: float, radius_m: int = 5000
-    ) -> list[PilgrimagePoint]:
+    async def nearby(self, lat: float, lng: float, radius_m: int = 5000) -> list[Point]:
         raise APIError("catalog down")

--- a/apps/agent/src/animichi/tests/unit/test_catalog_adapter.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_adapter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from animichi.agents.catalog_adapter import (
-    build_route_payload,
+    build_itinerary_payload,
     build_route_state,
     build_search_payload,
     build_search_state,
@@ -14,14 +14,14 @@ from animichi.agents.handlers._helpers import (
     _build_nearby_groups,
     rewrite_image_urls,
 )
-from animichi.clients.catalog_client import PilgrimagePoint, Route
+from animichi.clients.catalog_client import Itinerary, Point
 from animichi.tests.eval.mock_catalog_client import MockCatalogClient
 
 
 def _point(
     pid: str = "p1", bangumi_id: str = "160209", city: str | None = None
-) -> PilgrimagePoint:
-    return PilgrimagePoint(
+) -> Point:
+    return Point(
         id=pid,
         name="須賀神社",
         name_cn="须贺神社",
@@ -77,15 +77,15 @@ def test_search_state_localizes_catalog_city_at_trusted_boundary(
 
 
 async def test_route_state_localizes_catalog_city_at_trusted_boundary() -> None:
-    route = await MockCatalogClient().route(["p004"])
+    route = await MockCatalogClient().plan_itinerary(["p004"])
     route.ordered_points[0].city = "Tokyo"
     state = build_route_state(route, source_ref=None, locale="ja")
     assert state.ordered_points[0].city == "東京"
 
 
-async def test_build_route_payload_from_catalog_route() -> None:
-    route: Route = await MockCatalogClient().route(["p004", "p005"])
-    payload = build_route_payload(route)
+async def test_build_itinerary_payload_from_catalog_itinerary() -> None:
+    itinerary: Itinerary = await MockCatalogClient().plan_itinerary(["p004", "p005"])
+    payload = build_itinerary_payload(itinerary)
     assert payload["point_count"] == 2
     assert payload["status"] == "ok"
     itinerary = payload["timed_itinerary"]
@@ -93,16 +93,16 @@ async def test_build_route_payload_from_catalog_route() -> None:
     assert itinerary["spot_count"] == 2
 
 
-async def test_build_route_payload_summary_has_coordinate_counts() -> None:
-    route: Route = await MockCatalogClient().route(["p004", "p005"])
-    summary = build_route_payload(route)["summary"]
+async def test_build_itinerary_payload_summary_has_coordinate_counts() -> None:
+    itinerary: Itinerary = await MockCatalogClient().plan_itinerary(["p004", "p005"])
+    summary = build_itinerary_payload(itinerary)["summary"]
     assert isinstance(summary, dict)
     assert summary["with_coordinates"] == 2
     assert summary["without_coordinates"] == 0
 
 
-def test_build_route_payload_empty_route_has_zero_points() -> None:
-    payload = build_route_payload(Route())
+def test_build_itinerary_payload_empty_itinerary_has_zero_points() -> None:
+    payload = build_itinerary_payload(Itinerary())
     assert payload["point_count"] == 0
 
 

--- a/apps/agent/src/animichi/tests/unit/test_catalog_client.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_client.py
@@ -9,7 +9,7 @@ from animichi.clients.catalog_client import (
     GeocodeCandidate,
     GeocodeKind,
     GeocodeSource,
-    Route,
+    Itinerary,
 )
 
 _POINT = {
@@ -82,12 +82,12 @@ async def test_geocode_parses_candidates_and_posts_limit() -> None:
 
 
 async def test_route_parses_route() -> None:
-    """route() validates the Route envelope and POSTs point_ids."""
+    """plan_itinerary() validates the Itinerary envelope and POSTs point_ids."""
     payload = {"ordered_points": [_POINT], "point_count": 1}
     async with _mock_catalog(payload) as (client, requests):
-        route = await client.route(["p1"])
+        route = await client.plan_itinerary(["p1"])
 
-    assert isinstance(route, Route)
+    assert isinstance(route, Itinerary)
     assert route.point_count == 1
     assert json.loads(requests[0].content) == {"point_ids": ["p1"]}
 
@@ -96,7 +96,7 @@ async def test_route_posts_coordinate_origin() -> None:
     """route() sends origin only when coordinates are provided."""
     payload = {"ordered_points": [_POINT], "point_count": 1}
     async with _mock_catalog(payload) as (client, requests):
-        await client.route(["p1"], origin=(34.89, 135.8))
+        await client.plan_itinerary(["p1"], origin=(34.89, 135.8))
 
     assert json.loads(requests[0].content) == {
         "point_ids": ["p1"],

--- a/apps/agent/src/animichi/tests/unit/test_catalog_client_error_contract.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_client_error_contract.py
@@ -57,7 +57,7 @@ async def test_user_actionable_error_raises_without_retry(
     client = CatalogClient("https://catalog.test")
 
     with pytest.raises(RouteTooManyClustersError) as excinfo:
-        await client.route([f"p{i}" for i in range(3)])
+        await client.plan_itinerary([f"p{i}" for i in range(3)])
 
     assert len(requests) == 1
     assert excinfo.value.cluster_count == 62

--- a/apps/agent/src/animichi/tests/unit/test_catalog_client_http.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_client_http.py
@@ -59,8 +59,8 @@ async def test_reuses_one_http_client_across_requests() -> None:
     handler = MagicMock(side_effect=_ok)
     shared = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     client = CatalogClient("https://catalog.test", http_client=shared)
-    await client.points_by_work_id("8000")
-    await client.points_by_work_id("8001")
+    await client.points_by_bangumi_id("8000")
+    await client.points_by_bangumi_id("8001")
 
     assert client._http() is shared
     assert handler.call_count == 2
@@ -81,7 +81,7 @@ async def test_concurrent_requests_share_lazy_http_client(
 
     try:
         results = await asyncio.gather(
-            client.points_by_work_id("8000"), client.points_by_work_id("8001")
+            client.points_by_bangumi_id("8000"), client.points_by_bangumi_id("8001")
         )
 
         assert [result.rows for result in results] == [[], []]
@@ -105,7 +105,7 @@ async def test_retryable_status_then_success(
 
     sleep = _no_sleep(monkeypatch)
     _install_transport(monkeypatch, handler)
-    result = await CatalogClient("https://catalog.test").points_by_work_id("8000")
+    result = await CatalogClient("https://catalog.test").points_by_bangumi_id("8000")
 
     assert result.rows == []
     assert attempts == 2
@@ -125,7 +125,7 @@ async def test_does_not_retry_on_non_transient_4xx(
     sleep = _no_sleep(monkeypatch)
     _install_transport(monkeypatch, handler)
     with pytest.raises(APIError, match="HTTP 404"):
-        await CatalogClient("https://catalog.test").points_by_work_id("8000")
+        await CatalogClient("https://catalog.test").points_by_bangumi_id("8000")
 
     assert attempts == 1
     sleep.assert_not_awaited()
@@ -144,7 +144,7 @@ async def test_streaming_404_maps_buffered_server_envelope(
     _install_transport(monkeypatch, lambda request: _response(request, 404, body))
 
     with pytest.raises(WorkNotFoundError, match="8000"):
-        await CatalogClient("https://catalog.test").points_by_work_id("8000")
+        await CatalogClient("https://catalog.test").points_by_bangumi_id("8000")
 
 
 async def test_streaming_503_retries_without_reading_transport_body(
@@ -161,7 +161,7 @@ async def test_streaming_503_retries_without_reading_transport_body(
     _install_transport(monkeypatch, handler)
 
     with pytest.raises(TransientAPIError, match="HTTP 503"):
-        await CatalogClient("https://catalog.test").points_by_work_id("8000")
+        await CatalogClient("https://catalog.test").points_by_bangumi_id("8000")
 
     assert attempts == 3
 
@@ -169,7 +169,7 @@ async def test_streaming_503_retries_without_reading_transport_body(
 async def test_aclose_closes_shared_client(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_transport(monkeypatch, _ok)
     client = CatalogClient("https://catalog.test")
-    await client.points_by_work_id("8000")
+    await client.points_by_bangumi_id("8000")
     shared = client._client
 
     await client.aclose()
@@ -191,10 +191,10 @@ async def test_closed_client_is_not_resurrected(
     """After shutdown a request must fail loudly, not build a leaked pool."""
     constructor = _install_transport(monkeypatch, _ok)
     client = CatalogClient("https://catalog.test")
-    await client.points_by_work_id("8000")
+    await client.points_by_bangumi_id("8000")
     await client.aclose()
 
     with pytest.raises(RuntimeError, match="closed"):
-        await client.points_by_work_id("8001")
+        await client.points_by_bangumi_id("8001")
 
     constructor.assert_called_once()

--- a/apps/agent/src/animichi/tests/unit/test_catalog_client_retry_policy.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_client_retry_policy.py
@@ -45,9 +45,9 @@ async def test_status_in_url_does_not_defeat_retry(
 
     _no_sleep(monkeypatch)
     _install_transport(monkeypatch, handler)
-    result = await CatalogClient("https://catalog.test/tenant-404").points_by_work_id(
-        "8000"
-    )
+    result = await CatalogClient(
+        "https://catalog.test/tenant-404"
+    ).points_by_bangumi_id("8000")
 
     assert result.rows == []
     assert attempts == 2
@@ -65,7 +65,7 @@ async def test_retries_on_transport_error(monkeypatch: pytest.MonkeyPatch) -> No
 
     _no_sleep(monkeypatch)
     _install_transport(monkeypatch, handler)
-    result = await CatalogClient("https://catalog.test").points_by_work_id("8000")
+    result = await CatalogClient("https://catalog.test").points_by_bangumi_id("8000")
 
     assert result.rows == []
     assert attempts == 2
@@ -84,7 +84,7 @@ async def test_exhaustion_pins_attempts_and_backoff(
     sleep = _no_sleep(monkeypatch)
     _install_transport(monkeypatch, handler)
     with pytest.raises(APIError, match="HTTP 502"):
-        await CatalogClient("https://catalog.test", max_retries=3).points_by_work_id(
+        await CatalogClient("https://catalog.test", max_retries=3).points_by_bangumi_id(
             "8000"
         )
 
@@ -105,7 +105,7 @@ async def test_backoff_caps_at_thirty_seconds(
     sleep = _no_sleep(monkeypatch)
     _install_transport(monkeypatch, handler)
     with pytest.raises(APIError, match="HTTP 503"):
-        await CatalogClient("https://catalog.test", max_retries=8).points_by_work_id(
+        await CatalogClient("https://catalog.test", max_retries=8).points_by_bangumi_id(
             "8000"
         )
 

--- a/apps/agent/src/animichi/tests/unit/test_catalog_errors.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_errors.py
@@ -32,7 +32,7 @@ def test_route_too_many_clusters_parses_typed() -> None:
     body = _envelope(
         "ROUTE_TOO_MANY_CLUSTERS", {"cluster_count": 62, "max_clusters": 50}, 422
     )
-    exc = parse_catalog_error(422, body, "https://catalog.test/catalog/route")
+    exc = parse_catalog_error(422, body, "https://catalog.test/catalog/itinerary")
 
     assert isinstance(exc, RouteTooManyClustersError)
     assert exc.cluster_count == 62

--- a/apps/agent/src/animichi/tests/unit/test_catalog_geocoding_agent.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_geocoding_agent.py
@@ -195,7 +195,7 @@ async def test_partial_route_is_pending_sync_and_never_calls_catalog_route() -> 
     )
 
     assert outcome.status == "pending_sync"
-    assert all(call[0] != "route" for call in catalog.calls)
+    assert all(call[0] != "plan_itinerary" for call in catalog.calls)
     assert isinstance(deps.steps[-1].provenance, RejectedRoute)
 
 
@@ -209,4 +209,4 @@ async def test_route_threads_optional_pacing_to_catalog() -> None:
     catalog = MockCatalogClient()
     outcome = await run_route(_ctx(deps), catalog, str(ref), "packed")
     assert outcome.status == "ok"
-    assert ("route", (("p004",), None, "packed")) in catalog.calls
+    assert ("plan_itinerary", (("p004",), None, "packed")) in catalog.calls

--- a/apps/agent/src/animichi/tests/unit/test_catalog_geocoding_agent.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_geocoding_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Literal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -21,6 +22,7 @@ from animichi.clients.catalog_client import (
     AnimeCandidate,
     GeocodeCandidate,
     GeocodeKind,
+    Itinerary,
     ResolveAmbiguous,
     ResolveNotFound,
 )
@@ -172,6 +174,37 @@ async def test_empty_route_is_a_successful_typed_step() -> None:
     )
 
     assert (outcome.status, deps.steps[-1].is_success) == ("empty", True)
+    assert isinstance(deps.steps[-1].provenance, RejectedRoute)
+
+
+async def test_catalog_empty_itinerary_is_a_typed_route_empty() -> None:
+    deps = _deps()
+    ref = ResultRef("search:rows")
+    deps.tool_state.session.store_search_result(
+        ref,
+        SearchPayloadState(kind="bangumi", rows=[PointState(id="p004")], row_count=1),
+    )
+
+    class _EmptyItineraryCatalog(MockCatalogClient):
+        async def plan_itinerary(
+            self,
+            point_ids: list[str],
+            *,
+            origin: tuple[float, float] | None = None,
+            pacing: Literal["chill", "normal", "packed"] | None = None,
+        ) -> Itinerary:
+            self.calls.append(("plan_itinerary", (tuple(point_ids), origin, pacing)))
+            return Itinerary(ordered_points=[], point_count=0)
+
+    catalog = _EmptyItineraryCatalog()
+
+    outcome = await run_route(_ctx(deps), catalog, str(ref), None)
+    await project_tool_result(
+        deps, "plan_route", {"search_result_ref": str(ref)}, outcome
+    )
+
+    assert outcome.status == "empty"
+    assert ("plan_itinerary", (("p004",), None, None)) in catalog.calls
     assert isinstance(deps.steps[-1].provenance, RejectedRoute)
 
 

--- a/apps/agent/src/animichi/tests/unit/test_catalog_geocoding_location.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_geocoding_location.py
@@ -4,14 +4,14 @@ from unittest.mock import MagicMock
 
 from animichi.agents.catalog_tools import run_nearby_search
 from animichi.agents.runtime_deps import RuntimeDeps
-from animichi.clients.catalog_client import PilgrimagePoint
+from animichi.clients.catalog_client import Point
 from animichi.tests.eval.mock_catalog_client import MockCatalogClient
 
 
 class _EmptyNearby(MockCatalogClient):
     async def nearby(
         self, lat: float, lng: float, *, radius_m: int = 2000
-    ) -> list[PilgrimagePoint]:
+    ) -> list[Point]:
         self.calls.append(("nearby", (lat, lng, radius_m)))
         return []
 

--- a/apps/agent/src/animichi/tests/unit/test_catalog_read_gateway.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_read_gateway.py
@@ -14,7 +14,7 @@ from animichi.clients.catalog_client import (
 )
 
 _ALLOWED_READ_METHODS = frozenset(
-    {"resolve", "points_by_work_id", "nearby", "geocode", "route"}
+    {"resolve", "points_by_bangumi_id", "nearby", "geocode", "plan_itinerary"}
 )
 _WRITE_VERBS = frozenset(
     {
@@ -59,8 +59,8 @@ class _FakeReadGateway:
     async def resolve(self, query: str) -> object:
         return await self._noop(query)
 
-    async def points_by_work_id(self, work_id: str) -> object:
-        return await self._noop(work_id)
+    async def points_by_bangumi_id(self, bangumi_id: str) -> object:
+        return await self._noop(bangumi_id)
 
     async def nearby(
         self, lat: float, lng: float, *, radius_m: int = 2000
@@ -70,7 +70,7 @@ class _FakeReadGateway:
     async def geocode(self, query: str, *, limit: int = 5) -> list[object]:
         return cast(list[object], await self._noop(query, limit=limit))
 
-    async def route(
+    async def plan_itinerary(
         self,
         point_ids: list[str],
         *,

--- a/apps/agent/src/animichi/tests/unit/test_catalog_read_gateway.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_read_gateway.py
@@ -112,3 +112,12 @@ def test_fake_gateway_satisfies_read_protocol() -> None:
 def test_gateway_methods_are_awaitable_contracts() -> None:
     for name in _ALLOWED_READ_METHODS:
         assert inspect.iscoroutinefunction(getattr(CatalogReadGateway, name))
+
+
+async def test_gateway_stub_bodies_resolve_when_invoked() -> None:
+    for name in _ALLOWED_READ_METHODS:
+        stub = getattr(CatalogReadGateway, name)
+        signature = inspect.signature(stub)
+        args = {param: None for param in signature.parameters if param != "self"}
+        result = await stub(None, **args)
+        assert result is None

--- a/apps/agent/src/animichi/tests/unit/test_catalog_tool_upstream_degradation.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_tool_upstream_degradation.py
@@ -30,7 +30,7 @@ from animichi.agents.session_state import (
     SearchPayloadState,
 )
 from animichi.agents.tool_outcomes import NearbyUpstreamDown, RouteUpstreamDown
-from animichi.clients.catalog_client import GeocodeCandidate, PilgrimagePoint, Route
+from animichi.clients.catalog_client import GeocodeCandidate, Itinerary, Point
 from animichi.clients.errors import APIError
 from animichi.tests.eval.mock_catalog_client import MockCatalogClient
 from animichi.tests.tool_event_helpers import project_tool_result, tool_context
@@ -67,18 +67,18 @@ class _GeocodeDownCatalog(MockCatalogClient):
 class _NearbyDownCatalog(MockCatalogClient):
     async def nearby(
         self, lat: float, lng: float, *, radius_m: int = 2000
-    ) -> list[PilgrimagePoint]:
+    ) -> list[Point]:
         raise APIError("catalog down")
 
 
 class _RouteDownCatalog(MockCatalogClient):
-    async def route(
+    async def plan_itinerary(
         self,
         point_ids: list[str],
         *,
         origin: tuple[float, float] | None = None,
         pacing: Literal["chill", "normal", "packed"] | None = None,
-    ) -> Route:
+    ) -> Itinerary:
         raise APIError("catalog down")
 
 

--- a/apps/agent/src/animichi/tests/unit/test_eval_mock_web.py
+++ b/apps/agent/src/animichi/tests/unit/test_eval_mock_web.py
@@ -160,6 +160,6 @@ async def test_web_search_direct_injection_returns_wrapped_results() -> None:
 
 
 async def test_mock_catalog_route_accepts_dataset_point_ids() -> None:
-    route = await MockCatalogClient().route(["p004", "p005"])
+    route = await MockCatalogClient().plan_itinerary(["p004", "p005"])
 
     assert route.point_count == 2

--- a/apps/agent/src/animichi/tests/unit/test_fact_ledger_recorder.py
+++ b/apps/agent/src/animichi/tests/unit/test_fact_ledger_recorder.py
@@ -7,8 +7,8 @@ from datetime import UTC, datetime
 
 import pytest
 
-from animichi.agents.catalog_adapter import build_route_payload
-from animichi.clients.catalog_client import PilgrimagePoint, Route
+from animichi.agents.catalog_adapter import build_itinerary_payload
+from animichi.clients.catalog_client import Itinerary, Point
 from animichi.domain.fact_ledger import FactLedger, record_turn_facts
 
 _NOW = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
@@ -24,7 +24,7 @@ class _FakeStep:
     data: dict[str, object] | None = None
 
 
-def _point(**overrides: object) -> PilgrimagePoint:
+def _point(**overrides: object) -> Point:
     base: dict[str, object] = {
         "id": "p1",
         "name": "資生堂前",
@@ -34,13 +34,13 @@ def _point(**overrides: object) -> PilgrimagePoint:
         "time_seconds": 340,
     }
     base.update(overrides)
-    return PilgrimagePoint.model_validate(base)
+    return Point.model_validate(base)
 
 
-def _selected_route_payload(*points: PilgrimagePoint) -> dict[str, object]:
+def _selected_route_payload(*points: Point) -> dict[str, object]:
     """Build the real `plan_selected` step payload shape (not a hand-rolled dict)."""
-    route = Route(ordered_points=list(points), point_count=len(points))
-    return build_route_payload(route)
+    itinerary = Itinerary(ordered_points=list(points), point_count=len(points))
+    return build_itinerary_payload(itinerary)
 
 
 def test_recorder_derives_pacing_from_a_successful_plan_route_step() -> None:
@@ -75,7 +75,7 @@ def test_recorder_derives_scene_references_from_the_real_producer_shape() -> Non
 
 
 def test_recorder_ignores_the_catalog_sentinel_for_no_episode() -> None:
-    """PilgrimagePoint defaults episode/time_seconds to -1, not None (#473
+    """Point defaults episode/time_seconds to -1, not None (#473
     review) — the sentinel must never be recorded as "Episode -1 @ -1s"."""
     ledger = FactLedger()
     steps = [

--- a/apps/agent/src/animichi/tests/unit/test_partial_search_projection.py
+++ b/apps/agent/src/animichi/tests/unit/test_partial_search_projection.py
@@ -10,7 +10,7 @@ from animichi.agents.catalog_tools import run_work_search
 from animichi.agents.runtime_deps import RuntimeDeps
 from animichi.agents.runtime_models import SearchResponseModel
 from animichi.agents.tool_outcomes import SearchEmpty, SearchOk, SearchUpstreamDown
-from animichi.clients.catalog_client import PilgrimagePoint, SearchResult
+from animichi.clients.catalog_client import Point, SearchResult
 from animichi.clients.catalog_errors import (
     UpstreamUnavailableData,
     UpstreamUnavailableError,
@@ -21,13 +21,13 @@ from animichi.tests.tool_event_helpers import project_tool_result, tool_context
 
 
 class _PartialCatalog(MockCatalogClient):
-    async def points_by_work_id(self, work_id: str) -> SearchResult:
+    async def points_by_bangumi_id(self, bangumi_id: str) -> SearchResult:
         return SearchResult(
             rows=[
-                PilgrimagePoint(
+                Point(
                     id="p1",
                     name="Uji Bridge",
-                    bangumi_id=work_id,
+                    bangumi_id=bangumi_id,
                     latitude=34.89,
                     longitude=135.8,
                 )
@@ -37,12 +37,12 @@ class _PartialCatalog(MockCatalogClient):
 
 
 class _EmptyPartialCatalog(MockCatalogClient):
-    async def points_by_work_id(self, work_id: str) -> SearchResult:
+    async def points_by_bangumi_id(self, bangumi_id: str) -> SearchResult:
         return SearchResult(partial=True)
 
 
 class _UpstreamDownCatalog(MockCatalogClient):
-    async def points_by_work_id(self, work_id: str) -> SearchResult:
+    async def points_by_bangumi_id(self, bangumi_id: str) -> SearchResult:
         raise UpstreamUnavailableError(UpstreamUnavailableData(upstream="anitabi"))
 
 

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_catalog_client.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_catalog_client.py
@@ -6,9 +6,9 @@ import pytest
 from pydantic import ValidationError
 
 from animichi.clients.catalog_client import (
-    PilgrimagePoint,
+    Itinerary,
+    Point,
     ResolveResolved,
-    Route,
     SearchResult,
 )
 from animichi.tests.unit.test_catalog_client import _mock_catalog
@@ -28,19 +28,17 @@ async def test_resolve_posts_to_typed_phase1a_endpoint() -> None:
     assert json.loads(requests[0].content) == {"query": "京吹"}
 
 
-async def test_points_by_work_id_never_repeats_free_text_search() -> None:
+async def test_points_by_bangumi_id_never_repeats_free_text_search() -> None:
     async with _mock_catalog({"rows": [_POINT], "synced_at": "now"}) as (
         client,
         requests,
     ):
-        result = await client.points_by_work_id("115908")
-    assert result == SearchResult(
-        rows=[PilgrimagePoint.model_validate(_POINT)], synced_at="now"
-    )
-    assert str(requests[0].url).endswith("/catalog/points-by-work-id")
-    assert json.loads(requests[0].content) == {"work_id": "115908"}
+        result = await client.points_by_bangumi_id("115908")
+    assert result == SearchResult(rows=[Point.model_validate(_POINT)], synced_at="now")
+    assert str(requests[0].url).endswith("/catalog/points-by-bangumi-id")
+    assert json.loads(requests[0].content) == {"bangumi_id": "115908"}
 
 
 def test_route_rejects_count_without_matching_ordered_points() -> None:
     with pytest.raises(ValidationError, match="point_count must match"):
-        Route(point_count=1)
+        Itinerary(point_count=1)

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_selection_handlers.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_selection_handlers.py
@@ -128,6 +128,31 @@ async def test_all_empty_is_t4_and_preserves_pending() -> None:
     assert not state.routes
 
 
+async def test_empty_itinerary_is_error_terminal_without_route_write() -> None:
+    class _EmptyItineraryCatalog(_Catalog):
+        async def plan_itinerary(
+            self,
+            point_ids: list[str],
+            *,
+            origin: tuple[float, float] | None = None,
+            pacing: Literal["chill", "normal", "packed"] | None = None,
+        ) -> Itinerary:
+            self.calls.append(("plan_itinerary", (tuple(point_ids), origin, pacing)))
+            return Itinerary(ordered_points=[], point_count=0)
+
+    catalog = _EmptyItineraryCatalog({"1": SearchResult(rows=[_point("a", "1")])})
+    state = _pending()
+
+    result = await execute_multi_selection(
+        candidate_ids=["1"], state=state, locale="en", catalog=catalog
+    )
+
+    assert (result.status, result.success) == ("error", False)
+    assert ("plan_itinerary", (("a",), None, None)) in catalog.calls
+    assert not state.routes
+    assert state.pending_clarification is not None
+
+
 async def test_t4_does_not_project_a_route_from_a_prior_turn() -> None:
     catalog = _Catalog({"1": SearchResult(), "2": SearchResult()})
     state = _pending()

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_selection_handlers.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_selection_handlers.py
@@ -15,7 +15,7 @@ from animichi.agents.session_state import (
     SearchPayloadState,
     SessionState,
 )
-from animichi.clients.catalog_client import PilgrimagePoint, Route, SearchResult
+from animichi.clients.catalog_client import Itinerary, Point, SearchResult
 from animichi.clients.catalog_errors import (
     RouteTooManyClustersData,
     RouteTooManyClustersError,
@@ -24,8 +24,8 @@ from animichi.interfaces.response_builder import agent_result_to_response
 from animichi.tests.eval.mock_catalog_client import MockCatalogClient
 
 
-def _point(pid: str, work: str) -> PilgrimagePoint:
-    return PilgrimagePoint(
+def _point(pid: str, work: str) -> Point:
+    return Point(
         id=pid,
         name=pid,
         bangumi_id=work,
@@ -56,24 +56,24 @@ class _Catalog(MockCatalogClient):
         super().__init__()
         self.results = results
         self.route_error: bool | BaseException = False
-        self.nearby_rows: list[PilgrimagePoint] | None = None
+        self.nearby_rows: list[Point] | None = None
         self.nearby_error = False
 
-    async def points_by_work_id(self, work_id: str) -> SearchResult:
-        self.calls.append(("points_by_work_id", (work_id,)))
-        result = self.results[work_id]
+    async def points_by_bangumi_id(self, bangumi_id: str) -> SearchResult:
+        self.calls.append(("points_by_bangumi_id", (bangumi_id,)))
+        result = self.results[bangumi_id]
         if isinstance(result, BaseException):
             raise result
         return result
 
-    async def route(
+    async def plan_itinerary(
         self,
         point_ids: list[str],
         *,
         origin: tuple[float, float] | None = None,
         pacing: Literal["chill", "normal", "packed"] | None = None,
-    ) -> Route:
-        self.calls.append(("route", (tuple(point_ids), origin, pacing)))
+    ) -> Itinerary:
+        self.calls.append(("plan_itinerary", (tuple(point_ids), origin, pacing)))
         if isinstance(self.route_error, BaseException):
             raise self.route_error
         if self.route_error:
@@ -87,11 +87,11 @@ class _Catalog(MockCatalogClient):
             for point in result.rows
         }
         ordered = [points[item] for item in point_ids]
-        return Route(ordered_points=ordered, point_count=len(ordered))
+        return Itinerary(ordered_points=ordered, point_count=len(ordered))
 
     async def nearby(
         self, lat: float, lng: float, *, radius_m: int = 2000
-    ) -> list[PilgrimagePoint]:
+    ) -> list[Point]:
         self.calls.append(("nearby", (lat, lng, radius_m)))
         if self.nearby_error:
             raise OSError("down")
@@ -176,7 +176,7 @@ async def test_501_points_is_t6_without_route_call() -> None:
         candidate_ids=["1"], state=_pending(), locale="en", catalog=catalog
     )
     assert result.status == "too_large"
-    assert all(call[0] != "route" for call in catalog.calls)
+    assert all(call[0] != "plan_itinerary" for call in catalog.calls)
 
 
 async def test_place_selection_uses_staged_coords_without_geocode() -> None:

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_terminal_matrix.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_terminal_matrix.py
@@ -143,7 +143,7 @@ async def test_t7_partial_sync_returns_results_without_routing() -> None:
     assert (result.status, result.success, payload.partial) == ("partial", False, True)
     assert "results" in wire.data and "route" not in wire.data
     assert wire.data["results"]["partial"] is True
-    assert all(call[0] != "route" for call in catalog.calls)
+    assert all(call[0] != "plan_itinerary" for call in catalog.calls)
     assert state.pending_clarification is not None
     assert (result.steps[-1].is_success, result.steps[-1].error) == (True, None)
 

--- a/apps/agent/src/animichi/tests/unit/test_selected_route.py
+++ b/apps/agent/src/animichi/tests/unit/test_selected_route.py
@@ -12,7 +12,7 @@ from animichi.agents.catalog_adapter import build_search_payload
 from animichi.agents.runtime_deps import OnStep, StepEvent
 from animichi.agents.selected_route import execute_selected_route
 from animichi.agents.session_state import ResultRef, SearchPayloadState, SessionState
-from animichi.clients.catalog_client import PilgrimagePoint, Route
+from animichi.clients.catalog_client import Itinerary, Point
 from animichi.clients.errors import APIError
 from animichi.tests.eval.mock_catalog_client import FIXTURE_POINTS, MockCatalogClient
 
@@ -41,7 +41,7 @@ def _ordered_rows(result: AgentResult) -> list[dict[str, object]]:
     return [row.model_dump(mode="json") for row in state.routes[ref].ordered_points]
 
 
-def _euphonium_points() -> list[PilgrimagePoint]:
+def _euphonium_points() -> list[Point]:
     return [point.model_copy(deep=True) for point in FIXTURE_POINTS["115908"]]
 
 
@@ -80,7 +80,9 @@ async def test_selected_route_rows_keep_catalog_point_fields() -> None:
     assert rows[0] == _euphonium_points()[0].model_dump(mode="json")
     assert result.message == "Created a route with 2 selected stops."
     assert result.steps[0].model_initiated is False
-    assert catalog.calls == [("route", (("p004", "p005"), (34.8915, 135.8075), None))]
+    assert catalog.calls == [
+        ("plan_itinerary", (("p004", "p005"), (34.8915, 135.8075), None))
+    ]
 
 
 async def test_selected_route_rows_match_search_payload_rows() -> None:
@@ -112,9 +114,9 @@ async def test_selected_route_empty_point_ids_returns_error() -> None:
 
 
 class _FailingCatalog(MockCatalogClient):
-    async def route(
+    async def plan_itinerary(
         self, point_ids: list[str], *, origin: tuple[float, float] | None = None
-    ) -> Route:
+    ) -> Itinerary:
         raise APIError("catalog down")
 
 
@@ -178,7 +180,7 @@ async def test_selected_route_malformed_origin_routes_without_origin(
         catalog=catalog,
     )
 
-    assert catalog.calls == [("route", (("p004",), None, None))]
+    assert catalog.calls == [("plan_itinerary", (("p004",), None, None))]
 
 
 async def test_selected_route_preserves_hydrated_search_state() -> None:

--- a/apps/agent/src/animichi/tests/unit/test_selected_route_errors.py
+++ b/apps/agent/src/animichi/tests/unit/test_selected_route_errors.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from animichi.agents.agent_result import RejectedRoute
 from animichi.agents.selected_route import execute_selected_route
 from animichi.agents.session_state import SessionState
-from animichi.clients.catalog_client import Route
+from animichi.clients.catalog_client import Itinerary
 from animichi.clients.catalog_errors import (
     RouteTooManyClustersData,
     RouteTooManyClustersError,
@@ -21,26 +21,26 @@ from animichi.tests.eval.mock_catalog_client import MockCatalogClient
 
 
 class _TooManyClustersCatalog(MockCatalogClient):
-    async def route(
+    async def plan_itinerary(
         self, point_ids: list[str], *, origin: tuple[float, float] | None = None
-    ) -> Route:
+    ) -> Itinerary:
         raise RouteTooManyClustersError(
             RouteTooManyClustersData(cluster_count=62, max_clusters=50)
         )
 
 
 class _UpstreamDownCatalog(MockCatalogClient):
-    async def route(
+    async def plan_itinerary(
         self, point_ids: list[str], *, origin: tuple[float, float] | None = None
-    ) -> Route:
+    ) -> Itinerary:
         raise UpstreamUnavailableError(UpstreamUnavailableData(upstream="bangumi"))
 
 
 class _MalformedCatalog(MockCatalogClient):
-    async def route(
+    async def plan_itinerary(
         self, point_ids: list[str], *, origin: tuple[float, float] | None = None
-    ) -> Route:
-        return Route.model_validate({"point_count": 1})
+    ) -> Itinerary:
+        return Itinerary.model_validate({"point_count": 1})
 
 
 async def test_too_many_clusters_returns_actionable_message_en() -> None:

--- a/apps/agent/src/animichi/tests/unit/test_timeout_budgets.py
+++ b/apps/agent/src/animichi/tests/unit/test_timeout_budgets.py
@@ -41,7 +41,7 @@ async def test_catalog_budget_nests_inside_tool_and_agent_timeouts(
     )
 
     with pytest.raises(TransientAPIError, match="exceeded 80.0s"):
-        await CatalogClient("https://catalog.test").points_by_work_id("8000")
+        await CatalogClient("https://catalog.test").points_by_bangumi_id("8000")
 
     assert deadlines == [CATALOG_TOTAL_TIMEOUT_SECONDS]
     assert CATALOG_REQUEST_TIMEOUT_SECONDS < CATALOG_TOTAL_TIMEOUT_SECONDS

--- a/apps/agent/tests/fixtures/chat_stream/record_fixtures.py
+++ b/apps/agent/tests/fixtures/chat_stream/record_fixtures.py
@@ -62,7 +62,7 @@ def _search_response() -> PublicAPIResponse:
                 },
             ],
         },
-        "route": {
+        "itinerary": {
             "ordered_points": [
                 {
                     "id": "p1",

--- a/apps/agent/tests/fixtures/chat_stream/search.sse
+++ b/apps/agent/tests/fixtures/chat_stream/search.sse
@@ -22,7 +22,7 @@ data: {"type":"tool-output-available","toolCallId":"plan_route-fixture","output"
 
 data: {"type":"data-response","id":"response","data":{"intent":"plan_route"}}
 
-data: {"type":"data-response","id":"response","data":{"intent":"plan_route","success":true,"status":"ok","message":"宇治の聖地を2件、徒歩ルートにまとめました。","data":{"route":{"ordered_points":[{"id":"p1","name":"宇治橋","bangumi_id":"12345","episode":1,"latitude":34.891,"longitude":135.807},{"id":"p2","name":"京阪宇治駅","bangumi_id":"12345","episode":3,"latitude":34.911,"longitude":135.806}],"point_count":2,"status":"ok"}},"session":{},"route_history":[],"errors":[],"ui":{"component":"RoutePlannerWizard"}}}
+data: {"type":"data-response","id":"response","data":{"intent":"plan_route","success":true,"status":"ok","message":"宇治の聖地を2件、徒歩ルートにまとめました。","data":{"itinerary":{"ordered_points":[{"id":"p1","name":"宇治橋","bangumi_id":"12345","episode":1,"latitude":34.891,"longitude":135.807},{"id":"p2","name":"京阪宇治駅","bangumi_id":"12345","episode":3,"latitude":34.911,"longitude":135.806}],"point_count":2,"status":"ok"}},"session":{},"route_history":[],"errors":[],"ui":{"component":"RoutePlannerWizard"}}}
 
 data: {"type":"finish-step"}
 

--- a/apps/web/src/components/CatalogSearchResults.tsx
+++ b/apps/web/src/components/CatalogSearchResults.tsx
@@ -1,13 +1,13 @@
-import type { PilgrimagePoint } from "@animichi/contract";
+import type { Point } from "@animichi/contract";
 import { useCatalogSearch } from "../api/hooks/use-catalog-search";
 
 type Props = Readonly<{ query: string }>;
 
-function PointItem({ point }: Readonly<{ point: PilgrimagePoint }>) {
+function PointItem({ point }: Readonly<{ point: Point }>) {
   return <li className="catalog-result">{point.name}</li>;
 }
 
-function PointList({ points }: Readonly<{ points: readonly PilgrimagePoint[] }>) {
+function PointList({ points }: Readonly<{ points: readonly Point[] }>) {
   return (
     <ul aria-label="Pilgrimage points">
       {points.map((point) => (

--- a/apps/web/src/features/anime/fact-summary.ts
+++ b/apps/web/src/features/anime/fact-summary.ts
@@ -1,7 +1,7 @@
 import type {
   AnimeOverview,
   AnimeOverviewCircle,
-  AnimeSampleRoute,
+  AnimeSampleItinerary,
   AnimeScene,
 } from "@animichi/contract";
 
@@ -36,8 +36,8 @@ function topCities(circles: readonly AnimeOverviewCircle[]): CityCount[] {
     .map((circle) => ({ region: circle.region, count: circle.count }));
 }
 
-function estimateDurationMinutes(routes: readonly AnimeSampleRoute[]): number | null {
-  const largest = Math.max(0, ...routes.map((route) => route.point_ids.length));
+function estimateDurationMinutes(itineraries: readonly AnimeSampleItinerary[]): number | null {
+  const largest = Math.max(0, ...itineraries.map((itinerary) => itinerary.point_ids.length));
   if (largest === 0) return null;
   return largest * DWELL_FLOOR_MINUTES + (largest - 1) * WALK_BUFFER_MINUTES;
 }
@@ -46,8 +46,8 @@ export function buildFactSummary(overview: AnimeOverview): FactSummary {
   return {
     spotCount: overview.points_length,
     topCities: topCities(overview.circles),
-    durationMinutes: estimateDurationMinutes(overview.sample_routes),
-    routeCount: overview.sample_routes.length,
+    durationMinutes: estimateDurationMinutes(overview.sample_itineraries),
+    routeCount: overview.sample_itineraries.length,
   };
 }
 

--- a/apps/web/src/features/chat/components/Cards.tsx
+++ b/apps/web/src/features/chat/components/Cards.tsx
@@ -19,7 +19,7 @@ export function resultsOf(part: ChatDataPart) {
 
 export function routeOf(part: ChatDataPart) {
   const data = dataOf(part);
-  return data && "route" in data ? data.route : undefined;
+  return data && "itinerary" in data ? data.itinerary : undefined;
 }
 
 export function candidatesOf(part: ChatDataPart) {

--- a/apps/web/src/features/chat/lib/error-classifier.ts
+++ b/apps/web/src/features/chat/lib/error-classifier.ts
@@ -110,7 +110,7 @@ function resultRowCount(part: ChatDataPart): number | undefined {
 
 function routePointCount(part: ChatDataPart): number | undefined {
   const data = part.data;
-  const route = data && "route" in data ? data.route : undefined;
+  const route = data && "itinerary" in data ? data.itinerary : undefined;
   return route?.point_count ?? route?.ordered_points?.length;
 }
 

--- a/apps/web/src/features/chat/lib/supersession.ts
+++ b/apps/web/src/features/chat/lib/supersession.ts
@@ -33,8 +33,8 @@ export function intentOf(data: unknown): string | undefined {
 function hasRoute(data: unknown): boolean {
   if (typeof data !== "object" || data === null || !("data" in data)) return false;
   const inner = data.data;
-  if (typeof inner !== "object" || inner === null || !("route" in inner)) return false;
-  return typeof inner.route === "object" && inner.route !== null && Object.keys(inner.route).length > 0;
+  if (typeof inner !== "object" || inner === null || !("itinerary" in inner)) return false;
+  return typeof inner.itinerary === "object" && inner.itinerary !== null && Object.keys(inner.itinerary).length > 0;
 }
 
 /**

--- a/apps/web/tests/msw/anime-overview.ts
+++ b/apps/web/tests/msw/anime-overview.ts
@@ -42,7 +42,7 @@ export const fullOverviewFixture = {
       city: "Tokyo",
     },
   ],
-  sample_routes: [
+  sample_itineraries: [
     { region: "Takayama", point_ids: ["p1", "p2", "p3"] },
     { region: "Tokyo", point_ids: ["p4", "p5"] },
   ],
@@ -55,7 +55,7 @@ export function emptyOverviewFixture(bangumiId: string): AnimeOverview {
     points_length: 0,
     circles: [],
     scenes: [],
-    sample_routes: [],
+    sample_itineraries: [],
   };
 }
 

--- a/apps/web/tests/msw/fixtures.ts
+++ b/apps/web/tests/msw/fixtures.ts
@@ -1,4 +1,4 @@
-import type { PilgrimagePoint, SearchResult } from "@animichi/contract";
+import type { Point, SearchResult } from "@animichi/contract";
 
 /** Base origin the unit MSW swimlane serves; matches the jsdom `location.origin`. */
 export const TEST_ORIGIN = "http://localhost:3000";
@@ -12,7 +12,7 @@ const hakoneStation = {
   screenshot_url: "https://cdn.test/point-1.jpg",
   latitude: 35.2323,
   longitude: 139.1069,
-} satisfies PilgrimagePoint;
+} satisfies Point;
 
 /** A valid, contract-shaped catalog search payload. */
 export const searchSuccessFixture = {

--- a/apps/web/tests/unit/anime/anime-page.test.tsx
+++ b/apps/web/tests/unit/anime/anime-page.test.tsx
@@ -57,7 +57,7 @@ describe("AnimePage full state", () => {
 
 describe("AnimePage partial data", () => {
   it("omits the duration fact when there are no sample routes", () => {
-    render(<AnimePage overview={{ ...fullOverviewFixture, sample_routes: [] }} locale="ja" />);
+    render(<AnimePage overview={{ ...fullOverviewFixture, sample_itineraries: [] }} locale="ja" />);
     expect(screen.queryByText(/所要時間は約/)).toBeNull();
   });
 

--- a/apps/web/tests/unit/chat/_route-fixtures.ts
+++ b/apps/web/tests/unit/chat/_route-fixtures.ts
@@ -54,7 +54,7 @@ export function routePartRaw(points: readonly Record<string, unknown>[], extras:
     intent: "plan_route",
     success: true,
     status: "ok",
-    data: { route: { ordered_points: points, point_count: points.length, ...extras } },
+    data: { itinerary: { ordered_points: points, point_count: points.length, ...extras } },
   };
 }
 

--- a/apps/web/tests/unit/chat/chat-page-envelope-states.test.tsx
+++ b/apps/web/tests/unit/chat/chat-page-envelope-states.test.tsx
@@ -28,7 +28,7 @@ function failedEnvelopePatch(code: string, technical: string): FinalFramePatch {
 
 const zeroSpotsPatch: FinalFramePatch = (envelope) => ({
   ...envelope,
-  data: { route: { ordered_points: [], point_count: 0 } },
+  data: { itinerary: { ordered_points: [], point_count: 0 } },
 });
 
 const BROKEN_SCENE_POINT = {
@@ -43,7 +43,7 @@ const BROKEN_SCENE_POINT = {
 
 const brokenScenePatch: FinalFramePatch = (envelope) => ({
   ...envelope,
-  data: { route: { ordered_points: [BROKEN_SCENE_POINT], point_count: 2 } },
+  data: { itinerary: { ordered_points: [BROKEN_SCENE_POINT], point_count: 2 } },
 });
 
 describe("D1 recognition failure", () => {

--- a/apps/web/tests/unit/chat/data-part-card.test.tsx
+++ b/apps/web/tests/unit/chat/data-part-card.test.tsx
@@ -33,7 +33,7 @@ describe("DataPartCard", () => {
       message: "宇治の聖地を2件、徒歩ルートにまとめました。",
       data: {
         results: { rows: [{ id: "p1", name: "宇治橋" }, { id: "p2", name: "京阪宇治駅" }] },
-        route: { point_count: 2, total_walk_minutes: 12 },
+        itinerary: { point_count: 2, total_walk_minutes: 12 },
       },
     });
     expect(screen.getByText("宇治の聖地を2件、徒歩ルートにまとめました。")).toBeTruthy();
@@ -44,7 +44,7 @@ describe("DataPartCard", () => {
   it("appends the D3 short-route notice while keeping the spot cards", () => {
     renderPart({
       intent: "plan_route",
-      data: { route: { ordered_points: [{ id: "p1", name: "宇治橋" }], point_count: 1 } },
+      data: { itinerary: { ordered_points: [{ id: "p1", name: "宇治橋" }], point_count: 1 } },
     });
     expect(screen.getByText("宇治橋")).toBeTruthy();
     expect(screen.getByText(dict.errorStates.d3Notice)).toBeTruthy();

--- a/apps/web/tests/unit/chat/data-parts.test.ts
+++ b/apps/web/tests/unit/chat/data-parts.test.ts
@@ -15,7 +15,7 @@ describe("parseChatDataPart", () => {
       intent: "plan_route",
       success: true,
       message: "宇治の聖地を2件",
-      data: { route: { point_count: 2, total_walk_minutes: 12 } },
+      data: { itinerary: { point_count: 2, total_walk_minutes: 12 } },
     });
     expect(part?.message).toBe("宇治の聖地を2件");
   });

--- a/apps/web/tests/unit/chat/error-classifier.test.ts
+++ b/apps/web/tests/unit/chat/error-classifier.test.ts
@@ -10,8 +10,8 @@ function searchPart(intent: SearchIntent, results?: Record<string, unknown>): Ch
   return { intent, success: true, data };
 }
 
-function routePart(route?: Record<string, unknown>): ChatDataPart {
-  const data = route === undefined ? undefined : { route };
+function routePart(itinerary?: Record<string, unknown>): ChatDataPart {
+  const data = itinerary === undefined ? undefined : { itinerary };
   return { intent: "plan_route", success: true, data };
 }
 

--- a/apps/web/tests/unit/chat/route-card.test.tsx
+++ b/apps/web/tests/unit/chat/route-card.test.tsx
@@ -24,7 +24,7 @@ function fullRouteRaw() {
     ...routePartRaw(ujiPoints().slice(), { timed_itinerary: ujiItinerary() }),
     data: {
       results: { rows: [...ujiPoints(), offRoute] },
-      route: { ordered_points: ujiPoints().slice(), point_count: 3, timed_itinerary: ujiItinerary() },
+      itinerary: { ordered_points: ujiPoints().slice(), point_count: 3, timed_itinerary: ujiItinerary() },
     },
   };
 }
@@ -83,7 +83,7 @@ describe("AC4: a short route still renders the card plus the D3 note", () => {
   it("keeps the timeline and appends the explanatory notice for <3 spots", () => {
     const short = {
       ...routePartRaw(ujiPoints().slice(0, 2)),
-      data: { route: { ordered_points: ujiPoints().slice(0, 2), point_count: 2, timed_itinerary: { ...ujiItinerary(), stops: ujiItinerary().stops.slice(0, 2), legs: ujiItinerary().legs.slice(0, 1) } } },
+      data: { itinerary: { ordered_points: ujiPoints().slice(0, 2), point_count: 2, timed_itinerary: { ...ujiItinerary(), stops: ujiItinerary().stops.slice(0, 2), legs: ujiItinerary().legs.slice(0, 1) } } },
     };
     render(
       <ChatActionsProvider actions={{ send: vi.fn(), regenerate: vi.fn() }}>

--- a/apps/web/tests/unit/chat/save-copy-i18n.test.ts
+++ b/apps/web/tests/unit/chat/save-copy-i18n.test.ts
@@ -92,7 +92,7 @@ describe("the save target is derived from the rendered route", () => {
   });
 
   it("accepts bare id strings and drops blank ids from the stream", () => {
-    const raw = { intent: "plan_route", success: true, status: "ok", data: { route: { ordered_points: ["x", "", "y"], point_count: 3 } } };
+    const raw = { intent: "plan_route", success: true, status: "ok", data: { itinerary: { ordered_points: ["x", "", "y"], point_count: 3 } } };
     expect(routeSaveTarget(parsedPart(raw), chatDictFor("ja"))?.pointIds).toEqual(["x", "y"]);
   });
 

--- a/apps/web/tests/unit/chat/supersession.test.ts
+++ b/apps/web/tests/unit/chat/supersession.test.ts
@@ -33,6 +33,7 @@ describe("routeDocumentKey (route cards as the first living document)", () => {
 
   it("leaves non-route intents and malformed payloads keyless", () => {
     expect(routeDocumentKey({ intent: "search_bangumi", data: { results: {} } })).toBeUndefined();
+    expect(routeDocumentKey({ intent: "plan_route", data: null })).toBeUndefined();
     expect(routeDocumentKey({ intent: "plan_route", data: { itinerary: null } })).toBeUndefined();
     expect(routeDocumentKey({ intent: "plan_route", data: { itinerary: undefined } })).toBeUndefined();
     expect(routeDocumentKey({ intent: 42, data: {} })).toBeUndefined();

--- a/apps/web/tests/unit/chat/supersession.test.ts
+++ b/apps/web/tests/unit/chat/supersession.test.ts
@@ -33,8 +33,8 @@ describe("routeDocumentKey (route cards as the first living document)", () => {
 
   it("leaves non-route intents and malformed payloads keyless", () => {
     expect(routeDocumentKey({ intent: "search_bangumi", data: { results: {} } })).toBeUndefined();
-    expect(routeDocumentKey({ intent: "plan_route", data: { route: null } })).toBeUndefined();
-    expect(routeDocumentKey({ intent: "plan_route", data: { route: undefined } })).toBeUndefined();
+    expect(routeDocumentKey({ intent: "plan_route", data: { itinerary: null } })).toBeUndefined();
+    expect(routeDocumentKey({ intent: "plan_route", data: { itinerary: undefined } })).toBeUndefined();
     expect(routeDocumentKey({ intent: 42, data: {} })).toBeUndefined();
     expect(routeDocumentKey("not-an-object")).toBeUndefined();
   });

--- a/db/migrations/20260808000002_greenfield_rename_catalog.sql
+++ b/db/migrations/20260808000002_greenfield_rename_catalog.sql
@@ -1,0 +1,29 @@
+-- Catalog greenfield rename (#852, PR-2): itinerary_snapshots + bangumi_id columns.
+--
+-- Per docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md §3.1:
+--   route_snapshots  -> itinerary_snapshots (key column bangumi_id)
+--   aliases.work_id  -> bangumi_id
+--   series_edges.from_work_id/to_work_id -> from_bangumi_id/to_bangumi_id
+--   cluster_version.work_id -> bangumi_id
+-- ingest_jobs / raw_* / media_assets KEEP work_id (platform tables, D6) —
+-- deliberately NOT renamed.
+--
+-- Pure renames (ALTER TABLE ... RENAME preserves privileges, so the N1 role
+-- matrix grants follow the renamed objects automatically).
+
+-- Snapshot table: rename + key column.
+ALTER TABLE route_snapshots RENAME TO itinerary_snapshots;
+ALTER TABLE itinerary_snapshots RENAME COLUMN work_id TO bangumi_id;
+ALTER SEQUENCE route_snapshots_id_seq RENAME TO itinerary_snapshots_id_seq;
+ALTER INDEX idx_route_snapshots_work_version RENAME TO idx_itinerary_snapshots_bangumi_version;
+
+-- Blue/green publish pointer.
+ALTER TABLE cluster_version RENAME COLUMN work_id TO bangumi_id;
+
+-- Alias pipeline.
+ALTER TABLE aliases RENAME COLUMN work_id TO bangumi_id;
+
+-- Series relation graph.
+ALTER TABLE series_edges RENAME COLUMN from_work_id TO from_bangumi_id;
+ALTER TABLE series_edges RENAME COLUMN to_work_id TO to_bangumi_id;
+ALTER INDEX idx_series_edges_to RENAME TO idx_series_edges_to_bangumi;

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:5f//LNoKmxGqtPdz9P4p0bdQiPPmWzZzmYGP/X9EtIo=
+h1:j/z2bdAcu1YO3EpafyZVRi405uE1H6TUn+elhqsxU/U=
 20260623000001_init.sql h1:j96dtVbOQB/5eNuug4tZpdgURdZ5h0Zh4Vka7/dy1A0=
 20260713000001_user_routes.sql h1:th9ag/cdiRp9plYQraVBGIuRXeH4g5R3XvCuGZeFx8Q=
 20260714000001_catalog_geocoding.sql h1:EwkJGRPfg5camebXRzw+5xRVf6TWu23t3/tnw91uPwY=
@@ -14,3 +14,4 @@ h1:5f//LNoKmxGqtPdz9P4p0bdQiPPmWzZzmYGP/X9EtIo=
 20260806120000_role_matrix_n1.sql h1:KUy+gBB5U/Aj8brIrLHmdBbKv6+2EpPmnZKnsIRbJ3g=
 20260808000000_role_matrix_n2_jobs_routes.sql h1:3nyRuOWgaPzqTrSMCPg8Aw1gIdgFtFwCFLSqY0rkwvs=
 20260808000001_greenfield_rename_users.sql h1:3Rqg2jPXeY4UMoz9GHnevs1fKN3P2JCZ382+7Nv8kI4=
+20260808000002_greenfield_rename_catalog.sql h1:rr8esNnVJI9a05cn2uVEeRWyNmh3QW8pyArOZeC55qo=

--- a/packages/contract/openapi.json
+++ b/packages/contract/openapi.json
@@ -388,10 +388,10 @@
         }
       }
     },
-    "/catalog/points-by-work-id": {
+    "/catalog/points-by-bangumi-id": {
       "post": {
-        "operationId": "pointsByWorkId",
-        "summary": "Fetch pilgrimage points by resolved work id",
+        "operationId": "pointsByBangumiId",
+        "summary": "Fetch pilgrimage points by resolved bangumi id",
         "requestBody": {
           "required": true,
           "content": {
@@ -399,13 +399,13 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "work_id": {
+                  "bangumi_id": {
                     "type": "string",
                     "pattern": "^\\d+$"
                   }
                 },
                 "required": [
-                  "work_id"
+                  "bangumi_id"
                 ]
               }
             }
@@ -1009,10 +1009,10 @@
         }
       }
     },
-    "/catalog/route": {
+    "/catalog/itinerary": {
       "post": {
-        "operationId": "route",
-        "summary": "Plan an ordered, timed route over selected points",
+        "operationId": "planItinerary",
+        "summary": "Plan an ordered, timed itinerary over selected points",
         "requestBody": {
           "required": true,
           "content": {
@@ -1610,7 +1610,7 @@
                         ]
                       }
                     },
-                    "sample_routes": {
+                    "sample_itineraries": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -1637,7 +1637,7 @@
                     "points_length",
                     "circles",
                     "scenes",
-                    "sample_routes"
+                    "sample_itineraries"
                   ]
                 }
               }

--- a/packages/contract/src/chat-data-parts.ts
+++ b/packages/contract/src/chat-data-parts.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import {
   AnimeCandidate,
-  PilgrimagePoint,
+  Itinerary,
+  Point,
   ResolveOutcome,
-  Route,
   TimedItinerary,
 } from "./models.js";
 
-const StreamPoint = PilgrimagePoint.partial().extend({
+const StreamPoint = Point.partial().extend({
   lat: z.number().optional(),
   lng: z.number().optional(),
   ep: z.number().int().optional(),
@@ -24,7 +24,7 @@ const SearchResults = z.object({
   rows: z.array(StreamPoint).optional(),
 }).strict();
 
-const StreamRoute = Route.partial().extend({
+const StreamItinerary = Itinerary.partial().extend({
   ordered_points: z.union([z.array(z.string()), z.array(StreamPoint)]).optional(),
   point_count: z.number().int().nonnegative().optional(),
   status: z.string().optional(),
@@ -49,7 +49,7 @@ const ClarificationData = z.object({
 const SearchData = z.object({ results: SearchResults.optional() }).strict();
 const RouteData = z.object({
   results: SearchResults.optional(),
-  route: StreamRoute.optional(),
+  itinerary: StreamItinerary.optional(),
 }).strict();
 const EmptyData = z.object({}).strict();
 
@@ -75,7 +75,7 @@ const ResponseEnvelope = z.object({
 const searchPart = (intent: "search_bangumi" | "search_nearby") =>
   ResponseEnvelope.extend({ intent: z.literal(intent), data: SearchData.optional() });
 
-const routePart = (intent: "plan_route" | "plan_selected" | "plan_multi") =>
+const itineraryPart = (intent: "plan_route" | "plan_selected" | "plan_multi") =>
   ResponseEnvelope.extend({ intent: z.literal(intent), data: RouteData.optional() });
 
 const prosePart = (intent: "general_qa" | "greet_user" | "blocked") =>
@@ -84,9 +84,9 @@ const prosePart = (intent: "general_qa" | "greet_user" | "blocked") =>
 export const ChatResponseDataPart = z.discriminatedUnion("intent", [
   searchPart("search_bangumi"),
   searchPart("search_nearby"),
-  routePart("plan_route"),
-  routePart("plan_selected"),
-  routePart("plan_multi"),
+  itineraryPart("plan_route"),
+  itineraryPart("plan_selected"),
+  itineraryPart("plan_multi"),
   prosePart("general_qa"),
   prosePart("greet_user"),
   ResponseEnvelope.extend({ intent: z.literal("clarify"), data: ClarificationData.optional() }),

--- a/packages/contract/src/contract.ts
+++ b/packages/contract/src/contract.ts
@@ -10,13 +10,13 @@ import { z } from "zod";
 import { pickCatalogErrors } from "./errors.js";
 import {
   AnimeOverview,
+  Itinerary,
   Latitude,
   Longitude,
   Origin,
-  PilgrimagePoint,
+  Point,
   Pacing,
   ResolveOutcome,
-  Route,
 } from "./models.js";
 
 /** search(query, origin?) -> { rows, synced_at, partial? } */
@@ -27,7 +27,7 @@ export const SearchInput = z.object({
 export type SearchInput = z.infer<typeof SearchInput>;
 
 export const SearchResult = z.object({
-  rows: z.array(PilgrimagePoint),
+  rows: z.array(Point),
   synced_at: z.string(),
   // True when `rows` are an L1 preview (Anitabi `/lite`, first ~10 points)
   // returned immediately on an alias miss while the full ingest runs in the
@@ -40,9 +40,9 @@ export type SearchResult = z.infer<typeof SearchResult>;
 export const ResolveInput = z.object({ query: z.string().trim().min(1) });
 export type ResolveInput = z.infer<typeof ResolveInput>;
 
-/** pointsByWorkId(work_id) -> the existing SearchResult shape */
-export const PointsByWorkIdInput = z.object({ work_id: z.string().regex(/^\d+$/) });
-export type PointsByWorkIdInput = z.infer<typeof PointsByWorkIdInput>;
+/** pointsByBangumiId(bangumi_id) -> the existing SearchResult shape */
+export const PointsByBangumiIdInput = z.object({ bangumi_id: z.string().regex(/^\d+$/) });
+export type PointsByBangumiIdInput = z.infer<typeof PointsByBangumiIdInput>;
 
 /** spots(bangumi_id, origin?) -> { point, distance_m? } */
 export const SpotsInput = z.object({
@@ -52,7 +52,7 @@ export const SpotsInput = z.object({
 export type SpotsInput = z.infer<typeof SpotsInput>;
 
 export const SpotsResult = z.object({
-  point: PilgrimagePoint,
+  point: Point,
   distance_m: z.number().optional(),
 });
 export type SpotsResult = z.infer<typeof SpotsResult>;
@@ -66,7 +66,7 @@ export const NearbyInput = z.object({
 export type NearbyInput = z.infer<typeof NearbyInput>;
 
 export const NearbyResult = z.object({
-  rows: z.array(PilgrimagePoint),
+  rows: z.array(Point),
 });
 export type NearbyResult = z.infer<typeof NearbyResult>;
 
@@ -98,13 +98,13 @@ export type GeocodeCandidate = z.infer<typeof GeocodeCandidate>;
 export const GeocodeResult = z.object({ candidates: z.array(GeocodeCandidate) });
 export type GeocodeResult = z.infer<typeof GeocodeResult>;
 
-/** route(point_ids, origin?, pacing?) -> Route */
-export const RouteInput = z.object({
+/** planItinerary(point_ids, origin?, pacing?) -> Itinerary */
+export const ItineraryInput = z.object({
   point_ids: z.array(z.string()),
   origin: Origin.optional(),
   pacing: Pacing.optional(),
 });
-export type RouteInput = z.infer<typeof RouteInput>;
+export type ItineraryInput = z.infer<typeof ItineraryInput>;
 
 /** animeOverview(bangumi_id) -> AnimeOverview (public, anonymous, read-only GET) */
 export const AnimeOverviewInput = z.object({
@@ -122,13 +122,13 @@ export const catalogContract = {
     .route({ method: "POST", path: "/catalog/resolve", summary: "Resolve an anime title deterministically" })
     .input(ResolveInput)
     .output(ResolveOutcome),
-  pointsByWorkId: oc
+  pointsByBangumiId: oc
     .route({
       method: "POST",
-      path: "/catalog/points-by-work-id",
-      summary: "Fetch pilgrimage points by resolved work id",
+      path: "/catalog/points-by-bangumi-id",
+      summary: "Fetch pilgrimage points by resolved bangumi id",
     })
-    .input(PointsByWorkIdInput)
+    .input(PointsByBangumiIdInput)
     .errors(pickCatalogErrors(["UPSTREAM_UNAVAILABLE"]))
     .output(SearchResult),
   spots: oc
@@ -149,11 +149,11 @@ export const catalogContract = {
     })
     .input(GeocodeInput)
     .output(GeocodeResult),
-  route: oc
-    .route({ method: "POST", path: "/catalog/route", summary: "Plan an ordered, timed route over selected points" })
-    .input(RouteInput)
+  planItinerary: oc
+    .route({ method: "POST", path: "/catalog/itinerary", summary: "Plan an ordered, timed itinerary over selected points" })
+    .input(ItineraryInput)
     .errors(pickCatalogErrors(["ROUTE_TOO_MANY_CLUSTERS", "ROUTE_TOO_MANY_POINTS"]))
-    .output(Route),
+    .output(Itinerary),
   animeOverview: oc
     .route({
       method: "GET",

--- a/packages/contract/src/models.ts
+++ b/packages/contract/src/models.ts
@@ -32,8 +32,7 @@ export type Pacing = z.infer<typeof Pacing>;
  * A single pilgrimage point row.
  * Mirrors PilgrimagePointModel in runtime_models.py.
  */
-export const PilgrimagePoint = z.object({
-  id: z.string(),
+export const Point = z.object({  id: z.string(),
   name: z.string(),
   name_cn: z.string().optional(),
   bangumi_id: z.string(),
@@ -49,7 +48,7 @@ export const PilgrimagePoint = z.object({
   cover_url: z.string().optional(),
   city: z.string().optional(),
 });
-export type PilgrimagePoint = z.infer<typeof PilgrimagePoint>;
+export type Point = z.infer<typeof Point>;
 
 /**
  * One region bubble for the public anime overview: a place name, its spot count,
@@ -79,16 +78,16 @@ export const AnimeScene = z.object({
 });
 export type AnimeScene = z.infer<typeof AnimeScene>;
 
-/** A suggested per-region sample route: the region name plus its member point ids. */
-export const AnimeSampleRoute = z.object({
+/** A suggested per-region sample itinerary: the region name plus its member point ids. */
+export const AnimeSampleItinerary = z.object({
   region: z.string(),
   point_ids: z.array(z.string()),
 });
-export type AnimeSampleRoute = z.infer<typeof AnimeSampleRoute>;
+export type AnimeSampleItinerary = z.infer<typeof AnimeSampleItinerary>;
 
 /**
  * The public anime overview payload: bubble aggregation, 名場面 ranking, and
- * sample routes for one work. Exposed anonymously (catalog's first public
+ * sample itineraries for one work. Exposed anonymously (catalog's first public
  * surface) — every field is derived from already-public catalog data.
  */
 export const AnimeOverview = z.object({
@@ -96,7 +95,7 @@ export const AnimeOverview = z.object({
   points_length: z.number().int().nonnegative(),
   circles: z.array(AnimeOverviewCircle),
   scenes: z.array(AnimeScene),
-  sample_routes: z.array(AnimeSampleRoute),
+  sample_itineraries: z.array(AnimeSampleItinerary),
 });
 export type AnimeOverview = z.infer<typeof AnimeOverview>;
 
@@ -183,13 +182,13 @@ export const TimedItinerary = z.object({
 export type TimedItinerary = z.infer<typeof TimedItinerary>;
 
 /**
- * An ordered, timed pilgrimage route.
+ * An ordered, timed pilgrimage itinerary.
  * Mirrors RouteModel in runtime_models.py.
  */
-export const Route = z.object({
+export const Itinerary = z.object({
   id: z.string().optional(),
   version: z.string().optional(),
-  ordered_points: z.array(PilgrimagePoint),
+  ordered_points: z.array(Point),
   point_count: z.number().int(),
   cover_url: z.string().optional(),
   anime_title: z.string().optional(),
@@ -199,4 +198,4 @@ export const Route = z.object({
   total_cluster_count: z.number().int().optional(),
   timed_itinerary: TimedItinerary,
 });
-export type Route = z.infer<typeof Route>;
+export type Itinerary = z.infer<typeof Itinerary>;

--- a/packages/contract/test/chat-data-parts.test.ts
+++ b/packages/contract/test/chat-data-parts.test.ts
@@ -82,7 +82,7 @@ describe("ChatResponseDataPart rejects invalid data", () => {
   });
 
   it("rejects a malformed payload", () => {
-    const malformed = { intent: "plan_route", data: { route: { ordered_points: "bad" } } };
+    const malformed = { intent: "plan_route", data: { itinerary: { ordered_points: "bad" } } };
     expect(() => ChatResponseDataPart.parse(malformed)).toThrow();
   });
 });

--- a/workers/catalog/src/adapters/outbound/route-points.ts
+++ b/workers/catalog/src/adapters/outbound/route-points.ts
@@ -1,14 +1,14 @@
 /**
  * Outbound adapter for the `PointsForRoutePort`: fetch the points for a route
  * from Postgres (joined to bangumi for the anime title) and map the rows to
- * `RoutePoint`s, preserving the requested `ids` order. This adapter owns the
+ * `ItineraryPoint`s, preserving the requested `ids` order. This adapter owns the
  * only SQL on the plan-itinerary path.
  */
 
 import { sql } from "drizzle-orm";
-import type { PointsForRoutePort, RoutePoint } from "../../application/plan-itinerary";
+import type { ItineraryPoint, PointsForRoutePort } from "../../application/plan-itinerary";
 import { optional } from "../../lib/optional";
-import type { PilgrimagePoint } from "../../types";
+import type { Point } from "../../types";
 
 /** The one DB capability this adapter needs: run a query, get back `{ rows }`. */
 export interface RouteDb {
@@ -39,7 +39,7 @@ export function pointsForRoute(db: RouteDb): PointsForRoutePort {
 }
 
 /** SELECT the points for `ids` joined to their bangumi, preserving `ids` order. */
-async function fetchPoints(db: RouteDb, ids: string[]): Promise<RoutePoint[]> {
+async function fetchPoints(db: RouteDb, ids: string[]): Promise<ItineraryPoint[]> {
   if (ids.length === 0) return [];
   const result = await db.execute(pointsQuery(ids));
   const byId = indexRows(result.rows as PointRow[]);
@@ -50,7 +50,7 @@ async function fetchPoints(db: RouteDb, ids: string[]): Promise<RoutePoint[]> {
 }
 
 /** Index fetched rows by `id` (mapped to points), for ordered reassembly. */
-function indexRows(rows: PointRow[]): Map<string, RoutePoint> {
+function indexRows(rows: PointRow[]): Map<string, ItineraryPoint> {
   return new Map(rows.map((r) => [r.id, toPoint(r)]));
 }
 
@@ -66,17 +66,17 @@ function pointsQuery(ids: string[]) {
   `;
 }
 
-/** Map a joined DB row to a contract `PilgrimagePoint` (+ clustering geo). */
-function toPoint(r: PointRow): RoutePoint {
+/** Map a joined DB row to a contract `Point` (+ clustering geo). */
+function toPoint(r: PointRow): ItineraryPoint {
   return { ...scalarFields(r), latitude: r.latitude, longitude: r.longitude };
 }
 
-/** The non-coordinate `PilgrimagePoint` fields, dropping null optionals. */
-function scalarFields(r: PointRow): Omit<PilgrimagePoint, "latitude" | "longitude"> {
+/** The non-coordinate `Point` fields, dropping null optionals. */
+function scalarFields(r: PointRow): Omit<Point, "latitude" | "longitude"> {
   return { ...scalarBase(r), ...optional(scalarOptionals(r)) };
 }
 
-function scalarBase(r: PointRow): Omit<PilgrimagePoint, "latitude" | "longitude"> {
+function scalarBase(r: PointRow): Omit<Point, "latitude" | "longitude"> {
   return {
     id: r.id,
     name: r.name,

--- a/workers/catalog/src/api/anime-overview.ts
+++ b/workers/catalog/src/api/anime-overview.ts
@@ -161,13 +161,13 @@ function buildSampleItineraries(rows: OverviewRow[]): AnimeSampleItinerary[] {
   const groups = groupByRegion(rows);
   return rankRegions(groups)
     .slice(0, SAMPLE_ITINERARY_REGION_LIMIT)
-    .map((region) => toSampleItinerary(region, groups.get(region) ?? []));
+    .map(([region, members]) => toSampleItinerary(region, members));
 }
 
-function rankRegions(groups: Map<string, OverviewRow[]>): string[] {
-  return [...groups.entries()]
-    .sort(([ar, a], [br, b]) => b.length - a.length || ar.localeCompare(br))
-    .map(([region]) => region);
+function rankRegions(groups: Map<string, OverviewRow[]>): [string, OverviewRow[]][] {
+  return [...groups.entries()].sort(
+    ([ar, a], [br, b]) => b.length - a.length || ar.localeCompare(br),
+  );
 }
 
 function toSampleItinerary(region: string, members: OverviewRow[]): AnimeSampleItinerary {

--- a/workers/catalog/src/api/anime-overview.ts
+++ b/workers/catalog/src/api/anime-overview.ts
@@ -9,7 +9,7 @@
  *   - `circles`: bubble aggregation grouped by region (city), with centroid.
  *   - `scenes`: 名場面 ranking — co-located points (`clusterByLocation`, 50m)
  *     collapse into one scene ranked by shot count.
- *   - `sample_routes`: the top regions with their member point ids.
+ *   - `sample_itineraries`: the top regions with their member point ids.
  *
  * Read-only: a single typed `db.execute(sql`...`)` following the geo-query.ts
  * pattern. Wire shapes come from `../types` (import type erases at compile time,
@@ -18,13 +18,13 @@
 
 import { sql } from "drizzle-orm";
 import { clusterByLocation, type LocationCluster } from "../domain/clustering/cluster";
-import type { AnimeOverview, AnimeOverviewCircle, AnimeSampleRoute, AnimeScene } from "../types";
+import type { AnimeOverview, AnimeOverviewCircle, AnimeSampleItinerary, AnimeScene } from "../types";
 
 export type { AnimeOverview };
 
 const SCENE_LIMIT = 20;
-const SAMPLE_ROUTE_REGION_LIMIT = 3;
-const SAMPLE_ROUTE_POINT_CAP = 12;
+const SAMPLE_ITINERARY_REGION_LIMIT = 3;
+const SAMPLE_ITINERARY_POINT_CAP = 12;
 const CLUSTER_RADIUS_M = 50;
 
 /** The one DB capability this handler needs: run a query, get back `{ rows }`. */
@@ -65,7 +65,7 @@ function toOverview(bangumiId: string, rows: OverviewRow[]): AnimeOverview {
     points_length: rows.length,
     circles: buildCircles(rows),
     scenes: buildScenes(rows),
-    sample_routes: buildSampleRoutes(rows),
+    sample_itineraries: buildSampleItineraries(rows),
   };
 }
 
@@ -156,12 +156,12 @@ function representative(cluster: LocationCluster<OverviewRow>): OverviewRow {
   return rep;
 }
 
-/** One sample route per top region, listing its member point ids (capped). */
-function buildSampleRoutes(rows: OverviewRow[]): AnimeSampleRoute[] {
+/** One sample itinerary per top region, listing its member point ids (capped). */
+function buildSampleItineraries(rows: OverviewRow[]): AnimeSampleItinerary[] {
   const groups = groupByRegion(rows);
   return rankRegions(groups)
-    .slice(0, SAMPLE_ROUTE_REGION_LIMIT)
-    .map((region) => toSampleRoute(region, groups.get(region) ?? []));
+    .slice(0, SAMPLE_ITINERARY_REGION_LIMIT)
+    .map((region) => toSampleItinerary(region, groups.get(region) ?? []));
 }
 
 function rankRegions(groups: Map<string, OverviewRow[]>): string[] {
@@ -170,6 +170,6 @@ function rankRegions(groups: Map<string, OverviewRow[]>): string[] {
     .map(([region]) => region);
 }
 
-function toSampleRoute(region: string, members: OverviewRow[]): AnimeSampleRoute {
-  return { region, point_ids: members.slice(0, SAMPLE_ROUTE_POINT_CAP).map((m) => m.id) };
+function toSampleItinerary(region: string, members: OverviewRow[]): AnimeSampleItinerary {
+  return { region, point_ids: members.slice(0, SAMPLE_ITINERARY_POINT_CAP).map((m) => m.id) };
 }

--- a/workers/catalog/src/api/nearby.ts
+++ b/workers/catalog/src/api/nearby.ts
@@ -2,7 +2,7 @@
 import { sql } from "drizzle-orm";
 import type { CatalogDb, NeonSql } from "../db/client";
 import { findPointsWithinRadius, type NearbyPoint } from "../lib/geo-query";
-import type { PilgrimagePoint } from "../types";
+import type { Point } from "../types";
 
 export interface NearbyInput {
   lat: number;
@@ -22,7 +22,7 @@ interface PointDetail {
   city?: string | null;
 }
 
-function detailOptionals(d: PointDetail): Partial<PilgrimagePoint> {
+function detailOptionals(d: PointDetail): Partial<Point> {
   return {
     ...(d.name_cn != null && { name_cn: d.name_cn }),
     ...(d.episode != null && { episode: d.episode }),
@@ -32,11 +32,11 @@ function detailOptionals(d: PointDetail): Partial<PilgrimagePoint> {
   };
 }
 
-function merge(near: NearbyPoint, d?: PointDetail): PilgrimagePoint {
+function merge(near: NearbyPoint, d?: PointDetail): Point {
   return { ...mergeBase(near, d?.bangumi_id ?? "", d?.image ?? ""), ...(d ? detailOptionals(d) : {}) };
 }
 
-function mergeBase(near: NearbyPoint, bangumiId: string, image: string): PilgrimagePoint {
+function mergeBase(near: NearbyPoint, bangumiId: string, image: string): Point {
   return {
     id: near.id, name: near.name, bangumi_id: bangumiId, screenshot_url: image,
     latitude: near.latitude, longitude: near.longitude, distance_m: near.distanceM,
@@ -61,7 +61,7 @@ export async function nearby(
   db: CatalogDb,
   neonSql: NeonSql,
   input: NearbyInput,
-): Promise<{ rows: PilgrimagePoint[] }> {
+): Promise<{ rows: Point[] }> {
   const near = await findPointsWithinRadius(neonSql, { lat: input.lat, lng: input.lng, radiusM: input.radius_m });
   const details = await loadDetails(db, near.map((p) => p.id));
   return { rows: near.map((p) => merge(p, details.get(p.id))) };

--- a/workers/catalog/src/api/preview.ts
+++ b/workers/catalog/src/api/preview.ts
@@ -12,12 +12,12 @@ import {
   type AnitabiPoint,
   type FetchLike,
 } from "../ingest/sources";
-import type { PilgrimagePoint } from "../types";
+import type { Point } from "../types";
 
 /** A resolved work plus its fast `/lite` point preview. */
 export interface MissPreview {
   workId: string;
-  points: PilgrimagePoint[];
+  points: Point[];
 }
 
 /** Resolve a title and return a non-empty preview, preserving search miss behavior. */
@@ -56,7 +56,7 @@ async function fetchLitePreview(workId: string, fetchImpl?: FetchLike): Promise<
 }
 
 /** Map one official Anitabi `/lite` point to the public point contract. */
-function litePoint(point: AnitabiPoint, workId: string): PilgrimagePoint {
+function litePoint(point: AnitabiPoint, workId: string): Point {
   const [latitude, longitude] = liteGeo(point.geo);
   return {
     ...liteBase(point, workId, latitude, longitude),
@@ -64,7 +64,7 @@ function litePoint(point: AnitabiPoint, workId: string): PilgrimagePoint {
   };
 }
 
-function liteBase(point: AnitabiPoint, workId: string, latitude: number, longitude: number): PilgrimagePoint {
+function liteBase(point: AnitabiPoint, workId: string, latitude: number, longitude: number): Point {
   return {
     id: liteString(point.id),
     name: liteString(point.name),

--- a/workers/catalog/src/api/resolve.ts
+++ b/workers/catalog/src/api/resolve.ts
@@ -23,7 +23,7 @@ const MIN_SIMILAR_LEN = 2;
 const MAX_REVERSE_RATIO = 3;
 
 export interface AliasWork {
-  work_id: string;
+  bangumi_id: string;
   priority: number;
 }
 
@@ -56,7 +56,7 @@ async function aliasHit(db: ResolveDb, query: string): Promise<ResolveOutcome | 
 
 /** Apply the top-priority tie rule to alias-index works. */
 async function resolveHit(db: ResolveDb, works: AliasWork[]): Promise<ResolveOutcome | undefined> {
-  const candidates = await db.candidatesForWorks(works.map((work) => work.work_id));
+  const candidates = await db.candidatesForWorks(works.map((work) => work.bangumi_id));
   const survivors = survivingWorks(works, candidates);
   if (survivors.length === 0) return undefined;
   const top = topPriorityWorks(survivors);
@@ -69,15 +69,15 @@ async function resolveHit(db: ResolveDb, works: AliasWork[]): Promise<ResolveOut
 function dedupeWorks(rows: AliasWork[]): AliasWork[] {
   const priorities = new Map<string, number>();
   for (const row of rows) {
-    priorities.set(row.work_id, Math.max(priorities.get(row.work_id) ?? -Infinity, row.priority));
+    priorities.set(row.bangumi_id, Math.max(priorities.get(row.bangumi_id) ?? -Infinity, row.priority));
   }
-  return [...priorities].map(([work_id, priority]) => ({ work_id, priority }));
+  return [...priorities].map(([bangumi_id, priority]) => ({ bangumi_id, priority }));
 }
 
 /** Keep only alias works backed by loadable Bangumi metadata. */
 function survivingWorks(works: AliasWork[], candidates: AnimeCandidate[]): AliasWork[] {
   const ids = new Set(candidates.map((candidate) => candidate.bangumi_id));
-  return works.filter((work) => ids.has(work.work_id));
+  return works.filter((work) => ids.has(work.bangumi_id));
 }
 
 function topPriorityWorks(works: AliasWork[]): AliasWork[] {
@@ -86,13 +86,13 @@ function topPriorityWorks(works: AliasWork[]): AliasWork[] {
 }
 
 function candidatesForWorks(works: AliasWork[], candidates: AnimeCandidate[]): AnimeCandidate[] {
-  const ids = new Set(works.map((work) => work.work_id));
+  const ids = new Set(works.map((work) => work.bangumi_id));
   return candidates.filter((candidate) => ids.has(candidate.bangumi_id));
 }
 
 /** Rank by priority desc, point coverage desc/null-last, then stable id asc. */
 function rankCandidates(works: AliasWork[], candidates: AnimeCandidate[]): AnimeCandidate[] {
-  const priorities = new Map(works.map((work) => [work.work_id, work.priority]));
+  const priorities = new Map(works.map((work) => [work.bangumi_id, work.priority]));
   return [...candidates].sort((left, right) => compareCandidates(left, right, priorities));
 }
 
@@ -219,9 +219,9 @@ export function resolveDb(db: CatalogDb): ResolveDb {
 
 async function selectAliasWorks(db: CatalogDb, normalized: string): Promise<AliasWork[]> {
   const result = await db.execute(sql`
-    SELECT work_id, MAX(priority) AS priority
+    SELECT bangumi_id, MAX(priority) AS priority
     FROM aliases WHERE alias_normalized = ${normalized}
-    GROUP BY work_id
+    GROUP BY bangumi_id
   `);
   return result.rows.map(readAliasWork);
 }
@@ -238,7 +238,7 @@ async function selectCandidates(db: CatalogDb, workIds: string[]): Promise<Anime
 }
 
 function readAliasWork(row: Record<string, unknown>): AliasWork {
-  return { work_id: requiredString(row, "work_id"), priority: requiredNumber(row, "priority") };
+  return { bangumi_id: requiredString(row, "bangumi_id"), priority: requiredNumber(row, "priority") };
 }
 
 function readStoredCandidate(row: Record<string, unknown>): AnimeCandidate {

--- a/workers/catalog/src/api/route.ts
+++ b/workers/catalog/src/api/route.ts
@@ -1,29 +1,30 @@
 // TODO(refactor-skeleton): vertical slice — structure design catalog #837/#838
 /**
- * The `route` read API handler: plan an ordered, timed route over selected
- * points. Handler orchestration only — the SQL fetch lives in the outbound
- * adapter `adapters/outbound/route-points.ts` and the planning orchestration in
- * the use case `application/plan-itinerary.ts` (load points via port ->
- * cluster -> nearest-neighbor order -> timed itinerary -> contract `Route`).
+ * The `planItinerary` read API handler: plan an ordered, timed itinerary over
+ * selected points. Handler orchestration only — the SQL fetch lives in the
+ * outbound adapter `adapters/outbound/route-points.ts` and the planning
+ * orchestration in the use case `application/plan-itinerary.ts` (load points
+ * via port -> cluster -> nearest-neighbor order -> timed itinerary -> contract
+ * `Itinerary`).
  *
  * Read-only: a single SELECT, no writes.
  */
 
 import { pointsForRoute, type RouteDb } from "../adapters/outbound/route-points";
-import { planItinerary, type RouteInput } from "../application/plan-itinerary";
-import type { Origin, PilgrimagePoint, Route } from "../types";
+import { planItinerary as planItineraryUseCase, type ItineraryInput } from "../application/plan-itinerary";
+import type { Origin, Point, Itinerary } from "../types";
 
 /**
- * Output types (`PilgrimagePoint` / `Route`) and the `Origin` input come from
+ * Output types (`Point` / `Itinerary`) and the `Origin` input come from
  * `../types` — the single in-Worker mirror of `packages/contract/src/models.ts`.
  * `import type` erases at compile time, so the contract's zod runtime stays out
  * of the Worker bundle. Re-exported here so existing consumers keep importing
  * them from this handler.
  */
-export type { Origin, PilgrimagePoint, Route };
-export type { RouteDb, RouteInput };
+export type { Origin, Point, Itinerary };
+export type { RouteDb, ItineraryInput };
 
-/** Plan an ordered, timed route over `point_ids`. Empty/unknown ids -> count 0. */
-export function route(db: RouteDb, input: RouteInput): Promise<Route> {
-  return planItinerary(pointsForRoute(db), input);
+/** Plan an ordered, timed itinerary over `point_ids`. Empty/unknown ids -> count 0. */
+export function planItinerary(db: RouteDb, input: ItineraryInput): Promise<Itinerary> {
+  return planItineraryUseCase(pointsForRoute(db), input);
 }

--- a/workers/catalog/src/api/search.ts
+++ b/workers/catalog/src/api/search.ts
@@ -4,7 +4,7 @@
  *
  * Resolves the query through the alias index (NFKC-folded exact match on
  * `aliases.alias_normalized`, the same key `catalog/src/lib/alias.ts` writes)
- * to a `work_id` (a Bangumi subject id), then returns that work's `points`
+ * to a `bangumi_id` (a Bangumi subject id), then returns that work's `points`
  * joined to its `bangumi` metadata for the anime title.
  *
  * On an alias MISS (an uncovered work) this is TIERED so workerd never blocks on
@@ -23,8 +23,8 @@
  * surfaces as a defined retryable `UPSTREAM_UNAVAILABLE` oRPC error (502
  * envelope) instead of lying to the user with empty rows.
  *
- * Output mirrors the oRPC contract `SearchResult` / `PilgrimagePoint`. The wire
- * shapes (`Origin` / `PilgrimagePoint`) come from `../types` — the single
+ * Output mirrors the oRPC contract `SearchResult` / `Point`. The wire
+ * shapes (`Origin` / `Point`) come from `../types` — the single
  * in-Worker mirror of `packages/contract/src/models.ts`. `import type` erases at
  * compile time, keeping the contract's zod runtime out of the Worker bundle;
  * they are re-exported so existing consumers keep importing them from here.
@@ -39,10 +39,10 @@ import {
 } from "../lib/rows";
 import { ingestWork } from "../ingest/orchestrator";
 import type { FetchLike } from "../ingest/sources";
-import type { Origin, PilgrimagePoint } from "../types";
+import type { Origin, Point } from "../types";
 import { previewForQuery, type MissPreview } from "./preview";
 
-export type { Origin, PilgrimagePoint };
+export type { Origin, Point };
 
 export type { MissPreview } from "./preview";
 
@@ -89,15 +89,15 @@ export interface WorkPointRow {
  *     fallback). The published points then serve subsequent (alias-hit) reads.
  */
 export interface SearchDb {
-  workIdForAlias(aliasNormalized: string): Promise<string | undefined>;
-  pointsForWork(workId: string): Promise<WorkPointRow[]>;
+  bangumiIdForAlias(aliasNormalized: string): Promise<string | undefined>;
+  pointsForWork(bangumiId: string): Promise<WorkPointRow[]>;
   resolvePreview(query: string, fetchImpl?: FetchLike): Promise<MissPreview | null>;
-  runFullIngest(workId: string, fetchImpl?: FetchLike): Promise<void>;
+  runFullIngest(bangumiId: string, fetchImpl?: FetchLike): Promise<void>;
 }
 
 /** The search response: rows + freshness, plus `partial` when these are an L1 preview. */
 export interface SearchResult {
-  rows: PilgrimagePoint[];
+  rows: Point[];
   synced_at: string;
   partial?: boolean;
 }
@@ -108,17 +108,17 @@ export async function search(
   input: { query: string; origin?: Origin },
   opts: SearchOptions = {},
 ): Promise<SearchResult> {
-  const workId = await db.workIdForAlias(normalizeAlias(input.query));
-  if (workId) return hitResult(db, workId);
+  const bangumiId = await db.bangumiIdForAlias(normalizeAlias(input.query));
+  if (bangumiId) return hitResult(db, bangumiId);
   return missResult(db, input.query, opts);
 }
 
 /** Alias HIT: return the work's published points from the catalog (no preview/ingest). */
 export async function hitResult(
   db: Pick<SearchDb, "pointsForWork">,
-  workId: string,
+  bangumiId: string,
 ): Promise<SearchResult> {
-  const rows = await db.pointsForWork(workId);
+  const rows = await db.pointsForWork(bangumiId);
   return { rows: rows.map(toPoint), synced_at: syncedAt(rows) };
 }
 
@@ -157,8 +157,8 @@ function emptyResult(): SearchResult {
   return { rows: [], synced_at: new Date().toISOString() };
 }
 
-/** Map a joined DB row to the contract `PilgrimagePoint` shape. */
-function toPoint(r: WorkPointRow): PilgrimagePoint {
+/** Map a joined DB row to the contract `Point` shape. */
+function toPoint(r: WorkPointRow): Point {
   return {
     ...identity(r),
     ...geo(r),
@@ -167,17 +167,17 @@ function toPoint(r: WorkPointRow): PilgrimagePoint {
 }
 
 /** Required identity fields (id / name / bangumi_id / screenshot_url). */
-function identity(r: WorkPointRow): Pick<PilgrimagePoint, "id" | "name" | "bangumi_id" | "screenshot_url"> {
+function identity(r: WorkPointRow): Pick<Point, "id" | "name" | "bangumi_id" | "screenshot_url"> {
   return { id: r.id, name: r.name, bangumi_id: r.bangumi_id ?? "", screenshot_url: r.image ?? "" };
 }
 
 /** Required geo fields. */
-function geo(r: WorkPointRow): Pick<PilgrimagePoint, "latitude" | "longitude"> {
+function geo(r: WorkPointRow): Pick<Point, "latitude" | "longitude"> {
   return { latitude: r.latitude, longitude: r.longitude };
 }
 
 /** Optional metadata fields, omitted when null. */
-function meta(r: WorkPointRow): Partial<PilgrimagePoint> {
+function meta(r: WorkPointRow): Partial<Point> {
   return optional({
     name_cn: r.name_cn, episode: r.episode, time_seconds: r.time_seconds,
     title: r.title, title_cn: r.title_cn, cover_url: r.cover_url, city: r.city,
@@ -194,10 +194,10 @@ function syncedAt(rows: WorkPointRow[]): string {
 /** Build the production `SearchDb` over a Drizzle `CatalogDb`. */
 export function searchDb(db: CatalogDb): SearchDb {
   return {
-    workIdForAlias: (normalized) => firstWorkId(db, normalized),
-    pointsForWork: (workId) => selectPoints(db, workId),
+    bangumiIdForAlias: (normalized) => firstBangumiId(db, normalized),
+    pointsForWork: (bangumiId) => selectPoints(db, bangumiId),
     resolvePreview: (query, fetchImpl) => previewForQuery(query, fetchImpl),
-    runFullIngest: (workId, fetchImpl) => runFullIngest(db, workId, fetchImpl),
+    runFullIngest: (bangumiId, fetchImpl) => runFullIngest(db, bangumiId, fetchImpl),
   };
 }
 
@@ -205,19 +205,19 @@ export function searchDb(db: CatalogDb): SearchDb {
  * (it is fire-and-forget on `waitUntil`, and synchronous callers re-read the DB). */
 async function runFullIngest(
   db: CatalogDb,
-  workId: string,
+  bangumiId: string,
   fetchImpl?: FetchLike,
 ): Promise<void> {
-  await ingestWork(db, workId, { fetchImpl });
+  await ingestWork(db, bangumiId, { fetchImpl });
 }
 
-/** Exact-match the normalized alias -> the highest-priority work id.
+/** Exact-match the normalized alias -> the highest-priority bangumi id.
  * Raw `sql` (not the Drizzle query builder) — the builder hangs under workerd. */
-async function firstWorkId(db: CatalogDb, normalized: string): Promise<string | undefined> {
+async function firstBangumiId(db: CatalogDb, normalized: string): Promise<string | undefined> {
   const result = await db.execute(
-    sql`SELECT work_id FROM aliases WHERE alias_normalized = ${normalized} ORDER BY priority DESC LIMIT 1`,
+    sql`SELECT bangumi_id FROM aliases WHERE alias_normalized = ${normalized} ORDER BY priority DESC LIMIT 1`,
   );
-  return (result.rows as { work_id: string }[])[0]?.work_id;
+  return (result.rows as { bangumi_id: string }[])[0]?.bangumi_id;
 }
 
 function readWorkPointRow(row: Record<string, unknown>): WorkPointRow {

--- a/workers/catalog/src/api/spots.ts
+++ b/workers/catalog/src/api/spots.ts
@@ -4,13 +4,13 @@
  * optionally annotated with `distance_m` from a caller-supplied origin.
  *
  * Shape source of truth: packages/contract/src/contract.ts ->
- *   spots(bangumi_id, origin?) -> { point: PilgrimagePoint, distance_m? }
+ *   spots(bangumi_id, origin?) -> { point: Point, distance_m? }
  * The contract returns a SINGLE point (not a list), so we pick the work's
  * representative point (lowest id, deterministic) and 404 if the work has none.
  *
  * Read-only: a single typed `db.execute(sql`...`)` following the validated
  * geo-query.ts pattern (Drizzle has no native GEOGRAPHY predicate). The wire
- * shapes (`PilgrimagePoint` / `Origin`) come from `../types` — the single
+ * shapes (`Point` / `Origin`) come from `../types` — the single
  * in-Worker mirror of packages/contract/src/models.ts (import type erases at
  * compile time, keeping the contract's zod runtime out of the bundle).
  */
@@ -19,9 +19,9 @@ import type { CatalogDb } from "../db/client";
 import { sql } from "drizzle-orm";
 import { haversine } from "../domain/geo";
 import { optional } from "../lib/optional";
-import type { Origin, PilgrimagePoint } from "../types";
+import type { Origin, Point } from "../types";
 
-export type { Origin, PilgrimagePoint };
+export type { Origin, Point };
 
 /** Raw column shape returned by the points read query. */
 interface PointRow {
@@ -57,8 +57,8 @@ function representativeQuery(bangumiId: string) {
   `;
 }
 
-/** Map a DB row to the contract PilgrimagePoint shape (omitting null columns). */
-function toPoint(r: PointRow): PilgrimagePoint {
+/** Map a DB row to the contract Point shape (omitting null columns). */
+function toPoint(r: PointRow): Point {
   return {
     ...pointBase(r),
     ...optional({ episode: r.episode, time_seconds: r.time_seconds }),
@@ -67,7 +67,7 @@ function toPoint(r: PointRow): PilgrimagePoint {
   };
 }
 
-function pointBase(r: PointRow): PilgrimagePoint {
+function pointBase(r: PointRow): Point {
   return {
     id: r.id,
     name: r.name,
@@ -79,7 +79,7 @@ function pointBase(r: PointRow): PilgrimagePoint {
 }
 
 /** Distance in meters from a lat/lng origin to the point; undefined for named origins. */
-function distanceFrom(point: PilgrimagePoint, origin?: Origin): number | undefined {
+function distanceFrom(point: Point, origin?: Origin): number | undefined {
   if (!origin || typeof origin === "string") {
     return undefined;
   }
@@ -90,7 +90,7 @@ function distanceFrom(point: PilgrimagePoint, origin?: Origin): number | undefin
 export async function spots(
   db: CatalogDb,
   input: { bangumi_id: string; origin?: Origin },
-): Promise<{ point: PilgrimagePoint; distance_m?: number }> {
+): Promise<{ point: Point; distance_m?: number }> {
   const row = ((await db.execute(representativeQuery(input.bangumi_id))).rows as unknown as PointRow[])[0];
   if (!row) throw new SpotNotFoundError(input.bangumi_id);
   const point = toPoint(row);

--- a/workers/catalog/src/api/work-points.ts
+++ b/workers/catalog/src/api/work-points.ts
@@ -21,7 +21,7 @@ import {
   type WorkPointRow,
 } from "./search";
 
-/** Minimal persistence/upstream port for the work-id orchestration. */
+/** Minimal persistence/upstream port for the bangumi-id orchestration. */
 export interface WorkPointsDb {
   pointsForWork(workId: string): Promise<WorkPointRow[]>;
   previewForWork(workId: string, fetchImpl?: FetchLike): Promise<MissPreview>;
@@ -32,14 +32,14 @@ export interface WorkPointsDb {
 }
 
 /** Return published rows, or a guarded L1 preview while full ingest runs. */
-export async function pointsByWorkId(
+export async function pointsByBangumiId(
   db: WorkPointsDb,
-  workId: string,
+  bangumiId: string,
   options: SearchOptions = {},
 ): Promise<SearchResult> {
-  const published = await hitResult(db, workId);
+  const published = await hitResult(db, bangumiId);
   if (published.rows.length > 0) return published;
-  return uncoveredWork(db, workId, options);
+  return uncoveredWork(db, bangumiId, options);
 }
 
 async function uncoveredWork(
@@ -124,7 +124,7 @@ function syncingResult(): SearchResult {
   return { ...emptyResult(), partial: true };
 }
 
-/** Bind the work-id port to the shared ingest and preview infrastructure. */
+/** Bind the bangumi-id port to the shared ingest and preview infrastructure. */
 export function workPointsDb(db: CatalogDb): WorkPointsDb {
   const search = searchDb(db), jobs = new JobStore(db);
   return {

--- a/workers/catalog/src/application/plan-itinerary.ts
+++ b/workers/catalog/src/application/plan-itinerary.ts
@@ -7,7 +7,7 @@
  *
  * Flow: `port.loadPoints(point_ids)` -> `clusterByLocation` (50m) ->
  * deterministic 50-cluster cap -> `buildTimedItinerary` -> expand the ordered
- * clusters back to their member points (= `ordered_points`) -> `Route`.
+ * clusters back to their member points (= `ordered_points`) -> `Itinerary`.
  *
  * Origin is forwarded to the kernel only in `{lat,lng}` form; the contract's
  * named-place string Origin would need geocoding first (a follow-up, alongside
@@ -20,28 +20,28 @@ import { clusterByLocation } from "../domain/clustering/cluster";
 import type { Origin as KernelOrigin, TimedItinerary } from "../domain/itinerary/plan";
 import { buildTimedItinerary, MAX_ITINERARY_CLUSTERS } from "../domain/itinerary/plan";
 import { optional } from "../lib/optional";
-import type { Origin, Pacing, PilgrimagePoint, Route } from "../types";
+import type { Origin, Pacing, Point, Itinerary } from "../types";
 
-/** A route point: the contract `PilgrimagePoint` + the geo fields clustering needs. */
-export type RoutePoint = PilgrimagePoint & ClusterablePoint;
+/** An itinerary point: the contract `Point` + the geo fields clustering needs. */
+export type ItineraryPoint = Point & ClusterablePoint;
 
 /** A cluster whose members are full route points (for `ordered_points`). */
-type PointCluster = LocationCluster<RoutePoint>;
+type PointCluster = LocationCluster<ItineraryPoint>;
 
 /** Outbound capability the use case needs: load the points for route `ids`. */
 export interface PointsForRoutePort {
-  loadPoints(ids: string[]): Promise<RoutePoint[]>;
+  loadPoints(ids: string[]): Promise<ItineraryPoint[]>;
 }
 
-/** Inputs for {@link planItinerary} — mirrors `RouteInput` in the contract. */
-export interface RouteInput {
+/** Inputs for {@link planItinerary} — mirrors `ItineraryInput` in the contract. */
+export interface ItineraryInput {
   point_ids: string[];
   origin?: Origin;
   pacing?: Pacing;
 }
 
 /** Plan an ordered, timed route over `point_ids`. Empty/unknown ids -> count 0. */
-export async function planItinerary(port: PointsForRoutePort, input: RouteInput): Promise<Route> {
+export async function planItinerary(port: PointsForRoutePort, input: ItineraryInput): Promise<Itinerary> {
   const points = await port.loadPoints(input.point_ids);
   const allClusters = clusterByLocation(points, 50);
   const clusters = allClusters.slice(0, MAX_ITINERARY_CLUSTERS);
@@ -50,31 +50,31 @@ export async function planItinerary(port: PointsForRoutePort, input: RouteInput)
 }
 
 /** Kernel itinerary options: pacing + the coordinate form of Origin only. */
-function kernelOpts(input: RouteInput): { pacing?: Pacing; origin?: KernelOrigin } {
+function kernelOpts(input: ItineraryInput): { pacing?: Pacing; origin?: KernelOrigin } {
   const origin = typeof input.origin === "object" ? input.origin : undefined;
   return { pacing: input.pacing, origin };
 }
 
-/** Assemble the contract `Route` from the ordered clusters and the itinerary. */
-function assembleRoute(clusters: PointCluster[], itinerary: TimedItinerary, totalClusters: number): Route {
+/** Assemble the contract `Itinerary` from the ordered clusters and the timed itinerary. */
+function assembleRoute(clusters: PointCluster[], itinerary: TimedItinerary, totalClusters: number): Itinerary {
   const ordered = orderPoints(clusters, itinerary);
   return { ...animeMeta(ordered[0]), ...truncationMeta(clusters.length, totalClusters), ordered_points: ordered, point_count: ordered.length, timed_itinerary: itinerary };
 }
 
 /** Add disclosure fields only when the deterministic cluster cap was applied. */
-function truncationMeta(shown: number, total: number): Partial<Pick<Route, "truncated" | "shown_cluster_count" | "total_cluster_count">> {
+function truncationMeta(shown: number, total: number): Partial<Pick<Itinerary, "truncated" | "shown_cluster_count" | "total_cluster_count">> {
   if (shown === total) return {};
   return { truncated: true, shown_cluster_count: shown, total_cluster_count: total };
 }
 
 /** Expand the itinerary's ordered stops back to their member points, in order. */
-function orderPoints(clusters: PointCluster[], itinerary: TimedItinerary): PilgrimagePoint[] {
+function orderPoints(clusters: PointCluster[], itinerary: TimedItinerary): Point[] {
   const byCluster = new Map(clusters.map((c) => [c.clusterId, c]));
   return itinerary.stops.flatMap((s) => byCluster.get(s.cluster_id)?.points ?? []);
 }
 
-/** The anime-title metadata carried on the Route, taken from the lead point. */
-function animeMeta(lead?: PilgrimagePoint): Pick<Route, "anime_title" | "anime_title_cn" | "cover_url"> {
+/** The anime-title metadata carried on the Itinerary, taken from the lead point. */
+function animeMeta(lead?: Point): Pick<Itinerary, "anime_title" | "anime_title_cn" | "cover_url"> {
   return optional({
     anime_title: lead?.title,
     anime_title_cn: lead?.title_cn,

--- a/workers/catalog/src/db/schema.ts
+++ b/workers/catalog/src/db/schema.ts
@@ -70,7 +70,7 @@ export const points = pgTable("points", {
 // 20260620230000 — atomic version pointer (blue/green publish).
 export const clusterVersion = pgTable("cluster_version", {
   id: serial("id").primaryKey(),
-  workId: text("work_id").notNull(),
+  bangumiId: text("bangumi_id").notNull(),
   version: integer("version").notNull(),
   isCurrent: boolean("is_current").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -79,7 +79,7 @@ export const clusterVersion = pgTable("cluster_version", {
 // 20260620230000 — alias pipeline (NFKC-folded exact match via alias_normalized).
 export const aliases = pgTable("aliases", {
   id: serial("id").primaryKey(),
-  workId: text("work_id").notNull(),
+  bangumiId: text("bangumi_id").notNull(),
   alias: text("alias").notNull(),
   aliasNormalized: text("alias_normalized").notNull(),
   source: text("source").notNull(),
@@ -88,7 +88,7 @@ export const aliases = pgTable("aliases", {
 
 // 20260620230000 — series relation graph for series-aware resolve.
 export const seriesEdges = pgTable("series_edges", {
-  fromWorkId: text("from_work_id").notNull(),
-  toWorkId: text("to_work_id").notNull(),
+  fromBangumiId: text("from_bangumi_id").notNull(),
+  toBangumiId: text("to_bangumi_id").notNull(),
   relation: text("relation").notNull(),
 });

--- a/workers/catalog/src/enrich/enrich.ts
+++ b/workers/catalog/src/enrich/enrich.ts
@@ -156,9 +156,9 @@ function logClusters(workId: string, points: PointRow[]): number {
 function upsertAliases(workId: string, b: BangumiRow): SQL {
   const aliases = rankAliases(titleAliases(b));
   return sql`
-    INSERT INTO aliases (work_id, alias, alias_normalized, source, priority)
+    INSERT INTO aliases (bangumi_id, alias, alias_normalized, source, priority)
     VALUES ${sql.join(aliases.map((alias) => aliasValues(workId, alias)), sql`, `)}
-    ON CONFLICT (work_id, alias, source)
+    ON CONFLICT (bangumi_id, alias, source)
     DO UPDATE SET alias_normalized = EXCLUDED.alias_normalized, priority = EXCLUDED.priority
   `;
 }

--- a/workers/catalog/src/lib/alias.ts
+++ b/workers/catalog/src/lib/alias.ts
@@ -3,7 +3,7 @@
  *
  * Feeds the `aliases` catalog table
  * (`db/migrations/20260623000001_init.sql`):
- *   work_id, alias, alias_normalized, source, priority.
+ *   bangumi_id, alias, alias_normalized, source, priority.
  *
  * `alias_normalized` is the NFKC-folded form used for exact-match lookup
  * (btree `idx_aliases_normalized`); fuzzy match (pg_trgm) lands in Wave 2.

--- a/workers/catalog/src/lib/series.ts
+++ b/workers/catalog/src/lib/series.ts
@@ -26,10 +26,10 @@ export type Relation =
   | "character"
   | "other";
 
-/** A directed edge from the `series_edges` table (from_work_id, to_work_id, relation). */
+/** A directed edge from the `series_edges` table (from_bangumi_id, to_bangumi_id, relation). */
 export interface SeriesEdge {
-  fromWorkId: string;
-  toWorkId: string;
+  fromBangumiId: string;
+  toBangumiId: string;
   relation: Relation;
 }
 
@@ -51,8 +51,8 @@ function buildAdjacency(edges: SeriesEdge[]): Map<string, Set<string>> {
   const adj = new Map<string, Set<string>>();
   for (const edge of edges) {
     if (SAME_SERIES_RELATIONS.has(edge.relation)) {
-      link(adj, edge.fromWorkId, edge.toWorkId);
-      link(adj, edge.toWorkId, edge.fromWorkId);
+      link(adj, edge.fromBangumiId, edge.toBangumiId);
+      link(adj, edge.toBangumiId, edge.fromBangumiId);
     }
   }
   return adj;
@@ -70,13 +70,13 @@ function link(adj: Map<string, Set<string>>, from: string, to: string): void {
 
 /**
  * BFS over same-series edges (treated as bidirectional), returning every
- * work_id in the connected series component containing `startWorkId`
+ * bangumi_id in the connected series component containing `startBangumiId`
  * (inclusive). A visited set makes it cycle-safe.
  */
-export function walkSeries(edges: SeriesEdge[], startWorkId: string): Set<string> {
+export function walkSeries(edges: SeriesEdge[], startBangumiId: string): Set<string> {
   const adj = buildAdjacency(edges);
-  const visited = new Set<string>([startWorkId]);
-  let frontier = [startWorkId];
+  const visited = new Set<string>([startBangumiId]);
+  let frontier = [startBangumiId];
   while (frontier.length > 0) frontier = expand(frontier, adj, visited);
   return visited;
 }

--- a/workers/catalog/src/publish/gc.ts
+++ b/workers/catalog/src/publish/gc.ts
@@ -4,7 +4,7 @@
  *
  * Keeps the newest `keep` versions for a work and deletes the rest. The current
  * row (is_current=true) is NEVER deleted, even if it falls outside the keep
- * window — the live pointer must always survive. Route snapshots are not touched:
+ * window — the live pointer must always survive. Itinerary snapshots are not touched:
  * they are immutable and intentionally outlive their version (no-drift), so a GC'd
  * version's snapshot still reads back unchanged.
  *
@@ -19,8 +19,8 @@ export async function gcOldVersions(db: CatalogDb, workId: string, keep: number)
   if (keep < 1) throw new Error("keep must be >= 1");
   const rows = (await db.execute(sql`
       DELETE FROM cluster_version
-      WHERE work_id = ${workId} AND NOT is_current
-        AND version < (SELECT MIN(version) FROM (SELECT version FROM cluster_version WHERE work_id = ${workId} ORDER BY version DESC LIMIT ${keep}) AS kept)
+      WHERE bangumi_id = ${workId} AND NOT is_current
+        AND version < (SELECT MIN(version) FROM (SELECT version FROM cluster_version WHERE bangumi_id = ${workId} ORDER BY version DESC LIMIT ${keep}) AS kept)
       RETURNING id
     `)).rows as { id: number }[];
   return rows.length;

--- a/workers/catalog/src/publish/snapshots.ts
+++ b/workers/catalog/src/publish/snapshots.ts
@@ -1,12 +1,13 @@
 /**
- * Route-snapshot storage over `route_snapshots`
- * (`db/migrations/20260623000001_init.sql`):
- *   id, work_id, cluster_version, payload JSONB, created_at.
+ * Itinerary-snapshot storage over `itinerary_snapshots`
+ * (`db/migrations/20260623000001_init.sql`, renamed by the #852 catalog
+ * migration): id, bangumi_id, cluster_version, payload JSONB, created_at.
  *
- * A snapshot is bound to a specific cluster_version so a route computed against
- * an old version keeps its exact payload after a newer version publishes — shared
- * routes never drift. The snapshot is intentionally immutable per (work_id,
- * version) and survives version GC; the read path keys on (work_id, version).
+ * A snapshot is bound to a specific cluster_version so an itinerary computed
+ * against an old version keeps its exact payload after a newer version
+ * publishes — shared itineraries never drift. The snapshot is intentionally
+ * immutable per (bangumi_id, version) and survives version GC; the read path
+ * keys on (bangumi_id, version).
  *
  * Writes go through raw `sql` execute (the Drizzle read schema is query-only),
  * consistent with the ingest/raw-store and versioning cards owning all mutations.
@@ -14,26 +15,26 @@
 import { sql } from "drizzle-orm";
 import type { CatalogDb } from "../db/client";
 
-/** A JSON-serializable route snapshot payload. */
+/** A JSON-serializable itinerary snapshot payload. */
 export type SnapshotPayload = Record<string, unknown> | unknown[];
 
-/** UPSERT a route snapshot bound to (work_id, version) so it never drifts. */
-export async function saveRouteSnapshot(
-  db: CatalogDb, workId: string, version: number, payload: SnapshotPayload,
+/** UPSERT an itinerary snapshot bound to (bangumi_id, version) so it never drifts. */
+export async function saveItinerarySnapshot(
+  db: CatalogDb, bangumiId: string, version: number, payload: SnapshotPayload,
 ): Promise<void> {
   await db.execute(sql`
-    INSERT INTO route_snapshots (work_id, cluster_version, payload)
-    VALUES (${workId}, ${version}, ${JSON.stringify(payload)}::jsonb)
+    INSERT INTO itinerary_snapshots (bangumi_id, cluster_version, payload)
+    VALUES (${bangumiId}, ${version}, ${JSON.stringify(payload)}::jsonb)
   `);
 }
 
-/** Read back the snapshot payload bound to (work_id, version), or null. */
-export async function getRouteSnapshot(
-  db: CatalogDb, workId: string, version: number,
+/** Read back the snapshot payload bound to (bangumi_id, version), or null. */
+export async function getItinerarySnapshot(
+  db: CatalogDb, bangumiId: string, version: number,
 ): Promise<SnapshotPayload | null> {
   const rows = (await db.execute(sql`
-      SELECT payload FROM route_snapshots
-      WHERE work_id = ${workId} AND cluster_version = ${version} ORDER BY id DESC LIMIT 1
+      SELECT payload FROM itinerary_snapshots
+      WHERE bangumi_id = ${bangumiId} AND cluster_version = ${version} ORDER BY id DESC LIMIT 1
     `)).rows as { payload: SnapshotPayload }[];
   return rows[0]?.payload ?? null;
 }

--- a/workers/catalog/src/publish/versioning.ts
+++ b/workers/catalog/src/publish/versioning.ts
@@ -1,8 +1,8 @@
 /**
  * Atomic version publish over `cluster_version`
  * (`db/migrations/20260623000001_init.sql`):
- *   id, work_id, version, is_current, created_at, with the partial unique index
- *   `uq_cluster_version_one_current` (work_id) WHERE is_current.
+ *   id, bangumi_id, version, is_current, created_at, with the partial unique index
+ *   `uq_cluster_version_one_current` (bangumi_id) WHERE is_current.
  *
  * A publish is a blue/green pointer switch done in ONE server-side batch
  * transaction: flip any current row to is_current=false, THEN insert the new row
@@ -40,15 +40,15 @@ export function publishVersionStatements(
 
 /** Flip the work's current row (if any) to is_current=false. */
 function flipCurrentOff(workId: string): SQL {
-  return sql`UPDATE cluster_version SET is_current = FALSE WHERE work_id = ${workId} AND is_current`;
+  return sql`UPDATE cluster_version SET is_current = FALSE WHERE bangumi_id = ${workId} AND is_current`;
 }
 
 /** Atomically derive and insert max(version)+1 (1 when no row exists). */
 function insertCurrent(workId: string): SQL<PublishedVersionRow> {
   return sql<PublishedVersionRow>`
-    INSERT INTO cluster_version (work_id, version, is_current)
+    INSERT INTO cluster_version (bangumi_id, version, is_current)
     SELECT ${workId}, COALESCE(MAX(version), 0) + 1, TRUE
-    FROM cluster_version WHERE work_id = ${workId}
+    FROM cluster_version WHERE bangumi_id = ${workId}
     RETURNING version
   `;
 }

--- a/workers/catalog/src/router.ts
+++ b/workers/catalog/src/router.ts
@@ -2,10 +2,10 @@ import { catalogContract } from "@animichi/contract";
 import { implement } from "@orpc/server";
 import { resolve as resolveHandler, resolveDb } from "./api/resolve";
 import { search as searchHandler, searchDb } from "./api/search";
-import { pointsByWorkId, workPointsDb } from "./api/work-points";
+import { pointsByBangumiId, workPointsDb } from "./api/work-points";
 import { nearby as nearbyHandler } from "./api/nearby";
 import { geocode as geocodeHandler } from "./api/geocode";
-import { route as routeHandler } from "./api/route";
+import { planItinerary as planItineraryHandler } from "./api/route";
 import { spots as spotsHandler, SpotNotFoundError } from "./api/spots";
 import { animeOverview as animeOverviewHandler, AnimeOverviewNotFoundError } from "./api/anime-overview";
 import type { CatalogDb, NeonSql } from "./db/client";
@@ -37,8 +37,8 @@ const resolve = os.resolve.handler(async ({ input, context }) =>
   resolveHandler(resolveDb(context.db), input, { fetchImpl: context.fetchImpl }),
 );
 
-const pointsById = os.pointsByWorkId.handler(async ({ input, context }) =>
-  pointsByWorkId(workPointsDb(context.db), input.work_id, {
+const pointsById = os.pointsByBangumiId.handler(async ({ input, context }) =>
+  pointsByBangumiId(workPointsDb(context.db), input.bangumi_id, {
     fetchImpl: context.fetchImpl,
     waitUntil: context.waitUntil,
   }),
@@ -56,19 +56,19 @@ const geocode = os.geocode.handler(async ({ input, context }) =>
   geocodeHandler(context.db, input),
 );
 
-const MAX_ROUTE_POINT_IDS = 500;
+const MAX_ITINERARY_POINT_IDS = 500;
 
-/** Reject route inputs over the point_ids cap with the typed 400. */
-function assertRoutePointIdCap(count: number): Promise<void> {
-  if (count > MAX_ROUTE_POINT_IDS) {
-    return Promise.reject(routeTooManyPoints(count, MAX_ROUTE_POINT_IDS));
+/** Reject itinerary inputs over the point_ids cap with the typed 400. */
+function assertItineraryPointIdCap(count: number): Promise<void> {
+  if (count > MAX_ITINERARY_POINT_IDS) {
+    return Promise.reject(routeTooManyPoints(count, MAX_ITINERARY_POINT_IDS));
   }
   return Promise.resolve();
 }
 
-const route = os.route.handler(async ({ input, context }) => {
-  await assertRoutePointIdCap(input.point_ids.length);
-  return routeHandler(context.db, input);
+const planItinerary = os.planItinerary.handler(async ({ input, context }) => {
+  await assertItineraryPointIdCap(input.point_ids.length);
+  return planItineraryHandler(context.db, input);
 });
 
 const animeOverview = os.animeOverview.handler(async ({ input, context }) =>
@@ -98,11 +98,11 @@ async function callAnimeOverview(db: CatalogDb, input: { bangumi_id: string }) {
 export const catalogRouter = {
   search,
   resolve,
-  pointsByWorkId: pointsById,
+  pointsByBangumiId: pointsById,
   spots,
   nearby,
   geocode,
-  route,
+  planItinerary,
   animeOverview,
 };
 export type CatalogRouter = typeof catalogRouter;

--- a/workers/catalog/src/types.ts
+++ b/workers/catalog/src/types.ts
@@ -42,8 +42,8 @@ export interface GeocodeResult {
   candidates: GeocodeCandidate[];
 }
 
-/** A single pilgrimage point row — mirrors `PilgrimagePoint` in the contract. */
-export interface PilgrimagePoint {
+/** A single pilgrimage point row — mirrors `Point` in the contract. */
+export interface Point {
   id: string;
   name: string;
   name_cn?: string;
@@ -80,8 +80,8 @@ export interface AnimeScene {
   city?: string;
 }
 
-/** A per-region sample route — mirrors `AnimeSampleRoute`. */
-export interface AnimeSampleRoute {
+/** A per-region sample itinerary — mirrors `AnimeSampleItinerary`. */
+export interface AnimeSampleItinerary {
   region: string;
   point_ids: string[];
 }
@@ -92,7 +92,7 @@ export interface AnimeOverview {
   points_length: number;
   circles: AnimeOverviewCircle[];
   scenes: AnimeScene[];
-  sample_routes: AnimeSampleRoute[];
+  sample_itineraries: AnimeSampleItinerary[];
 }
 
 /** Stable anime identity and trusted display metadata — mirrors `AnimeCandidate`. */
@@ -152,7 +152,7 @@ export interface TransitLeg {
  * normal alias-hit response.
  */
 export interface SearchResult {
-  rows: PilgrimagePoint[];
+  rows: Point[];
   synced_at: string;
   partial?: boolean;
 }
@@ -170,11 +170,11 @@ export interface TimedItinerary {
   export_ics?: string;
 }
 
-/** An ordered, timed pilgrimage route — mirrors `Route` in the contract. */
-export interface Route {
+/** An ordered, timed pilgrimage itinerary — mirrors `Itinerary` in the contract. */
+export interface Itinerary {
   id?: string;
   version?: string;
-  ordered_points: PilgrimagePoint[];
+  ordered_points: Point[];
   point_count: number;
   cover_url?: string;
   anime_title?: string;

--- a/workers/catalog/test/anime-overview.worker.test.ts
+++ b/workers/catalog/test/anime-overview.worker.test.ts
@@ -71,7 +71,7 @@ describe("animeOverview (api/anime-overview.ts)", () => {
 
   it("suggests per-region sample routes ordered by spot count", async () => {
     const result = await animeOverview(fakeDb(SPREAD), { bangumi_id: "100" });
-    expect(result.sample_routes).toEqual([
+    expect(result.sample_itineraries).toEqual([
       { region: "Kamakura", point_ids: ["k1", "k2"] },
       { region: "Hakone", point_ids: ["h1"] },
     ]);
@@ -87,7 +87,7 @@ describe("animeOverview empty and missing work behavior", () => {
       points_length: 0,
       circles: [],
       scenes: [],
-      sample_routes: [],
+      sample_itineraries: [],
     });
   });
 
@@ -103,7 +103,7 @@ describe("animeOverview scene edge cases", () => {
     const noCity: FixtureRow[] = [row("n1", 35.0, 139.0, null), row("n2", 36.0, 140.0, "")];
     const result = await animeOverview(fakeDb(noCity), { bangumi_id: "200" });
     expect(result.circles).toEqual([]);
-    expect(result.sample_routes).toEqual([]);
+    expect(result.sample_itineraries).toEqual([]);
     expect(result.scenes).toHaveLength(2);
     expect(result.points_length).toBe(2);
   });
@@ -141,8 +141,8 @@ describe("animeOverview output caps", () => {
   it("caps scenes at 20, sample routes at 3 regions, and point ids at 12 per route", async () => {
     const result = await animeOverview(fakeDb(cappedFixture()), { bangumi_id: "400" });
     expect(result.scenes).toHaveLength(20);
-    expect(result.sample_routes.map((r) => r.region)).toEqual(["A", "B", "C"]);
-    expect(result.sample_routes[0]?.point_ids).toHaveLength(12);
+    expect(result.sample_itineraries.map((r) => r.region)).toEqual(["A", "B", "C"]);
+    expect(result.sample_itineraries[0]?.point_ids).toHaveLength(12);
   });
 });
 

--- a/workers/catalog/test/catalog-api.spike.test.ts
+++ b/workers/catalog/test/catalog-api.spike.test.ts
@@ -36,7 +36,7 @@ vi.mock("cloudflare:workers", () => ({
  * and the Python `backend/clients/catalog_client.py` speak: the request body IS
  * the raw input object (`{query}` / `{bangumi_id}` / `{lat,lng,radius_m}` /
  * `{point_ids}`) and the response IS the raw output (top-level `{rows}` /
- * `{point}` / `Route`), NOT the RPCHandler `{json: ...}` envelope. This proves
+ * `{point}` / `Itinerary`), NOT the RPCHandler `{json: ...}` envelope. This proves
  * real contract conformance: it would FAIL against the old RPCHandler.
  *
  * Schema comes from the full Atlas-applied `test-base` parent.
@@ -155,7 +155,7 @@ async function assertOverviewHit(): Promise<void> {
   expect(body.points_length).toBe(3);
   expect(body.circles.map((c) => [c.region, c.count])).toEqual([["Kamakura", 2], ["Hakone", 1]]);
   expect(body.scenes[0]).toMatchObject({ id: "ov-kama-1", shot_count: 2, city: "Kamakura" });
-  expect(body.sample_routes[0]).toEqual({ region: "Kamakura", point_ids: ["ov-kama-1", "ov-kama-2"] });
+  expect(body.sample_itineraries[0]).toEqual({ region: "Kamakura", point_ids: ["ov-kama-1", "ov-kama-2"] });
 }
 
 async function assertOverviewEmpty(): Promise<void> {
@@ -164,7 +164,7 @@ async function assertOverviewEmpty(): Promise<void> {
 }
 
 function emptyOverviewBody() {
-  return { bangumi_id: "999998", points_length: 0, circles: [], scenes: [], sample_routes: [] };
+  return { bangumi_id: "999998", points_length: 0, circles: [], scenes: [], sample_itineraries: [] };
 }
 
 async function assertOverview404(): Promise<void> {
@@ -185,5 +185,5 @@ databaseDescribe("Catalog API end-to-end (Hono app + OpenAPIHandler + Drizzle/Po
   it("spots 404s when the work has no points", assertSpots404);
   it("nearby returns points within the radius, nearest first with distance_m", assertNearbyHit);
   it("nearby excludes points outside the radius", assertNearbyMiss);
-  it("route returns a timed itinerary over the selected points (top-level Route)", assertRoute);
+  it("planItinerary returns a timed itinerary over the selected points (top-level Itinerary)", assertRoute);
 });

--- a/workers/catalog/test/catalog-seed.worker.test.ts
+++ b/workers/catalog/test/catalog-seed.worker.test.ts
@@ -23,7 +23,7 @@ const beta = workSeed("1002", "Beta");
 const alpha = workSeed("1001", "Alpha");
 
 describe("catalog seed fixtures are contract-derived", () => {
-  it("rejects a work id that `pointsByWorkId` would reject with a 400", () => {
+  it("rejects a work id that `pointsByBangumiId` would reject with a 400", () => {
     expect(() => workSeed("beta", "Beta")).toThrow();
   });
 

--- a/workers/catalog/test/catalog-spike-client.ts
+++ b/workers/catalog/test/catalog-spike-client.ts
@@ -16,7 +16,7 @@ export interface OverviewBody {
   points_length: number;
   circles: { region: string; count: number; lat: number; lng: number }[];
   scenes: { id: string; shot_count: number; screenshot_url: string | null; city?: string }[];
-  sample_routes: { region: string; point_ids: string[] }[];
+  sample_itineraries: { region: string; point_ids: string[] }[];
 }
 
 export interface RouteBody {

--- a/workers/catalog/test/contract-parity.worker.test.ts
+++ b/workers/catalog/test/contract-parity.worker.test.ts
@@ -16,18 +16,18 @@
  */
 
 import type {
-  PilgrimagePoint as ContractPilgrimagePoint,
+  Point as ContractPoint,
   TimedStop as ContractTimedStop,
   TransitLeg as ContractTransitLeg,
   TimedItinerary as ContractTimedItinerary,
-  Route as ContractRoute,
+  Itinerary as ContractItinerary,
   Pacing as ContractPacing,
   Origin as ContractOrigin,
   AnimeCandidate as ContractAnimeCandidate,
   ResolveOutcome as ContractResolveOutcome,
   AnimeOverviewCircle as ContractAnimeOverviewCircle,
   AnimeScene as ContractAnimeScene,
-  AnimeSampleRoute as ContractAnimeSampleRoute,
+  AnimeSampleItinerary as ContractAnimeSampleItinerary,
   AnimeOverview as ContractAnimeOverview,
 } from "../../../packages/contract/src/models";
 
@@ -49,11 +49,11 @@ import type {
 } from "../../../packages/contract/src/errors";
 
 import type {
-  PilgrimagePoint as LocalPilgrimagePoint,
+  Point as LocalPoint,
   TimedStop as LocalTimedStop,
   TransitLeg as LocalTransitLeg,
   TimedItinerary as LocalTimedItinerary,
-  Route as LocalRoute,
+  Itinerary as LocalItinerary,
   Pacing as LocalPacing,
   Origin as LocalOrigin,
   SearchResult as LocalSearchResult,
@@ -64,7 +64,7 @@ import type {
   ResolveOutcome as LocalResolveOutcome,
   AnimeOverviewCircle as LocalAnimeOverviewCircle,
   AnimeScene as LocalAnimeScene,
-  AnimeSampleRoute as LocalAnimeSampleRoute,
+  AnimeSampleItinerary as LocalAnimeSampleItinerary,
   AnimeOverview as LocalAnimeOverview,
 } from "../src/types";
 
@@ -86,9 +86,9 @@ type LocalErrorSpec = {
   [Code in keyof LocalCatalogErrors]: Pick<LocalCatalogErrors[Code], "status" | "category" | "message">;
 };
 
-// --- PilgrimagePoint ---
-const _pp_a: ContractPilgrimagePoint = null as unknown as ContractPilgrimagePoint;
-const _pp_b: LocalPilgrimagePoint = null as unknown as ContractPilgrimagePoint;
+// --- Point ---
+const _pp_a: ContractPoint = null as unknown as ContractPoint;
+const _pp_b: LocalPoint = null as unknown as ContractPoint;
 
 // --- TimedStop ---
 const _ts_a: ContractTimedStop = null as unknown as ContractTimedStop;
@@ -104,9 +104,9 @@ const _tl_attr_b: LocalTransitLeg["attribution"] = null as unknown as ContractTr
 const _ti_a: ContractTimedItinerary = null as unknown as ContractTimedItinerary;
 const _ti_b: LocalTimedItinerary = null as unknown as ContractTimedItinerary;
 
-// --- Route ---
-const _r_a: ContractRoute = null as unknown as LocalRoute;
-const _r_b: LocalRoute = null as unknown as ContractRoute;
+// --- Itinerary ---
+const _r_a: ContractItinerary = null as unknown as LocalItinerary;
+const _r_b: LocalItinerary = null as unknown as ContractItinerary;
 
 // --- Pacing ---
 const _pac_a: ContractPacing = null as unknown as ContractPacing;
@@ -131,8 +131,8 @@ const _aoc_a: ContractAnimeOverviewCircle = null as unknown as LocalAnimeOvervie
 const _aoc_b: LocalAnimeOverviewCircle = null as unknown as ContractAnimeOverviewCircle;
 const _asc_a: ContractAnimeScene = null as unknown as LocalAnimeScene;
 const _asc_b: LocalAnimeScene = null as unknown as ContractAnimeScene;
-const _asr_a: ContractAnimeSampleRoute = null as unknown as LocalAnimeSampleRoute;
-const _asr_b: LocalAnimeSampleRoute = null as unknown as ContractAnimeSampleRoute;
+const _asr_a: ContractAnimeSampleItinerary = null as unknown as LocalAnimeSampleItinerary;
+const _asr_b: LocalAnimeSampleItinerary = null as unknown as ContractAnimeSampleItinerary;
 const _aov_a: ContractAnimeOverview = null as unknown as LocalAnimeOverview;
 const _aov_b: LocalAnimeOverview = null as unknown as ContractAnimeOverview;
 

--- a/workers/catalog/test/db.spike.test.ts
+++ b/workers/catalog/test/db.spike.test.ts
@@ -34,15 +34,15 @@ beforeAll(async () => {
     VALUES ('washinomiya', 'lucky-star', '鷲宮神社', 36.1019, 139.6586, 1)
   `);
   await db.execute(sql`
-    INSERT INTO cluster_version (work_id, version, is_current)
+    INSERT INTO cluster_version (bangumi_id, version, is_current)
     VALUES ('lucky-star', 1, TRUE)
   `);
   await db.execute(sql`
-    INSERT INTO aliases (work_id, alias, alias_normalized, source, priority)
+    INSERT INTO aliases (bangumi_id, alias, alias_normalized, source, priority)
     VALUES ('lucky-star', 'らき☆すた', 'らきすた', 'bangumi', 10)
   `);
   await db.execute(sql`
-    INSERT INTO series_edges (from_work_id, to_work_id, relation)
+    INSERT INTO series_edges (from_bangumi_id, to_bangumi_id, relation)
     VALUES ('lucky-star', 'lucky-star-ova', 'sequel')
   `);
 }, 120_000);
@@ -73,13 +73,13 @@ async function assertPointRow(): Promise<void> {
 
 
 async function assertSchemaRelations(): Promise<void> {
-  const versions = await db.select().from(clusterVersion).where(eq(clusterVersion.workId, "lucky-star"));
+  const versions = await db.select().from(clusterVersion).where(eq(clusterVersion.bangumiId, "lucky-star"));
   expect(versions[0]?.version).toBe(1); expect(versions[0]?.isCurrent).toBe(true);
-  const aliasRows = await db.select().from(aliases).where(eq(aliases.workId, "lucky-star"));
+  const aliasRows = await db.select().from(aliases).where(eq(aliases.bangumiId, "lucky-star"));
   expect(aliasRows[0]?.aliasNormalized).toBe("らきすた");
   expect(aliasRows[0]?.priority).toBe(10);
-  const edges = await db.select().from(seriesEdges).where(eq(seriesEdges.fromWorkId, "lucky-star"));
-  expect(edges[0]?.toWorkId).toBe("lucky-star-ova");
+  const edges = await db.select().from(seriesEdges).where(eq(seriesEdges.fromBangumiId, "lucky-star"));
+  expect(edges[0]?.toBangumiId).toBe("lucky-star-ova");
   expect(edges[0]?.relation).toBe("sequel");
 }
 

--- a/workers/catalog/test/enrich.spike.test.ts
+++ b/workers/catalog/test/enrich.spike.test.ts
@@ -56,7 +56,7 @@ async function locationWkt(pointId: string): Promise<string | null> {
 async function currentVersion(workId: string): Promise<number | undefined> {
   const rows = (
     await db.execute(
-      sql`SELECT version FROM cluster_version WHERE work_id = ${workId} AND is_current`,
+      sql`SELECT version FROM cluster_version WHERE bangumi_id = ${workId} AND is_current`,
     )
   ).rows as { version: number }[];
   return rows[0]?.version;
@@ -65,7 +65,7 @@ async function currentVersion(workId: string): Promise<number | undefined> {
 async function allVersions(workId: string): Promise<number[]> {
   const rows = (
     await db.execute(
-      sql`SELECT version FROM cluster_version WHERE work_id = ${workId} ORDER BY version`,
+      sql`SELECT version FROM cluster_version WHERE bangumi_id = ${workId} ORDER BY version`,
     )
   ).rows as { version: number }[];
   return rows.map((r) => r.version);
@@ -101,7 +101,7 @@ async function bangumiRow(db: CatalogDb) {
 async function assertEnrichAliases(): Promise<void> {
   const rows = (await db.execute(
     sql`SELECT alias, alias_normalized, source FROM aliases
-        WHERE work_id = 'lucky-star' ORDER BY alias_normalized`,
+        WHERE bangumi_id = 'lucky-star' ORDER BY alias_normalized`,
   )).rows as { alias: string; alias_normalized: string; source: string }[];
   const normalized = rows.map((r) => r.alias_normalized);
   expect(normalized).toContain("らき☆すた".normalize("NFKC").toLowerCase());

--- a/workers/catalog/test/errors-wire.worker.test.ts
+++ b/workers/catalog/test/errors-wire.worker.test.ts
@@ -7,7 +7,7 @@ import type {
   UpstreamUnavailableData,
   WorkNotFoundData,
 } from "../src/lib/errors";
-import type { Route } from "../src/types";
+import type { Itinerary } from "../src/types";
 
 interface ErrorEnvelope<TData> {
   defined: true;
@@ -118,7 +118,7 @@ describe("catalog input validation on the OpenAPI wire", () => {
 describe("catalog route limits and typed errors on the OpenAPI wire", () => {
   it("serializes ROUTE_TOO_MANY_POINTS for route input over the router cap", async () => {
     const point_ids = Array.from({ length: 501 }, (_, i) => `p${String(i)}`);
-    const res = await call("route", { point_ids }, unreachableContext());
+    const res = await call("itinerary", { point_ids }, unreachableContext());
     expect(res.status).toBe(400);
     expect(await json<RouteTooManyPointsData>(res)).toEqual({
       defined: true, code: "ROUTE_TOO_MANY_POINTS", status: 400,
@@ -130,8 +130,8 @@ describe("catalog route limits and typed errors on the OpenAPI wire", () => {
   it("serializes a successful truncation signal after clustering 51 selected points", async () => {
     const rows = routeRows(51);
     const point_ids = rows.map((r) => r.id);
-    const res = await call("route", { point_ids }, context(rows));
-    const body = await res.json() as Route;
+    const res = await call("itinerary", { point_ids }, context(rows));
+    const body = await res.json() as Itinerary;
     expect(res.status).toBe(200);
     expect(body.ordered_points).toHaveLength(50);
     expect(body.timed_itinerary.stops).toHaveLength(50);

--- a/workers/catalog/test/fixtures/catalog-seed.ts
+++ b/workers/catalog/test/fixtures/catalog-seed.ts
@@ -18,7 +18,7 @@ import {
   AnimeCandidate,
   Latitude,
   Longitude,
-  PointsByWorkIdInput,
+  PointsByBangumiIdInput,
   ResolveOutcome,
 } from "@animichi/contract";
 import { aliases, bangumi, points } from "../../src/db/schema";
@@ -54,13 +54,13 @@ export interface AliasSeed {
   priority: number;
 }
 
-/** A work id the contract accepts on `pointsByWorkId` (bare Bangumi subject id). */
-export function contractWorkId(candidate: string): string {
-  return PointsByWorkIdInput.parse({ work_id: candidate }).work_id;
+/** A bangumi id the contract accepts on `pointsByBangumiId` (bare Bangumi subject id). */
+export function contractBangumiId(candidate: string): string {
+  return PointsByBangumiIdInput.parse({ bangumi_id: candidate }).bangumi_id;
 }
 
 export function workSeed(id: string, title: string): WorkSeed {
-  return { workId: contractWorkId(id), title };
+  return { workId: contractBangumiId(id), title };
 }
 
 export function pointSeed(
@@ -145,7 +145,7 @@ export function aliasInsert(seeds: readonly AliasSeed[]): SeedStatement {
   return statement(
     getTableName(aliases),
     [
-      aliasColumns.workId.name, aliasColumns.alias.name, aliasColumns.aliasNormalized.name,
+      aliasColumns.bangumiId.name, aliasColumns.alias.name, aliasColumns.aliasNormalized.name,
       aliasColumns.source.name, aliasColumns.priority.name,
     ],
     seeds.map((s) => [s.workId, s.alias, s.normalized, s.source, s.priority]),

--- a/workers/catalog/test/fixtures/l1-preview-point.ts
+++ b/workers/catalog/test/fixtures/l1-preview-point.ts
@@ -1,7 +1,7 @@
-import type { PilgrimagePoint } from "../../src/types";
+import type { Point } from "../../src/types";
 
 /** A canned L1 preview point (the lite shape, already mapped to the contract). */
-export const PREVIEW_POINT: PilgrimagePoint = {
+export const PREVIEW_POINT: Point = {
   id: "lite-1",
   name: "宇治橋",
   bangumi_id: "10380",

--- a/workers/catalog/test/fixtures/spike-suite-seed.ts
+++ b/workers/catalog/test/fixtures/spike-suite-seed.ts
@@ -52,14 +52,14 @@ function insertSeedPoints(db: CatalogDb): Promise<unknown> {
 
 function insertSeedCluster(db: CatalogDb): Promise<unknown> {
   return db.execute(sql`
-    INSERT INTO cluster_version (work_id, version, is_current)
+    INSERT INTO cluster_version (bangumi_id, version, is_current)
     VALUES ('lucky-star', 1, TRUE)
   `);
 }
 
 function insertSeedAlias(db: CatalogDb): Promise<unknown> {
   return db.execute(sql`
-    INSERT INTO aliases (work_id, alias, alias_normalized, source, priority)
+    INSERT INTO aliases (bangumi_id, alias, alias_normalized, source, priority)
     VALUES ('lucky-star', 'らき☆すた', 'らき☆すた', 'bangumi', 40)
   `);
 }

--- a/workers/catalog/test/in-memory-search-db.ts
+++ b/workers/catalog/test/in-memory-search-db.ts
@@ -43,7 +43,7 @@ export interface Recorder {
 export function fakeDb(aliasIndex: AliasIndex, miss: MissStubs = {}): Recorder {
   const lookups: string[] = [], resolved: string[] = [], ingested: string[] = [];
   const db: SearchDb = {
-    workIdForAlias: (alias) => Promise.resolve(recordLookup(lookups, aliasIndex, alias)),
+    bangumiIdForAlias: (alias) => Promise.resolve(recordLookup(lookups, aliasIndex, alias)),
     pointsForWork: (workId) => Promise.resolve(pointsFor(aliasIndex, workId)),
     resolvePreview: (query) => resolvePreview(miss, resolved, query),
     runFullIngest: (workId) => runFullIngest(miss, ingested, workId),

--- a/workers/catalog/test/ingest-orchestrator.spike.test.ts
+++ b/workers/catalog/test/ingest-orchestrator.spike.test.ts
@@ -87,7 +87,7 @@ async function bangumiExists(workId: string): Promise<boolean> {
 async function currentVersion(workId: string): Promise<number | undefined> {
   const rows = (
     await db.execute(
-      sql`SELECT version FROM cluster_version WHERE work_id = ${workId} AND is_current`,
+      sql`SELECT version FROM cluster_version WHERE bangumi_id = ${workId} AND is_current`,
     )
   ).rows as { version: number }[];
   return rows[0]?.version;

--- a/workers/catalog/test/nearby.worker.test.ts
+++ b/workers/catalog/test/nearby.worker.test.ts
@@ -81,7 +81,7 @@ describe("nearby (api/nearby.ts)", () => {
     expect(rows.map((r) => r.distance_m)).toEqual([5, 4200]);
   });
 
-  it("merges detail columns onto the contract PilgrimagePoint shape", async () => {
+  it("merges detail columns onto the contract Point shape", async () => {
     const { rows } = await run(GEO, DETAILS);
     expect(rows[0]).toMatchObject({
       id: "washinomiya",

--- a/workers/catalog/test/plan-itinerary.worker.test.ts
+++ b/workers/catalog/test/plan-itinerary.worker.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { planItinerary, type PointsForRoutePort, type RoutePoint } from "../src/application/plan-itinerary";
+import { planItinerary, type PointsForRoutePort, type ItineraryPoint } from "../src/application/plan-itinerary";
 import { pointsForRoute, type RouteDb } from "../src/adapters/outbound/route-points";
 
 /**
  * Tests at the use-case seam: `planItinerary` receives points through a fake
  * `PointsForRoutePort` — no DB, no SQL on this side. Verifies the
- * load -> cluster -> plan -> assemble orchestration and the contract `Route`
+ * load -> cluster -> plan -> assemble orchestration and the contract `Itinerary`
  * assembly. A small adapter check covers the port wiring (ids order preserved,
  * unknown ids dropped) against a fake `RouteDb`.
  *
@@ -16,7 +16,7 @@ import { pointsForRoute, type RouteDb } from "../src/adapters/outbound/route-poi
  *   c (35.0020) bangumi "k" "Lucky Star"
  */
 
-function point(id: string, lat: number, image = ""): RoutePoint {
+function point(id: string, lat: number, image = ""): ItineraryPoint {
   return {
     id, name: id.toUpperCase(), bangumi_id: "k", screenshot_url: image,
     latitude: lat, longitude: 135.0,
@@ -25,12 +25,12 @@ function point(id: string, lat: number, image = ""): RoutePoint {
 }
 
 const POINTS = [point("a", 35.0, "a.jpg"), point("b", 35.001), point("c", 35.002)];
-const MANY_POINTS: RoutePoint[] = Array.from({ length: 51 }, (_, i) =>
+const MANY_POINTS: ItineraryPoint[] = Array.from({ length: 51 }, (_, i) =>
   point(`p${String(i).padStart(3, "0")}`, 35 + i * 0.001),
 );
 
 /** A fake `PointsForRoutePort` returning only the requested ids, in ids order. */
-function fakePort(points: RoutePoint[]): PointsForRoutePort {
+function fakePort(points: ItineraryPoint[]): PointsForRoutePort {
   const byId = new Map(points.map((p) => [p.id, p]));
   return {
     loadPoints: (ids) =>
@@ -41,9 +41,9 @@ function fakePort(points: RoutePoint[]): PointsForRoutePort {
   };
 }
 
-const ids = (ps: RoutePoint[]): string[] => ps.map((p) => p.id);
+const ids = (ps: ItineraryPoint[]): string[] => ps.map((p) => p.id);
 
-describe("planItinerary use case — port load -> cluster -> plan -> Route", () => {
+describe("planItinerary use case — port load -> cluster -> plan -> Itinerary", () => {
   it("plans a timed route with a stop+leg itinerary for the selected ids", async () => {
     const r = await planItinerary(fakePort(POINTS), { point_ids: ["a", "b", "c"], pacing: "normal" });
     expect(r.point_count).toBe(3);

--- a/workers/catalog/test/publish.spike.test.ts
+++ b/workers/catalog/test/publish.spike.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, expect, it } from "vitest";
 import { sql } from "drizzle-orm";
 import type { CatalogDb } from "../src/db/client";
 import { publishVersion } from "../src/publish/versioning";
-import { getRouteSnapshot, saveRouteSnapshot } from "../src/publish/snapshots";
+import { getItinerarySnapshot, saveItinerarySnapshot } from "../src/publish/snapshots";
 import { gcOldVersions } from "../src/publish/gc";
 import {
   databaseDescribe,
@@ -13,7 +13,7 @@ import {
 
 /**
  * Spike for the Publish stage (card W3-1): atomic version switch over
- * `cluster_version`, no-drift route snapshots over `route_snapshots`, and
+ * `cluster_version`, no-drift itinerary snapshots over `itinerary_snapshots`, and
  * version GC.
  *
  * Uses the complete Atlas schema inherited by the suite branch, including the
@@ -25,7 +25,7 @@ let db: CatalogDb;
 async function currentVersions(workId: string): Promise<number[]> {
   const rows = (
     await db.execute(
-      sql`SELECT version FROM cluster_version WHERE work_id = ${workId} AND is_current ORDER BY version`,
+      sql`SELECT version FROM cluster_version WHERE bangumi_id = ${workId} AND is_current ORDER BY version`,
     )
   ).rows as { version: number }[];
   return rows.map((r) => r.version);
@@ -34,7 +34,7 @@ async function currentVersions(workId: string): Promise<number[]> {
 async function allVersions(workId: string): Promise<number[]> {
   const rows = (
     await db.execute(
-      sql`SELECT version FROM cluster_version WHERE work_id = ${workId} ORDER BY version`,
+      sql`SELECT version FROM cluster_version WHERE bangumi_id = ${workId} ORDER BY version`,
     )
   ).rows as { version: number }[];
   return rows.map((r) => r.version);
@@ -70,12 +70,12 @@ databaseDescribe("publishVersion atomic version switch over cluster_version", ()
   });
 });
 
-databaseDescribe("saveRouteSnapshot binds a route to a version so it never drifts", () => {
+databaseDescribe("saveItinerarySnapshot binds an itinerary to a version so it never drifts", () => {
   it("reads back a v1 snapshot unchanged after v2 publishes (no drift)", async () => {
     await publishVersion(db, "drift");
-    await saveRouteSnapshot(db, "drift", 1, { order: ["a", "b"] });
+    await saveItinerarySnapshot(db, "drift", 1, { order: ["a", "b"] });
     await publishVersion(db, "drift");
-    const snap = (await getRouteSnapshot(db, "drift", 1)) as { order: string[] };
+    const snap = (await getItinerarySnapshot(db, "drift", 1)) as { order: string[] };
     expect(snap.order).toEqual(["a", "b"]);
   });
 });

--- a/workers/catalog/test/resolve-api.spike.test.ts
+++ b/workers/catalog/test/resolve-api.spike.test.ts
@@ -36,7 +36,7 @@ import {
  * ingest. Do not stub it.
  *
  * Seeds and expectations are built by `./fixtures/catalog-seed`, so a work id
- * that `pointsByWorkId` would reject with a 400 cannot be written here (#363).
+ * that `pointsByBangumiId` would reject with a 400 cannot be written here (#363).
  */
 const handler = new OpenAPIHandler(catalogRouter);
 
@@ -97,13 +97,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function pointKey(value: unknown): string {
   if (!isRecord(value) || typeof value.id !== "string" || typeof value.bangumi_id !== "string") {
-    throw new Error("pointsByWorkId returned a malformed row");
+    throw new Error("pointsByBangumiId returned a malformed row");
   }
   return `${value.bangumi_id}:${value.id}`;
 }
 
 function pointKeys(value: unknown): string[] {
-  if (!isRecord(value) || !Array.isArray(value.rows)) throw new Error("pointsByWorkId returned no rows");
+  if (!isRecord(value) || !Array.isArray(value.rows)) throw new Error("pointsByBangumiId returned no rows");
   return value.rows.map(pointKey).sort();
 }
 
@@ -131,8 +131,8 @@ databaseDescribe("Phase 1a resolver SQL against Postgres", () => {
     await expect(call("resolve", { query: "Zero" })).resolves.toEqual(resolvedOutcome(ZERO, 0));
   });
 
-  it("returns published rows through pointsByWorkId", async () => {
-    const result = await call("points-by-work-id", { work_id: BETA.workId });
+  it("returns published rows through pointsByBangumiId", async () => {
+    const result = await call("points-by-bangumi-id", { bangumi_id: BETA.workId });
     expect(pointKeys(result)).toEqual([`${BETA.workId}:b-1`, `${BETA.workId}:b-2`]);
   });
 });

--- a/workers/catalog/test/resolve-db.worker.test.ts
+++ b/workers/catalog/test/resolve-db.worker.test.ts
@@ -27,7 +27,7 @@ describe("resolve production DB adapter", () => {
   it("groups aliases by work and derives stored candidate enrichment", async () => {
     const queries: string[] = [];
     const db = catalogDb([
-      [{ work_id: "3302", priority: 40 }],
+      [{ bangumi_id: "3302", priority: 40 }],
       [{
         id: "3302", title: "らき☆すた", title_cn: "幸运星",
         cover_url: "cover.jpg", air_date: "2007-04-08", points_count: "2",
@@ -41,13 +41,13 @@ describe("resolve production DB adapter", () => {
         cover_url: "cover.jpg", year: 2007, points_count: 2,
       },
     });
-    expect(queries[0]).toContain("GROUP BY work_id");
+    expect(queries[0]).toContain("GROUP BY bangumi_id");
     expect(queries[1]).toContain("COUNT(p.id) AS points_count");
   });
 
   it("resolves a stored candidate whose point count is zero", async () => {
     const resolved = await resolve({
-      worksForAlias: () => Promise.resolve([{ work_id: "zero", priority: 40 }]),
+      worksForAlias: () => Promise.resolve([{ bangumi_id: "zero", priority: 40 }]),
       candidatesForWorks: () => Promise.resolve([candidate("zero")]),
     }, { query: "Zero" });
     expect(resolved).toEqual({ outcome: "resolved", match: candidate("zero") });

--- a/workers/catalog/test/resolve-hit.worker.test.ts
+++ b/workers/catalog/test/resolve-hit.worker.test.ts
@@ -30,7 +30,7 @@ const EMPTY_SUBJECTS: FetchLike = () => Promise.resolve({
 describe("resolve alias HIT deduplication and ties", () => {
   it("deduplicates duplicate alias rows for one work before deciding ambiguity", async () => {
     const db = fakeDb(
-      [{ work_id: "3302", priority: 40 }, { work_id: "3302", priority: 40 }],
+      [{ bangumi_id: "3302", priority: 40 }, { bangumi_id: "3302", priority: 40 }],
       [candidate("3302", 2)],
     );
 
@@ -42,7 +42,7 @@ describe("resolve alias HIT deduplication and ties", () => {
 
   it("resolves one work reached through multiple source alias priorities", async () => {
     const db = fakeDb(
-      [{ work_id: "10380", priority: 40 }, { work_id: "10380", priority: 30 }],
+      [{ bangumi_id: "10380", priority: 40 }, { bangumi_id: "10380", priority: 30 }],
       [candidate("10380", 0)],
     );
 
@@ -52,7 +52,7 @@ describe("resolve alias HIT deduplication and ties", () => {
 
   it("clarifies two distinct works tied at top priority in ranking-tuple order", async () => {
     const db = fakeDb(
-      [{ work_id: "200", priority: 40 }, { work_id: "100", priority: 40 }],
+      [{ bangumi_id: "200", priority: 40 }, { bangumi_id: "100", priority: 40 }],
       [candidate("100", 3), candidate("200", 7)],
     );
 
@@ -65,7 +65,7 @@ describe("resolve alias HIT deduplication and ties", () => {
 
   it("drops an orphaned top alias and re-ranks the surviving work", async () => {
     const db = fakeDb(
-      [{ work_id: "missing", priority: 50 }, { work_id: "present", priority: 40 }],
+      [{ bangumi_id: "missing", priority: 50 }, { bangumi_id: "present", priority: 40 }],
       [candidate("present", 2)],
     );
 
@@ -76,7 +76,7 @@ describe("resolve alias HIT deduplication and ties", () => {
   });
 
   it("falls through to MISS when every alias work is orphaned", async () => {
-    const db = fakeDb([{ work_id: "missing", priority: 40 }], []);
+    const db = fakeDb([{ bangumi_id: "missing", priority: 40 }], []);
 
     await expect(resolve(db, { query: "Stale Alias" }, {
       fetchImpl: EMPTY_SUBJECTS,
@@ -88,9 +88,9 @@ describe("resolve alias HIT priority and candidate cap", () => {
   it("resolves a strictly dominant top priority among three works", async () => {
     const db = fakeDb(
       [
-        { work_id: "top", priority: 50 },
-        { work_id: "lower-a", priority: 40 },
-        { work_id: "lower-b", priority: 40 },
+        { bangumi_id: "top", priority: 50 },
+        { bangumi_id: "lower-a", priority: 40 },
+        { bangumi_id: "lower-b", priority: 40 },
       ],
       [candidate("top", 0), candidate("lower-a", 10), candidate("lower-b", 20)],
     );
@@ -102,8 +102,8 @@ describe("resolve alias HIT priority and candidate cap", () => {
   });
 
   it("caps an over-limit tie with stable points-count-null-last ordering", async () => {
-    const works = ["7", "2", "5", "1", "4", "3", "8", "6"].map((work_id) => ({
-      work_id,
+    const works = ["7", "2", "5", "1", "4", "3", "8", "6"].map((bangumi_id) => ({
+      bangumi_id,
       priority: 40,
     }));
     const candidates = [

--- a/workers/catalog/test/resolve-wire.worker.test.ts
+++ b/workers/catalog/test/resolve-wire.worker.test.ts
@@ -42,7 +42,7 @@ describe("Phase 1a catalog procedures on the oRPC wire", () => {
 
   it("serves the deterministic resolve outcome", async () => {
     const response = await call("resolve", { query: "Lucky Star" }, context([
-      [{ work_id: "3302", priority: 40 }],
+      [{ bangumi_id: "3302", priority: 40 }],
       [{
         id: "3302", title: "らき☆すた", title_cn: "幸运星",
         cover_url: null, air_date: "2007-04-08", points_count: "0",
@@ -66,7 +66,7 @@ describe("Phase 1a catalog procedures on the oRPC wire", () => {
       title: "らき☆すた", title_cn: null, cover_url: null,
       synced_at: "2026-07-16T00:00:00.000Z",
     };
-    const response = await call("points-by-work-id", { work_id: "3302" }, context([[point]]));
+    const response = await call("points-by-bangumi-id", { bangumi_id: "3302" }, context([[point]]));
 
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({

--- a/workers/catalog/test/route-api.worker.test.ts
+++ b/workers/catalog/test/route-api.worker.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { route, type PilgrimagePoint, type RouteDb } from "../src/api/route";
+import { planItinerary, type Point, type RouteDb } from "../src/api/route";
 
 /**
  * Tests for the `route` read API handler (catalog/src/api/route.ts), which
  * composes the data layer (fetch points + bangumi) with the pure W2-1 kernel
- * (catalog/src/domain/itinerary/plan.ts) to produce a contract `Route`.
+ * (catalog/src/domain/itinerary/plan.ts) to produce a contract `Itinerary`.
  *
  * No Docker: a typed fake `RouteDb` returns fixture rows shaped exactly like the
  * `SELECT ... FROM points LEFT JOIN bangumi` the handler issues, so this is a
- * pure-logic check of fetch -> cluster -> itinerary -> Route assembly. Named
+ * pure-logic check of fetch -> cluster -> itinerary -> Itinerary assembly. Named
  * *.worker.test.ts so the vitest-pool-workers config picks it up.
  *
  * Fixture (3 points on a meridian, > 50m apart so each is its own cluster;
@@ -63,10 +63,10 @@ function fakeDb(rows: FakeRow[]): RouteDb {
   };
 }
 
-const ids = (ps: PilgrimagePoint[]): string[] => ps.map((p) => p.id);
+const ids = (ps: Point[]): string[] => ps.map((p) => p.id);
 
 async function assertTimedRoute(): Promise<void> {
-  const r = await route(fakeDb(ROWS), { point_ids: ["a", "b", "c"], pacing: "normal" });
+  const r = await planItinerary(fakeDb(ROWS), { point_ids: ["a", "b", "c"], pacing: "normal" });
   expect(r.point_count).toBe(3);
   expect(r.timed_itinerary.stops.map((s) => s.cluster_id)).toEqual(["a", "b", "c"]);
   expect(r.timed_itinerary.legs.map((l) => [l.from_id, l.to_id])).toEqual([["a", "b"], ["b", "c"]]);
@@ -75,7 +75,7 @@ async function assertTimedRoute(): Promise<void> {
 }
 
 async function assertPointFields(): Promise<void> {
-  const r = await route(fakeDb(ROWS), { point_ids: ["a"] });
+  const r = await planItinerary(fakeDb(ROWS), { point_ids: ["a"] });
   const [a] = r.ordered_points;
   expect(a?.screenshot_url).toBe("a.jpg");
   expect(a?.bangumi_id).toBe("k");
@@ -84,23 +84,23 @@ async function assertPointFields(): Promise<void> {
   expect(r.timed_itinerary.legs).toEqual([]);
 }
 
-describe("route API handler — fetch -> cluster -> itinerary -> Route", () => {
-  it("plans a timed route with a stop+leg itinerary for the selected ids", assertTimedRoute);
+describe("planItinerary API handler — fetch -> cluster -> itinerary -> Itinerary", () => {
+  it("plans a timed itinerary with a stop+leg itinerary for the selected ids", assertTimedRoute);
 
   it("returns ordered_points in itinerary order (NN from origin near c -> c,b,a)", async () => {
-    const r = await route(fakeDb(ROWS), { point_ids: ["a", "b", "c"], origin: { lat: 35.0025, lng: 135.0 } });
+    const r = await planItinerary(fakeDb(ROWS), { point_ids: ["a", "b", "c"], origin: { lat: 35.0025, lng: 135.0 } });
     expect(ids(r.ordered_points)).toEqual(["c", "b", "a"]);
     expect(r.timed_itinerary.stops.map((s) => s.cluster_id)).toEqual(["c", "b", "a"]);
   });
 
   it("ordered_points (no origin) follow alphabetical NN seed a,b,c", async () => {
-    const r = await route(fakeDb(ROWS), { point_ids: ["c", "a", "b"] });
+    const r = await planItinerary(fakeDb(ROWS), { point_ids: ["c", "a", "b"] });
     expect(ids(r.ordered_points)).toEqual(["a", "b", "c"]);
     expect(r.point_count).toBe(3);
   });
 
   it("carries anime title + cover metadata from the lead point", async () => {
-    const r = await route(fakeDb(ROWS), { point_ids: ["a", "b", "c"] });
+    const r = await planItinerary(fakeDb(ROWS), { point_ids: ["a", "b", "c"] });
     expect(r.anime_title).toBe("Lucky Star");
     expect(r.anime_title_cn).toBe("幸运星");
     expect(r.cover_url).toBe("cover.jpg");
@@ -109,7 +109,7 @@ describe("route API handler — fetch -> cluster -> itinerary -> Route", () => {
   it("maps point fields: screenshot_url from image, coordinates as numbers", assertPointFields);
 
   it("unknown ids -> point_count 0 with an empty itinerary", async () => {
-    const r = await route(fakeDb(ROWS), { point_ids: ["nope", "missing"] });
+    const r = await planItinerary(fakeDb(ROWS), { point_ids: ["nope", "missing"] });
     expect(r.point_count).toBe(0);
     expect(r.ordered_points).toEqual([]);
     expect(r.timed_itinerary.stops).toEqual([]);
@@ -117,13 +117,13 @@ describe("route API handler — fetch -> cluster -> itinerary -> Route", () => {
   });
 
   it("empty point_ids -> point_count 0 (no DB rows)", async () => {
-    const r = await route(fakeDb(ROWS), { point_ids: [] });
+    const r = await planItinerary(fakeDb(ROWS), { point_ids: [] });
     expect(r.point_count).toBe(0);
     expect(r.ordered_points).toEqual([]);
   });
 
   it("caps 51 clusters and discloses the successful truncation", async () => {
-    const r = await route(fakeDb(MANY_ROWS), { point_ids: MANY_ROWS.map((entry) => entry.id) });
+    const r = await planItinerary(fakeDb(MANY_ROWS), { point_ids: MANY_ROWS.map((entry) => entry.id) });
     expect(r.point_count).toBe(50);
     expect(r.timed_itinerary.stops).toHaveLength(50);
     expect(ids(r.ordered_points)).not.toContain("p050");
@@ -132,7 +132,7 @@ describe("route API handler — fetch -> cluster -> itinerary -> Route", () => {
 
   it("keeps the response shape unchanged at the 50-cluster cap", async () => {
     const rows = MANY_ROWS.slice(0, 50);
-    const r = await route(fakeDb(rows), { point_ids: rows.map((entry) => entry.id) });
+    const r = await planItinerary(fakeDb(rows), { point_ids: rows.map((entry) => entry.id) });
     expect(r.point_count).toBe(50);
     expect(r).not.toHaveProperty("truncated");
     expect(r).not.toHaveProperty("shown_cluster_count");

--- a/workers/catalog/test/router-shape-lock.type-test.ts
+++ b/workers/catalog/test/router-shape-lock.type-test.ts
@@ -17,7 +17,7 @@ const validOutput: SearchResult = { rows: [], synced_at: "2026-07-13T00:00:00.00
 
 expectTypeOf(validOutput).toExtend<SearchResult>();
 os.search.handler(() => validOutput);
-os.pointsByWorkId.handler(() => validOutput);
+os.pointsByBangumiId.handler(() => validOutput);
 const resolved: ResolveOutcome = {
   outcome: "resolved",
   match: { bangumi_id: "3302", title: "らき☆すた" },
@@ -29,7 +29,7 @@ const overview: AnimeOverview = {
   points_length: 0,
   circles: [],
   scenes: [],
-  sample_routes: [],
+  sample_itineraries: [],
 };
 os.animeOverview.handler(() => overview);
 

--- a/workers/catalog/test/router-surface.worker.test.ts
+++ b/workers/catalog/test/router-surface.worker.test.ts
@@ -10,11 +10,11 @@ import { catalogRouter } from "../src/router";
 const PUBLIC_PROCEDURES = [
   "search",
   "resolve",
-  "pointsByWorkId",
+  "pointsByBangumiId",
   "spots",
   "nearby",
   "geocode",
-  "route",
+  "planItinerary",
   "animeOverview",
 ] as const;
 

--- a/workers/catalog/test/search-miss.worker.test.ts
+++ b/workers/catalog/test/search-miss.worker.test.ts
@@ -59,6 +59,31 @@ describe("search (alias miss — synchronous fallback when no waitUntil)", () =>
   });
 });
 
+describe("search (alias miss — production SearchDb wrapper)", () => {
+  it("runs the sync fallback through the real runFullIngest when the preview resolves", async () => {
+    const fetchImpl: FetchLike = (url) =>
+      url.includes("/v0/search/subjects")
+        ? Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ data: [{ id: 10380 }] }) })
+        : Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({
+              pointsLength: 1,
+              litePoints: [{ id: "lite-1", name: "宇治橋", geo: [34.8915, 135.8078], image: "/lite/p1.jpg", ep: 1, s: 12 }],
+            }),
+          });
+
+    const result = await search(
+      searchDb(catalogDb([])),
+      { query: "けいおん！" },
+      { fetchImpl },
+    );
+
+    expect(result.partial).toBe(true);
+    expect(result.rows.map((r) => r.id)).toEqual(["lite-1"]);
+  });
+});
+
 describe("search (alias miss — Anitabi lite 404 = no data, not an outage)", () => {
   const bangumiHit = { ok: true, status: 200, json: () => Promise.resolve({ data: [{ id: 10380 }] }) };
 

--- a/workers/catalog/test/search-row-shape.worker.test.ts
+++ b/workers/catalog/test/search-row-shape.worker.test.ts
@@ -29,7 +29,7 @@ function catalogDb(responses: unknown[][]): CatalogDb {
 }
 
 function runSearch(row: Record<string, unknown>) {
-  const db = catalogDb([[{ work_id: "1" }], [row]]);
+  const db = catalogDb([[{ bangumi_id: "1" }], [row]]);
   return search(searchDb(db), { query: "Lucky Star" });
 }
 

--- a/workers/catalog/test/search.worker.test.ts
+++ b/workers/catalog/test/search.worker.test.ts
@@ -9,7 +9,7 @@ import { assertContractShape, assertNullFieldsOmitted } from "./search-contract-
  *
  * `search` takes the narrow `SearchDb` port (the minimal surface it calls), so
  * these inject a typed in-memory fake instead of a real container. We assert:
- * a known alias maps points to the contract `PilgrimagePoint` shape; the query
+ * a known alias maps points to the contract `Point` shape; the query
  * is NFKC-normalized before the lookup; and — the focus of this card — that an
  * alias MISS is TIERED so workerd never blocks on the full ingest:
  *   - with a `waitUntil`: the L1 lite preview returns FAST (no awaiting the full
@@ -22,7 +22,7 @@ import { assertContractShape, assertNullFieldsOmitted } from "./search-contract-
  */
 
 describe("search (alias hit)", () => {
-  it("maps a known alias to PilgrimagePoint rows in contract shape", assertContractShape);
+  it("maps a known alias to Point rows in contract shape", assertContractShape);
 
   it("returns synced_at from the work's bangumi.updated_at", async () => {
     const { db } = fakeDb({ "lucky star": { workId: "1", rows: [ROW] } });

--- a/workers/catalog/test/series.worker.test.ts
+++ b/workers/catalog/test/series.worker.test.ts
@@ -16,14 +16,14 @@ import {
  */
 
 const SEQUEL_CHAIN: SeriesEdge[] = [
-  { fromWorkId: "A", toWorkId: "B", relation: "sequel" },
-  { fromWorkId: "B", toWorkId: "C", relation: "sequel" },
+  { fromBangumiId: "A", toBangumiId: "B", relation: "sequel" },
+  { fromBangumiId: "B", toBangumiId: "C", relation: "sequel" },
 ];
 
 function assertExcludesCharacter(): void {
   const edges: SeriesEdge[] = [
-    { fromWorkId: "A", toWorkId: "B", relation: "sequel" },
-    { fromWorkId: "B", toWorkId: "C", relation: "character" },
+    { fromBangumiId: "A", toBangumiId: "B", relation: "sequel" },
+    { fromBangumiId: "B", toBangumiId: "C", relation: "character" },
   ];
   expect([...walkSeries(edges, "A")].sort()).toEqual(["A", "B"]);
   expect(walkSeries(edges, "A").has("C")).toBe(false);
@@ -52,8 +52,8 @@ describe("walkSeries (series.ts)", () => {
 
   it("is cycle-safe: A->B->A does not loop forever", () => {
     const edges: SeriesEdge[] = [
-      { fromWorkId: "A", toWorkId: "B", relation: "sequel" },
-      { fromWorkId: "B", toWorkId: "A", relation: "prequel" },
+      { fromBangumiId: "A", toBangumiId: "B", relation: "sequel" },
+      { fromBangumiId: "B", toBangumiId: "A", relation: "prequel" },
     ];
     expect([...walkSeries(edges, "A")].sort()).toEqual(["A", "B"]);
   });
@@ -62,9 +62,9 @@ describe("walkSeries (series.ts)", () => {
 
   it("merges via side_story / summary / same_setting relations", () => {
     const edges: SeriesEdge[] = [
-      { fromWorkId: "A", toWorkId: "B", relation: "side_story" },
-      { fromWorkId: "B", toWorkId: "C", relation: "summary" },
-      { fromWorkId: "C", toWorkId: "D", relation: "same_setting" },
+      { fromBangumiId: "A", toBangumiId: "B", relation: "side_story" },
+      { fromBangumiId: "B", toBangumiId: "C", relation: "summary" },
+      { fromBangumiId: "C", toBangumiId: "D", relation: "same_setting" },
     ];
     expect([...walkSeries(edges, "A")].sort()).toEqual(["A", "B", "C", "D"]);
   });

--- a/workers/catalog/test/spike-db.ts
+++ b/workers/catalog/test/spike-db.ts
@@ -24,7 +24,7 @@ export const CATALOG_TABLES = [
   "bangumi",
   "points",
   "cluster_version",
-  "route_snapshots",
+  "itinerary_snapshots",
   "aliases",
   "series_edges",
   "leg_cache",

--- a/workers/catalog/test/spots.worker.test.ts
+++ b/workers/catalog/test/spots.worker.test.ts
@@ -9,7 +9,7 @@ import { spots, SpotNotFoundError } from "../src/api/spots";
  * `db.execute(sql`...`)` returning `{ rows }` (the geo-query.ts pattern), so a
  * typed fake `execute` returning fixture rows is injected via `fakeDb()` and
  * cast to CatalogDb at the boundary. Asserts the contract shape
- * { point, distance_m? } where `point` is a SINGLE PilgrimagePoint.
+ * { point, distance_m? } where `point` is a SINGLE Point.
  * Named *.worker.test.ts so the vitest-pool-workers config picks it up.
  */
 
@@ -64,7 +64,7 @@ async function assertNullCoercion(): Promise<void> {
 }
 
 describe("spots (api/spots.ts)", () => {
-  it("maps a known bangumi_id row to the contract PilgrimagePoint shape", assertContractShape);
+  it("maps a known bangumi_id row to the contract Point shape", assertContractShape);
 
   it("omits distance_m when no origin is given", async () => {
     const result = await spots(fakeDb([KAMAKURA]), { bangumi_id: "100" });

--- a/workers/catalog/test/work-points-wire.worker.test.ts
+++ b/workers/catalog/test/work-points-wire.worker.test.ts
@@ -14,7 +14,7 @@ async function call(body: unknown, context: CatalogContext): Promise<Response> {
 }
 
 async function handleRequest(body: unknown, context: CatalogContext) {
-  const request = new Request("https://catalog.test/catalog/points-by-work-id", {
+  const request = new Request("https://catalog.test/catalog/points-by-bangumi-id", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
@@ -38,7 +38,7 @@ function unreachableContext(): CatalogContext {
 
 describe("work-id contract on the OpenAPI wire", () => {
   it("rejects a nonnumeric work id before SQL or upstream access", async () => {
-    const response = await call({ work_id: "not-a-number" }, unreachableContext());
+    const response = await call({ bangumi_id: "not-a-number" }, unreachableContext());
     expect(response.status).toBe(400);
     expect(await response.json()).toMatchObject({ defined: false, status: 400 });
   });
@@ -46,8 +46,8 @@ describe("work-id contract on the OpenAPI wire", () => {
   it("serializes UPSTREAM_UNAVAILABLE for a preview outage", async () => {
     const fetchImpl = (() => Promise.reject(new Error("anitabi down"))) as unknown as typeof fetch;
     const response = await call(
-      { work_id: "3302" },
-      context([[], [], [{ work_id: "3302" }], []], fetchImpl),
+      { bangumi_id: "3302" },
+      context([[], [], [{ bangumi_id: "3302" }], []], fetchImpl),
     );
     expect(response.status).toBe(502);
     expect(await response.json()).toEqual({

--- a/workers/catalog/test/work-points.worker.test.ts
+++ b/workers/catalog/test/work-points.worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  pointsByWorkId,
+  pointsByBangumiId,
   type WorkPointsDb,
 } from "../src/api/work-points";
 import type {
@@ -8,10 +8,10 @@ import type {
   IngestGuard,
   IngestResult,
 } from "../src/ingest/orchestrator";
-import type { PilgrimagePoint } from "../src/types";
+import type { Point } from "../src/types";
 import type { WorkPointRow, MissPreview } from "../src/api/search";
 
-const PREVIEW: PilgrimagePoint = {
+const PREVIEW: Point = {
   id: "lite-1",
   name: "宇治橋",
   bangumi_id: "115908",
@@ -104,7 +104,7 @@ function waitUntilSpy(): {
   return { waitUntil: (promise) => void scheduled.push(promise), scheduled };
 }
 
-describe("pointsByWorkId tiered ingest", () => {
+describe("pointsByBangumiId tiered ingest", () => {
   it("returns a partial preview and schedules one ingest while the marker is in flight", async () => {
     let finish: (result: IngestResult) => void = () => undefined;
     const ingest = new Promise<IngestResult>((resolve) => (finish = resolve));
@@ -112,8 +112,8 @@ describe("pointsByWorkId tiered ingest", () => {
     const { waitUntil, scheduled } = waitUntilSpy();
 
     const [first, duplicate] = await Promise.all([
-      pointsByWorkId(db, "115908", { waitUntil }),
-      pointsByWorkId(db, "115908", { waitUntil }),
+      pointsByBangumiId(db, "115908", { waitUntil }),
+      pointsByBangumiId(db, "115908", { waitUntil }),
     ]);
 
     expect(first).toMatchObject({ rows: [PREVIEW], partial: true });
@@ -128,7 +128,7 @@ describe("pointsByWorkId tiered ingest", () => {
 
   it("serves a genuine-empty marker without previewing or re-ingesting", async () => {
     const { db, previews, claims, ingests } = fakeDb({ guard: "empty" });
-    const result = await pointsByWorkId(db, "115908", waitUntilSpy());
+    const result = await pointsByBangumiId(db, "115908", waitUntilSpy());
     expect(result.rows).toEqual([]);
     expect(result.partial).toBeUndefined();
     expect([previews, claims, ingests]).toEqual([[], [], []]);
@@ -136,7 +136,7 @@ describe("pointsByWorkId tiered ingest", () => {
 
   it("serves a recent-attempt marker without previewing or re-ingesting", async () => {
     const { db, previews, claims, ingests } = fakeDb({ guard: "recently_attempted" });
-    const result = await pointsByWorkId(db, "115908", waitUntilSpy());
+    const result = await pointsByBangumiId(db, "115908", waitUntilSpy());
     expect(result.rows).toEqual([]);
     expect(result.partial).toBe(true);
     expect([previews, claims, ingests]).toEqual([[], [], []]);
@@ -144,16 +144,16 @@ describe("pointsByWorkId tiered ingest", () => {
 
   it("returns empty partial when it loses the claim before preview", async () => {
     const { db, previews, ingests } = fakeDb({ claim: "in_progress" });
-    const result = await pointsByWorkId(db, "115908", waitUntilSpy());
+    const result = await pointsByBangumiId(db, "115908", waitUntilSpy());
     expect(result).toMatchObject({ rows: [], partial: true });
     expect([previews, ingests]).toEqual([[], []]);
   });
 });
 
-describe("pointsByWorkId completion semantics", () => {
+describe("pointsByBangumiId completion semantics", () => {
   it("re-reads published rows after claiming and closes the no-op claim", async () => {
     const recorder = fakeDb({ rowsSequence: [[], [PUBLISHED]] });
-    const result = await pointsByWorkId(recorder.db, "115908", waitUntilSpy());
+    const result = await pointsByBangumiId(recorder.db, "115908", waitUntilSpy());
     expect(result.rows.map((point) => point.id)).toEqual(["published-1"]);
     expect(recorder.completed).toEqual(["115908"]);
     expect([recorder.previews, recorder.ingests]).toEqual([[], []]);
@@ -161,7 +161,7 @@ describe("pointsByWorkId completion semantics", () => {
 
   it("keeps the published-points path unchanged", async () => {
     const { db, previews, claims, ingests } = fakeDb({ rows: [PUBLISHED] });
-    const result = await pointsByWorkId(db, "115908", waitUntilSpy());
+    const result = await pointsByBangumiId(db, "115908", waitUntilSpy());
     expect(result.rows.map((point) => point.id)).toEqual(["published-1"]);
     expect(result.synced_at).toBe("2026-07-17T00:00:00.000Z");
     expect(result.partial).toBeUndefined();
@@ -170,7 +170,7 @@ describe("pointsByWorkId completion semantics", () => {
 
   it("runs the claimed ingest synchronously when waitUntil is absent", async () => {
     const { db, ingests } = fakeDb();
-    const result = await pointsByWorkId(db, "115908");
+    const result = await pointsByBangumiId(db, "115908");
     expect(ingests).toEqual(["115908"]);
     expect(result).toMatchObject({ rows: [PREVIEW], partial: true });
   });
@@ -179,12 +179,12 @@ describe("pointsByWorkId completion semantics", () => {
     const ingest = Promise.reject(new Error("upstream unavailable"));
     void ingest.catch(() => undefined);
     const { db } = fakeDb({ ingest });
-    await expect(pointsByWorkId(db, "115908")).resolves.toMatchObject({ rows: [PREVIEW], partial: true });
+    await expect(pointsByBangumiId(db, "115908")).resolves.toMatchObject({ rows: [PREVIEW], partial: true });
   });
 
   it("returns the empty result when synchronous ingest finds no points", async () => {
     const { db } = fakeDb({ ingest: Promise.resolve({ status: "empty", reason: "no points" }) });
-    await expect(pointsByWorkId(db, "115908")).resolves.toMatchObject({ rows: [] });
+    await expect(pointsByBangumiId(db, "115908")).resolves.toMatchObject({ rows: [] });
   });
 
   it("swallows background ingest rejection inside the waitUntil promise", async () => {
@@ -192,7 +192,7 @@ describe("pointsByWorkId completion semantics", () => {
     void ingest.catch(() => undefined);
     const { db } = fakeDb({ ingest });
     const { waitUntil, scheduled } = waitUntilSpy();
-    await expect(pointsByWorkId(db, "115908", { waitUntil })).resolves.toMatchObject({
+    await expect(pointsByBangumiId(db, "115908", { waitUntil })).resolves.toMatchObject({
       rows: [PREVIEW], partial: true,
     });
     await expect(Promise.all(scheduled)).resolves.toEqual([undefined]);

--- a/workers/edge/catalog-outbound.test.ts
+++ b/workers/edge/catalog-outbound.test.ts
@@ -6,11 +6,11 @@ import { CATALOG_OUTBOUND_ALLOWLIST } from "./gateway/catalog-policy.ts";
 const EXPECTED_CATALOG_CALLS = [
   "POST /catalog/search",
   "POST /catalog/resolve",
-  "POST /catalog/points-by-work-id",
+  "POST /catalog/points-by-bangumi-id",
   "POST /catalog/spots",
   "POST /catalog/nearby",
   "POST /catalog/geocode",
-  "POST /catalog/route",
+  "POST /catalog/itinerary",
 ];
 
 function catalogEnv(received: Request[]): never {

--- a/workers/edge/gateway/catalog-policy.ts
+++ b/workers/edge/gateway/catalog-policy.ts
@@ -1,11 +1,11 @@
 export const CATALOG_OUTBOUND_ALLOWLIST = [
   "POST /catalog/search",
   "POST /catalog/resolve",
-  "POST /catalog/points-by-work-id",
+  "POST /catalog/points-by-bangumi-id",
   "POST /catalog/spots",
   "POST /catalog/nearby",
   "POST /catalog/geocode",
-  "POST /catalog/route",
+  "POST /catalog/itinerary",
 ] as const;
 
 const CATALOG_OUTBOUND_ROUTES = new Set<string>(CATALOG_OUTBOUND_ALLOWLIST);


### PR DESCRIPTION
## Summary

PR-2 of #852 (SK-G1 greenfield rename, catalog slice). Renames the catalog
data plane + contract + consumers to the published language per
[greenfield-language-and-data-plane.md](docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md):

**Data plane** (new append-only Atlas migration):
- `route_snapshots` → `itinerary_snapshots` (key column `bangumi_id`)
- `aliases.work_id`, `series_edges.from_work_id/to_work_id`, `cluster_version.work_id` → `bangumi_id` columns
- `ingest_jobs` / `raw_*` keep `work_id` (platform tables, D6 — deliberately not renamed)
- `atlas migrate hash` regenerated

**Contract** (`packages/contract`):
- `PilgrimagePoint`→`Point`, `Route`→`Itinerary`, `AnimeSampleRoute`→`AnimeSampleItinerary`, `sample_routes`→`sample_itineraries`
- `pointsByWorkId`→`pointsByBangumiId` (+ `/catalog/points-by-bangumi-id`), `route`→`planItinerary` (+ `/catalog/itinerary`)
- `StreamRoute`→`StreamItinerary`, `RouteData.route`→`itinerary`
- `openapi.json` regenerated (`users-openapi.json` untouched — PR-1's)

**Consumers** (same wave, no dual names):
- catalog worker: schema, publish (versioning/gc/snapshots), search/resolve/work-points/route/plan-itinerary/anime-overview, router, types + tests
- edge: outbound allowlist (`points-by-bangumi-id`, `itinerary`) + wire tests
- agent: `CatalogClient` (`Point`/`Itinerary`/`points_by_bangumi_id`/`plan_itinerary`), `CatalogReadGateway`, `chat_wire.py` wire key, eval mocks + unit tests
- web: anime overview `sample_itineraries`, chat data-part `itinerary` key, MSW fixtures + tests

## Gates

- contract: typecheck ✓ · vitest 65 ✓
- catalog worker: tsc ✓ · oxlint ✓ · worker tests 324 ✓ · spike 30 ✓
- edge: tsc ✓ · oxlint ✓ · `pnpm run test:worker` 286 ✓
- agent: ruff ✓ · mypy ✓ · unit 1748 ✓
- web: tsc ✓ · oxlint ✓ · vitest 1679 ✓

## Notes / risks

- `test_agent_eval.py::test_agent_trajectory` fails **identically on origin/main**
  (model-backed integration eval, no credentials in this env) — pre-existing, not a regression.
- PR-1 (users slice) is in a parallel worktree; contract files split cleanly
  (models.ts/chat-data-parts.ts here vs users/share/checkin there). Migration files are
  independent timestamped files. `atlas.sum`/`users-openapi.json` untouched by this PR's surface.
- The agent's internal `PublicAPIResponse.data["route"]` key is deliberately **not** renamed
  (agent-internal REST body; the SSE wire key `itinerary` is the contract surface).
- Deploy order (per expand–contract): migration applies first, worker rollout follows; no
  dual-read window — code only knows new names after the migration.

Closes part of #852