### PR TITLE
fix(#494): /healthz git_commit gate — hard-assert the baked deploy SHA

### DIFF
--- a/.github/scripts/post-deploy-assert-probes.test.sh
+++ b/.github/scripts/post-deploy-assert-probes.test.sh
@@ -172,7 +172,22 @@ test_showcase_mode_missing_or_malformed_fails() {
   rm -f "${fixture}" && echo "PASS: missing or malformed EDGE_SHOWCASE_MODE fails loudly"
 }
 
+# ── #494: /healthz must PROVE the baked git SHA — the pre-fix soft warning
+#    is now a hard assertion, and EXPECTED_GIT_COMMIT pins the exact deploy
+#    SHA (a stale pre-#494 image reports "unknown" and must fail the gate) ───
+HEALTHZ_OK_BODY='{"status":"ok","git_commit":"abc1234","git_branch":"main"}'
+HEALTHZ_UNKNOWN_BODY='{"status":"ok","git_commit":"unknown","git_branch":"unknown"}'
+
+test_healthz_asserts_baked_commit() {
+  run_json_probe_case "healthz accepts a real baked commit" 18815 200 "${HEALTHZ_OK_BODY}" 0 healthz
+  run_json_probe_case "healthz fails on git_commit unknown" 18816 200 "${HEALTHZ_UNKNOWN_BODY}" 1 healthz
+  run_json_probe_case "healthz fails on git_branch unknown" 18817 200 '{"status":"ok","git_commit":"abc1234","git_branch":"unknown"}' 1 healthz
+  run_json_probe_case "healthz fails when commit != deploy SHA" 18818 200 "${HEALTHZ_OK_BODY}" 1 healthz EXPECTED_GIT_COMMIT=deadbeef
+  run_json_probe_case "healthz accepts the exact deploy SHA" 18819 200 "${HEALTHZ_OK_BODY}" 0 healthz EXPECTED_GIT_COMMIT=abc1234
+}
+
 test_gate_token_is_sent_as_header
+test_healthz_asserts_baked_commit
 test_showcase_probes_accept_denial
 test_showcase_gate_down_fails
 test_classic_probes_keep_classic_contract

--- a/.github/scripts/post-deploy-assert.sh
+++ b/.github/scripts/post-deploy-assert.sh
@@ -174,17 +174,35 @@ diag() {
   echo
 }
 
+# #494: /healthz must PROVE the deployed git SHA — the container never carries
+# .git, so git_commit/git_branch are real only through the CI bake chain
+# ("Bake git build info" -> apps/agent/Dockerfile COPY apps/agent/src/animichi
+# -> animichi.build_info import in apps/agent/src/animichi/interfaces/routes/health.py).
+# "unknown" here therefore means the bake chain broke, and this used to be a
+# soft warning whose text described the PRE-FIX mechanism ("Dockerfile has no
+# GIT_SHA build arg") — silently letting every deploy pass unverified. Both
+# fields are now hard-asserted; when EXPECTED_GIT_COMMIT (the deploy run's own
+# SHA) is provided, the running container's commit must equal it exactly — the
+# P7 deploy-verification prerequisite (a stale pre-#494 image reports "unknown"
+# today and must fail the gate, not pass with a warning).
 cmd_healthz() {
   : "${ROOT_URL:?ROOT_URL is required}"
-  local status
+  local status git_commit git_branch expected
   status="$(fetch GET "${ROOT_URL}/healthz")"
   diag "${status}"
   [ "${status}" = "200" ] || fail "GET ${ROOT_URL}/healthz expected 200, got ${status}"
   jq -e '.status == "ok"' "${BODY_FILE}" >/dev/null || fail "GET ${ROOT_URL}/healthz body missing status:\"ok\""
-  local git_branch
+  git_commit="$(jq -r '.git_commit // "unknown"' "${BODY_FILE}")"
   git_branch="$(jq -r '.git_branch // "unknown"' "${BODY_FILE}")"
-  if [ "${git_branch}" = "unknown" ]; then
-    echo "::warning title=post-deploy healthz::git_branch reports 'unknown' — the container image does not embed .git (Dockerfile has no GIT_SHA build arg). Known gap, tracked separately; not asserted on here (see docs/ops/deployment.md)."
+  [[ "${git_commit}" =~ ^[0-9a-f]{7,}$ ]] || fail "GET ${ROOT_URL}/healthz git_commit is '${git_commit}', expected a hex SHA — the container image lost its baked build info (check the 'Bake git build info' step and the Dockerfile COPY of apps/agent/src/animichi)"
+  [ "${git_branch}" != "unknown" ] || fail "GET ${ROOT_URL}/healthz git_branch is 'unknown' — the container image lost its baked build info (same chain as the git_commit check)"
+  expected="${EXPECTED_GIT_COMMIT:-}"
+  if [ -n "${expected}" ]; then
+    case "${expected}" in
+      [0-9a-fA-F]*) expected="${expected:0:7}" ;;
+      *) fail "EXPECTED_GIT_COMMIT='${expected}' is not a hex commit SHA — refusing to compare" ;;
+    esac
+    [ "${git_commit}" = "${expected}" ] || fail "GET ${ROOT_URL}/healthz git_commit=${git_commit} != expected deploy SHA ${expected} — the running container is not the image this deploy baked (stale container or bake regression)"
   fi
 }
 

