### PR TITLE
docs(closeout): campaign spec + ADRs 0003-0005 + hook design + policy registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ edge tokens today and backs local-dev/E2E (#561). **Do not add new Supabase-auth
 - Live runtime **reference** → `docs/ARCHITECTURE.md`
 - Deploy runbook → `docs/ops/deployment.md`
 - **Single Source-of-Truth table + doc-change rules** → `docs/DOCS_POLICY.md` (the one canonical topic→path map)
+- Current **campaign tracking** (merged restructure-spec × GOAL; waves P0–P8; ADRs 0003–0005) →
+  `docs/superpowers/specs/2026-08-08-repo-closeout-spec.md`
 
 ## Tool routing (repo-specific; global tooling lives in `~/.claude/` — do not repeat it here)
 

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -20,9 +20,9 @@ Consumer rules: `docs/agents/domain.md` (when present). Per-package `CONTEXT.md`
 | **Auth appliance** | — | `supabase/` (auth-only, no package guide) |
 | **Browser E2E** | `e2e/CONTEXT.md` (lazy) | `e2e/` |
 
-System-wide ADRs: `docs/adr/` (incl. [0002 published language](./docs/adr/0002-published-language-point-bangumi-itinerary.md)).
+System-wide ADRs: `docs/adr/` (0002 published language · [0003 secrets architecture](./docs/adr/0003-secrets-architecture.md) · [0004 campaign merge](./docs/adr/0004-campaign-merge.md) · [0005 force-push policy](./docs/adr/0005-repo-force-push-policy.md)).
 
-Greenfield (no dual wire names / table aliases):  
+Greenfield (no dual wire names / table aliases):
 [`docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md`](./docs/superpowers/specs/2026-08-06-greenfield-language-and-data-plane.md).
 
 ## Relationships

--- a/docs/DOCS_POLICY.md
+++ b/docs/DOCS_POLICY.md
@@ -74,6 +74,9 @@ the current monorepo layout; `backend/…` and `worker/worker.js` are pre-monore
 | Eval | `apps/agent/src/animichi/tests/eval/` (Python) | |
 | Testing strategy | `docs/testing-strategy.md` | |
 | Deployment ops | `docs/ops/deployment.md`, `docs/ops/cloudflare-hardening.md` | |
+| Secrets architecture / worker secrets | `docs/adr/0003-secrets-architecture.md` | CF Secrets Store + Neon-hosted role passwords + Pulumi `neon.Role`; supersedes the ESC-first plan of #674 |
+| Local development gates | `docs/ops/local-gates.md` + `.pre-commit-config.yaml` | changed-package routing; pre-commit/pre-push split; integration tests stay in CI |
+| Close-out campaign (2026-08) | `docs/superpowers/specs/2026-08-08-repo-closeout-spec.md` | ADRs 0004/0005; merges restructure-spec × GOAL; waves P0–P8 |
 | Neon backup / RPO / bad-migration recovery | `docs/ops/neon-backup-rpo.md` | N5 (#860); PITR + HITL checklist; pairs with `migrations.md` |
 | Iteration specs (live) | `docs/superpowers/specs/` — 平层只放活跃 spec(cicd-rebuild、catalog-rpc、byok、s1.7、neon-test-infra、rebuild、ADR) | 过时 spec 一律入 `docs/superpowers/specs/archive/`(只进不出,iter6 A6/#640) |
 | Iteration plans | 当前 iteration 的计划在 `docs/iterations/<iterN>/`;历史执行 plan 全部在 `docs/superpowers/plans/archive/` | 平层不再新增 plan(iter6 A6/#640) |

--- a/docs/adr/0003-secrets-architecture.md
+++ b/docs/adr/0003-secrets-architecture.md
@@ -1,5 +1,13 @@
 # Secrets architecture: Cloudflare Secrets Store as runtime truth, Neon-hosted role passwords, Pulumi-managed roles
 
+> **Status**: accepted — records the target architecture, **not yet implemented as of writing**.
+> Current deployment still delivers `*_DATABASE_URL` via GitHub env secrets + `wrangler secret
+> bulk`, and `scripts/staging-roles-login.sh` still exists. The migration boundary is defined in
+> **P4 — Secrets re-architecture** of `docs/superpowers/specs/2026-08-08-repo-closeout-spec.md`
+> (Pulumi `neon.Role` → compose DSNs → write Secrets Store; remove `wrangler secret bulk` steps
+> and GitHub `*_DATABASE_URL` secrets; delete `scripts/staging-roles-login.sh`). This ADR is
+> authoritative for the target state; the spec's P4 wave owns the cutover.
+
 The skeleton-refactor campaign exposed three broken assumptions about secrets: (1) GitHub Actions secrets are a values source, not a delivery layer — the `workflow_call.secrets` shadowing bug (#826) cost three deploy cycles; (2) psql out-of-band scripts are not infrastructure (`scripts/staging-roles-login.sh` did `ALTER ROLE ... LOGIN PASSWORD` by hand); (3) the #674 ESC centralisation direction assumed a Pulumi Cloud account, which the repo does not use (self-managed R2 backend).
 
 ## Decision

--- a/docs/adr/0003-secrets-architecture.md
+++ b/docs/adr/0003-secrets-architecture.md
@@ -1,0 +1,28 @@
+# Secrets architecture: Cloudflare Secrets Store as runtime truth, Neon-hosted role passwords, Pulumi-managed roles
+
+The skeleton-refactor campaign exposed three broken assumptions about secrets: (1) GitHub Actions secrets are a values source, not a delivery layer — the `workflow_call.secrets` shadowing bug (#826) cost three deploy cycles; (2) psql out-of-band scripts are not infrastructure (`scripts/staging-roles-login.sh` did `ALTER ROLE ... LOGIN PASSWORD` by hand); (3) the #674 ESC centralisation direction assumed a Pulumi Cloud account, which the repo does not use (self-managed R2 backend).
+
+## Decision
+
+Secrets are managed by the platforms that own them, provisioned and consumed as code:
+
+- **Neon role passwords** — generated and stored by Neon. Roles are declared with Pulumi (`@pulumi/neon`, bridged from `kislerdm/terraform-provider-neon`); the password is a `/*out*/` property Neon generates. Passwords never enter git, scripts, or logs.
+- **Worker runtime secrets** — Cloudflare Secrets Store (account-level, open beta, 100 secrets/account). Values are written once via `wrangler secrets-store secret create` (or the REST API) and are **not readable back**; Workers consume them via a declarative binding in `wrangler.toml` (`env.<binding>.get()`).
+- **Connection strings** — composed by Pulumi from `neon.Role.password` + endpoint host, and written **directly** into Cloudflare Secrets Store. No intermediate store, no Neon API round-trip, no GitHub secrets copy.
+- **CI-only values** (e.g. `STAGING_GATE_TOKEN`, needed by the smoke step as a request header) stay in GitHub environment secrets — Secrets Store values are not readable back, so a CI-consumed value cannot live there.
+
+## Why
+
+- **No second IaC stack**: the repo is Pulumi; Neon roles via the bridged provider stay in Pulumi TypeScript.
+- **No Pulumi Cloud dependency**: ESC requires a Pulumi Cloud account; Cloudflare Secrets Store is native to the account we already use.
+- **No out-of-band DB operations**: role DDL moves from psql scripts into Pulumi; schema/GRANTs stay in Atlas migrations (`IF NOT EXISTS` guards make both idempotent).
+- **Shrinks the GitHub secrets surface**: the DATABASE_URL delivery chain (`wrangler secret bulk` from GitHub secrets) disappears; Workers read bindings instead.
+
+## Consequences
+
+- New `infra/` module: a `neon` Pulumi stack declaring `neon.Role` ×4 (catalog_svc, agent_svc, users_svc, jobs_svc) with passwords; exports connection strings as stack outputs (secret-marked).
+- `wrangler.toml` gains Secrets Store bindings for the worker packages; `wrangler secret bulk` steps and GitHub `*_DATABASE_URL` secrets are removed (Phase 5 of #674, adapted).
+- `scripts/staging-roles-login.sh` is deleted; its `--set-secrets` job is replaced by the Pulumi stack.
+- Atlas migrations keep `CREATE ROLE IF NOT EXISTS` (idempotent) and all GRANTs; role LOGIN state is driven by the Pulumi-managed role (Neon sets password → role is login-capable).
+- Rotation: Neon role password → recreate/rotate via Pulumi; Secrets Store value → update binding-backed secret (Workers pick up next deploy).
+- Supersedes: the #674 ESC-first plan for worker DSNs; ESC remains an option if a Pulumi Cloud account is ever adopted.

--- a/docs/adr/0004-campaign-merge.md
+++ b/docs/adr/0004-campaign-merge.md
@@ -1,0 +1,18 @@
+# One close-out campaign: repo-restructure-spec × skeleton-refactor GOAL
+
+Two documents written the same day (2026-08-06) describe overlapping end-states: `docs/superpowers/specs/2026-08-06-repo-restructure-spec.md` (W0–W6: root cleanup, docs/ reorg, edge ownership, workspace, src-layout, history rewrite) and `docs/iterations/refactor-skeleton-2026-08/GOAL.md` (W0–W8: vertical slices, DB roles, migration history). During execution the GOAL absorbed parts of the restructure spec (#853 config-sink implemented spec W2a/W4). Tracking them separately duplicated gates and masked gaps (the restructure W1 docs/ reorg and W3–W6 were never started).
+
+## Decision
+
+One merged campaign — the **repo close-out** — with a single definition of done: GOAL W0–W8 checkboxes all `[x]` **and** restructure spec §5 verification all green **and** issues #829/#845 closed. Waves are re-ordered by dependency, not by either document's numbering; every wave keeps the common gates (local hooks → PR → two-path comment gate → rebase-merge).
+
+## Why
+
+- Both contracts target the same repository end-state; one merge order, one acceptance list, one closing ceremony.
+- The restructure spec's own premise — "no parallel branches" — is only satisfiable under a single coordinated plan.
+
+## Consequences
+
+- Execution order: P0 gates → P1 docs+docs-reorg → P2 edge ownership → P3 workspace/config → P4 secrets re-architecture → P5 meta-gate + prod DSN → P6 production domain/SEO → P7 history-rewrite window (restructure W6 + GOAL W8 fused) → P8 close-out.
+- The 2026-08-08 close-out spec (`docs/superpowers/specs/2026-08-08-repo-closeout-spec.md`) is the single tracking artifact; GOAL.md checkboxes and restructure §5 checks are updated from it.
+- Deferrals are recorded in the GOAL change log, not silently dropped (Harness rebuild #827; landing go-live).

--- a/docs/adr/0005-repo-force-push-policy.md
+++ b/docs/adr/0005-repo-force-push-policy.md
@@ -1,0 +1,21 @@
+# Repository force-push policy: all branches protected, owner-authorized rewrites only
+
+The skeleton-refactor campaign force-pushed feature branches continuously (`rebase + push --force-with-lease`), and the history-rewrite wave (restructure W6 + GOAL W8) will force-push `main`. The GitHub ruleset `protect main` already blocks force-push on the default branch; feature branches were unprotected.
+
+## Decision
+
+- The `non_fast_forward` and `deletion` rules extend to **all branches** (ruleset pattern `*`), with **bypass actors = owner only** (`lifeodyssey`).
+- Daily workflow no longer uses local force-push: updating a feature branch against `main` is `git merge origin/main` + a normal push; PRs merge via GitHub rebase-merge (linear history is already enforced by `required_linear_history`).
+- A rewrite (W8 daily-squash, restructure W6 binary strip, or any forced update) is executed only inside the approved **history-rewrite window**: freeze declaration → double backup (git bundle + private archive repo) → rewrite → force-push as owner bypass → CI green + staging re-deploy evidence → `main-legacy` retained ≥30 days. The runbook is `docs/ops/git-daily-squash-runbook.md`.
+- `--no-verify` pushes are not technically blockable server-side; CI remains the terminal gate (it runs the same checks the local hooks run), and the policy is documented here and in the runbook.
+
+## Why
+
+- Force-push races and rebase churn cost real time during the campaign; a protected-by-default posture is the industry baseline.
+- The rewrite window needs a single, documented, auditable exception path instead of ad-hoc force-pushes.
+
+## Consequences
+
+- All future branch updates use merge (or `gh pr update-branch`); `git push --force-with-lease` is only valid with explicit owner approval (recorded in the runbook checklist).
+- The ruleset gains bypass actors; org-level rulesets are not required.
+- Hooks: pre-push continues to run local gates; CI (`required_status_checks`) is unchanged.

--- a/docs/ops/local-gates.md
+++ b/docs/ops/local-gates.md
@@ -1,0 +1,81 @@
+# Local Gates Design — changed-package routing (monorepo)
+
+Campaign lesson: code repeatedly reached CI that local gates should have caught (ruff format in `scripts/*.py`, SC2086 ×2, edge lint, TS typecheck, stale `atlas.sum`). CI remains the terminal gate; local gates make a red push the exception.
+
+## Principles
+
+1. **Changed-package routing** — a push touches packages; only those packages' gates run. Full-repo runs are reserved for the few sub-second checks.
+2. **Two stages**: pre-commit (seconds — formatting/lint/syntax/secrets) and pre-push (minutes — typecheck + unit tests + integrity). Integration tests do **not** run locally (see below).
+3. **No suppressions**: a failing gate must be fixed or explicitly triaged; `--no-verify` is documented as a policy violation (CI still enforces).
+4. **Sourcery is not a local hook**: PR review via the GitHub App (installed).
+
+## Package map (git diff path → gate set)
+
+| Path prefix | Package | pre-commit lint | pre-push checks |
+|---|---|---|---|
+| `apps/agent/` | agent | ruff + ruff-format (py) | `uv run mypy` + `uv run pytest src/animichi/tests/unit -q --cov --cov-fail-under=82` |
+| `apps/web/` | web | oxlint (type-aware) | `tsc --noEmit` + vitest unit |
+| `workers/catalog/` | catalog | oxlint | `tsc --noEmit` + vitest worker suite |
+| `workers/users/` | users | oxlint | `tsc --noEmit` + vitest |
+| `workers/edge/` | edge | oxlint | `tsc --noEmit` + `node --test workers/edge/*.test.ts` |
+| `workers/jobs/` | jobs | oxlint | `tsc --noEmit` + vitest |
+| `packages/contract/` | contract | oxlint | `tsc --noEmit` + contract tests |
+| `infra/` | infra | — (oxlint not used) | `tsc --noEmit` + `node --test topology-*.test.ts` |
+| `migrations/` | db | — | `atlas migrate validate --dir migrations/neon` |
+| `.github/` | ci | actionlint (workflows) | `check-actions-pinned.sh` + `assert-workflow-invariants.rb` |
+| `scripts/`, `.github/scripts/` | scripts | shellcheck (shell) + ruff (py) | — |
+| `docs/` | docs | — | doc-consistency subset (`test_secrets_docs_consistency.py` + link check) |
+| anything else / unknown | — | — | typecheck on all packages (conservative fallback) |
+
+`packages/contract` is treated as changed whenever any of its consumers changed (contract is the cross-service source of truth) — the router unions: changed packages ∪ {contract if any worker/web/agent changed}.
+
+## Changed-package detection
+
+```
+scripts/local-gates/changed-packages.sh
+  base = origin/main (or HEAD^ when origin is missing)
+  git diff --name-only $base...HEAD | prefix-map → sorted unique package set
+```
+
+Output format: one package per line (`agent catalog contract …`). Hooks read it and dispatch per-package commands; empty set → only universal checks.
+
+## pre-commit (universal + changed packages)
+
+Universal (always, sub-second):
+- trailing-whitespace, end-of-file-fixer, check-yaml, check-toml
+- gitleaks (secret scan)
+- shellcheck (on `scripts/` + `.github/scripts/` shell files, `--severity=warning`)
+- actionlint (on `.github/workflows/*.{yml,yaml}`)
+
+Changed packages:
+- agent → `ruff check --fix` + `ruff format` (all repo Python — ruff is fast enough to run repo-wide, kept universal for Python actually)
+- web/catalog/users/edge/jobs → `oxlint --type-aware --deny-warnings` scoped to the package
+
+Note: ruff runs repo-wide (universal) because Python files are few and ruff is sub-second; oxlint runs per changed TS package.
+
+## pre-push (changed packages, < ~3 min typical)
+
+- typecheck: changed package's `tsc --noEmit` (agent: mypy)
+- unit tests: changed package's fast suite (see table)
+- `db` changed → `atlas migrate validate --dir migrations/neon`
+- `ci` changed → pinned-actions + workflow invariants scripts
+- `docs` changed → doc-consistency subset
+- always: agent unit coverage gate when agent changed
+
+Command notes: pnpm workspaces — `pnpm --filter catalog typecheck` etc.; edge tests run from the repo root (`pnpm run test:worker`).
+
+## Why integration tests stay in CI
+
+Integration tests require real environments: Neon ephemeral branches (python-integration, catalog spikes), PostGIS+pgvector containers, Playwright browsers (cross-stack e2e). They are minutes-long, environment-dependent, and their value is cross-component behaviour, not per-push feedback. They run in CI on every PR (required lanes) and on demand locally via `make test-integration` / `make e2e` / `pnpm run test:spike`. Local hooks cover the unit layer; CI owns the integration layer — this is the standard monorepo split.
+
+## Failure handling
+
+- pre-commit failures: fix in working tree, re-run (auto-fix hooks modify files).
+- pre-push failures: fix or, when the failure is environmental (e.g. atlas needs docker), document the exemption in the commit/push — policy: no silent `--no-verify`; CI still gates.
+- Router bugs: unknown paths fall back to full typecheck (conservative).
+
+## Files
+
+- `scripts/local-gates/changed-packages.sh` — the router
+- `.pre-commit-config.yaml` — hook wiring (existing, reworked)
+- This document — the contract

--- a/docs/ops/local-gates.md
+++ b/docs/ops/local-gates.md
@@ -14,6 +14,13 @@ Campaign lesson: code repeatedly reached CI that local gates should have caught 
 | Path prefix | Package | pre-commit lint | pre-push checks |
 |---|---|---|---|
 | `apps/agent/` | agent | ruff + ruff-format (py) | `uv run mypy` + `uv run pytest src/animichi/tests/unit -q --cov --cov-fail-under=82` |
+
+Coverage floors are an intentional local/CI split: the local pre-push gate runs
+at `--cov-fail-under=82` as a fast signal (mirrors the merged
+`.pre-commit-config.yaml`), while CI remains the terminal gate at the canonical
+`apps/agent` floor of 87 (`apps/agent/pyproject.toml`; AGENTS.md). The local
+floor is deliberately looser than the CI floor — a red push must be the
+exception, but only CI is authoritative for coverage.
 | `apps/web/` | web | oxlint (type-aware) | `tsc --noEmit` + vitest unit |
 | `workers/catalog/` | catalog | oxlint | `tsc --noEmit` + vitest worker suite |
 | `workers/users/` | users | oxlint | `tsc --noEmit` + vitest |
@@ -31,7 +38,7 @@ Campaign lesson: code repeatedly reached CI that local gates should have caught 
 
 ## Changed-package detection
 
-```
+```text
 scripts/local-gates/changed-packages.sh
   base = origin/main (or HEAD^ when origin is missing)
   git diff --name-only $base...HEAD | prefix-map → sorted unique package set

--- a/docs/superpowers/specs/2026-08-08-repo-closeout-spec.md
+++ b/docs/superpowers/specs/2026-08-08-repo-closeout-spec.md
@@ -1,0 +1,89 @@
+# Repo Close-Out Campaign (2026-08-08)
+
+- Status: ACTIVE (owner-approved plan; supersedes per-wave ordering of `2026-08-06-repo-restructure-spec.md` and `refactor-skeleton-2026-08/GOAL.md`)
+- Tracking: this spec + GOAL checkboxes + restructure §5 checks; ADRs 0003/0004/0005 record the architecture decisions
+- Definition of done: GOAL W0–W8 `[x]` · restructure §5 verification green · issues #829/#845 closed
+
+## Confirmed decisions
+
+1. One merged campaign (ADR 0004); waves ordered by dependency, not document numbering.
+2. Branch discipline (ADR 0005): merge-based updates, GitHub rebase-merge, force-push banned on all branches except owner-authorized rewrite windows.
+3. W1 docs/ reorg uses a **fresh inventory** of the current tree, not the 08-06 mapping.
+4. Secrets architecture (ADR 0003): Neon-hosted role passwords, Pulumi `neon.Role` IaC, Cloudflare Secrets Store for worker runtime, connection strings composed by Pulumi, GitHub secrets only for CI-consumed values.
+5. IaC stack is Pulumi only (no Terraform; Neon via bridged provider).
+6. Deferred: Harness rebuild (#827), landing go-live. In scope: production domain activation + SEO validation, W8 daily-squash.
+7. Sourcery reviews PRs via the GitHub App (installed); not a local hook.
+
+## Waves
+
+### P0 — Gates and base discipline
+
+- Two-path comment gate backfill: #901 (2 threads), #902 (4 threads) — inline reply → resolve → top-level 线程判定 → merge.
+- Local hooks rework (design: `docs/ops/local-gates.md`): changed-package routing, fast pre-commit, medium pre-push; integration tests stay in CI (Neon/browser environments).
+- Ruleset: `non_fast_forward` + `deletion` on all branches, bypass = owner.
+- Merge #902 (hooks) after gate; then merge #901 (migration chain rebuild).
+- Acceptance: zero unresolved threads on #901/#902; hooks green on a populated worktree; ruleset listed.
+
+### P1 — Documentation and docs/ reorg
+
+- Matt-skill docs: ADR 0003/0004/0005 (written); campaign spec (this file); hook design (`docs/ops/local-gates.md`); merge as one docs PR.
+- W1 docs/ reorg: fresh inventory → `git mv` (superpowers specs → `docs/specs/` + archive buckets) → reference rewrites (scripted, enumerated by `git grep`) → DOCS_POLICY map/pointer update → zero-check (`git grep docs/superpowers` / `docs/adr/` = 0).
+- W0 remainder: GitHub deployments record sweep (inactive → DELETE, admin token), `.codacy.yml` path verification, `.gitignore` + `.DS_Store`.
+- Restructure §4 verification leftovers: deno.lock discovery, sqlfluff upward discovery, Sonar config file, zero-ref specs, `make dev-local` wrangler dependency, `git filter-repo --analyze` blood report, R2 image-link form.
+- Acceptance: zero grep hits on legacy paths; DOCS_POLICY map matches the tree; verification table with conclusions.
+
+### P2 — Edge ownership
+
+- Root `package.json` purification: runtime deps (hono/jose/…) + `test:worker` → `workers/edge/package.json`; root keeps orchestration.
+- `workers/edge/AGENTS.md` (the only package without one) + root AGENTS.md layout row.
+- Edge `src/` layout: remaining flat files → `src/` + `test/`; update the four file-pins (`auth.ts`, `turnstile.ts`, `containerEnv.ts`, `migrationBoundary.test.ts`) with mutation probes; READS + read-set sync; `node --test` green under the new layout.
+- Acceptance: staging deploy green with `/healthz` + smoke.
+
+### P3 — Workspace and config placement
+
+- `infra` into pnpm workspace (drop `infra/pnpm-lock.yaml`, root lockfile absorbs, CI infra install path updated).
+- `docker/test-postgres` → `apps/agent/docker/`; `fixtures/vision` into agent test tree; `spikes/` removal check; `atlas.hcl` → `db/`; `.sqlfluff` → `db/`; `deno.lock` verification; `apps/agent` stub `package.json`; `.gitignore` re-anchor.
+- Acceptance: workspace install green; config discovery verified.
+
+### P4 — Secrets re-architecture
+
+- Pulumi `neon` stack: `neon.Role` ×4 (import existing roles; passwords Neon-generated) → compose connection strings → write Cloudflare Secrets Store (wrangler/API, once, not readable back).
+- `wrangler.toml` Secrets Store bindings for catalog/users/jobs/edge; remove `wrangler secret bulk` steps and GitHub `*_DATABASE_URL` secrets; delete `scripts/staging-roles-login.sh`.
+- `STAGING_GATE_TOKEN` value cross-check vs Pulumi `stagingGateToken`; staging deploy chain validation (#826 close-out).
+- Acceptance: staging deploy green; secrets hash rows in deploy report; zero `*_DATABASE_URL` GitHub secrets.
+
+### P5 — Meta-gate and production DSN
+
+- New meta-check: every `docs/`-prefixed string in tracked files resolves (agnix-adjacent job).
+- #855: production least-privilege DSNs via the P4 stack (production is an empty data plane today; cutover at owner window).
+- Acceptance: meta-check in CI; prod wiring documented.
+
+### P6 — Production domain + SEO
+
+- Pulumi prod stack: `webDomain=animichi.com` + `webRoutesEnabled=true` (activation confirmed with owner; DNS/apex on the Cloudflare account).
+- SEO validation: sitemap/robots/og/jsonld/hreflang/IndexNow live on the apex; Lighthouse lane green.
+- Acceptance: apex serves the web app; SEO probes 200.
+
+### P7 — History rewrite window (single force-push day)
+
+- Pre-fix #494 (healthz `git_commit` always "unknown" — bake build info).
+- Freeze main → double backup (bundle + private archive repo) → daily-squash (#857 script, ~1820 → ~98 commits) → `git filter-repo` binary strip (blood report from P1) → owner-bypass force-push → CI green + staging re-deploy → `main-legacy` ≥30 days.
+- Acceptance: tip tree unchanged vs pre-rewrite; CI green; staging `/healthz` git_commit matches.
+
+### P8 — Close-out
+
+- Small debts: `workers/maintenance/CONTEXT.md` missing (post-#836), `check-skeleton-w0-docs.sh` failure, staging empty `atlas_schema_revisions` schema, tsx-dependent tests.
+- GOAL checkboxes W2/W6/W7/W8 + change log; restructure §5 full verification; issues #829/#845 closed; both clones aligned; worktrees pruned.
+
+## HITL stops
+
+| Wave | Stop |
+|---|---|
+| P4 | Secrets Store availability check; Neon password confirm; gate-token cross-check |
+| P6 | Production domain activation + apex DNS confirmation |
+| P7 | Freeze declaration + force-push authorization (owner bypass) |
+| P8 | #829/#845 close confirmation |
+
+## Verification (per wave)
+
+Each wave runs its subset; P8 runs the full restructure §5 list (check-agents-refs, test-docs, test:worker, read-set, link check, double-zero grep, `make check`, required-lane positive assertion, staging `/healthz` + smoke).

--- a/docs/superpowers/specs/2026-08-08-repo-closeout-spec.md
+++ b/docs/superpowers/specs/2026-08-08-repo-closeout-spec.md
@@ -27,7 +27,7 @@
 ### P1 — Documentation and docs/ reorg
 
 - Matt-skill docs: ADR 0003/0004/0005 (written); campaign spec (this file); hook design (`docs/ops/local-gates.md`); merge as one docs PR.
-- W1 docs/ reorg: fresh inventory → `git mv` (superpowers specs → `docs/specs/` + archive buckets) → reference rewrites (scripted, enumerated by `git grep`) → DOCS_POLICY map/pointer update → zero-check (`git grep docs/superpowers` / `docs/adr/` = 0).
+- W1 docs/ reorg: fresh inventory → `git mv` (superpowers specs → `docs/specs/` + archive buckets) → reference rewrites (scripted, enumerated by `git grep`) → DOCS_POLICY map/pointer update → zero-check (`git grep docs/superpowers` = 0; `docs/adr/` stays canonical — ADRs 0003-0005 are registered in DOCS_POLICY/CONTEXT-MAP and are not a legacy path).
 - W0 remainder: GitHub deployments record sweep (inactive → DELETE, admin token), `.codacy.yml` path verification, `.gitignore` + `.DS_Store`.
 - Restructure §4 verification leftovers: deno.lock discovery, sqlfluff upward discovery, Sonar config file, zero-ref specs, `make dev-local` wrangler dependency, `git filter-repo --analyze` blood report, R2 image-link form.
 - Acceptance: zero grep hits on legacy paths; DOCS_POLICY map matches the tree; verification table with conclusions.


### PR DESCRIPTION
Grill-with-docs output for the merged repo close-out campaign (owner-directed docs-first).

- **ADR 0003** secrets architecture: Cloudflare Secrets Store as runtime truth, Neon-hosted role passwords, Pulumi neon.Role IaC — replaces psql script + GitHub secrets chain, supersedes #674 ESC-first for worker DSNs
- **ADR 0004** campaign merge: restructure-spec × GOAL → one close-out campaign, single definition of done
- **ADR 0005** force-push policy: all-branch ban, owner-authorized rewrite windows, merge-based updates
- **Campaign spec** 2026-08-08-repo-closeout-spec.md: waves P0–P8, HITL stops, per-wave acceptance
- **Hook design** docs/ops/local-gates.md: changed-package routing, pre-commit/pre-push split, integration tests stay in CI
- DOCS_POLICY + AGENTS.md register the new canonical docs

## Summary by Sourcery

Document the merged repo close-out campaign, updated local development gates, and new repository policies for secrets and force-pushes.

Enhancements:
- Clarify branch protection and history rewrite procedures through an owner-authorized force-push policy tied to a defined rewrite window.
- Standardize secrets management around Cloudflare Secrets Store, Neon-hosted role passwords, and Pulumi-managed roles to reduce reliance on GitHub secrets.

Documentation:
- Register the new close-out campaign spec as the canonical tracking artifact for waves P0–P8 and definition-of-done criteria.
- Add ADRs describing the secrets architecture, the unified close-out campaign, and the repository force-push policy.
- Document the local gates design for changed-package routing, pre-commit vs pre-push responsibilities, and CI ownership of integration tests.
- Update DOCS_POLICY and AGENTS to reference the new campaign spec, ADRs, and local gates documentation as single sources of truth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added authoritative references for campaign tracking, architecture decisions, and repository operations.
  * Documented secrets management, local development checks, campaign close-out requirements, and force-push safeguards.
  * Added a repo close-out plan with phased execution, acceptance criteria, approvals, and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->