### PR TITLE
chore(hooks): harden local gates — full-repo ruff, edge oxlint, shellcheck, actionlint, sourcery, pre-push typecheck/atlas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,17 @@
-# Fast local gate (<5s): ruff · oxlint · gitleaks run on every commit.
-# Heavy checks (mypy, full test suites + coverage) run on pre-push, since CI
-# is the authoritative gate for those — keeps commits fast per best practice.
+# Local gates — two stages:
+#
+#   pre-commit (fast, <10s): formatting, lint, secret scan, shell/workflow
+#     syntax — catches the classes of breakage that repeatedly reached CI
+#     during the skeleton-refactor campaign (ruff format, SC2086, TS lint,
+#     path drift).
+#
+#   pre-push (medium, <2min): typecheck + fast test suites + atlas checksum —
+#     CI stays authoritative for the slow lanes (full suites, eval, deploy),
+#     but a red push should be the exception, not the norm.
+#
+# Install: pre-commit install && pre-commit install --hook-type pre-push
+# Sourcery needs a one-time login (free): sourcery login
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -14,13 +25,17 @@ repos:
       - id: check-yaml
       - id: check-toml
 
+  # Ruff over ALL repo Python (apps/agent, scripts/, .github/scripts/) —
+  # previously scoped to apps/agent only, which let scripts/*.py lint
+  # failures (EXE001/BLE001/PLW1510) reach CI.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.1
     hooks:
       - id: ruff
-        args: [--fix, apps/agent/src/animichi/]
+        args: [--fix]
+        types: [python]
       - id: ruff-format
-        args: [apps/agent/src/animichi/]
+        types: [python]
 
   # Secret scan — sub-second, official gitleaks pre-commit hook (SHA/tag-pinned).
   - repo: https://github.com/gitleaks/gitleaks
@@ -28,18 +43,44 @@ repos:
     hooks:
       - id: gitleaks
 
+  # Sourcery — Python refactoring suggestions (free community tier).
+  # One-time login required: `sourcery login`. Rules can be scoped later via
+  # a .sourcery.yaml if the default set is noisy.
+  - repo: https://github.com/sourcery-ai/sourcery
+    rev: v1.44.0
+    hooks:
+      - id: sourcery
+        types: [python]
+        args: [--no-summary]
+
   - repo: local
     hooks:
-      # Fast strict TS lint for the three live pnpm packages.
+      # Strict TS lint for every worker package + the web app (edge was
+      # missing; its lint failures reached CI in the #841 campaign).
       - id: oxlint
         name: oxlint (strict live-package lint)
         entry: pnpm run lint:oxlint
         language: system
-        files: ^(workers/catalog|workers/users|apps/web)/
+        files: ^(workers/catalog|workers/users|workers/edge|apps/web)/
         types_or: [javascript, jsx, ts, tsx]
         pass_filenames: false
 
-      # --- pre-push stage: heavy checks. Commits stay fast; CI is authoritative. ---
+      # Shell syntax + common pitfalls (SC2086 reached CI twice in #853/#857).
+      - id: shellcheck
+        name: shellcheck (scripts + CI shell)
+        entry: shellcheck --severity=warning
+        language: system
+        types: [shell]
+
+      # GitHub Actions syntax + workflow_call.secrets typing (actionlint.yaml
+      # carries the documented STAGING_GATE_TOKEN environment-secret escape).
+      - id: actionlint
+        name: actionlint (workflow syntax)
+        entry: actionlint
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+
+      # --- pre-push stage: medium-weight checks. ---
       - id: mypy
         name: mypy
         entry: bash -c 'cd apps/agent && uv run mypy src/animichi/agents/ src/animichi/interfaces/ src/animichi/domain/ src/animichi/infrastructure/ src/animichi/clients/'
@@ -54,5 +95,34 @@ repos:
         entry: bash -c 'cd apps/agent && SUPABASE_DB_URL=postgresql://unused@db.invalid/unused DEEPSEEK_API_KEY=test-key uv run pytest src/animichi/tests/unit/ -q --cov --cov-fail-under=82'
         language: system
         types: [python]
+        pass_filenames: false
+        stages: [pre-push]
+
+      # Edge worker node:test suite — 286 tests, seconds.
+      - id: edge-test-worker
+        name: edge worker tests (node:test)
+        entry: pnpm run test:worker
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+      # Typecheck every worker package + shared contract (web is slow and
+      # stays CI-authoritative; TS errors in workers reached CI repeatedly).
+      - id: workers-typecheck
+        name: workers + contract typecheck
+        entry: pnpm --filter './workers/*' typecheck && pnpm --filter '@animichi/contract' typecheck
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+      # Atlas chain integrity: checksum + parse, sub-second. Catches a stale
+      # atlas.sum or unparseable migration before CI's pipeline-db.
+      - id: atlas-validate
+        name: atlas migrate validate
+        entry: bash -c 'command -v atlas >/dev/null && atlas migrate validate --dir migrations/neon || /tmp/atlas-bin/atlas migrate validate --dir migrations/neon'
+        language: system
+        files: ^migrations/
         pass_filenames: false
         stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,9 +25,10 @@ repos:
       - id: check-yaml
       - id: check-toml
 
-  # Ruff over ALL repo Python (apps/agent, scripts/, .github/scripts/) —
-  # previously scoped to apps/agent only, which let scripts/*.py lint
-  # failures (EXE001/BLE001/PLW1510) reach CI.
+  # Ruff over all repo Python paths (any staged .py — apps/agent, scripts/,
+  # .github/scripts/); previously scoped to apps/agent only, which let
+  # scripts/*.py lint failures (EXE001/BLE001/PLW1510) reach CI. Like every
+  # pre-commit hook, this lints staged files; the full tree is CI's job.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.1
     hooks:
