### PR TITLE
P6: prod domain code prep — Pulumi activation keys + SEO verification script (#914)

### DIFF
--- a/docs/ops/prod-seo-validation.md
+++ b/docs/ops/prod-seo-validation.md
@@ -86,6 +86,7 @@ The flag is one config line: set `webRoutesEnabled false`, merge, re-apply via
 ### 1. SEO verification script (this repo, re-runnable, read-only)
 
 ```bash
+# from the repo root (the activation steps above ran from infra/ — cd .. first)
 bash scripts/verify-prod-seo.sh
 ```
 

--- a/docs/ops/prod-seo-validation.md
+++ b/docs/ops/prod-seo-validation.md
@@ -1,0 +1,130 @@
+# Prod Apex Activation + SEO Validation (P6 / #914)
+
+Runbook for the **code-prepared** production-domain launch: activating
+`animichi.com` as the web origin and validating the SEO surface on the apex.
+
+The Pulumi prod stack deliberately ships **without** the launch config
+(`webRoutesEnabled` stays `false`, see `infra/Pulumi.prod.yaml`). This document
+is the owner's activation checklist — every step is HITL, none of it happens
+from a deploy without the GitHub `production` environment approval.
+
+## What is already in place (no code needed)
+
+- SEO code, all committed and shipped with `apps/web`: `robots.txt`,
+  `sitemap.xml`, `og-image.png` (1200x630), home JSON-LD (`WebSite` +
+  `Organization`, `src/features/seo/home-structured-data.ts`), hreflang +
+  canonical (`src/features/seo/head.ts`), IndexNow key file
+  (`public/ab12ab12ab12ab12ab12ab12ab12ab12.txt`,
+  `src/features/seo/indexnow.ts`). The static-files unit suite pins them.
+- Lighthouse lane in CI: `Web / lighthouse` (`pipeline-web.yml`) — CLS
+  blocking at 0.10, LCP warn at 2500ms (`apps/web/lighthouserc.cjs`).
+- Pulumi consumption logic: `infra/src/web-routes.ts` (apex Custom Domain on
+  `animichi-web` + `/v1`, `/img`, `/tiles`, `/healthz` edge routes + www
+  placeholder/301 + optional legacy-domain redirects) and
+  `infra/src/hardening.ts` (DNSSEC, `/v1/*` rate limit, HSTS, CAA).
+
+## Domain ownership — evidence + owner confirmation
+
+Read-only verification performed for #914 (2026-08-09):
+
+- **No CF API token was available locally** for a zone-list query (the repo's
+  `CLOUDFLARE_API_TOKEN` is a GitHub secret, never local; the Pulumi R2 state
+  backend is passphrase-encrypted and unreadable without the passphrase).
+- **The zone provably exists in the account anyway**: the staging stack
+  (`infra/Pulumi.staging.yaml`) uses `cloudflareZoneId`
+  `44fdcc54545c1152a8e730137b671be4` with `stagingDomain: staging.animichi.com`,
+  and staging has been **live** since #541 step 6 (2026-08-05). A Cloudflare
+  Custom Domain for a subdomain requires the parent zone in the same account —
+  so the `animichi.com` zone (id `44fdcc54545c1152a8e730137b671be4`) already
+  lives in account `021233c1880a43aa68565496100e1f8c`.
+
+**Owner HITL confirmation** (before activating): open Cloudflare dashboard →
+your account → the `animichi.com` zone (id `44fd…`) and confirm (a) the zone
+is in the account, (b) the plan permits the apex Custom Domain + the
+4-issuer CAA set, (c) Universal SSL covers the apex.
+
+## Activation steps (HITL — do NOT run in a PR you expect to auto-merge)
+
+Order matters: hardening activates as soon as `cloudflareZoneId` is set (step
+1), CAA on `webDomain` (step 2), and only `webRoutesEnabled` (step 4)
+publishes the apex. The four committed keys are applied by CI's `deploy-prod`
+job (`run_pulumi: true` is catalog-only; GitHub `production` environment
+approval is the gate).
+
+From `infra/`:
+
+```bash
+# 1. Zone hardening turns on here: DNSSEC + /v1 rate limit + HSTS.
+pulumi config set cloudflareZoneId 44fdcc54545c1152a8e730137b671be4 --stack prod
+
+# 2. CAA records pin the apex (4 issuers, hardening.ts).
+pulumi config set webDomain animichi.com --stack prod
+
+# 3. www placeholder + 301-to-apex ruleset (prod only).
+pulumi config set wwwDomain www.animichi.com --stack prod
+
+# 4. THE LAUNCH — apex Custom Domain + narrowed edge routes together.
+pulumi config set webRoutesEnabled true --stack prod
+
+# Optional, one entry per legacy domain (each needs its own CF zone, #545):
+pulumi config set legacyRedirectZones '["<legacy zone id>"]' --stack prod
+```
+
+Commit `infra/Pulumi.prod.yaml`, merge, and let `deploy-prod` run behind the
+`production` environment approval. See `docs/ops/deployment.md` for the apply
+path.
+
+### Rollback
+
+The flag is one config line: set `webRoutesEnabled false`, merge, re-apply via
+`deploy-prod`. This removes the Custom Domain and the narrowed routes
+(`deleteBeforeReplace` semantics). Pulumi export/rollback backup: see
+`docs/ops/deployment.md` → "Pulumi rollback".
+
+## Post-activation verification
+
+### 1. SEO verification script (this repo, re-runnable, read-only)
+
+```bash
+bash scripts/verify-prod-seo.sh
+```
+
+Checks (all against `https://animichi.com`):
+
+| # | Check | Fails when |
+|---|---|---|
+| 1 | Home returns HTML (web Worker), not the edge JSON 404 | routes not narrowed / apex not on `animichi-web` |
+| 2 | `robots.txt` has `Sitemap: https://animichi.com/sitemap.xml` + `Disallow: /v1/` | robots not shipped |
+| 3 | `sitemap.xml` is a valid urlset with the apex `<loc>` + hreflang alternates | sitemap not shipped |
+| 4 | `og-image.png` is a 1200x630 PNG | og asset missing/wrong size |
+| 5 | Home JSON-LD: `WebSite` (with `SearchAction`) + `Organization` (with `logo`), both `url = https://animichi.com/` | structured data broken |
+| 6 | Home head: `canonical` + `ja`/`zh`/`en`/`x-default` hreflang alternates | head wiring broken |
+| 7 | IndexNow key file `/<key>.txt` serves the key verbatim (key read from the checked-in constant) | key file/constant drift or 404 |
+| 8 | `/v1/` answers 401/403 (edge auth) and `/healthz` answers 200 | route narrowing mis-assigned |
+| 9 | `www` 301s to the apex | www placeholder/redirect missing |
+
+Exit 0 = all green; non-zero = at least one check failed (each failure is
+printed). Safe to run before activation — a pre-launch run is expected to fail
+checks 1 and 9 (no DNS yet). The script takes an optional origin argument for
+read-only dry runs against other hosts; note staging is behind the WAF gate
+and answers 403 without the `x-staging-key` header.
+
+### 2. Lighthouse
+
+The `Web / lighthouse` lane (`pipeline-web.yml`, `apps/web/lighthouserc.cjs`)
+is already part of CI per-package gates; no extra step. Its CLS gate is the
+only hard assertion today.
+
+### 3. Owner dashboard spot-checks
+
+- Google Search Console / Bing Webmaster: submit `sitemap.xml`, confirm the
+  IndexNow ping for the home URL is accepted.
+- Rich-results test (or equivalent): home page parses `WebSite`/`Organization`
+  without errors.
+
+## Definition of done (all must hold)
+
+- `scripts/verify-prod-seo.sh` exits 0 (9/9 checks).
+- `Web / lighthouse` lane green on the activation push.
+- Owner confirmed the apex zone + Universal SSL (dashboard).
+- Search consoles accept the sitemap and the IndexNow key.

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -4,18 +4,40 @@ config:
     secure: v1:+pBUAY5DQexxcppn:PAx1EPqfroMHknjsk87vPP6usmoP2x8BlHMuxeNZs339sXPDS7Dr5LzwAyqHuRAncHPPEJ6OTuzgB2VF7F33TMoICpGfkC8oHEKm4aNt0mIrmaOOiaJ8ewt42hh3LGQhLJKqGaC9GLOvC7OsilRaZpGzOPdDNk8Quw5BeuYAvXM8fOUdoZvtsaRqI7X0H93VzFLcVf+eu3S64jO5n/jkF9k=
   seichijunrei-infra:cloudflareAccountId: 021233c1880a43aa68565496100e1f8c
   #
-  # ── Hostname cutover (#541), OFF today ──────────────────────────────────────
+  # ── Hostname cutover (#541 / #914), OFF today ───────────────────────────────
   # `animichi.com` has no DNS record yet. Flipping `webRoutesEnabled` is the
   # launch: it creates the apex Custom Domain, the /v1, /img, /healthz edge
   # routes, and the www placeholder + 301, all together. They share one flag
   # because separating DNS from route narrowing is precisely the failure mode —
   # the apex would answer a browser with the edge Worker's JSON 404.
   #
-  #   pulumi config set webRoutesEnabled true                   --stack prod
-  #   pulumi config set cloudflareZoneId <animichi.com zone id> --stack prod
-  #   pulumi config set webDomain animichi.com                  --stack prod
-  #   pulumi config set wwwDomain www.animichi.com              --stack prod
+  # Activation order (each key is committed here and applied by CI):
+  #
+  #   pulumi config set cloudflareZoneId 44fdcc54545c1152a8e730137b671be4 --stack prod
+  #   pulumi config set webDomain animichi.com                            --stack prod
+  #   pulumi config set wwwDomain www.animichi.com                        --stack prod
+  #   pulumi config set webRoutesEnabled true                             --stack prod
+  #
+  #   # Optional, one entry per legacy domain (each needs its own CF zone, #545):
+  #   pulumi config set legacyRedirectZones '["<legacy zone id>"]'        --stack prod
+  #
+  # Zone id 44fdcc54545c1152a8e730137b671be4 is the animichi.com zone — the
+  # SAME zone staging already lives in (Pulumi.staging.yaml, live since #541
+  # step 6). A CF Custom Domain for a subdomain requires the parent zone in the
+  # account, so the apex zone provably exists; owner still confirms via the CF
+  # dashboard before the launch.
+  #
+  # Not all keys activate at the flag flip. `cloudflareZoneId` ALONE (step 1)
+  # turns on the zone hardening in src/hardening.ts — DNSSEC signing, the
+  # /v1/* rate-limit ruleset, and the HSTS zone setting. `webDomain` (step 2)
+  # additionally pins the four CAA records to the apex. Only
+  # `webRoutesEnabled` (step 4) publishes the apex + narrows the routes.
+  #
+  # After the launch, verify the apex with scripts/verify-prod-seo.sh — the
+  # runbook is docs/ops/prod-seo-validation.md (runbook + HITL checklist,
+  # #914).
   #
   # Prod applies run through CI behind the GitHub `production` environment
-  # approval — see ../docs/ops/deployment.md. There is no staging gate here;
-  # `stagingGateEnabled` is read only on the staging stack.
+  # approval — `run_pulumi: true` only on the deploy-prod catalog job (see
+  # ../docs/ops/deployment.md and .github/workflows/ci.yml). There is no
+  # staging gate here; `stagingGateEnabled` is read only on the staging stack.

--- a/scripts/verify-prod-seo.sh
+++ b/scripts/verify-prod-seo.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Production apex SEO verification (#914) — re-runnable, read-only.
+#
+# Checks the canonical origin (https://animichi.com) for the full P6 SEO
+# surface after the #914 launch: sitemap / robots / og-image / home JSON-LD /
+# hreflang / IndexNow, plus the activation-level assertions that the apex is
+# really the web Worker (HTML home, www 301, edge-only /v1) and not the edge
+# Worker's JSON 404.
+#
+# Safe to run BEFORE activation: every failure is reported with an exit code,
+# so a pre-launch dry run is expected to fail the www/apex-html checks. Run it
+# again after `webRoutesEnabled` lands and every check must be green.
+#
+# Usage:
+#   bash scripts/verify-prod-seo.sh            # full post-activation check
+#   bash scripts/verify-prod-seo.sh <origin>   # check a different origin
+#                                             # (e.g. a preview host, read-only)
+#
+# Requires: curl, python3 (dig is used only for an informational DNS note).
+# The IndexNow key is read from apps/web/src/features/seo/indexnow.ts — the
+# checked-in source constant is the single source of truth, never hardcoded.
+
+ORIGIN="${1:-https://animichi.com}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+fail() { echo "✗ $*" >&2; FAIL=$((FAIL + 1)); }
+ok() { echo "✓ $*"; PASS=$((PASS + 1)); }
+warn() { echo "⚠ $*" >&2; }
+
+command -v curl >/dev/null || { echo "✗ curl not found" >&2; exit 2; }
+command -v python3 >/dev/null || { echo "✗ python3 not found" >&2; exit 2; }
+
+HTTP_CODE="$(mktemp "$TMP/http.XXXXXX")"
+fetch() { # fetch <outfile> <url> — stores the HTTP status in $HTTP_CODE
+  curl -fsSL --max-time 20 -o "$1" -w '%{http_code}' "$2" > "$HTTP_CODE" 2>/dev/null \
+    || true
+}
+
+echo "== Verifying SEO surface at $ORIGIN =="
+
+# ── Informational: DNS state (not a pass/fail check) ─────────────────────────
+if command -v dig >/dev/null 2>&1; then
+  warn "DNS: $(dig +short "$(echo "$ORIGIN" | sed -E 's#^https?://##')" A | tr '\n' ' ' | sed 's/ $//' || echo 'no A record yet')"
+fi
+
+# ── 1. Home page: HTML from the web Worker, not the edge JSON 404 ────────────
+fetch "$TMP/home.html" "$ORIGIN/"
+CODE="$(cat "$HTTP_CODE")"
+if [ "$CODE" != "200" ]; then
+  fail "home $ORIGIN/ → HTTP $CODE (expected 200)"
+else
+  if grep -q "<html" "$TMP/home.html"; then
+    ok "home serves HTML (web Worker owns the apex)"
+  elif grep -q '"error"' "$TMP/home.html"; then
+    fail "home answers the edge Worker's JSON error — routes not narrowed yet"
+  else
+    fail "home returned 200 but no <html> marker found"
+  fi
+fi
+
+# ── 2. robots.txt ────────────────────────────────────────────────────────────
+fetch "$TMP/robots.txt" "$ORIGIN/robots.txt"
+if [ "$(cat "$HTTP_CODE")" != "200" ]; then
+  fail "robots.txt → HTTP $(cat "$HTTP_CODE") (expected 200)"
+elif ! grep -q "Sitemap: $ORIGIN/sitemap.xml" "$TMP/robots.txt" \
+  || ! grep -q "Disallow: /v1/" "$TMP/robots.txt"; then
+  fail "robots.txt missing 'Sitemap: $ORIGIN/sitemap.xml' or 'Disallow: /v1/'"
+else
+  ok "robots.txt serves sitemap pointer + /v1/ disallow"
+fi
+
+# ── 3. sitemap.xml ───────────────────────────────────────────────────────────
+fetch "$TMP/sitemap.xml" "$ORIGIN/sitemap.xml"
+if [ "$(cat "$HTTP_CODE")" != "200" ]; then
+  fail "sitemap.xml → HTTP $(cat "$HTTP_CODE") (expected 200)"
+elif ! grep -q "<urlset" "$TMP/sitemap.xml" \
+  || ! grep -q "<loc>$ORIGIN/</loc>" "$TMP/sitemap.xml" \
+  || ! grep -q 'hreflang="x-default"' "$TMP/sitemap.xml"; then
+  fail "sitemap.xml is not a valid urlset with $ORIGIN/ + hreflang alternates"
+else
+  ok "sitemap.xml is a valid urlset with apex loc + hreflang"
+fi
+
+# ── 4. og-image.png (magic + 1200x630 dimensions) ────────────────────────────
+fetch "$TMP/og.png" "$ORIGIN/og-image.png"
+if [ "$(cat "$HTTP_CODE")" != "200" ]; then
+  fail "og-image.png → HTTP $(cat "$HTTP_CODE") (expected 200)"
+else
+  DIMS="$(python3 - "$TMP/og.png" <<'PY'
+import struct, sys
+data = open(sys.argv[1], "rb").read()
+if data[:8] != b"\x89PNG\r\n\x1a\n":
+    sys.exit(1)
+w, h = struct.unpack(">II", data[16:24])
+print(f"{w}x{h}")
+PY
+  )" || DIMS=""
+  if [ "$DIMS" = "1200x630" ]; then
+    ok "og-image.png is a 1200x630 PNG"
+  else
+    fail "og-image.png wrong or not a PNG (got '${DIMS:-invalid}')"
+  fi
+fi
+
+# ── 5. Home JSON-LD: WebSite + Organization on $ORIGIN/ ──────────────────────
+if [ ! -s "$TMP/home.html" ]; then
+  fail "home not fetched — cannot verify JSON-LD"
+else
+JSONLD="$(python3 - "$TMP/home.html" "$ORIGIN" <<'PY'
+import json, re, sys
+html, origin = open(sys.argv[1], encoding="utf-8").read(), sys.argv[2]
+found = re.findall(r'<script[^>]*application/ld\+json[^>]*>(.*?)</script>', html, re.S)
+nodes = []
+for block in found:
+    try:
+        data = json.loads(block)
+    except json.JSONDecodeError:
+        continue
+    nodes.extend(data if isinstance(data, list) else [data])
+def walk(node):
+    yield node
+    if isinstance(node, dict):
+        for v in node.values():
+            yield from walk(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from walk(v)
+types = [n.get("@type") for n in walk(nodes) if isinstance(n, dict)]
+site = next((n for n in walk(nodes) if isinstance(n, dict) and n.get("@type") == "WebSite"), None)
+org = next((n for n in walk(nodes) if isinstance(n, dict) and n.get("@type") == "Organization"), None)
+ok_site = bool(site and site.get("url") == f"{origin}/" and site.get("potentialAction"))
+ok_org = bool(org and org.get("url") == f"{origin}/" and org.get("logo"))
+print(json.dumps({"site": ok_site, "org": ok_org, "types": types}))
+PY
+)"
+SITE_OK="$(echo "$JSONLD" | python3 -c 'import json,sys; print(json.load(sys.stdin)["site"])')"
+ORG_OK="$(echo "$JSONLD" | python3 -c 'import json,sys; print(json.load(sys.stdin)["org"])')"
+if [ "$SITE_OK" = "True" ] && [ "$ORG_OK" = "True" ]; then
+  ok "home JSON-LD has WebSite (with SearchAction) + Organization (with logo)"
+else
+  fail "home JSON-LD incomplete — site=$SITE_OK org=$ORG_OK (expected WebSite + Organization)"
+fi
+fi
+
+# ── 6. hreflang + canonical on the home page ─────────────────────────────────
+if [ ! -s "$TMP/home.html" ]; then
+  fail "home not fetched — cannot verify hreflang/canonical"
+else
+HREFLANG_OK=1
+for HL in ja zh en x-default; do
+  grep -q "hreflang=\"$HL\" href=\"$ORIGIN/\"" "$TMP/home.html" || HREFLANG_OK=0
+done
+grep -q "rel=\"canonical\" href=\"$ORIGIN/\"" "$TMP/home.html" || HREFLANG_OK=0
+if [ "$HREFLANG_OK" = "1" ]; then
+  ok "home head has canonical + ja/zh/en/x-default hreflang alternates"
+else
+  fail "home head missing canonical or one of ja/zh/en/x-default hreflang"
+fi
+fi
+
+# ── 7. IndexNow key file (key read from the checked-in constant) ─────────────
+KEY="$(sed -n 's/.*INDEXNOW_KEY = "\([0-9a-f]\{32\}\)".*/\1/p' \
+  "$REPO_ROOT/apps/web/src/features/seo/indexnow.ts" | head -1)"
+if [ -z "$KEY" ]; then
+  fail "cannot read INDEXNOW_KEY from apps/web/src/features/seo/indexnow.ts"
+else
+  fetch "$TMP/indexnow.txt" "$ORIGIN/$KEY.txt"
+  if [ "$(cat "$HTTP_CODE")" != "200" ]; then
+    fail "IndexNow key file /$KEY.txt → HTTP $(cat "$HTTP_CODE") (expected 200)"
+  elif [ "$(cat "$TMP/indexnow.txt")" != "$KEY" ]; then
+    fail "IndexNow key file content does not equal the key"
+  else
+    ok "IndexNow key file /$KEY.txt serves the key verbatim"
+  fi
+fi
+
+# ── 8. Edge surface split: /v1/* stays edge, /healthz stays public ───────────
+fetch "$TMP/v1.json" "$ORIGIN/v1/"
+if [ "$(cat "$HTTP_CODE")" = "401" ] || [ "$(cat "$HTTP_CODE")" = "403" ]; then
+  ok "/v1/ is edge-auth protected (HTTP $(cat "$HTTP_CODE"))"
+else
+  fail "/v1/ → HTTP $(cat "$HTTP_CODE") (expected 401/403 at the edge)"
+fi
+fetch "$TMP/healthz.txt" "$ORIGIN/healthz"
+if [ "$(cat "$HTTP_CODE")" = "200" ]; then
+  ok "/healthz is reachable"
+else
+  fail "/healthz → HTTP $(cat "$HTTP_CODE") (expected 200)"
+fi
+
+# ── 9. www 301 → apex (created by the same flag flip) ────────────────────────
+WWW="$(echo "$ORIGIN" | sed -E 's#^https://#https://www.#')"
+curl -fsSIL --max-time 20 "$WWW/" > "$TMP/www.txt" 2>/dev/null || true
+WWW_CODE="$(head -1 "$TMP/www.txt" 2>/dev/null | awk '{print $2}')"
+if [ "$WWW_CODE" = "301" ] && grep -qi "location: $ORIGIN/" "$TMP/www.txt"; then
+  ok "www redirects 301 → $ORIGIN/"
+else
+  fail "www → HTTP ${WWW_CODE:-000} (expected 301 to the apex)"
+fi
+
+echo
+echo "== $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #914 (code portion — activation itself is HITL, not done here).

**No launch config set**: `webRoutesEnabled` remains unset (`false`) in `infra/Pulumi.prod.yaml`. This PR only prepares — comments/runbook/verification tooling.

## What ships

1. **`infra/Pulumi.prod.yaml`** — completed activation-key comment block:
   - exact `pulumi config set` order (zoneId → webDomain → wwwDomain → webRoutesEnabled, optional legacyRedirectZones)
   - zone id `44fdcc54545c1152a8e730137b671be4` (the animichi.com zone — same one staging is live in since #541 step 6)
   - staging semantics: hardening (DNSSEC + /v1 rate limit + HSTS) activates on `cloudflareZoneId` ALONE; CAA pins the apex on `webDomain`; only `webRoutesEnabled` publishes
   - apply path: CI `deploy-prod` (`run_pulumi: true` catalog job) behind GitHub `production` environment approval
2. **`scripts/verify-prod-seo.sh`** — re-runnable, read-only apex verification (9 checks): home HTML (web Worker, not edge JSON 404), robots.txt, sitemap.xml, og-image 1200x630 PNG, home JSON-LD (WebSite+Organization), canonical+hreflang (ja/zh/en/x-default), IndexNow key file (key read from source constant), /v1 edge-auth + /healthz, www 301→apex. Exit 0 = all green. Tested against staging (WAF-gate 403s expected) + shellcheck clean.
3. **`docs/ops/prod-seo-validation.md`** — activation runbook + HITL checklist + definition of done.

## Domain ownership verification (read-only)

- No CF API token locally (repo token is a CI-only secret); R2 Pulumi state is passphrase-encrypted — **neither reachable from this machine**.
- **Conclusion: the animichi.com zone provably exists in the CF account** — staging stack config (`Pulumi.staging.yaml`) uses zone id `44fdcc54545c1152a8e730137b671be4` + `staging.animichi.com`, live since 2026-08-05 (#541 step 6); a CF subdomain Custom Domain requires the parent zone in the same account.
- **Owner to confirm via dashboard**: zone presence/plan, apex Universal SSL, CAA headroom (4 issuers, hardening.ts).

## HITL activation steps (owner, after merge — DO NOT auto-run)

```bash
cd infra
pulumi config set cloudflareZoneId 44fdcc54545c1152a8e730137b671be4 --stack prod
pulumi config set webDomain animichi.com --stack prod
pulumi config set wwwDomain www.animichi.com --stack prod
pulumi config set webRoutesEnabled true --stack prod
```

Commit, merge → `deploy-prod` (production env approval) applies. Then:
`bash scripts/verify-prod-seo.sh` must exit 0; `Web / lighthouse` lane green; owner submits sitemap to search consoles + pings IndexNow.

## HITL confirmation points

- [ ] Owner: animichi.com zone + plan + Universal SSL OK on dashboard (zone id 44fd…)
- [ ] Owner: approve `production` environment apply
- [ ] Owner: run verify-prod-seo.sh → 9/9 green
- [ ] Owner: search console sitemap/IndexNow acceptance

## Summary by Sourcery

Prepare production domain activation for animichi.com and add tooling and documentation for SEO and launch verification without enabling the prod web routes yet.

Enhancements:
- Document the precise Pulumi config sequence and Cloudflare zone details for prod hostname cutover in infra/Pulumi.prod.yaml.
- Introduce a prod apex SEO verification script to validate HTML origin, robots/sitemap, structured data, IndexNow key, edge auth, and www redirects.
- Add an ops runbook describing HITL activation steps, rollback guidance, and SEO validation/definition-of-done for the production apex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a production activation and SEO validation runbook covering domain setup, redirects, security configuration, rollback procedures, and post-launch checks.
  * Expanded production deployment guidance with activation steps, ownership details, and verification instructions.

* **Chores**
  * Added a repeatable SEO verification tool that checks page metadata, structured data, indexing files, redirects, health endpoints, and key production routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->