### PR TITLE
chore(#916): P8 small debts — agent tsx toolchain declared, jobs rename closed out

### DIFF
--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -11,6 +11,9 @@ catalog** — it never calls external anime APIs in the request path and never w
 - `make test-eval` — official model-backed runner plus translation eval. The pytest eval entry is a
   transition alias sharing the same report/gate path, not the primary interface.
 - Directly: `cd apps/agent && uv run pytest src/animichi/tests/unit/`. Seed data: `src/animichi/tests/fixtures/seed.sql`.
+- The zod wire-contract tests (`tests/unit/test_chat_wire_contract.py`, 12 parametrized cases) spawn
+  `node --import tsx chat-wire-parser.ts`; they need the workspace TS toolchain, so run `pnpm install`
+  once (tsx is a declared devDependency of this package). CI always has it via the shared setup action.
 - In a worktree, format with `uv tool run ruff format` (not `uv run …`).
 
 ## Runtime call-path

--- a/apps/agent/AGENTS.md
+++ b/apps/agent/AGENTS.md
@@ -11,7 +11,7 @@ catalog** — it never calls external anime APIs in the request path and never w
 - `make test-eval` — official model-backed runner plus translation eval. The pytest eval entry is a
   transition alias sharing the same report/gate path, not the primary interface.
 - Directly: `cd apps/agent && uv run pytest src/animichi/tests/unit/`. Seed data: `src/animichi/tests/fixtures/seed.sql`.
-- The zod wire-contract tests (`tests/unit/test_chat_wire_contract.py`, 12 parametrized cases) spawn
+- The zod wire-contract tests (`src/animichi/tests/unit/test_chat_wire_contract.py`, 12 parametrized cases) spawn
   `node --import tsx chat-wire-parser.ts`; they need the workspace TS toolchain, so run `pnpm install`
   once (tsx is a declared devDependency of this package). CI always has it via the shared setup action.
 - In a worktree, format with `uv tool run ruff format` (not `uv run …`).

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -5,5 +5,8 @@
     "install": "uv sync --extra dev",
     "test": "uv run pytest src/animichi/tests/unit/ -v",
     "test:integration": "uv run pytest src/animichi/tests/integration/ -v --no-cov"
+  },
+  "devDependencies": {
+    "tsx": "^4.23.1"
   }
 }

--- a/docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md
+++ b/docs/iterations/refactor-skeleton-2026-08/PATH-DELTA.md
@@ -12,7 +12,7 @@
 | `workers/edge/wrangler.toml` | 根 `wrangler.toml` | DONE | Edge E1, #853 |
 | `workers/edge/package.json` runtime deps | 根 `package.json` | DONE | Edge E1, #853 |
 | `apps/agent/Dockerfile` | 根 `Dockerfile` | DONE | 容器 pin, #853 |
-| `workers/jobs/` | `workers/maintenance/` | TODO | J1 |
+| `workers/jobs/` | `workers/jobs/` | DONE | J1, #836 |
 | `migrations/neon/` | `db/migrations/` | TODO | DBA D19 |
 | `migrations/supabase/` | 根 `supabase/` | TODO | 过渡 |
 | `tests/e2e/` | 根 `e2e/` | TODO | monorepo 树 |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,11 @@ importers:
         specifier: 4.114.0
         version: 4.114.0(@cloudflare/workers-types@5.20260727.1)(@types/node@26.1.1)
 
-  apps/agent: {}
+  apps/agent:
+    devDependencies:
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
 
   apps/web:
     dependencies:


### PR DESCRIPTION
Part of #916.

## 1. jobs/maintenance CONTEXT debt (#836 rename leftover)
- Verified on main: `workers/jobs/CONTEXT.md` exists; CONTEXT-MAP.md rows already fixed by #923 (line 17 "rename #836 landed", domain table row plain `workers/jobs`). No change needed.
- Fixed the one remaining stale tracker row: `PATH-DELTA.md` J1 (`workers/jobs/ | workers/maintenance/ | TODO`) → DONE (#836) — the directory was renamed but the tracker was never updated.

## 2. check-skeleton-w0-docs.sh
- Already fixed on main by 523e5ec2 (#908): pin `workers/maintenance/CONTEXT.md` → `workers/jobs/CONTEXT.md`. Verified green on a clean origin/main worktree (`OK: skeleton W0 doc structure`, exit 0). Local clone showed red only because it sat on a stale branch. No change needed.
- Note: script lives at `scripts/`, not `.github/scripts/` (brief path).

## 3. agent 12 tsx-dependent tests (#892 leftover)
- `tests/unit/test_chat_wire_contract.py` (12 parametrized `test_real_response_builder_wire_parses_in_zod`) spawn `node --import tsx chat-wire-parser.ts`.
- CI runs them and they pass (hoisted via `.npmrc` `shamefully-hoist`); #892's gate note recorded them deselected locally.
- Fix: declare `tsx@^4.23.1` as devDependency in `apps/agent/package.json` (matches repo-wide pin), regenerate `pnpm-lock.yaml` importer, and document the requirement in `apps/agent/AGENTS.md`.
- Verified locally: 12 passed in the worktree with the declared toolchain.

No merge; squash on approval.

## Summary by Sourcery

Declare the TSX toolchain for the agent package and close out remaining tracking documentation for prior refactors.

New Features:
- Document the TSX-based zod wire-contract tests and their tooling requirement in AGENTS.md.

Enhancements:
- Add tsx as a devDependency in apps/agent/package.json to support TS-based wire-contract tests.

Documentation:
- Update PATH-DELTA.md to mark the workers/jobs rename as completed and aligned with the current directory structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running wire-contract tests, including required tooling, dependencies, and CI availability.
  * Updated migration documentation to reflect the completed workers/jobs path transition.

* **Chores**
  * Added `tsx` as a development tool for test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->