### PR TITLE
feat(#852): agent internal language slice — route→itinerary (PR-3)

### DIFF
--- a/apps/agent/src/animichi/agents/agent_result.py
+++ b/apps/agent/src/animichi/agents/agent_result.py
@@ -12,7 +12,7 @@ from pydantic_ai.messages import ModelMessage
 from pydantic_ai.usage import RunUsage
 
 from animichi.agents.runtime_models import AgentResultOutput
-from animichi.agents.session_state import ResultRef, RouteRef, SessionState
+from animichi.agents.session_state import ItineraryRef, ResultRef, SessionState
 
 
 @dataclass(frozen=True)
@@ -36,27 +36,27 @@ class RejectedSearch:
 
 
 @dataclass(frozen=True)
-class ProducedRoute:
-    """A route registry entry produced by the current transition."""
+class ProducedItinerary:
+    """An itinerary registry entry produced by the current transition."""
 
     status: Literal["ok"]
-    route_ref: RouteRef
+    itinerary_ref: ItineraryRef
 
 
-RouteRejectionStatus: TypeAlias = Literal[
+ItineraryRejectionStatus: TypeAlias = Literal[
     "empty", "stale_ref", "pending_sync", "upstream_unavailable", "contract_violation"
 ]
 
 
 @dataclass(frozen=True)
-class RejectedRoute:
-    """A current route outcome that did not produce a registry entry."""
+class RejectedItinerary:
+    """A current itinerary outcome that did not produce a registry entry."""
 
-    status: RouteRejectionStatus
+    status: ItineraryRejectionStatus
 
 
 StepProvenance: TypeAlias = (
-    ProducedSearch | RejectedSearch | ProducedRoute | RejectedRoute
+    ProducedSearch | RejectedSearch | ProducedItinerary | RejectedItinerary
 )
 StepData: TypeAlias = dict[str, object]
 UsagePayer: TypeAlias = Literal["platform", "byok"]
@@ -75,7 +75,7 @@ class TurnProvenance:
     """Exact producing refs owned by one completed agent transition."""
 
     search: ProducedSearch | None = None
-    route: ProducedRoute | None = None
+    itinerary: ProducedItinerary | None = None
 
 
 @dataclass
@@ -127,7 +127,8 @@ class AgentResult:
 
 def _turn_provenance(steps: list[StepRecord]) -> TurnProvenance:
     return TurnProvenance(
-        search=_last_search_provenance(steps), route=_last_route_provenance(steps)
+        search=_last_search_provenance(steps),
+        itinerary=_last_itinerary_provenance(steps),
     )
 
 
@@ -140,10 +141,10 @@ def _last_search_provenance(steps: list[StepRecord]) -> ProducedSearch | None:
     return None
 
 
-def _last_route_provenance(steps: list[StepRecord]) -> ProducedRoute | None:
+def _last_itinerary_provenance(steps: list[StepRecord]) -> ProducedItinerary | None:
     for step in reversed(steps):
-        if isinstance(step.provenance, ProducedRoute):
+        if isinstance(step.provenance, ProducedItinerary):
             return step.provenance
-        if isinstance(step.provenance, RejectedRoute):
+        if isinstance(step.provenance, RejectedItinerary):
             return None
     return None

--- a/apps/agent/src/animichi/agents/animichi_agent.py
+++ b/apps/agent/src/animichi/agents/animichi_agent.py
@@ -16,7 +16,7 @@ from pydantic_ai.output import ToolOutput
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai_harness.memory import Memory, MemoryStore
 
-from animichi.agents.agent_result import ProducedRoute, ProducedSearch, StepRecord
+from animichi.agents.agent_result import ProducedItinerary, ProducedSearch, StepRecord
 from animichi.agents.animichi_tools import TOOLS as ANIMICHI_TOOLS
 from animichi.agents.base import resolve_model
 from animichi.agents.error_boundary import error_boundary_hooks
@@ -25,8 +25,8 @@ from animichi.agents.runtime_deps import RuntimeDeps
 from animichi.agents.runtime_models import (
     ClarifyResponseModel,
     GreetingResponseModel,
+    ItineraryResponseModel,
     QAResponseModel,
-    RouteResponseModel,
     SearchResponseModel,
 )
 from animichi.agents.session_state import SessionState
@@ -45,7 +45,7 @@ USER_MEMORY_GUIDANCE = (
 RuntimeOutput = (
     ClarifyResponseModel
     | SearchResponseModel
-    | RouteResponseModel
+    | ItineraryResponseModel
     | GreetingResponseModel
     | QAResponseModel
 )
@@ -207,7 +207,7 @@ def _output_types() -> list[ToolOutput[RuntimeOutput]]:
     return [
         ToolOutput(ClarifyResponseModel, name="clarify_response"),
         ToolOutput(SearchResponseModel, name="search_response"),
-        ToolOutput(RouteResponseModel, name="route_response"),
+        ToolOutput(ItineraryResponseModel, name="route_response"),
         ToolOutput(GreetingResponseModel, name="greeting_response"),
         ToolOutput(QAResponseModel, name="qa_response"),
     ]
@@ -429,7 +429,7 @@ async def validate_output(
         ctx.deps.steps, session
     ):
         raise ModelRetry("Call a search tool before returning search_response.")
-    if isinstance(output, RouteResponseModel) and not _valid_route(
+    if isinstance(output, ItineraryResponseModel) and not _valid_itinerary(
         ctx.deps.steps, session
     ):
         raise ModelRetry("Call plan_route before returning route_response.")
@@ -447,11 +447,12 @@ def _valid_search(steps: list[StepRecord], session: SessionState) -> bool:
     )
 
 
-def _valid_route(steps: list[StepRecord], session: SessionState) -> bool:
+def _valid_itinerary(steps: list[StepRecord], session: SessionState) -> bool:
     step = _last_step(steps, {"plan_route", "plan_selected"})
     provenance = step.provenance if step is not None else None
     return (
-        isinstance(provenance, ProducedRoute) and provenance.route_ref in session.routes
+        isinstance(provenance, ProducedItinerary)
+        and provenance.itinerary_ref in session.itineraries
     )
 
 

--- a/apps/agent/src/animichi/agents/animichi_runner.py
+++ b/apps/agent/src/animichi/agents/animichi_runner.py
@@ -38,9 +38,9 @@ from animichi.agents.runtime_models import (
     ClarifyResponseModel,
     ErrorResponseModel,
     GreetingResponseModel,
+    ItineraryResponseModel,
     PartialResponseModel,
     QAResponseModel,
-    RouteResponseModel,
     SearchResponseModel,
 )
 from animichi.agents.session_state import CurrentAnime, SessionState
@@ -68,7 +68,7 @@ RUN_USAGE_LIMITS = UsageLimits(
 
 _STAGE_BY_OUTPUT: dict[type[AgentResultOutput], str] = {
     SearchResponseModel: "search",
-    RouteResponseModel: "route",
+    ItineraryResponseModel: "route",
     ClarifyResponseModel: "clarify",
     GreetingResponseModel: "greet_user",
     QAResponseModel: "general_qa",
@@ -150,7 +150,7 @@ def _seed_tool_state(deps: RuntimeDeps, context: dict[str, object] | None) -> No
     _seed_current_anime(deps.tool_state, context)
     session = deps.tool_state.session
     deps.ref_factory.reserve(
-        [*map(str, session.search_results), *map(str, session.routes)]
+        [*map(str, session.search_results), *map(str, session.itineraries)]
     )
 
 

--- a/apps/agent/src/animichi/agents/animichi_tools.py
+++ b/apps/agent/src/animichi/agents/animichi_tools.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from pydantic_ai import RunContext, Tool
 from pydantic_ai.tools import ToolFuncEither
 
-from animichi.agents.catalog_route_tools import run_route
+from animichi.agents.catalog_route_tools import run_itinerary
 from animichi.agents.catalog_tools import (
     run_nearby_search,
     run_resolve,
@@ -16,9 +16,9 @@ from animichi.agents.catalog_tools import (
 )
 from animichi.agents.runtime_deps import RuntimeDeps
 from animichi.agents.tool_outcomes import (
+    ItineraryToolResult,
     NearbyToolResult,
     ResolveResult,
-    RouteToolResult,
     SearchToolResult,
 )
 
@@ -70,9 +70,9 @@ async def plan_route(
     ctx: RunContext[RuntimeDeps],
     search_result_ref: Annotated[str, Field(min_length=1)],
     pacing: Literal["chill", "normal", "packed"] | None = None,
-) -> RouteToolResult:
+) -> ItineraryToolResult:
     """Plan one stored result; upstream_unavailable means retry later."""
-    return await run_route(ctx, ctx.deps.catalog, search_result_ref, pacing)
+    return await run_itinerary(ctx, ctx.deps.catalog, search_result_ref, pacing)
 
 
 TOOLS: list[Tool[RuntimeDeps] | ToolFuncEither[RuntimeDeps]] = [

--- a/apps/agent/src/animichi/agents/catalog_adapter.py
+++ b/apps/agent/src/animichi/agents/catalog_adapter.py
@@ -11,11 +11,11 @@ from typing import Literal
 from animichi.agents.geo_names import localized_city_name
 from animichi.agents.handlers._helpers import _build_nearby_groups, rewrite_image_urls
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItinerarySummaryState,
     NearbyGroupState,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteSummaryState,
     SearchMetadataState,
     SearchPayloadState,
     TimedItineraryState,
@@ -116,10 +116,10 @@ def build_search_state(
     )
 
 
-def build_route_state(
+def build_itinerary_state(
     itinerary: Itinerary, source_ref: ResultRef | None, *, locale: str
-) -> RoutePayloadState:
-    """Adapt a non-empty catalog route into the typed route registry."""
+) -> ItineraryPayloadState:
+    """Adapt a non-empty catalog route into the typed itinerary registry."""
     localized = itinerary.model_copy(
         update={
             "ordered_points": [
@@ -132,10 +132,10 @@ def build_route_state(
     timed = payload["timed_itinerary"]
     raw_points = payload["ordered_points"]
     points = raw_points if isinstance(raw_points, list) else []
-    return RoutePayloadState(
+    return ItineraryPayloadState(
         ordered_points=[PointState.model_validate(row) for row in points],
         timed_itinerary=TimedItineraryState.model_validate(timed),
-        summary=RouteSummaryState.model_validate(summary),
+        summary=ItinerarySummaryState.model_validate(summary),
         source_ref=source_ref,
     )
 

--- a/apps/agent/src/animichi/agents/catalog_route_tools.py
+++ b/apps/agent/src/animichi/agents/catalog_route_tools.py
@@ -1,4 +1,4 @@
-"""Catalog-backed route tool execution."""
+"""Catalog-backed itinerary tool execution."""
 
 from __future__ import annotations
 
@@ -6,89 +6,107 @@ from typing import Literal
 
 from pydantic_ai import RunContext
 
-from animichi.agents.agent_result import ProducedRoute, RejectedRoute, StepProvenance
-from animichi.agents.catalog_adapter import build_route_state
+from animichi.agents.agent_result import (
+    ProducedItinerary,
+    RejectedItinerary,
+    StepProvenance,
+)
+from animichi.agents.catalog_adapter import build_itinerary_state
 from animichi.agents.catalog_failures import CATALOG_FAILURES
 from animichi.agents.catalog_tools import _clear_pending
 from animichi.agents.runtime_deps import RuntimeDeps
-from animichi.agents.session_state import ResultRef, RouteRef
+from animichi.agents.session_state import ItineraryRef, ResultRef
 from animichi.agents.tool_event_bridge import register_tool_provenance
 from animichi.agents.tool_outcomes import (
-    RouteEmpty,
-    RouteOk,
-    RoutePendingSync,
-    RouteStaleRef,
-    RouteUpstreamDown,
+    ItineraryEmpty,
+    ItineraryOk,
+    ItineraryPendingSync,
+    ItineraryStaleRef,
+    ItineraryUpstreamDown,
 )
 from animichi.clients.catalog_client import CatalogClientProtocol, Itinerary
 
 Pacing = Literal["chill", "normal", "packed"]
 
 
-async def run_route(
+async def run_itinerary(
     ctx: RunContext[RuntimeDeps],
     catalog: CatalogClientProtocol,
     search_result_ref: str,
     pacing: Pacing | None,
-) -> RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync | RouteUpstreamDown:
-    """Route exactly the registry payload named by the model-supplied ref."""
+) -> (
+    ItineraryOk
+    | ItineraryEmpty
+    | ItineraryStaleRef
+    | ItineraryPendingSync
+    | ItineraryUpstreamDown
+):
+    """Build exactly the registry payload named by the model-supplied ref."""
     ref = ResultRef(search_result_ref)
     payload = ctx.deps.tool_state.session.search_results.get(ref)
-    outcome: RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync | RouteUpstreamDown
+    outcome: (
+        ItineraryOk
+        | ItineraryEmpty
+        | ItineraryStaleRef
+        | ItineraryPendingSync
+        | ItineraryUpstreamDown
+    )
     try:
-        outcome = await _route_outcome(ctx, catalog, ref, payload, pacing)
+        outcome = await _itinerary_outcome(ctx, catalog, ref, payload, pacing)
     except CATALOG_FAILURES:
         _clear_pending(ctx.deps)
-        outcome = RouteUpstreamDown()
-    register_tool_provenance(ctx, _route_provenance(outcome))
+        outcome = ItineraryUpstreamDown()
+    register_tool_provenance(ctx, _itinerary_provenance(outcome))
     return outcome
 
 
-async def _route_outcome(
+async def _itinerary_outcome(
     ctx: RunContext[RuntimeDeps],
     catalog: CatalogClientProtocol,
     ref: ResultRef,
     payload: object,
     pacing: Pacing | None,
-) -> RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync:
+) -> ItineraryOk | ItineraryEmpty | ItineraryStaleRef | ItineraryPendingSync:
     from animichi.agents.session_state import SearchPayloadState
 
     if not isinstance(payload, SearchPayloadState):
-        return RouteStaleRef()
+        return ItineraryStaleRef()
     if payload.partial:
-        return RoutePendingSync()
+        return ItineraryPendingSync()
     if not payload.rows:
-        return RouteEmpty()
+        return ItineraryEmpty()
     itinerary = await catalog.plan_itinerary(
         [point.id for point in payload.rows if point.id], pacing=pacing
     )
     if itinerary.point_count < 1:
-        return RouteEmpty()
-    return _store_route(ctx, itinerary, ref)
+        return ItineraryEmpty()
+    return _store_itinerary(ctx, itinerary, ref)
 
 
-def _store_route(
+def _store_itinerary(
     ctx: RunContext[RuntimeDeps], itinerary: Itinerary, ref: ResultRef
-) -> RouteOk:
-    route_ref = RouteRef(ctx.deps.ref_factory("route", itinerary.point_count))
-    state = build_route_state(itinerary, ref, locale=ctx.deps.locale)
-    ctx.deps.tool_state.session.store_route(route_ref, state)
+) -> ItineraryOk:
+    itinerary_ref = ItineraryRef(ctx.deps.ref_factory("route", itinerary.point_count))
+    state = build_itinerary_state(itinerary, ref, locale=ctx.deps.locale)
+    ctx.deps.tool_state.session.store_itinerary(itinerary_ref, state)
     _clear_pending(ctx.deps)
     minutes = state.timed_itinerary.total_minutes if state.timed_itinerary else 0
-    return RouteOk(
-        route_ref=str(route_ref),
+    return ItineraryOk(
+        itinerary_ref=str(itinerary_ref),
         point_count=itinerary.point_count,
         total_minutes=minutes,
     )
 
 
-def _route_provenance(
-    outcome: RouteOk
-    | RouteEmpty
-    | RouteStaleRef
-    | RoutePendingSync
-    | RouteUpstreamDown,
+def _itinerary_provenance(
+    outcome: ItineraryOk
+    | ItineraryEmpty
+    | ItineraryStaleRef
+    | ItineraryPendingSync
+    | ItineraryUpstreamDown,
 ) -> StepProvenance:
-    if isinstance(outcome, RouteOk):
-        return ProducedRoute(status="ok", route_ref=RouteRef(outcome.route_ref))
-    return RejectedRoute(status=outcome.status)
+    if isinstance(outcome, ItineraryOk):
+        return ProducedItinerary(
+            status="ok", itinerary_ref=ItineraryRef(outcome.itinerary_ref)
+        )
+    return RejectedItinerary(status=outcome.status)

--- a/apps/agent/src/animichi/agents/export/__init__.py
+++ b/apps/agent/src/animichi/agents/export/__init__.py
@@ -1,4 +1,4 @@
-"""Route export helpers — ICS calendar and Google Maps URL builder."""
+"""Itinerary export helpers — ICS calendar and Google Maps URL builder."""
 
 from animichi.agents.export.ics import build_ics_calendar
 from animichi.agents.export.maps_url import build_google_maps_url

--- a/apps/agent/src/animichi/agents/export/ics.py
+++ b/apps/agent/src/animichi/agents/export/ics.py
@@ -18,7 +18,7 @@ def build_ics_calendar(
     """Serialize a TimedItinerary as an iCalendar (.ics) string.
 
     Args:
-        itinerary: The timed route to serialize.
+        itinerary: The timed itinerary to serialize.
         title:     Calendar display name (unused in VEVENT SUMMARY; kept for
                    future X-WR-CALNAME support).
         date:      Date string in YYYYMMDD format.  Defaults to today.

--- a/apps/agent/src/animichi/agents/route_area_splitter.py
+++ b/apps/agent/src/animichi/agents/route_area_splitter.py
@@ -1,4 +1,4 @@
-"""LLM-based area splitting for route planning.
+"""LLM-based area splitting for itinerary planning.
 
 When pilgrimage spots span multiple geographic areas (e.g., Your Name has spots
 in Shinjuku AND Hida-Furukawa 300km away), this module asks the LLM to group
@@ -54,16 +54,16 @@ class AreaSplitResult(BaseModel):
     )
 
 
-route_planner_agent: Agent[None, AreaSplitResult] = Agent(
+itinerary_planner_agent: Agent[None, AreaSplitResult] = Agent(
     resolve_model(None),
-    name="route_planner",
+    name="itinerary_planner",
     output_type=AreaSplitResult,
     instructions=_SPLIT_INSTRUCTIONS,
     retries=1,
 )
 
 
-@route_planner_agent.tool_plain
+@itinerary_planner_agent.tool_plain
 def calculate_distance(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
     """Calculate distance in meters between two coordinates.
 
@@ -120,7 +120,7 @@ async def split_into_areas(
         return None
 
     try:
-        result = await route_planner_agent.run(
+        result = await itinerary_planner_agent.run(
             _build_prompt(points),
             model=model,
         )

--- a/apps/agent/src/animichi/agents/route_export.py
+++ b/apps/agent/src/animichi/agents/route_export.py
@@ -1,4 +1,4 @@
-"""Backward-compatible re-exports for route export helpers.
+"""Backward-compatible re-exports for itinerary export helpers.
 
 Implementation lives in ``animichi.agents.export``.
 """

--- a/apps/agent/src/animichi/agents/runtime_models.py
+++ b/apps/agent/src/animichi/agents/runtime_models.py
@@ -30,14 +30,14 @@ class SearchResponseModel(_CompactOutput):
     )
 
 
-class RouteResponseModel(_CompactOutput):
-    """Brief prose wrapper for a registry-backed route response."""
+class ItineraryResponseModel(_CompactOutput):
+    """Brief prose wrapper for a registry-backed itinerary response."""
 
     message: str = Field(
         description=(
-            "Brief 1-2 sentence wrapper around a completed route; the app "
-            "renders the route from typed SessionState, so never re-type stops, "
-            "legs, or times here."
+            "Brief 1-2 sentence wrapper around a completed itinerary; the app "
+            "renders the itinerary from typed SessionState, so never re-type "
+            "stops, legs, or times here."
         )
     )
 
@@ -125,7 +125,7 @@ class ErrorResponseModel(_CompactOutput):
 RuntimeStageOutput = (
     ClarifyResponseModel
     | SearchResponseModel
-    | RouteResponseModel
+    | ItineraryResponseModel
     | GreetingResponseModel
     | QAResponseModel
 )

--- a/apps/agent/src/animichi/agents/selected_route.py
+++ b/apps/agent/src/animichi/agents/selected_route.py
@@ -1,4 +1,4 @@
-"""Direct selected-point route execution (no ExecutorAgent needed)."""
+"""Direct selected-point itinerary execution (no ExecutorAgent needed)."""
 
 from __future__ import annotations
 
@@ -8,18 +8,21 @@ from pydantic import ValidationError
 
 from animichi.agents.agent_result import (
     AgentResult,
-    ProducedRoute,
-    RejectedRoute,
-    RouteRejectionStatus,
+    ItineraryRejectionStatus,
+    ProducedItinerary,
+    RejectedItinerary,
     StepRecord,
 )
-from animichi.agents.catalog_adapter import build_itinerary_payload, build_route_state
+from animichi.agents.catalog_adapter import (
+    build_itinerary_payload,
+    build_itinerary_state,
+)
 from animichi.agents.error_messages import (
     CATALOG_ROUTE_UNAVAILABLE_MESSAGE,
     build_error_message,
 )
 from animichi.agents.runtime_deps import OnStep, StepEvent, StepStatus, new_step_call_id
-from animichi.agents.runtime_models import RouteResponseModel
+from animichi.agents.runtime_models import ItineraryResponseModel
 from animichi.agents.selection_messages import selected_route_message
 from animichi.agents.session_state import SessionState
 from animichi.clients.catalog_client import CatalogClientProtocol, Itinerary
@@ -28,10 +31,10 @@ from animichi.clients.errors import APIError
 logger = structlog.get_logger(__name__)
 
 _TRANSIENT_ERRORS = (APIError, httpx.TransportError, httpx.TimeoutException)
-_ROUTE_ERRORS = _TRANSIENT_ERRORS
+_ITINERARY_ERRORS = _TRANSIENT_ERRORS
 
 
-async def execute_selected_route(
+async def execute_selected_itinerary(
     *,
     point_ids: list[str],
     state: SessionState,
@@ -40,7 +43,7 @@ async def execute_selected_route(
     catalog: CatalogClientProtocol,
     on_step: OnStep | None = None,
 ) -> AgentResult:
-    """Route user-selected point IDs directly, returning AgentResult."""
+    """Build a user-selected itinerary from point IDs directly, returning AgentResult."""
     if not point_ids:
         return _error_result("point_ids is required", locale, state)
 
@@ -59,9 +62,9 @@ async def execute_selected_route(
             CATALOG_ROUTE_UNAVAILABLE_MESSAGE,
             locale,
             state,
-            route_status="contract_violation",
+            itinerary_status="contract_violation",
         )
-    except _ROUTE_ERRORS as exc:
+    except _ITINERARY_ERRORS as exc:
         logger.warning("selected_route_catalog_error", error=str(exc))
         await _emit_step(on_step, call_id, "error", {})
         # Typed CatalogError -> localized, actionable text from OUR mapping
@@ -125,15 +128,15 @@ def _build_success_result(
     locale: str,
     state: SessionState,
 ) -> AgentResult:
-    """Assemble the AgentResult returned on a successful route lookup."""
-    route_ref = state.next_route_ref("selected", 1)
-    state.store_route(
-        route_ref, build_route_state(itinerary, source_ref=None, locale=locale)
+    """Assemble the AgentResult returned on a successful itinerary lookup."""
+    itinerary_ref = state.next_itinerary_ref("selected", 1)
+    state.store_itinerary(
+        itinerary_ref, build_itinerary_state(itinerary, source_ref=None, locale=locale)
     )
-    step.provenance = ProducedRoute(status="ok", route_ref=route_ref)
+    step.provenance = ProducedItinerary(status="ok", itinerary_ref=itinerary_ref)
     state.pending_clarification = None
     state.geocode_staging = None
-    output = RouteResponseModel(
+    output = ItineraryResponseModel(
         message=selected_route_message(locale, itinerary.point_count)
     )
     return AgentResult(
@@ -149,9 +152,9 @@ def _error_result(
     locale: str,
     state: SessionState,
     *,
-    route_status: RouteRejectionStatus = "upstream_unavailable",
+    itinerary_status: ItineraryRejectionStatus = "upstream_unavailable",
 ) -> AgentResult:
-    output = RouteResponseModel(message=error)
+    output = ItineraryResponseModel(message=error)
     return AgentResult(
         output=output,
         intent="plan_selected",
@@ -161,7 +164,7 @@ def _error_result(
                 tool="plan_selected",
                 is_success=False,
                 error=error,
-                provenance=RejectedRoute(status=route_status),
+                provenance=RejectedItinerary(status=itinerary_status),
                 model_initiated=False,
             )
         ],

--- a/apps/agent/src/animichi/agents/selection.py
+++ b/apps/agent/src/animichi/agents/selection.py
@@ -10,17 +10,17 @@ import httpx
 
 from animichi.agents.agent_result import (
     AgentResult,
-    ProducedRoute,
+    ProducedItinerary,
     ProducedSearch,
     StepData,
     StepProvenance,
     StepRecord,
     TurnProvenance,
 )
-from animichi.agents.catalog_adapter import build_route_state, build_search_state
+from animichi.agents.catalog_adapter import build_itinerary_state, build_search_state
 from animichi.agents.geo_names import localized_city_name
 from animichi.agents.runtime_deps import OnStep, StepEvent, StepStatus, new_step_call_id
-from animichi.agents.runtime_models import RouteResponseModel, SearchResponseModel
+from animichi.agents.runtime_models import ItineraryResponseModel, SearchResponseModel
 from animichi.agents.selection_messages import PLACE_MESSAGES, multi_message
 from animichi.agents.session_state import (
     CurrentAnime,
@@ -35,7 +35,7 @@ from animichi.clients.catalog_errors import (
 )
 from animichi.clients.errors import APIError
 
-MAX_ROUTE_POINT_IDS = 500
+MAX_ITINERARY_POINT_IDS = 500
 _FETCH_ERRORS = (
     APIError,
     httpx.TransportError,
@@ -129,7 +129,7 @@ async def execute_multi_selection(
         return await _multi_terminal_event(
             state, steps, locale, status, on_step, call_id, search=provenance
         )
-    if len(merged.rows) > MAX_ROUTE_POINT_IDS:
+    if len(merged.rows) > MAX_ITINERARY_POINT_IDS:
         return await _multi_terminal_event(
             state, steps, locale, "too_large", on_step, call_id, search=provenance
         )
@@ -149,24 +149,26 @@ async def execute_multi_selection(
         return await _multi_terminal_event(
             state, steps, locale, "error", on_step, call_id, search=provenance
         )
-    route_ref = state.next_route_ref("multi", state.clarification_revision)
-    state.store_route(
-        route_ref, build_route_state(itinerary, result_ref, locale=locale)
+    itinerary_ref = state.next_itinerary_ref("multi", state.clarification_revision)
+    state.store_itinerary(
+        itinerary_ref, build_itinerary_state(itinerary, result_ref, locale=locale)
     )
     _set_current_anime(state, candidate_ids)
     omitted = _omitted_titles(state, merged.omitted_work_ids)
     _consume_pending(state)
-    steps.append(_server_step("plan_multi", True, {"route_ref": str(route_ref)}))
-    await _emit(on_step, call_id, "plan_multi", "done", {"route_ref": str(route_ref)})
+    steps.append(_server_step("plan_multi", True, {"route_ref": str(itinerary_ref)}))
+    await _emit(
+        on_step, call_id, "plan_multi", "done", {"route_ref": str(itinerary_ref)}
+    )
     return AgentResult(
-        output=RouteResponseModel(message=multi_message(locale, "ok", omitted)),
+        output=ItineraryResponseModel(message=multi_message(locale, "ok", omitted)),
         intent="plan_multi",
         session_state=state,
         steps=steps,
         success_override=True,
         provenance=TurnProvenance(
             search=ProducedSearch(outcome="ok", result_ref=result_ref),
-            route=ProducedRoute(status="ok", route_ref=route_ref),
+            itinerary=ProducedItinerary(status="ok", itinerary_ref=itinerary_ref),
         ),
     )
 
@@ -276,7 +278,7 @@ def _multi_terminal(
     expected = status in {"empty", "partial", "too_large"}
     steps.append(_server_step("plan_multi", expected, {"status": status}))
     return AgentResult(
-        output=RouteResponseModel(message=multi_message(locale, status)),
+        output=ItineraryResponseModel(message=multi_message(locale, status)),
         intent="plan_multi",
         session_state=state,
         steps=steps,

--- a/apps/agent/src/animichi/agents/session_state.py
+++ b/apps/agent/src/animichi/agents/session_state.py
@@ -12,7 +12,7 @@ from animichi.domain.fact_ledger import FactLedger
 MAX_REFS = 8
 
 ResultRef = NewType("ResultRef", str)
-RouteRef = NewType("RouteRef", str)
+ItineraryRef = NewType("ItineraryRef", str)
 
 RefT = TypeVar("RefT")
 PayloadT = TypeVar("PayloadT")
@@ -66,8 +66,8 @@ class NearbyGroupState(_SessionModel):
     closest_distance_m: float | None = None
 
 
-class RouteSummaryState(_SessionModel):
-    """Counts and totals for a stored route."""
+class ItinerarySummaryState(_SessionModel):
+    """Counts and totals for a stored itinerary."""
 
     point_count: int
     total_minutes: int
@@ -136,12 +136,12 @@ class TimedItineraryState(_SessionModel):
     export_ics: str = ""
 
 
-class RoutePayloadState(_SessionModel):
-    """Full route payload addressed by a server-owned route ref."""
+class ItineraryPayloadState(_SessionModel):
+    """Full itinerary payload addressed by a server-owned itinerary ref."""
 
     ordered_points: list[PointState] = Field(default_factory=list)
     timed_itinerary: TimedItineraryState | None = None
-    summary: RouteSummaryState | None = None
+    summary: ItinerarySummaryState | None = None
     source_ref: ResultRef | None = None
 
 
@@ -190,17 +190,17 @@ class StaleRef(_SessionModel):
 
 
 SearchResultLookup: TypeAlias = SearchPayloadState | StaleRef
-RouteLookup: TypeAlias = RoutePayloadState | StaleRef
+ItineraryLookup: TypeAlias = ItineraryPayloadState | StaleRef
 
 
 class SessionState(_SessionModel):
-    """Versioned identity, candidate, search, and route carrier."""
+    """Versioned identity, candidate, search, and itinerary carrier."""
 
     current_anime: CurrentAnime | None = None
     search_results: dict[ResultRef, SearchPayloadState] = Field(default_factory=dict)
     search_result_lru: list[ResultRef] = Field(default_factory=list)
-    routes: dict[RouteRef, RoutePayloadState] = Field(default_factory=dict)
-    route_lru: list[RouteRef] = Field(default_factory=list)
+    itineraries: dict[ItineraryRef, ItineraryPayloadState] = Field(default_factory=dict)
+    itinerary_lru: list[ItineraryRef] = Field(default_factory=list)
     pending_clarification: PendingClarification | None = None
     geocode_staging: GeocodeStaging | None = None
     last_result_ref: ResultRef | None = None
@@ -218,8 +218,8 @@ class SessionState(_SessionModel):
             self.search_result_lru,
             "search_result_lru" in fields,
         )
-        self.route_lru = _restore_lru(
-            self.routes, self.route_lru, "route_lru" in fields
+        self.itinerary_lru = _restore_lru(
+            self.itineraries, self.itinerary_lru, "itinerary_lru" in fields
         )
         self.compaction_retained_entities.enforce_bounds()
         return self
@@ -243,22 +243,24 @@ class SessionState(_SessionModel):
         _store_lru(self.search_results, self.search_result_lru, ref, payload)
         return payload
 
-    def store_route(self, ref: RouteRef, payload: RoutePayloadState) -> None:
-        """Store and mark a route payload as the most recently used."""
-        _store_lru(self.routes, self.route_lru, ref, payload)
+    def store_itinerary(
+        self, ref: ItineraryRef, payload: ItineraryPayloadState
+    ) -> None:
+        """Store and mark an itinerary payload as the most recently used."""
+        _store_lru(self.itineraries, self.itinerary_lru, ref, payload)
 
-    def next_route_ref(self, kind: str, seed: int) -> RouteRef:
-        """Return the first collision-free opaque route ref at or above seed."""
-        while RouteRef(f"route:{kind}:{seed}") in self.routes:
+    def next_itinerary_ref(self, kind: str, seed: int) -> ItineraryRef:
+        """Return the first collision-free opaque itinerary ref at or above seed."""
+        while ItineraryRef(f"route:{kind}:{seed}") in self.itineraries:
             seed += 1
-        return RouteRef(f"route:{kind}:{seed}")
+        return ItineraryRef(f"route:{kind}:{seed}")
 
-    def get_route(self, ref: RouteRef) -> RouteLookup:
-        """Return a route payload or a typed stale-ref outcome."""
-        payload = self.routes.get(ref)
+    def get_itinerary(self, ref: ItineraryRef) -> ItineraryLookup:
+        """Return an itinerary payload or a typed stale-ref outcome."""
+        payload = self.itineraries.get(ref)
         if payload is None:
             return StaleRef()
-        _store_lru(self.routes, self.route_lru, ref, payload)
+        _store_lru(self.itineraries, self.itinerary_lru, ref, payload)
         return payload
 
     def is_empty(self) -> bool:

--- a/apps/agent/src/animichi/agents/tool_outcomes.py
+++ b/apps/agent/src/animichi/agents/tool_outcomes.py
@@ -102,31 +102,35 @@ NearbyToolResult: TypeAlias = Annotated[
 ]
 
 
-class RouteOk(_Outcome):
+class ItineraryOk(_Outcome):
     status: Literal["ok"] = "ok"
-    route_ref: str
+    itinerary_ref: str
     point_count: int = Field(ge=1)
     total_minutes: int
 
 
-class RouteEmpty(_Outcome):
+class ItineraryEmpty(_Outcome):
     status: Literal["empty"] = "empty"
 
 
-class RouteStaleRef(_Outcome):
+class ItineraryStaleRef(_Outcome):
     status: Literal["stale_ref"] = "stale_ref"
 
 
-class RoutePendingSync(_Outcome):
+class ItineraryPendingSync(_Outcome):
     status: Literal["pending_sync"] = "pending_sync"
 
 
-class RouteUpstreamDown(_Outcome):
+class ItineraryUpstreamDown(_Outcome):
     status: Literal["upstream_unavailable"] = "upstream_unavailable"
 
 
-RouteToolResult: TypeAlias = Annotated[
-    RouteOk | RouteEmpty | RouteStaleRef | RoutePendingSync | RouteUpstreamDown,
+ItineraryToolResult: TypeAlias = Annotated[
+    ItineraryOk
+    | ItineraryEmpty
+    | ItineraryStaleRef
+    | ItineraryPendingSync
+    | ItineraryUpstreamDown,
     Field(discriminator="status"),
 ]
 

--- a/apps/agent/src/animichi/domain/entities.py
+++ b/apps/agent/src/animichi/domain/entities.py
@@ -165,8 +165,8 @@ class TransportInfo(BaseModel):
         return f"{minutes}min"
 
 
-class RouteSegment(BaseModel):
-    """Route segment between two locations."""
+class ItinerarySegment(BaseModel):
+    """Itinerary segment between two locations."""
 
     order: int = Field(..., ge=1)
     point: Point
@@ -175,11 +175,11 @@ class RouteSegment(BaseModel):
     cumulative_duration_minutes: int = Field(0, ge=0)
 
 
-class Route(BaseModel):
-    """Complete pilgrimage route."""
+class Itinerary(BaseModel):
+    """Complete pilgrimage itinerary."""
 
     origin: Station
-    segments: list[RouteSegment]
+    segments: list[ItinerarySegment]
     total_distance_km: float = Field(..., ge=0)
     total_duration_minutes: int = Field(..., ge=0)
     google_maps_url: HttpUrl | None = None
@@ -219,7 +219,7 @@ class AnimichiSession(BaseModel):
     search_radius_km: float = Field(5.0, ge=1, le=20)
     nearby_bangumi: list[Bangumi] = Field(default_factory=list)
     points: list[Point] = Field(default_factory=list)
-    route: Route | None = None
+    itinerary: Itinerary | None = None
 
     # NEW: Bangumi-specific fields for direct bangumi search
     bangumi_id: str | None = None

--- a/apps/agent/src/animichi/interfaces/persistence.py
+++ b/apps/agent/src/animichi/interfaces/persistence.py
@@ -15,8 +15,8 @@ from pydantic_core import to_jsonable_python
 
 from animichi.agents.agent_result import AgentResult
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
     PointState,
-    RoutePayloadState,
     SearchPayloadState,
 )
 from animichi.domain.ports import (
@@ -111,7 +111,7 @@ async def persist_result(
 
     route_record = None
     if result is not None:
-        route_record = await maybe_persist_route(
+        route_record = await maybe_persist_itinerary(
             bangumi_repo=bangumi_repo,
             session_id=session_id,
             request=request,
@@ -276,7 +276,7 @@ async def load_session_state(
     return normalize_session_state(state)
 
 
-async def maybe_persist_route(
+async def maybe_persist_itinerary(
     *,
     bangumi_repo: BangumiRepo | None,
     session_id: str,
@@ -284,7 +284,7 @@ async def maybe_persist_route(
     result: AgentResult,
     response: PublicAPIResponse,
 ) -> dict[str, object] | None:
-    if result.provenance.route is None:
+    if result.provenance.itinerary is None:
         return None
     if not response.success and response.status != "partial":
         return None
@@ -305,11 +305,11 @@ async def maybe_persist_route(
     if not point_ids:
         return None
 
-    route_state = _current_route(result)
-    if route_state is None:
+    itinerary_state = _current_itinerary(result)
+    if itinerary_state is None:
         return None
     anime_ids = await _existing_anime_ids(
-        bangumi_repo, _route_anime_ids(result, route_state), session_id
+        bangumi_repo, _itinerary_anime_ids(result, itinerary_state), session_id
     )
     origin_station = request.origin
     if (
@@ -319,7 +319,7 @@ async def maybe_persist_route(
     ):
         origin_station = f"{request.origin_lat},{request.origin_lng}"
 
-    route_record: dict[str, object] = {
+    itinerary_record: dict[str, object] = {
         "route_id": None,
         "anime_ids": anime_ids,
         "origin_station": origin_station,
@@ -328,14 +328,14 @@ async def maybe_persist_route(
         "created_at": datetime.now(UTC).isoformat(),
     }
 
-    return route_record
+    return itinerary_record
 
 
-def _current_route(result: AgentResult) -> RoutePayloadState | None:
-    produced = result.provenance.route
+def _current_itinerary(result: AgentResult) -> ItineraryPayloadState | None:
+    produced = result.provenance.itinerary
     if produced is None:
         return None
-    return result.session_state.routes.get(produced.route_ref)
+    return result.session_state.itineraries.get(produced.itinerary_ref)
 
 
 async def _existing_anime_ids(
@@ -350,14 +350,16 @@ async def _existing_anime_ids(
         return []
 
 
-def _route_anime_ids(result: AgentResult, route: RoutePayloadState) -> list[str]:
+def _itinerary_anime_ids(
+    result: AgentResult, itinerary: ItineraryPayloadState
+) -> list[str]:
     source = (
-        result.session_state.search_results.get(route.source_ref)
-        if route.source_ref is not None
+        result.session_state.search_results.get(itinerary.source_ref)
+        if itinerary.source_ref is not None
         else None
     )
     if source is None:
-        return _distinct_work_ids(route.ordered_points)
+        return _distinct_work_ids(itinerary.ordered_points)
     return _search_anime_ids(source)
 
 

--- a/apps/agent/src/animichi/interfaces/public_api.py
+++ b/apps/agent/src/animichi/interfaces/public_api.py
@@ -42,7 +42,7 @@ from animichi.agents.runtime_deps import (
     TitleTranslator,
     new_step_call_id,
 )
-from animichi.agents.selected_route import execute_selected_route
+from animichi.agents.selected_route import execute_selected_itinerary
 from animichi.agents.selection import (
     SelectionError,
     execute_multi_selection,
@@ -560,7 +560,7 @@ class RuntimeAPI:
         context: dict[str, object] | None,
         on_step: OnStep | None,
     ) -> AgentResult:
-        return await execute_selected_route(
+        return await execute_selected_itinerary(
             point_ids=list(request.selected_point_ids or []),
             state=_selection_state(context),
             origin=request.origin,

--- a/apps/agent/src/animichi/interfaces/response_builder.py
+++ b/apps/agent/src/animichi/interfaces/response_builder.py
@@ -11,7 +11,7 @@ from animichi.agents.runtime_models import (
     PartialResponseModel,
 )
 from animichi.agents.session_state import (
-    RoutePayloadState,
+    ItineraryPayloadState,
     SearchPayloadState,
 )
 from animichi.application.errors import ApplicationError
@@ -49,7 +49,7 @@ def _search_wire(payload: SearchPayloadState) -> dict[str, object]:
     return data
 
 
-def _route_wire(payload: RoutePayloadState) -> dict[str, object]:
+def _itinerary_wire(payload: ItineraryPayloadState) -> dict[str, object]:
     data = payload.model_dump(mode="json")
     data["point_count"] = len(payload.ordered_points)
     data["status"] = "ok" if payload.ordered_points else "empty"
@@ -66,14 +66,14 @@ def _project_search(result: AgentResult) -> dict[str, object] | None:
     return _search_wire(payload) if payload is not None else None
 
 
-def _project_route(result: AgentResult) -> dict[str, object] | None:
-    produced = result.provenance.route
+def _project_itinerary(result: AgentResult) -> dict[str, object] | None:
+    produced = result.provenance.itinerary
     payload = (
-        result.session_state.routes.get(produced.route_ref)
+        result.session_state.itineraries.get(produced.itinerary_ref)
         if produced is not None
         else None
     )
-    return _route_wire(payload) if payload is not None else None
+    return _itinerary_wire(payload) if payload is not None else None
 
 
 def _clarify_data(result: AgentResult) -> dict[str, object]:
@@ -106,20 +106,20 @@ def _response_data(result: AgentResult) -> dict[str, object]:
         if search is not None:
             data["results"] = search
     if result.intent in {"plan_route", "plan_selected", "plan_multi"}:
-        route = _project_route(result)
-        if route is not None:
-            data["route"] = route
+        itinerary = _project_itinerary(result)
+        if itinerary is not None:
+            data["route"] = itinerary
     return data
 
 
 def _partial_data(result: AgentResult) -> dict[str, object]:
     data: dict[str, object] = {}
     search = _project_search(result)
-    route = _project_route(result)
+    itinerary = _project_itinerary(result)
     if search is not None:
         data["results"] = search
-    if route is not None:
-        data["route"] = route
+    if itinerary is not None:
+        data["route"] = itinerary
     return data
 
 

--- a/apps/agent/src/animichi/tests/eval/eval_harness.py
+++ b/apps/agent/src/animichi/tests/eval/eval_harness.py
@@ -265,11 +265,11 @@ agent_dataset = Dataset(name=DATASET_NAME, cases=CASES, evaluators=build_evaluat
 
 
 async def _selected_task(inp: AgentInput) -> AgentResult:
-    from animichi.agents.selected_route import execute_selected_route
+    from animichi.agents.selected_route import execute_selected_itinerary
     from animichi.agents.session_state import SessionState
     from animichi.tests.eval.mock_catalog_client import MockCatalogClient
 
-    return await execute_selected_route(
+    return await execute_selected_itinerary(
         point_ids=inp.selected_point_ids or [],
         state=SessionState(),
         origin=None,

--- a/apps/agent/src/animichi/tests/eval/evaluators.py
+++ b/apps/agent/src/animichi/tests/eval/evaluators.py
@@ -16,7 +16,7 @@ from pydantic_ai.settings import ModelSettings
 from pydantic_evals.evaluators import Evaluator, EvaluatorContext, LLMJudge
 
 from animichi.agents.agent_result import AgentResult
-from animichi.agents.session_state import RoutePayloadState, SearchPayloadState
+from animichi.agents.session_state import ItineraryPayloadState, SearchPayloadState
 from animichi.utils.language import resolve_reply_language
 
 EVALUATOR_VERSION = "official-v1"
@@ -121,12 +121,12 @@ def _available_data_keys(result: AgentResult) -> set[str]:
         pending = result.session_state.pending_clarification
         return {"reason", "candidates"} if pending is not None else set()
     search = _latest_search(result)
-    route = _latest_route(result)
+    itinerary = _latest_itinerary(result)
     keys: set[str] = set()
     if result.intent in {"search_bangumi", "search_nearby", "plan_multi"}:
         keys.update({"results"} if search is not None else set())
     if result.intent in {"plan_route", "plan_selected", "plan_multi"}:
-        keys.update({"route"} if route is not None else set())
+        keys.update({"route"} if itinerary is not None else set())
     return keys
 
 
@@ -137,11 +137,11 @@ def _latest_search(result: AgentResult) -> SearchPayloadState | None:
     return result.session_state.search_results.get(produced.result_ref)
 
 
-def _latest_route(result: AgentResult) -> RoutePayloadState | None:
-    produced = result.provenance.route
+def _latest_itinerary(result: AgentResult) -> ItineraryPayloadState | None:
+    produced = result.provenance.itinerary
     if produced is None:
         return None
-    return result.session_state.routes.get(produced.route_ref)
+    return result.session_state.itineraries.get(produced.itinerary_ref)
 
 
 def _acceptable_min_steps(ctx: _Ctx) -> list[int]:
@@ -182,14 +182,16 @@ class NonemptyResults(Evaluator[AgentInput, AgentResult, AgentExpected]):
 
 
 def _nonempty(result: AgentResult) -> bool:
-    route = _latest_route(result)
-    if route is None:
+    itinerary = _latest_itinerary(result)
+    if itinerary is None:
         search = _latest_search(result)
         return search is not None and search.row_count > 0
-    if route.source_ref is None:
+    if itinerary.source_ref is None:
         return False
-    source = result.session_state.search_results.get(route.source_ref)
-    return bool(route.ordered_points) and source is not None and source.row_count > 0
+    source = result.session_state.search_results.get(itinerary.source_ref)
+    return (
+        bool(itinerary.ordered_points) and source is not None and source.row_count > 0
+    )
 
 
 @dataclass

--- a/apps/agent/src/animichi/tests/eval/test_agent_eval_mock_runtime.py
+++ b/apps/agent/src/animichi/tests/eval/test_agent_eval_mock_runtime.py
@@ -25,8 +25,8 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from animichi.agents.agent_result import AgentResult
 from animichi.agents.animichi_runner import run_animichi_agent
 from animichi.agents.runtime_models import (
+    ItineraryResponseModel,
     QAResponseModel,
-    RouteResponseModel,
     SearchResponseModel,
 )
 from animichi.clients.catalog_client import CatalogClientProtocol
@@ -175,10 +175,10 @@ def _route_driver(title: str) -> FunctionModel:
 
 
 async def test_route_case_returns_route_output_via_catalog() -> None:
-    """A full resolve->search->route flow yields typed RouteResponse offline."""
+    """A full resolve->search->route flow yields typed ItineraryResponse offline."""
     result, catalog = await _run(
         _route_driver("響け！ユーフォニアム"), text="響けの聖地を巡るルート"
     )
-    assert isinstance(result.output, RouteResponseModel)
+    assert isinstance(result.output, ItineraryResponseModel)
     assert ("route", (("p004", "p005", "p006"), None)) in catalog.calls
     assert {name for name, _ in catalog.calls} <= _ALLOWED_CATALOG_METHODS

--- a/apps/agent/src/animichi/tests/integration/conftest.py
+++ b/apps/agent/src/animichi/tests/integration/conftest.py
@@ -15,18 +15,18 @@ from animichi.agents.agent_result import AgentResult, StepRecord
 from animichi.agents.runtime_deps import OnStep, StepEvent, new_step_call_id
 from animichi.agents.runtime_models import (
     ClarifyResponseModel,
+    ItineraryResponseModel,
     QAResponseModel,
-    RouteResponseModel,
     SearchResponseModel,
 )
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItineraryRef,
     NearbyGroupState,
     OrderedCandidate,
     PendingClarification,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchMetadataState,
     SearchPayloadState,
     SessionState,
@@ -143,12 +143,12 @@ def _make_agent_result(text: str, _locale: str) -> AgentResult:
         )
 
     if "路线" in text or "ルート" in text:
-        output = RouteResponseModel(message="已为你规划好 2 个巡礼点的路线。")
-        route_ref = RouteRef("route:test:1")
+        output = ItineraryResponseModel(message="已为你规划好 2 个巡礼点的路线。")
+        itinerary_ref = ItineraryRef("route:test:1")
         state = SessionState()
-        state.store_route(
-            route_ref,
-            RoutePayloadState(
+        state.store_itinerary(
+            itinerary_ref,
+            ItineraryPayloadState(
                 ordered_points=_ROUTE_POINTS,
                 timed_itinerary=TimedItineraryState(
                     total_minutes=75,

--- a/apps/agent/src/animichi/tests/integration/test_fact_ledger_persistence.py
+++ b/apps/agent/src/animichi/tests/integration/test_fact_ledger_persistence.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from animichi.agents.agent_result import AgentResult, StepRecord
-from animichi.agents.runtime_models import RouteResponseModel
+from animichi.agents.runtime_models import ItineraryResponseModel
 from animichi.agents.session_state import SessionState
 from animichi.domain.fact_ledger import record_turn_facts
 from animichi.infrastructure.session.memory import InMemorySessionStore
@@ -25,7 +25,7 @@ _SECOND_TURN = datetime(2026, 7, 28, 9, 31, tzinfo=UTC)
 
 def _turn_result(session: SessionState, *, pacing: str) -> AgentResult:
     return AgentResult(
-        output=RouteResponseModel(message="Routed."),
+        output=ItineraryResponseModel(message="Routed."),
         intent="plan_route",
         session_state=session,
         steps=[

--- a/apps/agent/src/animichi/tests/integration/test_tool_outcome_schemas.py
+++ b/apps/agent/src/animichi/tests/integration/test_tool_outcome_schemas.py
@@ -12,6 +12,11 @@ import pytest
 from pydantic import BaseModel
 
 from animichi.agents.tool_outcomes import (
+    ItineraryEmpty,
+    ItineraryOk,
+    ItineraryPendingSync,
+    ItineraryStaleRef,
+    ItineraryUpstreamDown,
     NearbyEmpty,
     NearbyMissingLocation,
     NearbyOk,
@@ -22,11 +27,6 @@ from animichi.agents.tool_outcomes import (
     ResolveNotFound,
     ResolveResolved,
     ResolveUpstreamDown,
-    RouteEmpty,
-    RouteOk,
-    RoutePendingSync,
-    RouteStaleRef,
-    RouteUpstreamDown,
     SearchEmpty,
     SearchOk,
     SearchUpstreamDown,
@@ -55,11 +55,14 @@ _MODELS_WITH_EXPECTED_PROPERTIES: tuple[_ModelWithProperties, ...] = (
     (NearbyPlaceUnresolved, frozenset({"outcome", "clarification_reason"})),
     (NearbyMissingLocation, frozenset({"outcome", "clarification_reason"})),
     (NearbyUpstreamDown, frozenset({"outcome"})),
-    (RouteOk, frozenset({"status", "route_ref", "point_count", "total_minutes"})),
-    (RouteEmpty, frozenset({"status"})),
-    (RouteStaleRef, frozenset({"status"})),
-    (RoutePendingSync, frozenset({"status"})),
-    (RouteUpstreamDown, frozenset({"status"})),
+    (
+        ItineraryOk,
+        frozenset({"status", "itinerary_ref", "point_count", "total_minutes"}),
+    ),
+    (ItineraryEmpty, frozenset({"status"})),
+    (ItineraryStaleRef, frozenset({"status"})),
+    (ItineraryPendingSync, frozenset({"status"})),
+    (ItineraryUpstreamDown, frozenset({"status"})),
     (
         TranslateTitleResult,
         frozenset({"original", "translated", "source", "confidence"}),

--- a/apps/agent/src/animichi/tests/unit/conftest_public_api.py
+++ b/apps/agent/src/animichi/tests/unit/conftest_public_api.py
@@ -9,7 +9,7 @@ import pytest
 
 from animichi.agents.agent_result import (
     AgentResult,
-    ProducedRoute,
+    ProducedItinerary,
     ProducedSearch,
     StepRecord,
     TurnProvenance,
@@ -17,19 +17,19 @@ from animichi.agents.agent_result import (
 from animichi.agents.runtime_models import (
     ClarifyResponseModel,
     GreetingResponseModel,
+    ItineraryResponseModel,
     QAResponseModel,
-    RouteResponseModel,
     RuntimeStageOutput,
     SearchResponseModel,
 )
 from animichi.agents.session_state import (
     CurrentAnime,
+    ItineraryPayloadState,
+    ItineraryRef,
     OrderedCandidate,
     PendingClarification,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchPayloadState,
     SessionState,
 )
@@ -44,7 +44,7 @@ def _build_output(intent: str, message: str, state: SessionState) -> RuntimeStag
     if intent in {"search_bangumi", "search_nearby"}:
         return SearchResponseModel(message=message)
     if intent in {"plan_route", "plan_selected", "plan_multi"}:
-        return RouteResponseModel(message=message)
+        return ItineraryResponseModel(message=message)
     if intent == "greet_user":
         return GreetingResponseModel(message=message)
     return QAResponseModel(message=message)
@@ -130,9 +130,11 @@ def _seed_route(state: SessionState, intent: str, rows: list[PointState]) -> Non
                 ),
             ),
         )
-    state.store_route(
-        RouteRef("route:test"),
-        RoutePayloadState(ordered_points=rows, source_ref=source_ref if rows else None),
+    state.store_itinerary(
+        ItineraryRef("itinerary:test"),
+        ItineraryPayloadState(
+            ordered_points=rows, source_ref=source_ref if rows else None
+        ),
     )
 
 
@@ -161,16 +163,18 @@ def make_result(
 
 def _provenance(intent: str, state: SessionState) -> TurnProvenance:
     search = None
-    route = None
+    itinerary = None
     if intent in {"search_bangumi", "search_nearby", "plan_multi"}:
         ref = state.last_result_ref
         if ref is not None:
             payload = state.search_results[ref]
             outcome: Literal["ok", "empty"] = "ok" if payload.row_count else "empty"
             search = ProducedSearch(outcome=outcome, result_ref=ref)
-    if intent in {"plan_route", "plan_selected", "plan_multi"} and state.route_lru:
-        route = ProducedRoute(status="ok", route_ref=state.route_lru[-1])
-    return TurnProvenance(search=search, route=route)
+    if intent in {"plan_route", "plan_selected", "plan_multi"} and state.itinerary_lru:
+        itinerary = ProducedItinerary(
+            status="ok", itinerary_ref=state.itinerary_lru[-1]
+        )
+    return TurnProvenance(search=search, itinerary=itinerary)
 
 
 def make_fake_agent(

--- a/apps/agent/src/animichi/tests/unit/eval_evaluator_fixtures.py
+++ b/apps/agent/src/animichi/tests/unit/eval_evaluator_fixtures.py
@@ -8,7 +8,7 @@ from pydantic_evals.otel.span_tree import SpanNode, SpanTree
 
 from animichi.agents.agent_result import (
     AgentResult,
-    ProducedRoute,
+    ProducedItinerary,
     ProducedSearch,
     StepRecord,
     TurnProvenance,
@@ -41,15 +41,17 @@ def result(
 
 def _provenance(intent: str, state: SessionState) -> TurnProvenance:
     search = None
-    route = None
+    itinerary = None
     if intent in {"search_bangumi", "search_nearby", "plan_multi"}:
         ref = state.last_result_ref
         if ref is not None:
             outcome = "ok" if state.search_results[ref].row_count else "empty"
             search = ProducedSearch(outcome=outcome, result_ref=ref)
-    if intent in {"plan_route", "plan_selected", "plan_multi"} and state.route_lru:
-        route = ProducedRoute(status="ok", route_ref=state.route_lru[-1])
-    return TurnProvenance(search=search, route=route)
+    if intent in {"plan_route", "plan_selected", "plan_multi"} and state.itinerary_lru:
+        itinerary = ProducedItinerary(
+            status="ok", itinerary_ref=state.itinerary_lru[-1]
+        )
+    return TurnProvenance(search=search, itinerary=itinerary)
 
 
 def ctx(

--- a/apps/agent/src/animichi/tests/unit/test_catalog_adapter.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_adapter.py
@@ -6,7 +6,7 @@ import pytest
 
 from animichi.agents.catalog_adapter import (
     build_itinerary_payload,
-    build_route_state,
+    build_itinerary_state,
     build_search_payload,
     build_search_state,
 )
@@ -79,7 +79,7 @@ def test_search_state_localizes_catalog_city_at_trusted_boundary(
 async def test_route_state_localizes_catalog_city_at_trusted_boundary() -> None:
     route = await MockCatalogClient().plan_itinerary(["p004"])
     route.ordered_points[0].city = "Tokyo"
-    state = build_route_state(route, source_ref=None, locale="ja")
+    state = build_itinerary_state(route, source_ref=None, locale="ja")
     assert state.ordered_points[0].city == "東京"
 
 

--- a/apps/agent/src/animichi/tests/unit/test_catalog_geocoding_agent.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_geocoding_agent.py
@@ -8,8 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pydantic_ai import RunContext
 
-from animichi.agents.agent_result import RejectedRoute, RejectedSearch
-from animichi.agents.catalog_route_tools import run_route
+from animichi.agents.agent_result import RejectedItinerary, RejectedSearch
+from animichi.agents.catalog_route_tools import run_itinerary
 from animichi.agents.catalog_tools import run_nearby_search, run_resolve
 from animichi.agents.runtime_deps import RuntimeDeps
 from animichi.agents.session_state import (
@@ -152,13 +152,13 @@ async def test_place_ambiguity_stages_coords_and_pending_in_same_outcome() -> No
 async def test_route_never_uses_hidden_last_result_default() -> None:
     deps = _deps()
     deps.tool_state.session = SessionState()
-    outcome = await run_route(_ctx(deps), MockCatalogClient(), "missing-ref", None)
+    outcome = await run_itinerary(_ctx(deps), MockCatalogClient(), "missing-ref", None)
     await project_tool_result(
         deps, "plan_route", {"search_result_ref": "missing-ref"}, outcome
     )
     assert outcome.status == "stale_ref"
     assert deps.steps[-1].is_success is True
-    assert isinstance(deps.steps[-1].provenance, RejectedRoute)
+    assert isinstance(deps.steps[-1].provenance, RejectedItinerary)
 
 
 async def test_empty_route_is_a_successful_typed_step() -> None:
@@ -168,13 +168,13 @@ async def test_empty_route_is_a_successful_typed_step() -> None:
         ref, SearchPayloadState(kind="bangumi", rows=[], row_count=0)
     )
 
-    outcome = await run_route(_ctx(deps), MockCatalogClient(), str(ref), None)
+    outcome = await run_itinerary(_ctx(deps), MockCatalogClient(), str(ref), None)
     await project_tool_result(
         deps, "plan_route", {"search_result_ref": str(ref)}, outcome
     )
 
     assert (outcome.status, deps.steps[-1].is_success) == ("empty", True)
-    assert isinstance(deps.steps[-1].provenance, RejectedRoute)
+    assert isinstance(deps.steps[-1].provenance, RejectedItinerary)
 
 
 async def test_catalog_empty_itinerary_is_a_typed_route_empty() -> None:
@@ -198,14 +198,14 @@ async def test_catalog_empty_itinerary_is_a_typed_route_empty() -> None:
 
     catalog = _EmptyItineraryCatalog()
 
-    outcome = await run_route(_ctx(deps), catalog, str(ref), None)
+    outcome = await run_itinerary(_ctx(deps), catalog, str(ref), None)
     await project_tool_result(
         deps, "plan_route", {"search_result_ref": str(ref)}, outcome
     )
 
     assert outcome.status == "empty"
     assert ("plan_itinerary", (("p004",), None, None)) in catalog.calls
-    assert isinstance(deps.steps[-1].provenance, RejectedRoute)
+    assert isinstance(deps.steps[-1].provenance, RejectedItinerary)
 
 
 async def test_partial_route_is_pending_sync_and_never_calls_catalog_route() -> None:
@@ -222,14 +222,14 @@ async def test_partial_route_is_pending_sync_and_never_calls_catalog_route() -> 
     )
     catalog = MockCatalogClient()
 
-    outcome = await run_route(_ctx(deps), catalog, str(ref), None)
+    outcome = await run_itinerary(_ctx(deps), catalog, str(ref), None)
     await project_tool_result(
         deps, "plan_route", {"search_result_ref": str(ref)}, outcome
     )
 
     assert outcome.status == "pending_sync"
     assert all(call[0] != "plan_itinerary" for call in catalog.calls)
-    assert isinstance(deps.steps[-1].provenance, RejectedRoute)
+    assert isinstance(deps.steps[-1].provenance, RejectedItinerary)
 
 
 async def test_route_threads_optional_pacing_to_catalog() -> None:
@@ -240,6 +240,6 @@ async def test_route_threads_optional_pacing_to_catalog() -> None:
         SearchPayloadState(kind="bangumi", rows=[PointState(id="p004")], row_count=1),
     )
     catalog = MockCatalogClient()
-    outcome = await run_route(_ctx(deps), catalog, str(ref), "packed")
+    outcome = await run_itinerary(_ctx(deps), catalog, str(ref), "packed")
     assert outcome.status == "ok"
     assert ("plan_itinerary", (("p004",), None, "packed")) in catalog.calls

--- a/apps/agent/src/animichi/tests/unit/test_catalog_tool_upstream_degradation.py
+++ b/apps/agent/src/animichi/tests/unit/test_catalog_tool_upstream_degradation.py
@@ -8,28 +8,28 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic_ai import ModelRetry
 
-from animichi.agents.agent_result import RejectedRoute, RejectedSearch
+from animichi.agents.agent_result import RejectedItinerary, RejectedSearch
 from animichi.agents.animichi_agent import validate_output
 from animichi.agents.animichi_runner import runtime_stage
-from animichi.agents.catalog_route_tools import run_route
+from animichi.agents.catalog_route_tools import run_itinerary
 from animichi.agents.catalog_tools import run_nearby_search
 from animichi.agents.runtime_deps import RuntimeDeps
 from animichi.agents.runtime_models import (
     ClarifyResponseModel,
+    ItineraryResponseModel,
     QAResponseModel,
-    RouteResponseModel,
     SearchResponseModel,
 )
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItineraryRef,
     OrderedCandidate,
     PendingClarification,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchPayloadState,
 )
-from animichi.agents.tool_outcomes import NearbyUpstreamDown, RouteUpstreamDown
+from animichi.agents.tool_outcomes import ItineraryUpstreamDown, NearbyUpstreamDown
 from animichi.clients.catalog_client import GeocodeCandidate, Itinerary, Point
 from animichi.clients.errors import APIError
 from animichi.tests.eval.mock_catalog_client import MockCatalogClient
@@ -132,19 +132,21 @@ async def test_route_api_error_becomes_route_upstream_down() -> None:
         ref,
         SearchPayloadState(kind="nearby", rows=[PointState(id="p1")], row_count=1),
     )
-    deps.tool_state.session.store_route(RouteRef("route:prior"), RoutePayloadState())
+    deps.tool_state.session.store_itinerary(
+        ItineraryRef("route:prior"), ItineraryPayloadState()
+    )
 
-    outcome = await run_route(tool_context(deps), catalog, str(ref), None)
+    outcome = await run_itinerary(tool_context(deps), catalog, str(ref), None)
     await project_tool_result(
         deps, "plan_route", {"search_result_ref": str(ref)}, outcome
     )
 
-    assert isinstance(outcome, RouteUpstreamDown)
+    assert isinstance(outcome, ItineraryUpstreamDown)
     assert deps.steps[-1].data == {"status": "upstream_unavailable"}
-    assert isinstance(deps.steps[-1].provenance, RejectedRoute)
+    assert isinstance(deps.steps[-1].provenance, RejectedItinerary)
     assert deps.tool_state.session.pending_clarification is None
     context = MagicMock(deps=deps)
-    stale_route = RouteResponseModel(message="stale")
+    stale_route = ItineraryResponseModel(message="stale")
     with pytest.raises(ModelRetry):
         await validate_output(context, stale_route)
     with pytest.raises(ModelRetry):

--- a/apps/agent/src/animichi/tests/unit/test_chat_wire_contract.py
+++ b/apps/agent/src/animichi/tests/unit/test_chat_wire_contract.py
@@ -11,9 +11,9 @@ import pytest
 from animichi.agents.agent_result import AgentResult
 from animichi.agents.runtime_models import BlockedResponseModel, PartialResponseModel
 from animichi.agents.session_state import (
+    ItinerarySummaryState,
     NearbyGroupState,
     OrderedCandidate,
-    RouteSummaryState,
     SearchMetadataState,
     SessionState,
 )
@@ -98,14 +98,14 @@ def _enrich_search(result: AgentResult) -> None:
 
 
 def _enrich_route(result: AgentResult) -> None:
-    if not result.session_state.route_lru:
+    if not result.session_state.itinerary_lru:
         return
-    route = result.session_state.routes[result.session_state.route_lru[-1]]
+    route = result.session_state.itineraries[result.session_state.itinerary_lru[-1]]
     route.summary = _route_summary()
 
 
-def _route_summary() -> RouteSummaryState:
-    return RouteSummaryState(
+def _route_summary() -> ItinerarySummaryState:
+    return ItinerarySummaryState(
         point_count=1,
         total_minutes=1,
         total_distance_m=1.0,

--- a/apps/agent/src/animichi/tests/unit/test_entities.py
+++ b/apps/agent/src/animichi/tests/unit/test_entities.py
@@ -11,9 +11,9 @@ from animichi.domain.entities import (
     AnimichiSession,
     Bangumi,
     Coordinates,
+    Itinerary,
+    ItinerarySegment,
     Point,
-    Route,
-    RouteSegment,
     Station,
     TransportInfo,
 )
@@ -337,11 +337,11 @@ class TestTransportInfo:
 
 
 class TestRoute:
-    """Test Route entity and related components."""
+    """Test Itinerary entity and related components."""
 
     @pytest.fixture
     def sample_route_data(self):
-        """Create sample data for route testing."""
+        """Create sample data for itinerary testing."""
         station = Station(
             name="Tokyo Station",
             coordinates=Coordinates(latitude=35.6812, longitude=139.7671),
@@ -379,7 +379,7 @@ class TestRoute:
                 cumulative_distance += transport.distance_km
                 cumulative_duration += transport.duration_minutes
 
-            segment = RouteSegment(
+            segment = ItinerarySegment(
                 order=i,
                 point=point,
                 transport=transport,
@@ -391,27 +391,27 @@ class TestRoute:
         return station, segments
 
     def test_create_route(self, sample_route_data):
-        """Test creating a route."""
+        """Test creating a itinerary."""
         station, segments = sample_route_data
 
-        route = Route(
+        itinerary = Itinerary(
             origin=station,
             segments=segments,
             total_distance_km=10.5,
             total_duration_minutes=90,
-            google_maps_url="https://maps.google.com/route",
+            google_maps_url="https://maps.google.com/itinerary",
         )
 
-        assert route.origin == station
-        assert len(route.segments) == 4
-        assert route.total_distance_km == 10.5
-        assert route.total_duration_minutes == 90
+        assert itinerary.origin == station
+        assert len(itinerary.segments) == 4
+        assert itinerary.total_distance_km == 10.5
+        assert itinerary.total_duration_minutes == 90
 
     def test_route_duration_formatted(self, sample_route_data):
-        """Test route duration formatting."""
+        """Test itinerary duration formatting."""
         station, segments = sample_route_data
 
-        route1 = Route(
+        route1 = Itinerary(
             origin=station,
             segments=segments,
             total_distance_km=10.5,
@@ -419,7 +419,7 @@ class TestRoute:
         )
         assert route1.total_duration_formatted == "45min"
 
-        route2 = Route(
+        route2 = Itinerary(
             origin=station,
             segments=segments,
             total_distance_km=20,
@@ -428,43 +428,43 @@ class TestRoute:
         assert route2.total_duration_formatted == "2h 5min"
 
     def test_route_points_count(self, sample_route_data):
-        """Test counting points in route."""
+        """Test counting points in itinerary."""
         station, segments = sample_route_data
 
-        route = Route(
+        itinerary = Itinerary(
             origin=station,
             segments=segments,
             total_distance_km=10.5,
             total_duration_minutes=90,
         )
-        assert route.points_count == 4
+        assert itinerary.points_count == 4
 
     def test_route_groups_points_by_bangumi(self, sample_route_data):
-        """Test that route groups points into the correct number of bangumi groups."""
+        """Test that itinerary groups points into the correct number of bangumi groups."""
         station, segments = sample_route_data
 
-        route = Route(
+        itinerary = Itinerary(
             origin=station,
             segments=segments,
             total_distance_km=10.5,
             total_duration_minutes=90,
         )
 
-        groups = route.get_bangumi_groups()
+        groups = itinerary.get_bangumi_groups()
         assert len(groups) == 2, f"Expected 2 bangumi groups, got {len(groups)}"
 
     def test_route_group_keys_match_bangumi_ids(self, sample_route_data):
-        """Test that bangumi group keys match the bangumi IDs in the route."""
+        """Test that bangumi group keys match the bangumi IDs in the itinerary."""
         station, segments = sample_route_data
 
-        route = Route(
+        itinerary = Itinerary(
             origin=station,
             segments=segments,
             total_distance_km=10.5,
             total_duration_minutes=90,
         )
 
-        groups = route.get_bangumi_groups()
+        groups = itinerary.get_bangumi_groups()
         assert "BG001" in groups, "Expected BG001 in bangumi groups"
         assert "BG002" in groups, "Expected BG002 in bangumi groups"
 
@@ -472,14 +472,14 @@ class TestRoute:
         """Test that each bangumi group contains the correct number of points."""
         station, segments = sample_route_data
 
-        route = Route(
+        itinerary = Itinerary(
             origin=station,
             segments=segments,
             total_distance_km=10.5,
             total_duration_minutes=90,
         )
 
-        groups = route.get_bangumi_groups()
+        groups = itinerary.get_bangumi_groups()
         assert len(groups["BG001"]) == 2, (
             f"Expected 2 points in BG001, got {len(groups['BG001'])}"
         )
@@ -500,7 +500,7 @@ class TestAnimichiSession:
         assert session.search_radius_km == 5.0
         assert session.nearby_bangumi == []
         assert session.points == []
-        assert session.route is None
+        assert session.itinerary is None
         assert isinstance(session.created_at, datetime)
         assert isinstance(session.updated_at, datetime)
 

--- a/apps/agent/src/animichi/tests/unit/test_eval_evaluators_component.py
+++ b/apps/agent/src/animichi/tests/unit/test_eval_evaluators_component.py
@@ -10,12 +10,12 @@ from animichi.agents.agent_result import AgentResult
 from animichi.agents.base import parse_model_spec
 from animichi.agents.runtime_models import QAResponseModel, SearchResponseModel
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItineraryRef,
     OrderedCandidate,
     PendingClarification,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchPayloadState,
     SessionState,
 )
@@ -62,9 +62,9 @@ def _route_result(source_rows: int, route_rows: int, *, intent: str) -> AgentRes
         source_rows, kind="multi" if intent == "plan_multi" else "bangumi"
     )
     source_ref = state.last_result_ref
-    state.store_route(
-        RouteRef("route:1"),
-        RoutePayloadState(
+    state.store_itinerary(
+        ItineraryRef("route:1"),
+        ItineraryPayloadState(
             ordered_points=[PointState(id=f"r-{index}") for index in range(route_rows)],
             source_ref=source_ref,
         ),

--- a/apps/agent/src/animichi/tests/unit/test_model_layer_phase3.py
+++ b/apps/agent/src/animichi/tests/unit/test_model_layer_phase3.py
@@ -163,7 +163,8 @@ async def test_override_helpers_forward_the_shared_client() -> None:
     # `test_injected_title_translator_runs_on_the_server_model`, asserted on the
     # context that is actually supplied rather than on its absence.
     with patch(
-        "animichi.agents.route_area_splitter.route_planner_agent.run", new=AsyncMock()
+        "animichi.agents.route_area_splitter.itinerary_planner_agent.run",
+        new=AsyncMock(),
     ) as run:
         run.return_value.output = SimpleNamespace(areas=[])
         await split_into_areas([{} for _ in range(11)], model=model)

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_output_contract.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_output_contract.py
@@ -15,8 +15,8 @@ from animichi.agents.runtime_deps import RuntimeDeps
 from animichi.agents.runtime_models import (
     ClarifyResponseModel,
     GreetingResponseModel,
+    ItineraryResponseModel,
     QAResponseModel,
-    RouteResponseModel,
     SearchResponseModel,
 )
 from animichi.agents.session_state import (
@@ -39,7 +39,7 @@ def _deps(state: SessionState | None = None) -> RuntimeDeps:
     "output",
     [
         SearchResponseModel(message="Found matching spots."),
-        RouteResponseModel(message="Your route is ready."),
+        ItineraryResponseModel(message="Your route is ready."),
         GreetingResponseModel(message="Hello."),
         QAResponseModel(message="A complete answer with no schema length cap."),
     ],
@@ -80,7 +80,7 @@ def test_compact_outputs_forbid_historical_fields() -> None:
             "search_nearby",
         ),
         (
-            RouteResponseModel(message="x"),
+            ItineraryResponseModel(message="x"),
             [StepRecord("plan_route", True)],
             "plan_route",
         ),

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_route_persistence.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_route_persistence.py
@@ -5,17 +5,17 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from animichi.agents.agent_result import AgentResult, ProducedRoute, TurnProvenance
-from animichi.agents.runtime_models import RouteResponseModel
+from animichi.agents.agent_result import AgentResult, ProducedItinerary, TurnProvenance
+from animichi.agents.runtime_models import ItineraryResponseModel
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItineraryRef,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchPayloadState,
     SessionState,
 )
-from animichi.interfaces.persistence import maybe_persist_route
+from animichi.interfaces.persistence import maybe_persist_itinerary
 from animichi.interfaces.response_builder import agent_result_to_response
 from animichi.interfaces.schemas import PublicAPIRequest
 
@@ -33,19 +33,21 @@ def _route_result(
     source_ref = ResultRef("search:test")
     if source is not None:
         state.store_search_result(source_ref, source)
-    state.store_route(
-        RouteRef("route:test"),
-        RoutePayloadState(
+    state.store_itinerary(
+        ItineraryRef("route:test"),
+        ItineraryPayloadState(
             ordered_points=route_rows,
             source_ref=source_ref if source is not None else None,
         ),
     )
     return AgentResult(
-        output=RouteResponseModel(message="Route ready."),
+        output=ItineraryResponseModel(message="Route ready."),
         intent=intent,
         session_state=state,
         provenance=TurnProvenance(
-            route=ProducedRoute(status="ok", route_ref=RouteRef("route:test"))
+            itinerary=ProducedItinerary(
+                status="ok", itinerary_ref=ItineraryRef("route:test")
+            )
         ),
     )
 
@@ -96,7 +98,7 @@ async def test_route_intents_derive_associations_from_typed_state(
 ) -> None:
     result = _route_result(intent, route_rows, source)
     response = agent_result_to_response(result, include_debug=False)
-    record = await maybe_persist_route(
+    record = await maybe_persist_itinerary(
         bangumi_repo=None,
         session_id="session-id",
         request=PublicAPIRequest(text="route these"),
@@ -116,7 +118,7 @@ async def test_route_persistence_filters_missing_anime_foreign_keys() -> None:
     response = agent_result_to_response(result, include_debug=False)
     db = MagicMock()
     db.bangumi.filter_existing_ids = AsyncMock(return_value=["1"])
-    record = await maybe_persist_route(
+    record = await maybe_persist_itinerary(
         bangumi_repo=db.bangumi,
         session_id="session-id",
         request=PublicAPIRequest(text="route these"),

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_selection_handlers.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_selection_handlers.py
@@ -149,7 +149,7 @@ async def test_empty_itinerary_is_error_terminal_without_route_write() -> None:
 
     assert (result.status, result.success) == ("error", False)
     assert ("plan_itinerary", (("a",), None, None)) in catalog.calls
-    assert not state.routes
+    assert not state.itineraries
     assert state.pending_clarification is not None
 
 

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_selection_handlers.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_selection_handlers.py
@@ -6,12 +6,12 @@ from typing import Literal
 
 from animichi.agents.selection import execute_multi_selection, execute_place_selection
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItineraryRef,
     OrderedCandidate,
     PendingClarification,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchPayloadState,
     SessionState,
 )
@@ -125,7 +125,7 @@ async def test_all_empty_is_t4_and_preserves_pending() -> None:
     )
     assert (result.status, result.success) == ("empty", False)
     assert state.pending_clarification is not None
-    assert not state.routes
+    assert not state.itineraries
 
 
 async def test_empty_itinerary_is_error_terminal_without_route_write() -> None:
@@ -166,9 +166,9 @@ async def test_t4_does_not_project_a_route_from_a_prior_turn() -> None:
             anime_id="old-anime",
         ),
     )
-    state.store_route(
-        RouteRef("route:prior:1"),
-        RoutePayloadState(
+    state.store_itinerary(
+        ItineraryRef("route:prior:1"),
+        ItineraryPayloadState(
             ordered_points=[PointState(id="old-point", bangumi_id="old-anime")],
             source_ref=prior_result_ref,
         ),

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_terminal_matrix.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_terminal_matrix.py
@@ -20,14 +20,14 @@ async def test_500_points_routes_but_501_does_not() -> None:
         candidate_ids=["1"], state=_pending(), locale="en", catalog=catalog
     )
     assert routed.success is True
-    assert len(routed.session_state.routes) == 1
+    assert len(routed.session_state.itineraries) == 1
     catalog = _Catalog({"1": SearchResult(rows=five_hundred + [_point("500", "1")])})
     rejected = await execute_multi_selection(
         candidate_ids=["1"], state=_pending(), locale="en", catalog=catalog
     )
     assert (rejected.status, rejected.success) == ("too_large", False)
     assert (rejected.steps[-1].is_success, rejected.steps[-1].error) == (True, None)
-    assert not rejected.session_state.routes
+    assert not rejected.session_state.itineraries
 
 
 async def test_50_cluster_success_and_typed_51_cluster_rejection() -> None:
@@ -116,7 +116,7 @@ async def test_t5_preserves_pending_and_writes_no_registry_refs() -> None:
         "Catalog fetch failed",
     )
     assert state.pending_clarification is not None
-    assert not state.search_results and not state.routes
+    assert not state.search_results and not state.itineraries
 
 
 async def test_route_transport_failure_is_typed_and_preserves_pending() -> None:

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_tool_outcomes.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_tool_outcomes.py
@@ -6,9 +6,9 @@ import pytest
 from pydantic import TypeAdapter, ValidationError
 
 from animichi.agents.tool_outcomes import (
+    ItineraryToolResult,
     NearbyToolResult,
     ResolveResult,
-    RouteToolResult,
     SearchToolResult,
 )
 
@@ -91,7 +91,7 @@ def test_nearby_result_partition(payload: dict[str, object]) -> None:
     [
         {
             "status": "ok",
-            "route_ref": "route:1",
+            "itinerary_ref": "route:1",
             "point_count": 2,
             "total_minutes": 30,
         },
@@ -102,6 +102,6 @@ def test_nearby_result_partition(payload: dict[str, object]) -> None:
 )
 def test_route_result_partition(payload: dict[str, object]) -> None:
     assert (
-        TypeAdapter(RouteToolResult).validate_python(payload).status
+        TypeAdapter(ItineraryToolResult).validate_python(payload).status
         == payload["status"]
     )

--- a/apps/agent/src/animichi/tests/unit/test_phase1c_validator.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1c_validator.py
@@ -10,15 +10,15 @@ from animichi.agents.animichi_agent import validate_output
 from animichi.agents.runtime_deps import RuntimeDeps
 from animichi.agents.runtime_models import (
     ClarifyResponseModel,
-    RouteResponseModel,
+    ItineraryResponseModel,
     SearchResponseModel,
 )
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItineraryRef,
     OrderedCandidate,
     PendingClarification,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchPayloadState,
     SessionState,
 )
@@ -53,22 +53,22 @@ def _context(state: SessionState, steps: list[StepRecord]) -> MagicMock:
             [],
         ),
         (
-            RouteResponseModel(message="x"),
+            ItineraryResponseModel(message="x"),
             SessionState(),
             [StepRecord("plan_route", True)],
         ),
         (
-            RouteResponseModel(message="x"),
+            ItineraryResponseModel(message="x"),
             SessionState(
-                routes={RouteRef("route:1"): RoutePayloadState()},
-                route_lru=[RouteRef("route:1")],
+                itineraries={ItineraryRef("route:1"): ItineraryPayloadState()},
+                itinerary_lru=[ItineraryRef("route:1")],
             ),
             [],
         ),
     ],
 )
 async def test_search_and_route_reject_step_or_registry_fabrication(
-    output: SearchResponseModel | RouteResponseModel,
+    output: SearchResponseModel | ItineraryResponseModel,
     state: SessionState,
     steps: list[StepRecord],
 ) -> None:

--- a/apps/agent/src/animichi/tests/unit/test_phase1d_partial.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1d_partial.py
@@ -10,15 +10,15 @@ from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai.usage import RunUsage
 
 import animichi.agents.animichi_runner as runner
-from animichi.agents.agent_result import ProducedRoute, ProducedSearch, StepRecord
+from animichi.agents.agent_result import ProducedItinerary, ProducedSearch, StepRecord
 from animichi.agents.animichi_agent import RuntimeOutput
 from animichi.agents.runtime_deps import RuntimeDeps
 from animichi.agents.runtime_models import PartialResponseModel, SearchResponseModel
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItineraryRef,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchPayloadState,
     SessionState,
 )
@@ -61,16 +61,16 @@ async def _usage_limit_run(*_args: object, **kwargs: object) -> NoReturn:
 async def _route_usage_limit_run(*_args: object, **kwargs: object) -> NoReturn:
     deps = kwargs["deps"]
     assert isinstance(deps, RuntimeDeps)
-    ref = RouteRef("route:new")
-    deps.tool_state.session.store_route(
+    ref = ItineraryRef("route:new")
+    deps.tool_state.session.store_itinerary(
         ref,
-        RoutePayloadState(ordered_points=[PointState(id="new", bangumi_id="1")]),
+        ItineraryPayloadState(ordered_points=[PointState(id="new", bangumi_id="1")]),
     )
     deps.steps.append(
         StepRecord(
             "plan_route",
             True,
-            provenance=ProducedRoute(status="ok", route_ref=ref),
+            provenance=ProducedItinerary(status="ok", itinerary_ref=ref),
         )
     )
     raise UsageLimitExceeded("request limit reached")
@@ -159,9 +159,9 @@ async def test_usage_limit_projects_current_route_over_stale_route(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     state = SessionState()
-    state.store_route(
-        RouteRef("route:old"),
-        RoutePayloadState(ordered_points=[PointState(id="old", bangumi_id="1")]),
+    state.store_itinerary(
+        ItineraryRef("route:old"),
+        ItineraryPayloadState(ordered_points=[PointState(id="old", bangumi_id="1")]),
     )
     _install_run(monkeypatch, _route_usage_limit_run)
     result = await runner.run_animichi_agent(

--- a/apps/agent/src/animichi/tests/unit/test_phase1d_persistence.py
+++ b/apps/agent/src/animichi/tests/unit/test_phase1d_persistence.py
@@ -7,13 +7,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from pydantic_ai.messages import ModelRequest, UserPromptPart
 
-from animichi.agents.agent_result import AgentResult, ProducedRoute, TurnProvenance
+from animichi.agents.agent_result import AgentResult, ProducedItinerary, TurnProvenance
 from animichi.agents.runtime_models import BlockedResponseModel, PartialResponseModel
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItineraryRef,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchPayloadState,
     SessionState,
 )
@@ -24,7 +24,7 @@ from animichi.interfaces.public_api import PublicAPIRequest, RuntimeAPI
 
 def _partial_route_result() -> AgentResult:
     search_ref = ResultRef("search:partial")
-    route_ref = RouteRef("route:partial")
+    itinerary_ref = ItineraryRef("route:partial")
     state = SessionState()
     state.store_search_result(
         search_ref,
@@ -35,9 +35,9 @@ def _partial_route_result() -> AgentResult:
             anime_id="1",
         ),
     )
-    state.store_route(
-        route_ref,
-        RoutePayloadState(
+    state.store_itinerary(
+        itinerary_ref,
+        ItineraryPayloadState(
             ordered_points=[PointState(id="p1", bangumi_id="1")],
             source_ref=search_ref,
         ),
@@ -49,7 +49,7 @@ def _partial_route_result() -> AgentResult:
         status="partial",
         success_override=False,
         provenance=TurnProvenance(
-            route=ProducedRoute(status="ok", route_ref=route_ref)
+            itinerary=ProducedItinerary(status="ok", itinerary_ref=itinerary_ref)
         ),
     )
 

--- a/apps/agent/src/animichi/tests/unit/test_public_api_pipeline.py
+++ b/apps/agent/src/animichi/tests/unit/test_public_api_pipeline.py
@@ -92,7 +92,7 @@ async def test_selected_point_ids_bypass_planner(mock_db: MagicMock) -> None:
             PointState(id="p1", name="A", latitude=34.88, longitude=135.80),
             PointState(id="p2", name="B", latitude=34.89, longitude=135.81),
         ]
-        itinerary_ref = ItineraryRef("itinerary:selected")
+        itinerary_ref = ItineraryRef("route:selected")
         itinerary_state = SessionState(
             itineraries={itinerary_ref: ItineraryPayloadState(ordered_points=points)},
             itinerary_lru=[itinerary_ref],

--- a/apps/agent/src/animichi/tests/unit/test_public_api_pipeline.py
+++ b/apps/agent/src/animichi/tests/unit/test_public_api_pipeline.py
@@ -11,11 +11,11 @@ from structlog import testing
 
 from animichi.agents.agent_result import AgentResult, StepRecord
 from animichi.agents.animichi_runner import run_animichi_agent
-from animichi.agents.runtime_models import RouteResponseModel
+from animichi.agents.runtime_models import ItineraryResponseModel
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItineraryRef,
     PointState,
-    RoutePayloadState,
-    RouteRef,
     SessionState,
 )
 from animichi.infrastructure.session.memory import InMemorySessionStore
@@ -92,21 +92,21 @@ async def test_selected_point_ids_bypass_planner(mock_db: MagicMock) -> None:
             PointState(id="p1", name="A", latitude=34.88, longitude=135.80),
             PointState(id="p2", name="B", latitude=34.89, longitude=135.81),
         ]
-        route_ref = RouteRef("route:selected")
-        route_state = SessionState(
-            routes={route_ref: RoutePayloadState(ordered_points=points)},
-            route_lru=[route_ref],
+        itinerary_ref = ItineraryRef("itinerary:selected")
+        itinerary_state = SessionState(
+            itineraries={itinerary_ref: ItineraryPayloadState(ordered_points=points)},
+            itinerary_lru=[itinerary_ref],
         )
-        output = RouteResponseModel(message="已为2处选定取景地规划路线。")
+        output = ItineraryResponseModel(message="已为2处选定取景地规划路线。")
         return AgentResult(
             output=output,
             intent="plan_selected",
-            session_state=route_state,
+            session_state=itinerary_state,
             steps=[
                 StepRecord(
                     tool="plan_selected",
                     is_success=True,
-                    data={"route_ref": str(route_ref)},
+                    data={"route_ref": str(itinerary_ref)},
                 )
             ],
         )
@@ -117,7 +117,7 @@ async def test_selected_point_ids_bypass_planner(mock_db: MagicMock) -> None:
             new=AsyncMock(side_effect=AssertionError("planner should be bypassed")),
         ),
         patch(
-            "animichi.interfaces.public_api.execute_selected_route",
+            "animichi.interfaces.public_api.execute_selected_itinerary",
             new=AsyncMock(side_effect=fake_selected_route),
         ),
     ):

--- a/apps/agent/src/animichi/tests/unit/test_response_builder.py
+++ b/apps/agent/src/animichi/tests/unit/test_response_builder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from animichi.agents.agent_result import (
     AgentResult,
-    ProducedRoute,
+    ProducedItinerary,
     ProducedSearch,
     StepRecord,
     TurnProvenance,
@@ -12,17 +12,17 @@ from animichi.agents.agent_result import (
 from animichi.agents.runtime_models import (
     ClarifyResponseModel,
     ErrorResponseModel,
+    ItineraryResponseModel,
     QAResponseModel,
-    RouteResponseModel,
     SearchResponseModel,
 )
 from animichi.agents.session_state import (
+    ItineraryPayloadState,
+    ItineraryRef,
     OrderedCandidate,
     PendingClarification,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchPayloadState,
     SessionState,
 )
@@ -49,9 +49,9 @@ def _search_state(*, empty: bool = False, kind: str = "bangumi") -> SessionState
 
 def _route_state(*, multi: bool = False) -> SessionState:
     state = _search_state(kind="multi" if multi else "bangumi")
-    state.store_route(
-        RouteRef("route:1"),
-        RoutePayloadState(
+    state.store_itinerary(
+        ItineraryRef("itinerary:1"),
+        ItineraryPayloadState(
             ordered_points=[PointState(id="p1", bangumi_id="1")],
             source_ref=state.last_result_ref,
         ),
@@ -66,7 +66,7 @@ def _result(
     steps: list[StepRecord] | None = None,
 ) -> AgentResult:
     output = (
-        RouteResponseModel(message="Route ready.")
+        ItineraryResponseModel(message="Itinerary ready.")
         if intent.startswith("plan_")
         else SearchResponseModel(message="Search complete.")
     )
@@ -81,15 +81,17 @@ def _result(
 
 def _provenance(intent: str, state: SessionState) -> TurnProvenance:
     search = None
-    route = None
+    itinerary = None
     if intent in {"search_bangumi", "search_nearby", "plan_multi"}:
         ref = state.last_result_ref
         if ref is not None:
             outcome = "ok" if state.search_results[ref].row_count else "empty"
             search = ProducedSearch(outcome=outcome, result_ref=ref)
-    if intent.startswith("plan_") and state.route_lru:
-        route = ProducedRoute(status="ok", route_ref=state.route_lru[-1])
-    return TurnProvenance(search=search, route=route)
+    if intent.startswith("plan_") and state.itinerary_lru:
+        itinerary = ProducedItinerary(
+            status="ok", itinerary_ref=state.itinerary_lru[-1]
+        )
+    return TurnProvenance(search=search, itinerary=itinerary)
 
 
 def test_search_projection_uses_registry_rows() -> None:

--- a/apps/agent/src/animichi/tests/unit/test_route_area_splitter.py
+++ b/apps/agent/src/animichi/tests/unit/test_route_area_splitter.py
@@ -59,7 +59,7 @@ class TestSplitIntoAreasLargeSets:
         mock_run_result.output = mock_output
 
         with patch(
-            "animichi.agents.route_area_splitter.route_planner_agent"
+            "animichi.agents.route_area_splitter.itinerary_planner_agent"
         ) as mock_agent:
             mock_agent.run = AsyncMock(return_value=mock_run_result)
             result = await split_into_areas(_make_points(15))
@@ -75,7 +75,7 @@ class TestSplitIntoAreasLargeSets:
 class TestSplitIntoAreasHandlesFailure:
     async def test_returns_none_on_agent_exception(self) -> None:
         with patch(
-            "animichi.agents.route_area_splitter.route_planner_agent"
+            "animichi.agents.route_area_splitter.itinerary_planner_agent"
         ) as mock_agent:
             mock_agent.run = AsyncMock(side_effect=RuntimeError("LLM timeout"))
             result = await split_into_areas(_make_points(15))
@@ -100,7 +100,7 @@ class TestSplitIntoAreasFixesOrphans:
         mock_run_result.output = mock_output
 
         with patch(
-            "animichi.agents.route_area_splitter.route_planner_agent"
+            "animichi.agents.route_area_splitter.itinerary_planner_agent"
         ) as mock_agent:
             mock_agent.run = AsyncMock(return_value=mock_run_result)
             result = await split_into_areas(_make_points(12))

--- a/apps/agent/src/animichi/tests/unit/test_route_export.py
+++ b/apps/agent/src/animichi/tests/unit/test_route_export.py
@@ -1,4 +1,4 @@
-"""Unit tests for route_export module — Google Maps URL builder and .ics generator."""
+"""Unit tests for itinerary export module — Google Maps URL builder and .ics generator."""
 
 from animichi.agents.models import TimedItinerary, TimedStop
 from animichi.agents.route_export import build_google_maps_url, build_ics_calendar

--- a/apps/agent/src/animichi/tests/unit/test_runtime_model_alias_http.py
+++ b/apps/agent/src/animichi/tests/unit/test_runtime_model_alias_http.py
@@ -60,7 +60,7 @@ async def test_selected_route_rejects_alias_before_route_sink(
 ) -> None:
     app, _ = build_app()
     with patch(
-        "animichi.interfaces.public_api.execute_selected_route",
+        "animichi.interfaces.public_api.execute_selected_itinerary",
         new_callable=AsyncMock,
         side_effect=RuntimeError("selected route sink must not run"),
     ) as sink:

--- a/apps/agent/src/animichi/tests/unit/test_runtime_models.py
+++ b/apps/agent/src/animichi/tests/unit/test_runtime_models.py
@@ -7,14 +7,14 @@ from animichi.agents.runtime_models import (
     ClarifyResponseModel,
     ErrorResponseModel,
     GreetingResponseModel,
+    ItineraryResponseModel,
     QAResponseModel,
-    RouteResponseModel,
     SearchResponseModel,
 )
 
 _FIVE_RESPONSE_MODELS = (
     SearchResponseModel,
-    RouteResponseModel,
+    ItineraryResponseModel,
     GreetingResponseModel,
     ClarifyResponseModel,
     QAResponseModel,
@@ -54,7 +54,7 @@ def test_clarify_candidate_ids_description_states_ordering_contract() -> None:
 def test_error_response_model_is_runner_only_never_a_model_output() -> None:
     assert ErrorResponseModel not in (
         SearchResponseModel,
-        RouteResponseModel,
+        ItineraryResponseModel,
         GreetingResponseModel,
         ClarifyResponseModel,
         QAResponseModel,

--- a/apps/agent/src/animichi/tests/unit/test_selected_route.py
+++ b/apps/agent/src/animichi/tests/unit/test_selected_route.py
@@ -10,7 +10,7 @@ import pytest
 from animichi.agents.agent_result import AgentResult
 from animichi.agents.catalog_adapter import build_search_payload
 from animichi.agents.runtime_deps import OnStep, StepEvent
-from animichi.agents.selected_route import execute_selected_route
+from animichi.agents.selected_route import execute_selected_itinerary
 from animichi.agents.session_state import ResultRef, SearchPayloadState, SessionState
 from animichi.clients.catalog_client import Itinerary, Point
 from animichi.clients.errors import APIError
@@ -37,8 +37,10 @@ _POINT_FIELDS = {
 
 def _ordered_rows(result: AgentResult) -> list[dict[str, object]]:
     state = result.session_state
-    ref = state.route_lru[-1]
-    return [row.model_dump(mode="json") for row in state.routes[ref].ordered_points]
+    ref = state.itinerary_lru[-1]
+    return [
+        row.model_dump(mode="json") for row in state.itineraries[ref].ordered_points
+    ]
 
 
 def _euphonium_points() -> list[Point]:
@@ -55,7 +57,7 @@ def _spy_events() -> tuple[list[tuple[str, str]], OnStep]:
 
 
 async def _run_empty_route(on_step: OnStep | None) -> AgentResult:
-    return await execute_selected_route(
+    return await execute_selected_itinerary(
         point_ids=["ghost"],
         state=SessionState(),
         origin=None,
@@ -67,7 +69,7 @@ async def _run_empty_route(on_step: OnStep | None) -> AgentResult:
 
 async def test_selected_route_rows_keep_catalog_point_fields() -> None:
     catalog = MockCatalogClient()
-    result = await execute_selected_route(
+    result = await execute_selected_itinerary(
         point_ids=["p004", "p005"],
         state=SessionState(),
         origin="34.8915,135.8075",
@@ -87,7 +89,7 @@ async def test_selected_route_rows_keep_catalog_point_fields() -> None:
 
 async def test_selected_route_rows_match_search_payload_rows() -> None:
     catalog = MockCatalogClient()
-    result = await execute_selected_route(
+    result = await execute_selected_itinerary(
         point_ids=["p004", "p005", "p006"],
         state=SessionState(),
         origin=None,
@@ -101,7 +103,7 @@ async def test_selected_route_rows_match_search_payload_rows() -> None:
 
 
 async def test_selected_route_empty_point_ids_returns_error() -> None:
-    result = await execute_selected_route(
+    result = await execute_selected_itinerary(
         point_ids=[],
         state=SessionState(),
         origin=None,
@@ -121,7 +123,7 @@ class _FailingCatalog(MockCatalogClient):
 
 
 async def test_selected_route_catalog_api_error_returns_error() -> None:
-    result = await execute_selected_route(
+    result = await execute_selected_itinerary(
         point_ids=["p004"],
         state=SessionState(),
         origin=None,
@@ -139,7 +141,7 @@ async def test_selected_route_emits_running_and_done_steps() -> None:
     async def _record(event: StepEvent) -> None:
         events.append((event.tool, event.status))
 
-    await execute_selected_route(
+    await execute_selected_itinerary(
         point_ids=["p004"],
         state=SessionState(),
         origin=None,
@@ -172,7 +174,7 @@ async def test_selected_route_malformed_origin_routes_without_origin(
     origin: str,
 ) -> None:
     catalog = MockCatalogClient()
-    await execute_selected_route(
+    await execute_selected_itinerary(
         point_ids=["p004"],
         state=SessionState(),
         origin=origin,
@@ -195,14 +197,14 @@ async def test_selected_route_preserves_hydrated_search_state() -> None:
             anime_id="115908",
         ),
     )
-    result = await execute_selected_route(
+    result = await execute_selected_itinerary(
         point_ids=["p004", "p005"],
         state=state,
         origin=None,
         locale="en",
         catalog=MockCatalogClient(),
     )
-    route = state.routes[state.route_lru[-1]]
+    route = state.itineraries[state.itinerary_lru[-1]]
     assert result.session_state.search_results[source_ref].row_count == 3
     assert route.source_ref is None
 

--- a/apps/agent/src/animichi/tests/unit/test_selected_route_errors.py
+++ b/apps/agent/src/animichi/tests/unit/test_selected_route_errors.py
@@ -7,8 +7,8 @@ typed errors — while untyped failures keep the legacy fallback.
 
 from __future__ import annotations
 
-from animichi.agents.agent_result import RejectedRoute
-from animichi.agents.selected_route import execute_selected_route
+from animichi.agents.agent_result import RejectedItinerary
+from animichi.agents.selected_route import execute_selected_itinerary
 from animichi.agents.session_state import SessionState
 from animichi.clients.catalog_client import Itinerary
 from animichi.clients.catalog_errors import (
@@ -44,7 +44,7 @@ class _MalformedCatalog(MockCatalogClient):
 
 
 async def test_too_many_clusters_returns_actionable_message_en() -> None:
-    result = await execute_selected_route(
+    result = await execute_selected_itinerary(
         point_ids=["p1"],
         state=SessionState(),
         origin=None,
@@ -60,7 +60,7 @@ async def test_too_many_clusters_returns_actionable_message_en() -> None:
 
 
 async def test_too_many_clusters_returns_actionable_message_ja() -> None:
-    result = await execute_selected_route(
+    result = await execute_selected_itinerary(
         point_ids=["p1"],
         state=SessionState(),
         origin=None,
@@ -74,7 +74,7 @@ async def test_too_many_clusters_returns_actionable_message_ja() -> None:
 
 
 async def test_retryable_error_returns_try_again_message() -> None:
-    result = await execute_selected_route(
+    result = await execute_selected_itinerary(
         point_ids=["p1"],
         state=SessionState(),
         origin=None,
@@ -89,7 +89,7 @@ async def test_retryable_error_returns_try_again_message() -> None:
 
 
 async def test_catalog_contract_violation_is_typed_without_exposing_details() -> None:
-    result = await execute_selected_route(
+    result = await execute_selected_itinerary(
         point_ids=["p1"],
         state=SessionState(),
         origin=None,
@@ -98,4 +98,4 @@ async def test_catalog_contract_violation_is_typed_without_exposing_details() ->
     )
 
     assert result.output.message == "Catalog route unavailable"
-    assert result.steps[0].provenance == RejectedRoute(status="contract_violation")
+    assert result.steps[0].provenance == RejectedItinerary(status="contract_violation")

--- a/apps/agent/src/animichi/tests/unit/test_session_state.py
+++ b/apps/agent/src/animichi/tests/unit/test_session_state.py
@@ -9,14 +9,14 @@ from animichi.agents.session_state import (
     MAX_REFS,
     CurrentAnime,
     GeocodeStaging,
+    ItineraryPayloadState,
+    ItineraryRef,
+    ItinerarySummaryState,
     NearbyGroupState,
     OrderedCandidate,
     PendingClarification,
     PointState,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
-    RouteSummaryState,
     SearchMetadataState,
     SearchPayloadState,
     SessionState,
@@ -40,8 +40,8 @@ def _search_payload(index: int = 0) -> SearchPayloadState:
     )
 
 
-def _route_payload(source_ref: ResultRef) -> RoutePayloadState:
-    return RoutePayloadState(
+def _route_payload(source_ref: ResultRef) -> ItineraryPayloadState:
+    return ItineraryPayloadState(
         ordered_points=[],
         source_ref=source_ref,
     )
@@ -61,16 +61,16 @@ def test_session_state_round_trips_every_component() -> None:
         clarification_revision=3,
     )
     result_ref = ResultRef("bangumi:3:1")
-    route_ref = RouteRef("route:3:1")
+    itinerary_ref = ItineraryRef("route:3:1")
     state.store_search_result(result_ref, _search_payload())
-    state.store_route(route_ref, _route_payload(result_ref))
+    state.store_itinerary(itinerary_ref, _route_payload(result_ref))
 
     restored = SessionState.model_validate(state.model_dump(mode="json"))
 
     assert restored == state
     assert restored.last_result_ref == result_ref
     assert isinstance(restored.search_results[result_ref], SearchPayloadState)
-    assert isinstance(restored.routes[route_ref], RoutePayloadState)
+    assert isinstance(restored.itineraries[itinerary_ref], ItineraryPayloadState)
 
 
 @pytest.mark.parametrize(
@@ -81,7 +81,7 @@ def test_session_state_round_trips_every_component() -> None:
         (SearchMetadataState, {}),
         (NearbyGroupState, {"bangumi_id": "1", "title": "Anime"}),
         (
-            RouteSummaryState,
+            ItinerarySummaryState,
             {
                 "point_count": 1,
                 "total_minutes": 10,
@@ -92,7 +92,7 @@ def test_session_state_round_trips_every_component() -> None:
             },
         ),
         (SearchPayloadState, {"kind": "bangumi"}),
-        (RoutePayloadState, {}),
+        (ItineraryPayloadState, {}),
         (OrderedCandidate, {"id": "1", "title": "Anime"}),
         (
             PendingClarification,
@@ -142,19 +142,19 @@ def test_evicted_search_ref_returns_typed_stale_outcome() -> None:
 def test_route_registry_evicts_least_recently_used_ref() -> None:
     state = SessionState()
     source_ref = ResultRef("bangumi:0:source")
-    refs = [RouteRef(f"route:0:{index}") for index in range(MAX_REFS)]
+    refs = [ItineraryRef(f"route:0:{index}") for index in range(MAX_REFS)]
     for ref in refs:
-        state.store_route(ref, _route_payload(source_ref))
-    assert isinstance(state.get_route(refs[0]), RoutePayloadState)
-    assert state.route_lru[-1] == refs[0]
+        state.store_itinerary(ref, _route_payload(source_ref))
+    assert isinstance(state.get_itinerary(refs[0]), ItineraryPayloadState)
+    assert state.itinerary_lru[-1] == refs[0]
 
-    newest = RouteRef("route:0:newest")
-    state.store_route(newest, _route_payload(source_ref))
+    newest = ItineraryRef("route:0:newest")
+    state.store_itinerary(newest, _route_payload(source_ref))
 
-    assert refs[0] in state.routes
-    assert refs[1] not in state.routes
-    assert len(state.routes) == MAX_REFS
-    assert isinstance(state.get_route(refs[1]), StaleRef)
+    assert refs[0] in state.itineraries
+    assert refs[1] not in state.itineraries
+    assert len(state.itineraries) == MAX_REFS
+    assert isinstance(state.get_itinerary(refs[1]), StaleRef)
 
 
 def test_restore_trims_oversized_registries_to_last_max_refs() -> None:

--- a/apps/agent/src/animichi/tests/unit/test_session_state_boundaries.py
+++ b/apps/agent/src/animichi/tests/unit/test_session_state_boundaries.py
@@ -9,9 +9,9 @@ from pydantic import ValidationError
 
 from animichi.agents.session_state import (
     MAX_REFS,
+    ItineraryPayloadState,
+    ItineraryRef,
     ResultRef,
-    RoutePayloadState,
-    RouteRef,
     SearchPayloadState,
     SessionState,
 )
@@ -22,8 +22,8 @@ def _search_payload() -> SearchPayloadState:
     return SearchPayloadState(kind="bangumi")
 
 
-def _route_payload() -> RoutePayloadState:
-    return RoutePayloadState()
+def _route_payload() -> ItineraryPayloadState:
+    return ItineraryPayloadState()
 
 
 def test_search_lru_survives_jsonb_registry_key_reordering() -> None:
@@ -44,19 +44,19 @@ def test_search_lru_survives_jsonb_registry_key_reordering() -> None:
 
 
 def test_route_lru_survives_jsonb_registry_key_reordering() -> None:
-    refs = [RouteRef(value) for value in ("z", "a", "b", "c", "d", "e", "f", "g")]
+    refs = [ItineraryRef(value) for value in ("z", "a", "b", "c", "d", "e", "f", "g")]
     state = SessionState()
     for ref in refs:
-        state.store_route(ref, _route_payload())
+        state.store_itinerary(ref, _route_payload())
     serialized = state.model_dump(mode="json")
-    registry = cast(dict[str, object], serialized["routes"])
-    serialized["routes"] = {key: registry[key] for key in sorted(registry)}
+    registry = cast(dict[str, object], serialized["itineraries"])
+    serialized["itineraries"] = {key: registry[key] for key in sorted(registry)}
 
     restored = SessionState.model_validate(serialized)
-    restored.store_route(RouteRef("new"), _route_payload())
+    restored.store_itinerary(ItineraryRef("new"), _route_payload())
 
-    assert refs[0] not in restored.routes
-    assert refs[1] in restored.routes
+    assert refs[0] not in restored.itineraries
+    assert refs[1] in restored.itineraries
 
 
 def test_session_state_restore_bounds_an_oversized_compaction_ledger() -> None:
@@ -111,7 +111,7 @@ def test_session_state_restore_bounds_an_oversized_compaction_ledger() -> None:
     ],
 )
 def test_route_snapshot_recursively_rejects_unknown_fields(itinerary: object) -> None:
-    snapshot = {"routes": {"route:0:1": {"timed_itinerary": itinerary}}}
+    snapshot = {"itineraries": {"route:0:1": {"timed_itinerary": itinerary}}}
 
     with pytest.raises(ValidationError, match="unknown"):
         SessionState.model_validate(snapshot)

--- a/apps/agent/src/animichi/tests/unit/test_tool_plumbing_function_model.py
+++ b/apps/agent/src/animichi/tests/unit/test_tool_plumbing_function_model.py
@@ -12,8 +12,8 @@ from animichi.agents.animichi_runner import run_animichi_agent
 from animichi.agents.runtime_models import (
     ClarifyResponseModel,
     GreetingResponseModel,
+    ItineraryResponseModel,
     QAResponseModel,
-    RouteResponseModel,
     SearchResponseModel,
 )
 from animichi.tests.eval.mock_catalog_client import MockCatalogClient
@@ -85,7 +85,7 @@ def _route_model() -> FunctionModel:
         (
             _route_model(),
             "plan_route",
-            RouteResponseModel,
+            ItineraryResponseModel,
             ["resolve_anime", "search_bangumi", "plan_route"],
         ),
     ],
@@ -93,7 +93,7 @@ def _route_model() -> FunctionModel:
 async def test_real_tool_chain_builds_server_owned_stage(
     model: FunctionModel,
     intent: str,
-    family: type[SearchResponseModel] | type[RouteResponseModel],
+    family: type[SearchResponseModel] | type[ItineraryResponseModel],
     steps: list[str],
 ) -> None:
     result = await run_animichi_agent(


### PR DESCRIPTION
## Summary

PR-3 of #852 (SK-G1 greenfield rename, **agent language slice** = S3 per the C5 decomposition). Renames the remaining **internal Python identifiers** in `apps/agent` from the legacy `Route` vocabulary to the greenfield `Itinerary` language per [greenfield-language-and-data-plane.md](docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md).

### Scope (all `apps/agent` internal — no cross-package surface)

- **Domain**: `entities.py` `Route`/`RouteSegment` → `Itinerary`/`ItinerarySegment` (+ `AnimichiSession.route` field → `itinerary`)
- **Session registry** (`session_state.py`): `RouteRef` → `ItineraryRef`, `RouteSummaryState`/`RoutePayloadState`/`RouteLookup` → `Itinerary*`, `routes`/`route_lru` → `itineraries`/`itinerary_lru`, `store_route`/`next_route_ref`/`get_route` → `store_itinerary`/`next_itinerary_ref`/`get_itinerary`
- **Tool outcomes** (`tool_outcomes.py`): `RouteOk`/`RouteEmpty`/`RouteStaleRef`/`RoutePendingSync`/`RouteUpstreamDown`/`RouteToolResult` → `Itinerary*`
- **Provenance** (`agent_result.py`): `ProducedRoute`/`RejectedRoute`/`RouteRejectionStatus` → `ProducedItinerary`/`RejectedItinerary`/`ItineraryRejectionStatus`, `TurnProvenance.route` → `.itinerary`
- **Runtime output** (`runtime_models.py`): `RouteResponseModel` → `ItineraryResponseModel`
- **Tool plumbing**: `run_route` → `run_itinerary` (catalog_route_tools), `build_route_payload`/`build_route_state` → `build_itinerary_payload`/`build_itinerary_state` (catalog_adapter), `execute_selected_route` → `execute_selected_itinerary` (selected_route), `MAX_ROUTE_POINT_IDS` → `MAX_ITINERARY_POINT_IDS` (selection)
- **Consumers**: animichi_agent/animichi_runner/animichi_tools, response_builder/persistence/public_api, eval harness + evaluators, all unit/integration tests

### Deliberately NOT renamed (platform / wire / #891 surface)

- `catalog_client.py` client types (`Route`/`PilgrimagePoint`), `catalog_read_gateway.py`, `chat_wire.py` line keys — all in **#891 (PR-2, catalog slice)**, which is still OPEN; identical renames there, this PR rebases cleanly onto it
- SSE/REST wire values: `data["route"]` REST body key (deliberately kept per #891), step-data key `route_ref`, tool names `plan_route`/`route_response`/`route_history`, runtime stage `"route"`
- Catalog platform error codes `RouteTooManyClustersError`/`RouteTooManyPointsError` (catalog route endpoint)
- Ref string values (`"route:{kind}:{seed}"` opaque server-owned handles), FastAPI `interfaces/routes/`, user-facing message copy
- `RouteTooManyPointsError` message text (user-facing copy, out of rename scope)

### Gates

| Package | Result |
|---|---|
| apps/agent unit | **1729 passed** (12 deselected: `test_real_response_builder_wire_parses_in_zod` needs the pnpm `tsx` toolchain, fails identically on clean origin/main in this env — not a regression) |
| apps/agent ruff | ✓ (`ruff check` + `ruff format --check`, project config) |
| apps/agent mypy | ✓ (agents/interfaces/domain/infrastructure/clients/tests-eval/scripts, 139 files) |

### Notes

- **This is the S3 slice only** — depends on #891 (PR-2) merging first; based on origin/main per slice discipline, rebase onto #891 at merge time. The catalog_client import lines this PR leaves as `Route` flip to `Itinerary` automatically in that rebase.
- No behavior change: pure identifier rename; ref string values, wire keys, and prompt text are untouched.

Closes part of #852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced itinerary-based planning terminology across planning results, selections, outcomes, and session history.
  * Planning responses now identify itineraries and provide itinerary-specific status, references, and provenance.
  * Added clearer handling for empty results, stale references, pending synchronization, and upstream service failures.
* **Updates**
  * Selected-point planning and itinerary retrieval now use the updated itinerary model.
  * Existing response formatting and calendar export behavior remain available with itinerary terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->