### PR TITLE
docs(#852): S4 收尾——清 rename 后文档残留旧名 (PR-4)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,7 +118,7 @@ no local retriever, handler registry, SQL route planner, or direct Anitabi/Bangu
 
 ## HTTP Service — `interfaces/fastapi_service.py`
 
-FastAPI. Main endpoints: `GET /healthz`, `POST /v1/runtime`, `POST /v1/runtime/stream` (SSE), `POST /v1/feedback`, `GET /v1/conversations`, `PATCH /v1/conversations/{id}`, `GET /v1/routes`, `GET /v1/bangumi/popular`, `GET /v1/bangumi/nearby`. Auth is NOT enforced here — it is enforced upstream in the CF Worker.
+FastAPI. Main endpoints: `GET /healthz`, `POST /v1/runtime`, `POST /v1/runtime/stream` (SSE), `POST /v1/feedback`, `GET /v1/conversations`, `PATCH /v1/conversations/{id}`, `GET /v1/bangumi/popular`, `GET /v1/bangumi/nearby`. Auth is NOT enforced here — it is enforced upstream in the CF Worker.
 
 ## Response Contract
 

--- a/docs/architecture-diagrams.md
+++ b/docs/architecture-diagrams.md
@@ -28,8 +28,8 @@ flowchart TD
         PAI["animichi agent - pydantic-ai 2.9.1<br/>6 tools, 5 typed outputs, output validator"]
     end
 
-    CAT["Catalog Worker - workers/catalog<br/>typed oRPC contract - packages/contract<br/>resolve, pointsByWorkId, route, geocode"]
-    PG[("Supabase Postgres + PostGIS<br/>sessions, messages, routes + route_anime<br/>via asyncpg")]
+    CAT["Catalog Worker - workers/catalog<br/>typed oRPC contract - packages/contract<br/>resolve, pointsByBangumiId, planItinerary, geocode"]
+    PG[("Supabase Postgres + PostGIS<br/>sessions, messages, saved_routes + saved_route_anime<br/>via asyncpg")]
     LLM["MiMo mimo-v2.5 - prod primary<br/>OpenAI SDK, header X-App-Client<br/>DeepSeek fallback dormant"]
     DDG["DuckDuckGo - web_search tool<br/>output wrapped as untrusted"]
     OBS["Logfire<br/>service animichi-runtime,<br/>environment = app_env"]
@@ -45,7 +45,7 @@ flowchart TD
 
 Endpoints (`interfaces/routes/`): `POST /v1/runtime` (JSON), `POST
 /v1/runtime/stream` (SSE step events), `POST /v1/chat` (Vercel AI protocol
-adapter over the same RuntimeAPI), plus read-only conversations/routes/bangumi
+adapter over the same RuntimeAPI), plus read-only conversations/bangumi
 routes and `/healthz`.
 
 ---
@@ -91,7 +91,7 @@ sequenceDiagram
     end
     API->>RB: agent_result_to_response
     RB->>RB: project data.results and data.route from<br/>THIS turn provenance only - never registry recency
-    API->>DB: envelope snapshot, messages, route + route_anime
+    API->>DB: envelope snapshot, messages
     API-->>C: 200 for success AND graceful terminals -<br/>clarify, partial, blocked, empty, too_large.<br/>400 invalid_selection. 500 only for real faults.
 ```
 
@@ -201,7 +201,7 @@ default and fallback actually need.
 ```mermaid
 flowchart TD
     subgraph TURN["During a turn"]
-        REGY["SessionState registry<br/>search_results maps ResultRef to rows and partial flag<br/>routes maps RouteRef to ordered points<br/>LRU-tracked, evictable refs"]
+        REGY["SessionState registry<br/>search_results maps ResultRef to rows and partial flag<br/>itineraries maps ItineraryRef to ordered points<br/>LRU-tracked, evictable refs"]
         PEND["PendingClarification<br/>reason, candidate_ids,<br/>ordered_candidates, revision"]
         PROV["TurnProvenance from steps -<br/>Produced or Rejected, Search or Route -<br/>what THIS turn actually did"]
     end
@@ -213,12 +213,10 @@ flowchart TD
     subgraph SAVE["Persisted per turn"]
         ENV["session envelope - ONE key<br/>session_state_v2 full snapshot,<br/>interactions stay pure history"]
         MSGS["messages - user and assistant,<br/>including clarify, partial and blocked turns"]
