### PR TITLE
fix(hooks): remove sourcery pre-commit hook — PR review App, not a local gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,6 @@
 # Install: pre-commit install && pre-commit install --hook-type pre-push
 # Policy: fix a failing gate or document an environmental exemption — no
 # silent --no-verify (CI still enforces).
-# Sourcery needs a one-time login (free): sourcery login
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -49,16 +47,6 @@ repos:
     rev: v8.30.1
     hooks:
       - id: gitleaks
-
-  # Sourcery — Python refactoring suggestions (free community tier).
-  # One-time login required: `sourcery login`. Rules can be scoped later via
-  # a .sourcery.yaml if the default set is noisy.
-  - repo: https://github.com/sourcery-ai/sourcery
-    rev: v1.44.0
-    hooks:
-      - id: sourcery
-        types: [python]
-        args: [--no-summary]
 
   - repo: local
     hooks:


### PR DESCRIPTION
Owner directive: sourcery reviews PRs via the GitHub App (installed); it must not block local commits. Removed the hook + login comment from .pre-commit-config.yaml. docs/ops/local-gates.md already documents it as PR-review-only.

Push used --no-verify: new worktree lacks node_modules (changed-package routing falls back to full typecheck on unknown paths); config-only change, CI validates.

## Summary by Sourcery

Build:
- Update .pre-commit-config.yaml to drop the Sourcery hook and its login guidance so it no longer blocks local commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the Sourcery pre-commit integration and related configuration comments.
  * Other local pre-commit checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->