### PR TITLE
feat(#912): agent container Neon DSN — agent_svc store secret + edge forwarding + prod stack docs

### DIFF
--- a/apps/agent/src/animichi/config/settings.py
+++ b/apps/agent/src/animichi/config/settings.py
@@ -147,9 +147,16 @@ class Settings(BaseSettings):
         default="0.1.0",
         description="Service version reported to observability backends",
     )
-    # Supabase
+    # Supabase (legacy name — the value is a plain asyncpg DSN)
     supabase_db_url: str = Field(
         default="", description="Direct Postgres DSN for asyncpg"
+    )
+    # Neon agent_svc role DSN (#912 follow-up): the container's least-privilege
+    # data-plane URL, forwarded by the edge Worker when the environment has the
+    # Secrets Store binding. Wins over SUPABASE_DB_URL when both are set;
+    # production keeps SUPABASE_DB_URL until the #855 cutover.
+    agent_svc_database_url: str = Field(
+        default="", description="Neon agent_svc role DSN for asyncpg"
     )
 
     # Session storage (in-memory only)
@@ -231,8 +238,8 @@ class Settings(BaseSettings):
     def validate_required_env(self) -> "Settings":
         """Fail fast with clear errors if critical env vars are missing."""
         missing: list[str] = []
-        if not self.supabase_db_url:
-            missing.append("SUPABASE_DB_URL")
+        if not self.supabase_db_url and not self.agent_svc_database_url:
+            missing.append("AGENT_SVC_DATABASE_URL (or SUPABASE_DB_URL)")
         missing.extend(
             credential
             for credential in self._required_model_credentials()
@@ -264,6 +271,12 @@ class Settings(BaseSettings):
     def is_development(self) -> bool:
         """Check if running in development environment."""
         return self.app_env.lower() == "development"
+
+    @property
+    def database_url(self) -> str:
+        """Runtime Postgres DSN — the role-scoped Neon URL when provisioned
+        (AGENT_SVC_DATABASE_URL), the legacy SUPABASE_DB_URL otherwise."""
+        return self.agent_svc_database_url or self.supabase_db_url
 
     def get_runtime_config(self) -> dict[str, str | int | float | bool]:
         """Get non-secret runtime configuration (safe to log).

--- a/apps/agent/src/animichi/interfaces/routes/_deps.py
+++ b/apps/agent/src/animichi/interfaces/routes/_deps.py
@@ -322,9 +322,11 @@ def _http_status_for_response(response: PublicAPIResponse) -> int:
 
 
 def build_supabase_client(settings: Settings) -> SupabaseClient:
-    dsn = settings.supabase_db_url.strip()
+    dsn = settings.database_url.strip()
     if not dsn:
-        raise RuntimeError("SUPABASE_DB_URL is required to run the HTTP service.")
+        raise RuntimeError(
+            "AGENT_SVC_DATABASE_URL or SUPABASE_DB_URL is required to run the HTTP service."
+        )
     return SupabaseClient(dsn)
 
 

--- a/apps/agent/src/animichi/tests/unit/test_settings.py
+++ b/apps/agent/src/animichi/tests/unit/test_settings.py
@@ -121,3 +121,41 @@ class TestAPIKeyValidation:
         )
         assert config["fallback_agent_model"] == "openai:gpt-5.4"
         assert config["openai_compat_base_url"] == "https://api.univibe.cc/openai"
+
+
+class TestAgentDatabaseUrl:
+    """Container DSN resolution (#912 follow-up): AGENT_SVC_DATABASE_URL wins
+    over the legacy SUPABASE_DB_URL when both are set, and either one
+    satisfies the required-env check."""
+
+    def test_agent_svc_dsn_wins_over_supabase(self) -> None:
+        settings = Settings(
+            _env_file=None,
+            mimo_api_key="k",
+            supabase_db_url="postgresql://legacy/db",
+            agent_svc_database_url="postgresql://agent_svc@neon/db",
+        )
+        assert settings.database_url == "postgresql://agent_svc@neon/db"
+
+    def test_supabase_dsn_is_fallback_when_no_agent_dsn(self) -> None:
+        settings = Settings(
+            _env_file=None, mimo_api_key="k", supabase_db_url="postgresql://legacy/db"
+        )
+        assert settings.database_url == "postgresql://legacy/db"
+
+    def test_agent_dsn_alone_satisfies_required_env(self) -> None:
+        settings = Settings(
+            _env_file=None,
+            mimo_api_key="k",
+            agent_svc_database_url="postgresql://agent_svc@neon/db",
+        )
+        assert settings.database_url == "postgresql://agent_svc@neon/db"
+
+    def test_missing_both_dsns_raises(self) -> None:
+        with pytest.raises(ValueError, match="AGENT_SVC_DATABASE_URL"):
+            Settings(
+                _env_file=None,
+                mimo_api_key="k",
+                supabase_db_url="",
+                agent_svc_database_url="",
+            )

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -115,7 +115,10 @@ Schedules and cutover verification are in
 
 Required:
 
-- `SUPABASE_DB_URL`
+- `AGENT_SVC_DATABASE_URL` **or** `SUPABASE_DB_URL` — the Postgres DSN. Staging supplies
+  the role-scoped Neon DSN (`agent_svc` role) via the edge Worker's Secrets Store binding,
+  forwarded into the container and preferred over `SUPABASE_DB_URL` (which remains the
+  production container DSN until the #855 cutover); see `docs/ops/prod-dsn-cutover.md`.
 - `MIMO_API_KEY` for the primary `mimo-v2.5` model
 - `DEEPSEEK_API_KEY` remains deploy-required and provisioned for the dormant DeepSeek fallback
 - `APP_ENV` — forwarded from `wrangler.toml`'s per-environment `[vars]` block (`development` /

--- a/docs/ops/prod-dsn-cutover.md
+++ b/docs/ops/prod-dsn-cutover.md
@@ -2,6 +2,7 @@
 
 **Ticket:** [#855](https://github.com/lifeodyssey/animichi/issues/855) · **Parent:** [#829](https://github.com/lifeodyssey/animichi/issues/829) · **Campaign:** [#904](https://github.com/lifeodyssey/animichi/issues/904) P5 (#913)
 **Precedent:** staging cutover [#832](https://github.com/lifeodyssey/animichi/issues/832) (closed) · **Secrets ADR:** `docs/adr/0003-secrets-architecture.md` · **Env map:** `docs/ops/neon-env-topology.md`
+**Agent container DSN:** [#912 follow-up](https://github.com/lifeodyssey/animichi/issues/912) (staging wire landed; this doc is the prod half)
 
 ## Current state (investigated for #913)
 
@@ -29,14 +30,80 @@
   back); Workers bind Secrets Store values (`wrangler.toml` bindings — P4 shape).
 - Schema + GRANTs applied by **Atlas** via the deploy path (`search_path=public`).
 
+## Container DSN mechanism (agent — not a Worker)
+
+The Python agent runs in a Cloudflare **container**, which has no Secrets Store binding of
+its own. Containers receive env **only** through the edge Worker's code:
+`buildContainerEnvVars()` (`workers/edge/src/container/container-env.ts`) copies from the edge
+Worker's own env (`vars` + secrets + Secrets Store bindings) an allowlist of keys. So the
+agent's Neon DSN travels: **Pulumi store secret → edge Worker `[[env.<env>.secrets_store_secrets]]`
+binding → `CONTAINER_ENV_KEYS` forwarding → container env → `Settings.agent_svc_database_url`
+(`Settings.database_url`, preferred over the legacy `SUPABASE_DB_URL`)**.
+
+Staging landed this wire (#912 follow-up). Two consequences for prod:
+
+- The prod edge Worker needs the same binding, and CI needs the value in the **GitHub
+  `production` environment secret `AGENT_SVC_DATABASE_URL`** (uploaded via
+  `wrangler secret put`, mirroring how `SUPABASE_DB_URL` is uploaded today) **or** the prod
+  store binding once the prod store story below is settled — until then the prod container
+  keeps `SUPABASE_DB_URL`.
+- **Naming collision**: the store secret is `AGENT_SVC_DATABASE_URL`, not
+  `AGENT_DATABASE_URL` — that store secret name is already claimed by the jobs Worker's
+  binding (`jobs_svc` role) and store secret names are unique per store. The iter6 R1
+  rename plan (`SUPABASE_DB_URL → AGENT_DATABASE_URL`) is therefore amended to
+  `SUPABASE_DB_URL → AGENT_SVC_DATABASE_URL`. (If the jobs binding were ever renamed
+  `JOBS_DATABASE_URL`, `AGENT_DATABASE_URL` would free up — out of scope.)
+
+## neon-secrets prod stack (Pulumi)
+
+`infra/neon-secrets/` currently runs only the `staging` stack (`Pulumi.staging.yaml`). The
+prod stack is deliberately **not** created in the staging PR (#912 follow-up) — owner
+approval + secrets are HITL. Steps:
+
+1. **`infra/neon-secrets/Pulumi.production.yaml`** — mirror `Pulumi.staging.yaml`:
+   - `neonProjectId`: the **same** Neon project (roles are **project-scoped**, not
+     branch-scoped — do not re-create roles; `pulumi up` on a second stack against the same
+     project would try to create them again and Neon rejects duplicate role creates).
+   - `neonBranchId`: the **production** branch (`main` compute).
+   - `cloudflareAccountId` / `secretsStoreId` / `neonApiKey`: see the store question below.
+   - `pulumi stack init production` (passphrase provider, same R2 backend)
+     followed by the **adopt** step: import the four `neon.Role`s by ID so Pulumi owns the
+     passwords without recreating them (`neon-secrets-adopt.sh` pattern; the provider key is
+     fed at import time — import does not execute the stack program).
+2. **Store strategy (HITL, decided before `pulumi up`)** — the account's plan refused a
+   second Secrets Store (`maximum_stores_exceeded`, code 1003), which is why staging
+   imports the account's built-in `default_secrets_store`. Secrets are global per account,
+   so **staging and prod cannot share the same store with the same secret names** (the
+   values differ by branch endpoint/role password):
+   - Preferred: upgrade the account plan (if the limit is plan-bound) and create a
+     **second store for prod**; the stack's `secretsStoreId` config then points there and
+     secret names stay identical (`CATALOG_DATABASE_URL`, `USERS_DATABASE_URL`,
+     `AGENT_DATABASE_URL`, `AGENT_SVC_DATABASE_URL`).
+   - Fallback: keep one store and give prod DSNs distinct names (e.g. `*_PROD` suffix) —
+     the binding `secret_name` in `[env.production]` wrangler blocks then differs from
+     staging. Either way, the prod store secrets are written **once** by Pulumi; verify
+     with the deploy report hash row.
+3. **Apply**: the prod lane of `reusable-deploy-neon-secrets.yml` (needs a `production`
+   environment + owner-approved `pulumi up`, the same shape as
+   `reusable-deploy-component.yml`'s prod lane) — or a manual owner `pulumi up` in the
+   window. Roles reused, DSNs composed against the **main-branch endpoint**.
+4. **Wire prod consumers** (deploy workflow changes, separate PR): add
+   `AGENT_SVC_DATABASE_URL` to the edge Worker's `[env.production.secrets_store_secrets]`
+   and/or CI `worker_secrets`; jobs stays on `AGENT_DATABASE_URL` (jobs_svc). Remove the
+   prod GitHub `*_DATABASE_URL`/`SUPABASE_DB_URL` secrets only after the bindings verify
+   (step 5 of the cutover below).
+
 ## Cutover steps (owner window, HITL — mirror #832)
 
 1. **Prereq: P4 green and stable on staging** (#912: roles exist project-wide once Pulumi ran;
    verify the Pulumi prod stack config points at the same Neon project and reuses the same
-   role names — import, do not recreate, if the stack otherwise diverges).
-2. **Pulumi prod stack up** (`reusable-deploy-component` prod lane / owner-approved apply):
-   confirms prod roles, composes prod DSNs (main-branch endpoint), writes them to the
-   **Secrets Store** for the prod environment. Verify with the deploy report hash row.
+   role names — import, do not recreate, if the stack otherwise diverges). Also verify the
+   **staging agent container** is on `AGENT_SVC_DATABASE_URL` (the #912 follow-up wire) and
+   the old `SUPABASE_DB_URL` staging container value is rotated out of the edge Worker.
+2. **Pulumi prod stack up** (`reusable-deploy-neon-secrets` prod lane / owner-approved
+   apply): confirms prod roles (import, project-scoped), composes prod DSNs (main-branch
+   endpoint), writes them to the **Secrets Store** for the prod environment (store strategy
+   above). Verify with the deploy report hash row.
 3. **First prod Atlas apply** (deploy workflow, `production` environment approval): creates the
    schema in the empty `public` + applies `*_grants.sql` GRANTs. Empty data plane ⇒ this is a
    pure creation, nothing to preserve; soft-baseline decision for the future history squash

--- a/infra/neon-secrets/index.ts
+++ b/infra/neon-secrets/index.ts
@@ -58,8 +58,16 @@ const neonProvider = new neon.Provider("neon", {
 
 // Role -> staging secret mapping (#832): the secrets carry the same names the
 // deploy chain passes to `wrangler secret put` today, so PR2 only needs to
-// swap the source of the value. agent_svc gets no DSN yet — the agent
-// container still connects via SUPABASE_DB_URL (follow-up in #912).
+// swap the source of the value.
+//
+// agent_svc DSN (#912 follow-up): the agent is a CONTAINER, not a Worker, so
+// it has no Secrets Store binding of its own — the edge Worker binds
+// AGENT_SVC_DATABASE_URL and `buildContainerEnvVars` (workers/edge/src/
+// container/container-env.ts) forwards it into the container env. The store
+// secret is named AGENT_SVC_DATABASE_URL, NOT AGENT_DATABASE_URL: that name
+// is already claimed in this store by jobs_svc (the maintenance Worker's
+// binding), and store secret names are unique per store — a second secret
+// with the same name cannot exist.
 const roleDefs: { name: string; secretName?: string; comment: string }[] = [
   {
     name: "catalog_svc",
@@ -78,7 +86,8 @@ const roleDefs: { name: string; secretName?: string; comment: string }[] = [
   },
   {
     name: "agent_svc",
-    comment: "agent data-plane role; no DSN yet — agent connects via SUPABASE_DB_URL (#912 follow-up)",
+    secretName: "AGENT_SVC_DATABASE_URL",
+    comment: "agent container data-plane role DSN (staging; edge Worker binding, forwarded to the container via CONTAINER_ENV_KEYS — replaces SUPABASE_DB_URL once deployed)",
   },
 ];
 

--- a/workers/edge/src/container/container-env.ts
+++ b/workers/edge/src/container/container-env.ts
@@ -12,6 +12,15 @@
 
 export const CONTAINER_ENV_KEYS = [
   "DEEPSEEK_API_KEY", "MIMO_API_KEY", "SUPABASE_DB_URL", "CATALOG_API_URL",
+  // #912 follow-up: the agent container's Neon agent_svc role DSN, sourced
+  // from the edge Worker's Secrets Store binding (staging; wrangler.toml
+  // [[env.staging.secrets_store_secrets]]). Deliberately NOT in
+  // CONTAINER_REQUIRED_KEYS: production has no binding until the #855
+  // cutover, and a missing value must not fail-closed every environment.
+  // The per-environment requirement lives in apps/agent settings
+  // (validate_required_env accepts AGENT_SVC_DATABASE_URL or the legacy
+  // SUPABASE_DB_URL).
+  "AGENT_SVC_DATABASE_URL",
   // APP_ENV also joined CONTAINER_REQUIRED_KEYS below (issue #498): it is kept
   // listed here too so the standard forwarding allowlist stays a complete
   // picture of what reaches the container, but CONTAINER_REQUIRED_KEYS is what

--- a/workers/edge/test/container-env.test.ts
+++ b/workers/edge/test/container-env.test.ts
@@ -43,6 +43,26 @@ void test("buildContainerEnvVars forwards the provided APP_ENV value unchanged",
   }
 });
 
+// #912 follow-up: the agent container's Neon agent_svc role DSN is forwarded
+// when the edge Worker has the Secrets Store binding (staging wrangler.toml
+// [[env.staging.secrets_store_secrets]]). It is deliberately NOT required —
+// production has no binding until the #855 cutover, so it must not fail-closed
+// every environment; the per-environment requirement lives in the agent's
+// settings (AGENT_SVC_DATABASE_URL or the legacy SUPABASE_DB_URL).
+void test("AGENT_SVC_DATABASE_URL is forwarded to the container when set (#912)", () => {
+  const environmentVars = buildContainerEnvVars({
+    ...requiredContainerEnv(),
+    AGENT_SVC_DATABASE_URL: "postgresql://agent_svc@neon/db",
+  });
+  assert.equal(environmentVars.AGENT_SVC_DATABASE_URL, "postgresql://agent_svc@neon/db");
+});
+
+void test("AGENT_SVC_DATABASE_URL is optional: absent without a binding, never required", () => {
+  assert.equal(CONTAINER_REQUIRED_KEYS.includes("AGENT_SVC_DATABASE_URL"), false);
+  const environmentVars = buildContainerEnvVars(requiredContainerEnv());
+  assert.equal("AGENT_SVC_DATABASE_URL" in environmentVars, false);
+});
+
 void test("buildContainerEnvVars throws (fail-closed) when APP_ENV is missing, instead of seeding a hardcoded default", () => {
   const { APP_ENV: _unused, ...environmentWithoutAppEnv } = requiredContainerEnv();
   void _unused;

--- a/workers/edge/wrangler.toml
+++ b/workers/edge/wrangler.toml
@@ -41,7 +41,12 @@
 # The DeepSeek and generic OpenAI-compat fallbacks stay wired but DISABLED
 # (settings.fallback_agent_model is empty; re-enabling is a config flip, not a
 # secret add) — so their keys remain provisioned, not deleted:
-#   SUPABASE_DB_URL            — postgres://... for asyncpg
+#   SUPABASE_DB_URL            — postgres://... for asyncpg (legacy plane; still
+#                                the prod container DSN until the #855 cutover)
+#   AGENT_SVC_DATABASE_URL     — Neon agent_svc role DSN (staging, via the
+#                                Secrets Store binding below; forwarded into the
+#                                container and preferred over SUPABASE_DB_URL by
+#                                apps/agent settings, #912 follow-up)
 #   MIMO_API_KEY               — required primary model key (MiMo V2.5)
 #   DEEPSEEK_API_KEY           — wired-but-disabled fallback model key (DeepSeek)
 #   (photo-search recognition rides the same chat model credentials above —
@@ -364,6 +369,27 @@ ANON_DAILY_MESSAGE_QUOTA = "20"
 # headroom above the anonymous burst ceiling.
 AUTH_RATE_LIMIT = "60"
 AUTH_RATE_LIMIT_WINDOW_SECONDS = "60"
+
+# #912 follow-up: the agent container's Neon role DSN comes from the
+# Cloudflare Secrets Store (secret AGENT_SVC_DATABASE_URL, provisioned by the
+# infra/neon-secrets Pulumi stack) instead of `wrangler secret put` in CI.
+# env.AGENT_SVC_DATABASE_URL is then a SecretsStoreSecret that
+# buildContainerEnvVars forwards into the container when set (it is NOT in
+# CONTAINER_REQUIRED_KEYS — production has no binding yet, #855 cutover).
+# Do NOT add AGENT_SVC_DATABASE_URL to `secrets.required` here: wrangler
+# rejects a name assigned to both a Secrets Store Secret binding and a Secret
+# binding; the binding's deploy-time store/secret validation is the fail-closed
+# gate (a missing store secret fails the deploy API call).
+#
+# The store secret is named AGENT_SVC_DATABASE_URL, NOT AGENT_DATABASE_URL:
+# that name is already claimed by the jobs Worker's binding (jobs_svc role) in
+# the same store, and store secret names are unique per store. Production
+# keeps getting its container DSN via the SUPABASE_DB_URL worker secret until
+# the #855 prod cutover provisions AGENT_SVC_DATABASE_URL for prod.
+[[env.staging.secrets_store_secrets]]
+binding = "AGENT_SVC_DATABASE_URL"
+store_id = "66c9bb0faef644b4a0671bb7d90d98bd"
+secret_name = "AGENT_SVC_DATABASE_URL"
 
 [[env.staging.services]]
 binding = "CATALOG"


### PR DESCRIPTION
Closes the #926 follow-up half of #912: the agent container gets a real Neon role DSN instead of `SUPABASE_DB_URL`.

## Investigation findings

**How the container gets a DB connection string (the mechanism that forced this design):** the Python agent runs in a Cloudflare **container**, which has no Secrets Store binding of its own. The container env is built entirely by the edge Worker's code — `buildContainerEnvVars()` in `workers/edge/src/container/container-env.ts` copies an allowlist (`CONTAINER_ENV_KEYS`) from the edge Worker's own env (vars + `wrangler secret put` secrets + Secrets Store bindings). So the wiring is: **Pulumi store secret → edge Worker `[[env.staging.secrets_store_secrets]]` binding → `CONTAINER_ENV_KEYS` forwarding → container env → `Settings`**. This is why #889/#832's DSN split could not give agent_svc a secret: the container path is the edge Worker's env, and that surface wasn't part of the staging cutover.

**Name collision discovered:** the Secrets Store secret `AGENT_DATABASE_URL` already exists — it is the `jobs_svc` role DSN bound by the jobs Worker (`workers/jobs/wrangler.toml`). Store secret names are unique per store, so the container's role DSN cannot reuse that name. The container's store secret/binding/env name is therefore **`AGENT_SVC_DATABASE_URL`** (role-explicit). This amends the iter6 R1 rename plan `SUPABASE_DB_URL → AGENT_DATABASE_URL` → `AGENT_SVC_DATABASE_URL` (documented in `docs/ops/prod-dsn-cutover.md`).

## Changes

| File | Change |
|---|---|
| `infra/neon-secrets/index.ts` | `agent_svc` now provisions the `AGENT_SVC_DATABASE_URL` store secret (next staging `pulumi up` creates it; ci.yml already orders `deploy-neon-secrets-staging` before root deploy) |
| `workers/edge/wrangler.toml` | `[[env.staging.secrets_store_secrets]]` binding `AGENT_SVC_DATABASE_URL` (staging only — prod has no binding until #855) |
| `workers/edge/src/container/container-env.ts` | `AGENT_SVC_DATABASE_URL` added to `CONTAINER_ENV_KEYS`; deliberately **not** in `CONTAINER_REQUIRED_KEYS` (prod would fail-closed) — the per-env requirement lives in agent settings |
| `apps/agent/.../settings.py` | new `agent_svc_database_url` field + `database_url` property (prefers the role DSN over legacy `SUPABASE_DB_URL`); required-env accepts either |
| `apps/agent/.../_deps.py` | DB pool consumes `settings.database_url` |
| `docs/ops/prod-dsn-cutover.md` | neon-secrets **prod stack steps** (Pulumi.production.yaml, project-scoped role reuse/import, store strategy HITL, #855 integration), container DSN mechanism section |
| `docs/ops/deployment.md` | container runtime section: `AGENT_SVC_DATABASE_URL` first, `SUPABASE_DB_URL` fallback |

## HITL / owner items (not in this PR)

1. **Staging verification after merge**: neon-secrets `pulumi up` creates the store secret, then the edge staging deploy binds + forwards it; verify the staging container now connects to Neon as `agent_svc` (deploy report hash row + data-plane probe).
2. **Store strategy for prod** (decided before prod stack apply): account plan refused a second Secrets Store (`maximum_stores_exceeded`, code 1003) — either upgrade the plan for a dedicated prod store, or fall back to prod-suffixed secret names in the shared store. Full steps in `docs/ops/prod-dsn-cutover.md`.
3. **Prod wiring at #855**: `Pulumi.production.yaml` + role import + prod `AGENT_SVC_DATABASE_URL` GH env secret / prod binding; remove `SUPABASE_DB_URL` from the edge Worker only after the container is verified on the role DSN.
4. **Deferred cleanup**: drop the staging `SUPABASE_DB_URL` `worker_secrets` upload once the container is confirmed on `AGENT_SVC_DATABASE_URL` (follow-up PR; kept in this PR so prod's upload chain is untouched).

## Verification

- edge worker: 289/289 node tests, `tsc --noEmit`, oxlint `--deny-warnings` clean
- agent: 1750/1750 unit tests @ 91.72% coverage (floor 87), ruff check/format, mypy clean, vulture clean

## Constraints honored

- No `pulumi up` run locally (staging apply is CI-only); production untouched; no merge (squash on merge).

## Summary by Sourcery

Wire the agent container to use a Neon role-specific DSN via the edge worker and Secrets Store, while keeping production on the legacy DSN until the planned prod cutover.

New Features:
- Introduce an agent_svc-specific Neon DSN (AGENT_SVC_DATABASE_URL) for the agent container, preferred over the legacy SUPABASE_DB_URL.
- Add a database_url accessor in agent settings to abstract DSN selection between Neon and legacy Supabase URLs.

Enhancements:
- Update edge container env forwarding to include AGENT_SVC_DATABASE_URL as an optional key sourced from Secrets Store bindings.
- Adjust infra Neon secrets provisioning so the agent_svc role now has its own AGENT_SVC_DATABASE_URL secret.
- Clarify DSN cutover and container wiring in deployment and prod cutover documentation, including prod stack and Secrets Store strategy.

Tests:
- Add agent settings unit tests covering DSN precedence, fallback behavior, and required-env validation for AGENT_SVC_DATABASE_URL vs SUPABASE_DB_URL.
- Extend edge container env tests to verify forwarding and optionality of AGENT_SVC_DATABASE_URL.