### PR TITLE
fix(ci): run Pulumi stack export from the project dir so stack names resolve (#933)

### DIFF
--- a/.github/workflows/reusable-deploy-component.yml
+++ b/.github/workflows/reusable-deploy-component.yml
@@ -510,6 +510,15 @@ jobs:
         # runs under the catalog deploy jobs; look there for the backup, not
         # under a root/web/users run.
         if: ${{ inputs.run_pulumi }}
+        # #933: `pulumi stack select "$PULUMI_STACK"` must run from inside the
+        # `infra/` project directory. From the repo root there is no
+        # Pulumi.yaml for pulumi to resolve the bare "staging" stack name
+        # against, so every run died with "pass the fully qualified name
+        # (organization/project/stack)" and the rollback backup (and the
+        # subsequent `up`) never ran. Mirroring the "Pulumi up" step's
+        # work-dir: infra makes `staging` resolve to seichijunrei-infra/staging
+        # exactly like the deploy action does.
+        working-directory: infra
         env:
           # Least-privilege split (#674): Pulumi only touches R2/DNS/Routes/
           # Rulesets — it gets its own token instead of the wrangler CI token.

--- a/.github/workflows/reusable-deploy-neon-secrets.yml
+++ b/.github/workflows/reusable-deploy-neon-secrets.yml
@@ -110,6 +110,14 @@ jobs:
       # script below is itself the snapshot for that run.
       - name: Pulumi stack export (rollback backup)
         shell: bash
+        # #933: same fix as reusable-deploy-component.yml — from the repo root
+        # (no Pulumi.yaml) `pulumi stack select staging` always failed with
+        # "pass the fully qualified name (organization/project/stack)", which
+        # the `if !` guard below silently swallowed as "first run". Running
+        # inside the project makes `staging` resolve to
+        # animichi-neon-secrets/staging, so the guard only fires when the
+        # stack genuinely does not exist yet.
+        working-directory: infra/neon-secrets
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}


### PR DESCRIPTION
## Problem

Every staging deploy job (`Deploy staging / Deploy`, `Deploy web staging / Deploy`) fails in the
`Pulumi stack export (rollback backup)` step:

```
error: if you're using the --stack flag, pass the fully qualified name (organization/project/stack)
```

(pre-existing; e.g. CI run 31317102233, blocks staging `pulumi up`).

## Root cause

The export step runs `pulumi stack select "$PULUMI_STACK"` (PULUMI_STACK=`staging`) from the **repo
root**, where there is no `Pulumi.yaml`. Without a project file, pulumi cannot resolve the bare
stack name against a project, so it demands an FQN. The `Pulumi up` steps never had this problem
because they run inside the project dir (`work-dir: infra` / `working-directory: infra/neon-secrets`),
where `staging` resolves to `seichijunrei-infra/staging` / `animichi-neon-secrets/staging`.

Verified locally: same error reproduces from a dir without `Pulumi.yaml`; `stack select` + `export`
work from inside the project.

## Fix

Add `working-directory` to both export steps, mirroring the up steps:

- `reusable-deploy-component.yml` (project `seichijunrei-infra`): `working-directory: infra`
- `reusable-deploy-neon-secrets.yml` (project `animichi-neon-secrets`): `working-directory: infra/neon-secrets`

## Latent bug also fixed

neon-secrets' export step wrapped `pulumi stack select` in `if ! ... ; then "first run"` — the FQN
error was silently swallowed as "stack does not exist" on **every** run, so its rollback backup
never actually landed on R2. With the working-directory fix the guard now only fires when the stack
genuinely does not exist yet.

## Verification

- `actionlint` passes on both workflows (also enforced by pre-commit hook)
- Local repro: `pulumi stack select staging` at repo root → exact CI error; from project dir →
  select + `export` succeed

## Summary by Sourcery

Ensure Pulumi stack export steps run from the correct project directories so staging deployments can create rollback backups successfully.

CI:
- Set the working directory to the infra project for the component deployment Pulumi stack export step so bare stack names resolve correctly.
- Set the working directory to the infra/neon-secrets project for the neon-secrets Pulumi stack export step so stack selection and export behave correctly, only treating missing stacks as first runs.