--- a/.github/workflows/reusable-deploy-component.yml
+++ b/.github/workflows/reusable-deploy-component.yml
@@ -811,6 +811,11 @@ jobs:
           # non-empty, and the gate ruleset only matches the staging
           # hostname anyway.
           STAGING_GATE_TOKEN: ${{ secrets.STAGING_GATE_TOKEN }}
+          # #494: the healthz probe hard-asserts git_commit equals this
+          # run's SHA (baked by the "Bake git build info" step) — the P7
+          # deploy-verification proof. `github.sha` in a workflow_call is
+          # the caller's commit, i.e. exactly what the bake wrote.
+          EXPECTED_GIT_COMMIT: ${{ github.sha }}
           # First cold start after an image change takes minutes; base 12 →
           # sleep budget 12*(1+2+3+4)=120s plus 5×20s request timeouts ≈ 220s ceiling, still bounded.
           POST_DEPLOY_ASSERT_RETRY_BACKOFF_BASE_SECONDS: "12"

--- a/.github/workflows/reusable-post-deploy-test.yml
+++ b/.github/workflows/reusable-post-deploy-test.yml
@@ -175,6 +175,8 @@ jobs:
         env:
           ROOT_URL: ${{ steps.urls.outputs.root_url }}
           STAGING_GATE_TOKEN: ${{ secrets.STAGING_GATE_TOKEN }}
+          # #494: hard-assert the deployed git_commit equals this run's SHA.
+          EXPECTED_GIT_COMMIT: ${{ github.sha }}
         run: bash .github/scripts/post-deploy-assert.sh healthz
 
       - name: "edge rejects an invalid bearer token (401; 403 showcase_denied in showcase mode)"

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -587,13 +587,17 @@ itself was a pure UI-affordance gap rather than new untested rollback logic; see
 - default session storage is in-memory unless a distributed backend is introduced later
 - OpenTelemetry exporters are opt-in and disabled by default
 - AI Gateway is documented but not yet wired in backend provider configuration
-- **CURRENTLY BROKEN — do not rely on this**: `/healthz`'s `git_branch`/`git_commit` fields are
-  always `"unknown"` in every deployed environment. `Dockerfile` never `COPY`s `.git` into the
-  image, so the `git rev-parse`/`git branch --show-current` calls in
-  `apps/agent/src/animichi/interfaces/routes/health.py` fail every time. "Verify `/healthz` `git_branch`
-  after a deploy" (referenced in `docs/superpowers/specs/2026-07-06-frontend-rebuild-spec.md:215`
-  and `docs/superpowers/specs/2026-07-28-284-byok-design.md:1080`) cannot confirm anything today —
-  tracked in issue #494.
+- `/healthz`'s `git_branch`/`git_commit` are real in deployed containers via the CI bake chain:
+  `reusable-deploy-component.yml`'s "Bake git build info" step writes
+  `apps/agent/src/animichi/build_info.py` (gitignored, regenerated per deploy) from
+  `GITHUB_SHA`/`GITHUB_REF_NAME`; the image's `COPY apps/agent/src/animichi` ships it and
+  `apps/agent/src/animichi/interfaces/routes/health.py` imports it at startup (fallback: env vars →
+  git shell-out → `"unknown"`). The container never carries `.git`, so `"unknown"` in a deployed
+  environment means the bake chain broke — and since #494's gate fix,
+  `.github/scripts/post-deploy-assert.sh healthz` **hard-fails the deploy** on `"unknown"` and, when
+  `EXPECTED_GIT_COMMIT` is passed (both CI smoke sites), asserts `git_commit` equals the deploy run's
+  own SHA. Live-verified 2026-08-05 (staging returned the deployed SHA; production's last deploy
+  predates the bake fix, so prod still reports `"unknown"` until its next deploy).
 
 ## HISTORICAL (pre-2026-07): feat/ssr-cloudflare Post-deploy Notes
 