-        RTBL["routes table + route_anime join table"]
     end
 
     REGY --> ENV
     PROJ --> MSGS
-    PROJ --> RTBL
 
     subgraph NEXTTURN["Next request"]
         HYD["hydrate - envelope first,<br/>legacy interaction scan as fallback"]

--- a/docs/ops/anonymous-session-purge.md
+++ b/docs/ops/anonymous-session-purge.md
@@ -13,18 +13,20 @@ row once:
 - `conversations.user_id` matches the `anon_` prefix, and
 - `conversations.updated_at` is older than `anonymous_session_retention_days`
   (`Settings`, default 30 days), and
-- the session produced **no** `routes` row.
+- the session produced **no** `saved_routes` row.
 
 A session that produced a route is retained **permanently**, unconditionally
 — that exclusion is not configurable, only the retention window is.
 
 Each session is purged in its own transaction, and the conversation delete
-re-checks the anon/cutoff predicate rather than trusting the earlier scan —
+re-checks the same anon/cutoff predicate rather than trusting the earlier scan —
 closing the race where the owner logs in (`POST /v1/session/migrate`)
-between the eligibility scan and the delete. A session lost to that race, or
-refused by the `routes.session_id` FK backstop, is logged and skipped; the
-rest of the sweep continues. See `agent/scripts/purge_anonymous_sessions.py`
-docstrings and `agent/infrastructure/supabase/repositories/session.py`
+between the eligibility scan and the delete. A session that no longer matches
+that predicate counts as `raced` and is skipped; the rest of the sweep
+continues. The `routes.session_id` FK backstop was dropped with the
+`saved_routes` rename (#852), so no FK race is possible anymore. See
+`agent/scripts/purge_anonymous_sessions.py` docstrings and
+`agent/infrastructure/supabase/repositories/session.py`
 (`purge_session`) for the mechanics.
 
 ## Trigger: `workers/jobs`
@@ -45,20 +47,20 @@ The shared trigger/deploy/secret runbook is [`maintenance-worker.md`](./maintena
 
 ## Reading a run
 
-The job writes `purged=N raced=N failed=N` to the step's `$GITHUB_STEP_SUMMARY`
+The job writes `purged=N raced=N` to the step's `$GITHUB_STEP_SUMMARY`
 (via `animichi.scripts.purge_anonymous_sessions._write_step_summary`):
 
 - `purged` — sessions actually deleted this run.
-- `raced` — the find-then-delete race resolved itself (the session was no
-  longer anon-owned or no longer past cutoff by the time the delete ran,
-  typically because the owner logged in mid-sweep). Not a failure.
-- `failed` — a per-session database error (most likely the `routes` FK
-  backstop catching a route written between the scan and the delete). Logged
-  as `anonymous_session_purge_failed` with the session id; the sweep still
-  exits 0 unless something outside the per-session loop breaks.
+- `raced` — the delete's re-check resolved the find-then-delete race (the
+  session was no longer anon-owned or no longer past cutoff by the time the
+  delete ran, typically because the owner logged in mid-sweep). Not a failure.
 
-A nonzero exit code means an **unexpected** (non-Postgres) error escaped the
-per-session isolation — that's a programming bug, not a race, and should page
+Since the `saved_routes` FK backstop was dropped (#852), there is no per-session
+`failed` bucket anymore: a per-session database error propagates and aborts the
+sweep instead of being isolated.
+
+A nonzero exit code means a per-session database error or an **unexpected**
+(non-Postgres) error escaped the run — that's a bug, not a race, and should page
 someone.
 
 ## Related

--- a/docs/ops/jobs-worker.md
+++ b/docs/ops/jobs-worker.md
@@ -16,9 +16,10 @@ Both expressions appear under the default, staging, and production `[triggers]` 
 fails an unknown schedule instead of guessing which deletion to run.
 
 The session sweep retains the Python race guarantees: it finds anonymous, stale, routeless
-candidates, re-checks anonymous ownership and cutoff per session, and lets the `routes.session_id`
-foreign key roll back a raced deletion. Each session is isolated in its own atomic statement, so one
-FK race does not abort the remaining candidates.
+candidates, re-checks anonymous ownership and cutoff per session, and counts a delete that matches
+zero rows as raced. Each session is isolated in its own atomic statement, so a raced session does not
+abort the remaining candidates. The `routes.session_id` FK backstop no longer exists — the rename
+dropped the cross-BC FK (#852), so no FK race is possible.
 
 ## Secret chain
 

--- a/docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md
+++ b/docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md
@@ -59,16 +59,16 @@ Workflow: `.grok/workflows/structure-design-three-packages.rhai`
 
 | 今日 | 目标 |
 |---|---|
-| `PilgrimagePoint` | **`Point`** |
-| `Route`（规划结果） | **`Itinerary`** |
-| `work_id` | **`bangumi_id`**（仍为数字字符串时用 regex 约束，名改正） |
-| `pointsByWorkId` | **`pointsByBangumiId`** |
-| `POST /catalog/route` | **`POST /catalog/itinerary`** |
+| `Point`（原 `PilgrimagePoint`，#891 已落地） | **`Point`** |
+| `Itinerary`（原 `Route`，#891 已落地） | **`Itinerary`** |
+| `bangumi_id`（原 `work_id`，#891 已落地） | **`bangumi_id`**（仍为数字字符串时用 regex 约束，名改正） |
+| `pointsByBangumiId`（#891 已落地） | **`pointsByBangumiId`** |
+| `POST /catalog/itinerary`（#891 已落地） | **`POST /catalog/itinerary`** |
 | `POST /catalog/spots` | **`POST /catalog/point`**（或 `/catalog/points/get`；实现选定一，文档锁定） |
-| `UserRoute` / `/v1/users/routes` | **`SavedRoute` / `/v1/users/saved-routes`** |
-| share/checkin `route_id` | **`saved_route_id`** |
-| `AnimeSampleRoute` / `sample_routes` | **`AnimeSampleItinerary` / `sample_itineraries`** |
-| Agent Python 镜像类型 | 与 contract **同词**（Point / Itinerary / …） |
+| `SavedRoute` / `/v1/users/saved-routes`（#890 已落地） | **`SavedRoute` / `/v1/users/saved-routes`** |
+| `saved_route_id`（#890 已落地） | **`saved_route_id`** |
+| `AnimeSampleItinerary` / `sample_itineraries`（#891 已落地） | **`AnimeSampleItinerary` / `sample_itineraries`** |
+| 与 contract 同词（Point / Itinerary / …，#892 已落地） | 与 contract **同词**（Point / Itinerary / …） |
 
 **兼容：** 无。Web、MSW、eval fixture、Agent `CatalogClient` **同波或紧后 PR 改完**。
 
@@ -85,7 +85,7 @@ Workflow: `.grok/workflows/structure-design-three-packages.rhai`
 | `aliases` | **`work_id` → `bangumi_id`** | 列改名 |
 | `series_edges` | 若有 `work_id` → **`bangumi_id`** | 同 |
 | `cluster_version` | **`work_id` → `bangumi_id`** | 同 |
-| `route_snapshots` | **`itinerary_snapshots`**；键列 `bangumi_id` | 缓存/发布快照，非 SavedRoute |
+| `itinerary_snapshots`（原 `route_snapshots`，#891 已落地） | **`itinerary_snapshots`**；键列 `bangumi_id` | 缓存/发布快照，非 SavedRoute |
 | `leg_cache` | 评估保留或改 `transit_leg_cache` | 实现时定，避免 `route` 歧义 |
 | `ingest_jobs` / `raw_*` / `media_assets` | **保留**（平台表） | 非粉丝语言 |
 | `locations`（gazetteer） | **保留** | 非 Point |
@@ -94,7 +94,7 @@ Workflow: `.grok/workflows/structure-design-three-packages.rhai`
 
 | 今日 | 目标 |
 |---|---|
-| `routes`（用户保存） | **`saved_routes`**（见 Users §2.5） |
+| `saved_routes`（原 `routes`，#890 已落地） | **`saved_routes`**（见 Users §2.5） |
 | （无） | **`route_shares`**、`walk_checkins` |
 | `user_memory` | 休眠预留形状见 Users 设计 |
 

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -6,7 +6,7 @@ Single source of truth for the types exchanged between the **Python Agent servic
 
 | File | Contents |
 |---|---|
-| `src/models.ts` | Zod schemas + inferred TS types: `PilgrimagePoint`, `TimedStop`, `TransitLeg`, `TimedItinerary`, `Route`, `Pacing`, `Origin` |
+| `src/models.ts` | Zod schemas + inferred TS types: `Point`, `TimedStop`, `TransitLeg`, `TimedItinerary`, `Itinerary`, `Pacing`, `Origin` |
 | `src/contract.ts` | oRPC contract + additional response types: `SearchResult`, `SpotsResult`, `NearbyResult` and the `catalogContract` object |
 | `src/errors.ts` | Typed error registry: `CATALOG_ERROR_DEFS` (code → status/category/message/data schema), `ErrorCategory`, per-code data schemas, `pickCatalogErrors()` |
 | `src/index.ts` | Re-exports everything above |
@@ -37,10 +37,10 @@ Cloudflare Worker bundle. The parity test also uses `import type` exclusively.
 
 ```ts
 // CORRECT — in catalog code and tests
-import type { PilgrimagePoint } from "../../packages/contract/src/models";
+import type { Point } from "../../packages/contract/src/models";
 
 // WRONG — pulls zod runtime into the Worker bundle
-import { PilgrimagePoint } from "../../packages/contract/src/models";
+import { Point } from "../../packages/contract/src/models";
 ```
 
 ### 2. Do NOT codegen Python models


### PR DESCRIPTION
Closes #852 的文档部分(PR-4 / S4 收尾)。

#890(users rename)、#891(catalog rename)、#892(agent Route→Itinerary)已合并,清文档残留旧名。只动文档与配置,无代码行为变更。

## 改动域

**架构文档**
- `docs/ARCHITECTURE.md` — 主端点列表移除已删除的 `GET /v1/routes`(D4,legacy writer 随 endpoint 删除)
- `docs/architecture-diagrams.md` — `routes + route_anime` → `saved_routes + saved_route_anime`;registry `routes/RouteRef` → `itineraries/ItineraryRef`;移除 agent 已不再写入的 RTBL(route_anime)持久化节点;catalog RPC 节点 `pointsByWorkId/route` → `pointsByBangumiId/planItinerary`

**Ops runbook(活文档)**
- `docs/ops/anonymous-session-purge.md` — `routes` 表 → `saved_routes`;`routes.session_id` FK backstop 已随 rename 删除(#852),`failed` 计数不再存在、per-session 错误现在中止整个 sweep,与 `purge_anonymous_sessions.py` / `workers/jobs` 现状一致
- `docs/ops/jobs-worker.md` — 同上:`saved_routes.claim_session_id` 语境、FK backstop 已删除

**契约文档**
- `packages/contract/README.md` — 类型清单与 import 示例 `PilgrimagePoint/Route` → `Point/Itinerary`(与 `src/models.ts` 实际导出一致)

**活 spec(只改「今日」现状列,不动「目标」列)**
- `docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md` — §2/§3 的「今日」单元格改为已落地新名并标注 PR(#890/#891/#892);目标列原样保留

## 明确未改(残留清单,有意保留)

- 历史文档:`docs/archive/`、`docs/superpowers/plans/`、`docs/iterations/`、`docs/superpowers/specs/archive/`、dated design docs(07-30 catalog-rpc-spec、07-17 neon-test-infra-spec、08-06 CA/结构重构设计文、naming-audit、branch-tag-sweep、pr-comment-debt 等)
- 旧名映射/禁止语(`_Avoid:`、rename 对照表、ADR-0002、db/AGENTS.md 「Renamed from」列)— 有意为之
- HTTP 路由/文件路径语境(`interfaces/routes/`、`src/routes/`、Pulumi/zone routes、`routes:` wrangler 键)
- `work_id`(ingest_jobs/raw_* 平台表,D6 保留)
- agent 侧 `session_id`/`route_history`/`plan_route`/`route_response` — 代码仍为此名
- DB migration 文件(历史记录)

## 验证

- `uv run pytest test_secrets_docs_consistency.py test_anonymous_docs_consistency.py test_deploy_model_env_consistency.py test_documentation_guardrails.py` → **28 passed**(coverage 门为运行子集所致,与本次无关)
- `scripts/check-db-ownership-doc.sh` → OK
- `scripts/check-skeleton-w0-docs.sh` → 仍失败,但为**存量失败**(`workers/maintenance/CONTEXT.md` 在 #836 maintenance→jobs 改名后缺失,origin/main 上同样失败),非本次改动引入