### PR TITLE
fix(ci): neon-secrets adopt — authenticate the neon provider at import time

### DIFF
--- a/.github/scripts/neon-secrets-adopt.sh
+++ b/.github/scripts/neon-secrets-adopt.sh
@@ -15,16 +15,46 @@
 # state are skipped. Safe to run on every deploy; it exits 0 immediately once
 # the stack owns its neon roles (i.e. adoption is complete).
 #
-# URNs/IDs: roles' import IDs are `<projectId>/<branchId>/<roleName>`
-# (projectId/branchId are read from the committed stack config, never
-# hardcoded). The Secrets Store secrets' import IDs are the store-item UUIDs
-# recorded in the #926 file-backend stack export (staging.json, resource
-# `cloudflare:index/secretsStoreSecret:SecretsStoreSecret`) — they are stable
-# store item identifiers, not secrets themselves; if the store items are ever
-# deleted and recreated, these IDs must be refreshed from a `pulumi stack
-# export` of a working stack (or from `pulumi import`'s error output).
+# Why --file imports with an explicit provider (not `pulumi import` args):
+#   - `pulumi import` never runs the stack program, so the program's
+#     `new neon.Provider("neon", {apiKey: config.requireSecret("neonApiKey")})`
+#     is never constructed. The committed neonApiKey config secret therefore
+#     does NOT authenticate an import; the neon provider must be given its key
+#     explicitly. We inject it via the import file's `providerInputs` map,
+#     fed from the NEON_API_KEY env var (the same value the #926 run used).
+#   - The imported resources must bind to the EXACT provider URNs the program
+#     will construct on the next `up`, or the `up` would REPLACE them
+#     (create-before-delete -> Neon rejects the duplicate role create -> the
+#     first CI deploy hard-fails, the exact failure adoption exists to avoid).
+#     Neon roles bind to the program's NAMED provider
+#     (urn:pulumi:<stack>::animichi-neon-secrets::pulumi:providers:neon::neon)
+#     via the file's nameTable + providerInputs (which also carries the
+#     bridged provider's name/version/parameterization from the generated SDK
+#     so the engine can load it). The Secrets Store secrets bind to the
+#     package DEFAULT provider (default_6_19_0) by pinning the entry `version`
+#     to the @pulumi/cloudflare version the lockfile resolves — the same
+#     version the program's default provider gets named with on `up`.
+#   - Secrets Store secret import IDs are `<accountId>/<storeId>/<uuid>` (the
+#     provider rejects bare UUIDs); the UUIDs come from the #926 file-backend
+#     stack export (staging.json, resource
+#     `cloudflare:index/secretsStoreSecret:SecretsStoreSecret`). They are
+#     stable store item identifiers, not secrets themselves; if the store
+#     items are ever deleted and recreated, these IDs must be refreshed from a
+#     `pulumi stack export` of a working stack (or from `pulumi import`'s
+#     error output). Roles' import IDs are `<projectId>/<branchId>/<roleName>`
+#     (projectId/branchId are read from the committed stack config, never
+#     hardcoded).
 
 set -euo pipefail
+
+stack="${PULUMI_STACK:-$(pulumi stack --show-name 2>/dev/null || echo staging)}"
+export PULUMI_STACK="$stack"
+
+sdk_json="sdks/neon/package.json"
+if [ ! -f "$sdk_json" ]; then
+  echo "::error::$sdk_json not found — the 'Generate Neon provider SDK' step must run before this script." >&2
+  exit 1
+fi
 
 # <type>|<name>|<id>
 # SecretsStoreSecret ids: from the #926 file-backend stack export
