### PR TITLE
chore(cleanup): fix stale codacy eval path, ignore .context/ (W0 remainder, #909)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -6,6 +6,6 @@ engines:
     enabled: true
 
 exclude_paths:
-  - "src/animichi/tests/eval/**"
+  - "apps/agent/src/animichi/tests/eval/**"
   - "docs/**"
   - "**/*.snap"

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ node_modules
 .codex/
 .baoyu-skills/
 .impeccable/
+.context/
 
 # Large design-probe / mockup image artifacts (kept on disk, not in git)
 docs/design/redesign-probes/


### PR DESCRIPTION
Part of #909 (W0 cleanup remainder).

- **.codacy.yml**: exclude_paths path `src/animichi/tests/eval/**` was stale (pre-monorepo layout, dir no longer exists at repo root); corrected to `apps/agent/src/animichi/tests/eval/**` (live path).
- **.gitignore**: `.context/` added (was untracked at repo root). `.DS_Store` verified already covered under `# IDE`.

Deployments purge executed directly via REST API — 867 inactive records deleted, 0 remaining; not part of this PR (no code change).

Constraints: no merge, squash only.

## Summary by Sourcery

Update static analysis configuration and git ignore rules as part of repository cleanup.

Enhancements:
- Correct Codacy exclude path to point at the current eval tests directory in the monorepo layout.

Chores:
- Add the .context/ directory to .gitignore to prevent it from being tracked at the repo root.