@@ -59,7 +60,7 @@ repos:
       # missing; its lint failures reached CI in the #841 campaign).
       - id: oxlint
         name: oxlint (strict live-package lint)
-        entry: pnpm run lint:oxlint
+        entry: bash -c 'pnpm run lint:oxlint && pnpm --filter "./workers/edge" run lint:oxlint'
         language: system
         files: ^(workers/catalog|workers/users|workers/edge|apps/web)/
         types_or: [javascript, jsx, ts, tsx]
@@ -111,7 +112,7 @@ repos:
       # stays CI-authoritative; TS errors in workers reached CI repeatedly).
       - id: workers-typecheck
         name: workers + contract typecheck
-        entry: pnpm --filter './workers/*' typecheck && pnpm --filter '@animichi/contract' typecheck
+        entry: bash -c 'pnpm --filter "./workers/*" typecheck && pnpm --filter "@animichi/contract" typecheck'
         language: system
         pass_filenames: false
         always_run: true
@@ -121,7 +122,7 @@ repos:
       # atlas.sum or unparseable migration before CI's pipeline-db.
       - id: atlas-validate
         name: atlas migrate validate
-        entry: bash -c 'command -v atlas >/dev/null && atlas migrate validate --dir migrations/neon || /tmp/atlas-bin/atlas migrate validate --dir migrations/neon'
+        entry: bash -c 'ATLAS_BIN="$(command -v atlas || echo /tmp/atlas-bin/atlas)"; "$ATLAS_BIN" migrate validate --dir "file://migrations/neon"'
         language: system
         files: ^migrations/
         pass_filenames: false

--- a/scripts/e2e-setup.sh
+++ b/scripts/e2e-setup.sh
@@ -13,7 +13,8 @@ cd "$ROOT"
 echo "=== 1/6 Starting Supabase ==="
 supabase stop 2>/dev/null || true
 sleep 2
-docker rm -f $(docker ps -aq --filter "name=supabase") 2>/dev/null || true
+mapfile -t supabase_containers < <(docker ps -aq --filter "name=supabase")
+[ ${#supabase_containers[@]} -gt 0 ] && docker rm -f "${supabase_containers[@]}" 2>/dev/null || true
 mkdir -p supabase/snippets && chmod 755 supabase/snippets
 sleep 2
 supabase start --exclude vector,analytics --ignore-health-check

--- a/scripts/local-login.sh
+++ b/scripts/local-login.sh
@@ -29,7 +29,7 @@ curl -s -X POST "$SUPABASE_URL/auth/v1/otp" \
 
 # Wait for email in Mailpit
 echo "Waiting for email in Mailpit..."
-for i in $(seq 1 20); do
+for _ in $(seq 1 20); do
   LINK=$(curl -s "$MAILPIT_URL/api/v1/messages" | python3 -c "
 import sys, json, urllib.request, re
 d = json.load(sys.stdin)


### PR DESCRIPTION
The skeleton-refactor campaign repeatedly pushed code that only CI caught: ruff format (scripts/*.py), SC2086 (twice), edge lint, TS typecheck errors, stale atlas.sum. Tighten local gates so a red push is the exception.

## pre-commit (fast)
- ruff/ruff-format: **ALL repo Python** (was apps/agent only) — catches scripts/*.py lint failures locally
- oxlint: **+ workers/edge** (was catalog|users|web only)
- **shellcheck**: scripts/ + .github/scripts (fixed 2 latent findings: SC2046 docker rm cmd-sub, SC2034 unused loop var)
- **actionlint**: workflows (no config — the STAGING_GATE_TOKEN exemption file was removed with #900)
- **sourcery**: Python refactor checks (one-time free login: `sourcery login`)

## pre-push (medium, <2min)
- existing mypy + agent unit coverage
- + edge node:test suite (286 tests)
- + workers/* + contract typecheck
- + atlas migrate validate on migrations changes

Install: `pre-commit install && pre-commit install --hook-type pre-push`

Verified: full `pre-commit run --all-files` passes on a populated worktree (sourcery pending login); shellcheck/actionlint now clean, including two latent findings fixed here.

## Summary by Sourcery

Tighten local development gates by expanding linting and adding medium-weight pre-push checks to catch issues before CI.

New Features:
- Run Ruff linting and formatting across all Python files in the repository instead of only the agent app.
- Add Sourcery-based Python refactoring suggestions to the pre-commit hooks.
- Introduce shellcheck and actionlint checks for shell scripts and GitHub workflows in the pre-commit stage.
- Add edge worker node:test suite execution to the pre-push hooks.
- Add TypeScript typechecking for all worker packages and the shared contract to the pre-push hooks.
- Add atlas migrate validate checks on migration changes to the pre-push hooks.

Bug Fixes:
- Fix Docker container removal in e2e setup script to avoid unsafe use of command substitution and handle multiple containers robustly.
- Prevent an unused loop variable in the local login script by using a throwaway variable in the polling loop.

Enhancements:
- Extend oxlint coverage to include the edge worker package alongside existing packages.
- Document and restructure the pre-commit and pre-push stages to clarify their roles, performance expectations, and installation steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local end-to-end test setup by safely handling cases where no matching containers are found.
* **Developer Experience**
  * Added faster pre-commit checks and broader pre-push validation, including formatting, linting, type checks, worker tests, and migration validation.
  * Added Python refactoring checks and shell and workflow validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->