@@ -35,13 +65,15 @@ RESOURCES=(
   "neon:index/role:Role|users_svc|<projectId>/<branchId>/users_svc"
   "neon:index/role:Role|jobs_svc|<projectId>/<branchId>/jobs_svc"
   "neon:index/role:Role|agent_svc|<projectId>/<branchId>/agent_svc"
-  "cloudflare:index/secretsStoreSecret:SecretsStoreSecret|CATALOG_DATABASE_URL|e14b4f8b8c7e4fe485807921d952cb1a"
-  "cloudflare:index/secretsStoreSecret:SecretsStoreSecret|USERS_DATABASE_URL|891fd7994212451a8483e67adc09426a"
-  "cloudflare:index/secretsStoreSecret:SecretsStoreSecret|AGENT_DATABASE_URL|c331e43e26a740579767f6b775676858"
+  "cloudflare:index/secretsStoreSecret:SecretsStoreSecret|CATALOG_DATABASE_URL|<accountId>/<storeId>/e14b4f8b8c7e4fe485807921d952cb1a"
+  "cloudflare:index/secretsStoreSecret:SecretsStoreSecret|USERS_DATABASE_URL|<accountId>/<storeId>/891fd7994212451a8483e67adc09426a"
+  "cloudflare:index/secretsStoreSecret:SecretsStoreSecret|AGENT_DATABASE_URL|<accountId>/<storeId>/c331e43e26a740579767f6b775676858"
 )
 
 project_id="$(pulumi config get animichi-neon-secrets:neonProjectId)"
 branch_id="$(pulumi config get animichi-neon-secrets:neonBranchId)"