### PR DESCRIPTION
## 断点分析(根因)

`/healthz` 的 `git_commit`/`git_branch` "恒 unknown" 的说法追溯来源是**过期文档**,而非当前代码链断裂:

1. **CI 烘焙链完整且曾实测通过**:`reusable-deploy-component.yml` "Bake git build info" → `apps/agent/Dockerfile` `COPY apps/agent/src/animichi` → `health.py` 的 `_baked_build_info()` import。2026-08-05 的 staging 部署实测 `/healthz` 返回 `"git_commit":"9e379f0","git_branch":"main"`(真实 SHA,deploy 日志证据)。
2. **#651(→ src/animichi)与 #853(Dockerfile/wrangler 迁移)均三处同步更新**(bake 路径、COPY、import),链路一致。
3. **deployment.md:590 的 "CURRENTLY BROKEN" 写于 2026-07-29(f746fb84),早于 8/4 的修复(a26a374b)**,从未更新;`post-deploy-assert.sh:187` 的软警告同样描述修复前的机制("Dockerfile has no GIT_SHA build arg")。
4. **生产镜像早于修复**:deploy.yml 最后一次运行在 2026-04,prod 的 /healthz 是修复前镜像——所以"实测 prod"必然 unknown。staging(唯一在修复后部署过的环境)返回真实 SHA。
5. 8/6 起 CI 全红(web smoke、root secret 上传的 "Required Worker name missing" 等无关问题),导致 #853 后没有任何新探针可以反驳过期说法。

**结论:断点是"验证面"缺失/过期** —— 部署门没有真正断言 SHA,P7 前置(部署验证需 /healthz 证明 SHA)不成立。

## 修复(最小面)

- `post-deploy-assert.sh cmd_healthz`:软警告 → **硬断言**——`git_commit` 必须是 hex SHA、`git_branch` 不得为 "unknown";传入 `EXPECTED_GIT_COMMIT` 时还须等于本次部署 run 自身的 SHA(精确证明落地的是本次镜像)。
- 两个 CI 调用点(组件部署 Smoke + reusable-post-deploy-test.yml)传入 `EXPECTED_GIT_COMMIT: ${{ github.sha }}`。
- `deployment.md:590`:删除 "CURRENTLY BROKEN" 过期说明,改写为当前机制 + 断言行为。
- `post-deploy-assert-probes.test.sh`:新增 5 个 behavioral 用例(接受真实 SHA / unknown 失败 / 分支 unknown 失败 / SHA 不匹配失败 / 精确匹配通过)。

## 验证

- 本地:18/18 probe-contract 用例通过(含 5 新),transport 用例全过,shellcheck/actionlint 干净。
- 本地模拟 CI 烘焙(生成 `build_info.py` 后):healthz 单元测试 8/8 通过,烘焙值优先于 env/git 的解析顺序实测正确。
- 镜像级验证依赖 CI:下一次 staging 部署的 Smoke 将硬断言 `git_commit == ${GITHUB_SHA::7}`;此前 CI 全红与 #494 无关(#826/#832 secret 上传链路),本 PR 不触碰。

## 备注

- 未改烘焙链本身(无证据表明其断裂,且有 8/5 实测为证)。
- prod 在下次部署前仍会报 "unknown"(旧镜像)——这正说明硬断言的必要性:部署后它将成为验证 SHA 落地的门。

## Summary by Sourcery

Enforce strict verification of baked git commit information via the /healthz endpoint as part of post-deploy checks, and align docs, tests, and CI workflows with this gate.

Bug Fixes:
- Convert the /healthz git_commit/git_branch check from a non-blocking warning into a hard assertion that fails deploys when build info is missing or mismatched.
- Ensure post-deploy health checks validate that the running container's git_commit matches the current deploy run's SHA when provided.

Enhancements:
- Document the current CI bake chain that supplies git_commit/git_branch to /healthz and its role in deploy verification.
- Add behavioral probe tests covering successful and failing /healthz scenarios around baked commit, branch, and expected deploy SHA.

CI:
- Update reusable deploy and post-deploy test workflows to pass the deploy run's SHA into healthz assertions for commit verification.

Documentation:
- Refresh deployment documentation to describe the working /healthz git_commit/git_branch bake mechanism and its enforced deploy gate, removing outdated "currently broken" notes.

Tests:
- Introduce new post-deploy probe tests to exercise the stricter /healthz gate, including unknown values and SHA mismatch cases.