### PR TITLE
ci: test lanes PR-only — push-to-main runs deploys only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
 
   security:
     name: Security
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/reusable-security.yml
     # Caller ceiling for the reusable: its gitleaks job declares
     # `pull-requests: read` at job level, and a reusable job cannot request
@@ -75,6 +76,7 @@ jobs:
 
   agent-eval-smoke:
     timeout-minutes: 45
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     name: Agent Eval (L0 smoke, ~80 cases)
     runs-on: ubuntu-latest
     permissions:
@@ -270,6 +272,7 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/reusable-cross-stack-e2e.yml
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
 
   # ── Stage 3: Deploy (security/hygiene gated, push-main promotion path) ──
   # Promotion: push main → CI → staging → post-staging (api) → prod (human gate) → post-prod.


### PR DESCRIPTION
Every squash merge re-ran the full test/security lanes on the main push, duplicating what the PR run already validated.

- security / agent-eval-smoke / ci-cross-stack-e2e: now run only on pull_request or workflow_dispatch
- python-integration / catalog-spikes: already carried PR-only conditions (fork-safety), unchanged
- The 6 deploy jobs keep their push-to-main trigger; their `needs:` tolerate skipped upstreams (`!failure() && !cancelled()`)
- pipeline-* workflows are already pull_request-only; merge_group trigger retained for future merge-queue use

Effect: a merge to main now triggers only the deploy chain (~6 jobs) instead of the full ~40-job matrix.

## Summary by Sourcery

CI:
- Limit security, agent-eval-smoke, and cross-stack end-to-end CI jobs to pull_request and workflow_dispatch events to avoid re-running full test lanes on main pushes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation triggers so security, evaluation smoke tests, and cross-stack end-to-end checks run only for pull requests or manual runs.
  * These checks no longer run automatically on code pushes or merge-group events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->