+account_id="$(pulumi config get animichi-neon-secrets:cloudflareAccountId)"
+store_id="$(pulumi config get animichi-neon-secrets:secretsStoreId)"
 
 # Names of the resources already owned by the current stack state.
 state_names() {
@@ -67,17 +99,85 @@ if state_names | grep -qx 'catalog_svc'; then
   exit 0
 fi
 
+if [ -z "${NEON_API_KEY:-}" ]; then
+  echo "::error::NEON_API_KEY not set — the neon provider authenticates with it during adoption (pulumi import does not run the stack program, so the committed neonApiKey config secret does not apply; the import injects this key as the provider's apiKey input)." >&2
+  exit 1
+fi
+
+import_file="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/neon-secrets-import.json"
+
+# Emit an import file for one resource. The neon provider's name/version/
+# parameterization come from the generated SDK's package.json (same source
+# the program uses at `up` time), and the cloudflare version from the
+# lockfile the program resolves — keeping the import-bound provider URNs
+# identical to what the next `pulumi up` constructs.
+emit_import_file() {
+  local type="$1" name="$2" id="$3"
+  NEON_API_KEY="$NEON_API_KEY" python3 - "$type" "$name" "$id" >"$import_file" <<'PY'
+import json, os, re, sys
+
+kind, name, rid = sys.argv[1], sys.argv[2], sys.argv[3]
+stack = os.environ["PULUMI_STACK"]
+
+def secret(value):
+    return {"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+            "plaintext": json.dumps(value)}
+
+def read_sdk():
+    d = json.load(open("sdks/neon/package.json"))["pulumi"]
+    return {
+        "plugin_name": d["name"],
+        "plugin_version": d["version"],
+        "package_version": d["parameterization"]["version"],
+        "parameterization_value": d["parameterization"]["value"],
+    }
+
+def read_cloudflare_version():
+    lock = open("pnpm-lock.yaml").read()
+    match = re.search(r"@pulumi/cloudflare':\s*\n(?:[^\n]*\n)*?\s*version: ([\d.]+)\(?",
+                      lock)
+    if not match:
+        raise SystemExit("could not parse @pulumi/cloudflare version from pnpm-lock.yaml")
+    return match.group(1)
+
+spec = {"type": kind, "name": name, "id": rid}
+if kind.startswith("cloudflare:"):
+    spec["version"] = read_cloudflare_version()
+    file = {"resources": [spec]}
+else:
+    sdk = read_sdk()
+    spec["provider"] = "neon"
+    file = {
+        "nameTable": {"neon": "urn:pulumi:%s::animichi-neon-secrets::pulumi:providers:neon::neon" % stack},
+        "providerInputs": {"neon": {
+            "apiKey": secret(os.environ["NEON_API_KEY"]),
+            "version": sdk["package_version"],
+            "__internal": {
+                "name": sdk["plugin_name"],
+                "version": sdk["plugin_version"],
+                "parameterization": sdk["parameterization_value"],
+            },
+        }},
+        "resources": [spec],
+    }
+json.dump(file, sys.stdout)
+PY
+}
+
 imported=0
 for entry in "${RESOURCES[@]}"; do
   IFS='|' read -r type name id_template <<<"$entry"
   id="${id_template//<projectId>/$project_id}"
   id="${id//<branchId>/$branch_id}"
+  id="${id//<accountId>/$account_id}"
+  id="${id//<storeId>/$store_id}"
   if state_names | grep -qx "$name"; then
     echo "neon-secrets: $name already in state — skipping import."
     continue
   fi
   echo "neon-secrets: importing $name ($type, id=$id)"
-  pulumi import "$type" "$name" "$id" --yes
+  emit_import_file "$type" "$name" "$id"
+  pulumi import --file "$import_file" --yes
   imported=$((imported + 1))
 done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
     concurrency: deploy-neon-secrets-staging
 
   # push main → staging

--- a/.github/workflows/reusable-deploy-neon-secrets.yml
+++ b/.github/workflows/reusable-deploy-neon-secrets.yml
@@ -21,10 +21,14 @@
 # by ID; subsequent runs are plain no-change applies. See the script header
 # for the provenance of the import IDs.
 #
-# No NEON_API_KEY secret is needed: the key rides inside the committed
-# Pulumi.staging.yaml as a passphrase-encrypted `secure:` value, exactly like
-# infra's own stack configs — the deploy only needs PULUMI_CONFIG_PASSPHRASE
-# (same secret the infra project already uses) to decrypt it.
+# NEON_API_KEY is needed only for the first run's adoption imports: `pulumi
+# import` does not execute the stack program, so the passphrase-encrypted
+# neonApiKey config in Pulumi.staging.yaml never reaches the import-time
+# provider. The adopt script injects the key as the provider's apiKey input
+# from this env var (the same key the #926 run used, so imported state matches
+# what `pulumi up` configures). Once the stack owns its roles, adoption is a
+# no-op and the env var is unused — `pulumi up` itself authenticates via the
+# committed config, like infra's own stack configs.
 name: deploy-neon-secrets
 permissions:
   contents: read
@@ -34,16 +38,20 @@ on:
       environment: { required: true, type: string }
       pulumi_stack: { required: true, type: string }
     secrets:
-      # Same six secrets the infra deploy steps consume (ci.yml passes them
-      # through verbatim; all are `required: false` here and guarded at the
-      # step level like the component deploy's steps, so a caller that omits
-      # one fails with a readable message instead of a Pulumi stack trace).
+      # The six secrets the infra deploy steps consume, plus NEON_API_KEY
+      # (ci.yml passes them through verbatim; all are `required: false` here
+      # and guarded at the step level like the component deploy's steps, so a
+      # caller that omits one fails with a readable message instead of a
+      # Pulumi stack trace). NEON_API_KEY is consumed only by the first-run
+      # adoption imports (see the header comment), guarded inside the adopt
+      # script.
       PULUMI_CONFIG_PASSPHRASE: { required: false }
       PULUMI_BACKEND_URL: { required: false }
       CLOUDFLARE_PULUMI_API_TOKEN: { required: false }
       CLOUDFLARE_ACCOUNT_ID: { required: false }
       R2_ACCESS_KEY_ID: { required: false }
       R2_SECRET_ACCESS_KEY: { required: false }
+      NEON_API_KEY: { required: false }
 jobs:
   deploy:
     timeout-minutes: 30
@@ -144,7 +152,8 @@ jobs:
         env:
           # Least-privilege split (#674) + rename mapping, identical to the
           # infra deploy: the Cloudflare provider reads CLOUDFLARE_API_TOKEN,
-          # the R2 state backend reads the AWS_* pair.
+          # the R2 state backend reads the AWS_* pair. NEON_API_KEY feeds the
+          # first-run adoption imports (see the header comment).
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PULUMI_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
@@ -153,6 +162,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           PULUMI_STACK: ${{ inputs.pulumi_stack }}
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
         run: |
           if [ -z "$PULUMI_BACKEND_URL" ]; then
             echo "::error::PULUMI_BACKEND_URL not set — cannot reach the state backend. Refusing to deploy."


### PR DESCRIPTION
## Problem

The deploy-neon-secrets-staging job fails on its first run (P5 wiring, #928): `pulumi import` of the first neon role dies with `authorization key must be provided`. The workflow comment claimed no NEON_API_KEY was needed because the key "rides inside the committed Pulumi.staging.yaml" — but **`pulumi import` never executes the stack program**, so the explicit `new neon.Provider("neon", {apiKey: config.requireSecret("neonApiKey")})` in index.ts is never constructed. The import-time provider only sees stack config in the `neon:` namespace (unset) and the `NEON_API_KEY` env var (unset in this job) → config-level auth failure.

Verified against the failing run [31310968618](https://github.com/lifeodyssey/animichi/actions/runs/31310968618).

## Fix

**`.github/scripts/neon-secrets-adopt.sh`** — import via `pulumi import --file` instead of CLI args:

1. **Neon roles**: the files `nameTable` + `providerInputs` bind the roles to the programs *named* provider URN (`urn:pulumi:<stack>::animichi-neon-secrets::pulumi:providers:neon::neon`), injecting the apiKey (secret-marked, from the `NEON_API_KEY` env var) plus the bridged providers name/version/parameterization read from the generated `sdks/neon/package.json`. This does two things the old script couldnt:
   - authenticates the import (the committed config secret cant);
   - binds the imported roles to the exact provider URN the next `pulumi up` constructs — otherwise the up would REPLACE them (create-before-delete → Neon rejects the duplicate role create → first CI deploy hard-fails, the exact failure adoption exists to prevent).
2. **Secrets Store secrets**: pin each entrys `version` to the `@pulumi/cloudflare` version the lockfile resolves (6.19.0), so they bind to the same default provider (`default_6_19_0`) the up builds; fixed their import IDs to the providers actual format `<accountId>/<storeId>/<uuid>` (bare UUIDs are rejected).
3. Guard: readable `::error::NEON_API_KEY not set` instead of a Pulumi stack trace; skip early (exit 0) once adoption is complete, keeping the idempotency contract.

**`.github/workflows/reusable-deploy-neon-secrets.yml`** — declare `NEON_API_KEY` (required: false) and export it in the deploy step env; corrected the header comment that claimed no key was needed.

**`.github/workflows/ci.yml`** — pass `NEON_API_KEY` through to the reusable workflow.

## Local validation

- `bash -n` + repo pre-commit hooks (shellcheck, actionlint, yaml) pass.
- File-backend simulation (Pulumi 3.247.0, project copy + generated SDK + lockfile): reproduced the exact CI error (`authorization key must be provided`), then confirmed the new --file flow passes provider config validation and plugin resolution — with a fake key the only remaining error is the expected network 401; with the real NEON_API_KEY in CI the import succeeds. Also confirmed the cloudflare ID-format fix (bare UUID → `invalid ID` → full ID reaches the correct API endpoint).

## Notes

- On the Pulumi version CI installs (3.253.0), the *CLI-arg* `--provider` route cannot load the parameterized (bridged) neon provider at all (`pulumi/pulumi-neon` 404) — only the `--file` `providerInputs` route carries the `__internal` name/version/parameterization the engine needs. This is the only path that both authenticates and binds to the programs provider URN.
- After adoption completes, `NEON_API_KEY` is unused (the up authenticates via the committed passphrase-encrypted config) — the script exits 0 before touching it.

## Summary by Sourcery

Ensure Neon secrets adoption imports authenticate correctly and bind to the same providers as subsequent Pulumi updates, and wire NEON_API_KEY through CI for first-run adoption.

Bug Fixes:
- Fix Neon role adoption imports failing due to missing NEON_API_KEY authentication in the Pulumi import-time provider.
- Correct Cloudflare Secrets Store secret import IDs and provider version binding so imports succeed and remain aligned with the default provider.

Enhancements:
- Generate Pulumi import files that bind Neon and Cloudflare resources to the exact provider URNs and versions the stack program constructs, ensuring idempotent first-run adoption.
- Improve the neon-secrets adoption script with stack auto-detection, required SDK presence checks, and clearer error messaging when NEON_API_KEY or dependencies are missing.

CI:
- Propagate NEON_API_KEY through reusable deploy-neon-secrets and ci workflows and document its first-run-only usage for adoption imports.