### PR TITLE
feat(ci): SAFE-1 production freeze — manifest, resolver, eligibility gate (#937)

### DIFF
--- a/.github/release-manifests/production-pre-campaign.json
+++ b/.github/release-manifests/production-pre-campaign.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": 1,
+  "release_name": "production-pre-campaign",
+  "description": "Immutable pre-campaign production release surface (SAFE-1). Component/worker mapping matches ci.yml + deploy.yml production jobs; secret names only, never values.",
+  "source_revision": "b94c30ab6a519f1cce9eb0a3f7885953f8ff54cf",
+  "atlas": {
+    "directory": "migrations/neon",
+    "target": "20260809000031",
+    "digest_sha256": "e0428e7a9b25745a8d1f22f8fbcec5c915a8e18d56a7a45f5fe3554158b6ab80"
+  },
+  "components": {
+    "catalog": {
+      "working_directory": "workers/catalog",
+      "worker_name": "catalog",
+      "wrangler_config": "workers/catalog/wrangler.toml",
+      "environment": "production",
+      "pulumi_stack": "prod",
+      "run_pulumi": true,
+      "build_filter": "",
+      "worker_secrets": ["DATABASE_URL"],
+      "post_deploy_secrets": [],
+      "depends_on": [],
+      "deploy_eligible": true,
+      "rollback_eligible": false
+    },
+    "web": {
+      "working_directory": "apps/web",
+      "worker_name": "animichi-web",
+      "wrangler_config": "apps/web/wrangler.jsonc",
+      "environment": "production",
+      "pulumi_stack": "prod",
+      "run_pulumi": false,
+      "build_filter": "web",
+      "worker_secrets": [],
+      "post_deploy_secrets": [],
+      "depends_on": [],
+      "deploy_eligible": true,
+      "rollback_eligible": false
+    },
+    "users": {
+      "working_directory": "workers/users",
+      "worker_name": "users",
+      "wrangler_config": "workers/users/wrangler.toml",
+      "environment": "production",
+      "pulumi_stack": "prod",
+      "run_pulumi": false,
+      "build_filter": "",
+      "worker_secrets": ["DATABASE_URL", "NEON_AUTH_JWKS_URL"],
+      "post_deploy_secrets": [],
+      "depends_on": ["catalog"],
+      "deploy_eligible": true,
+      "rollback_eligible": false
+    },
+    "maintenance": {
+      "working_directory": "workers/jobs",
+      "worker_name": "jobs",
+      "wrangler_config": "workers/jobs/wrangler.toml",
+      "environment": "production",
+      "pulumi_stack": "prod",
+      "run_pulumi": false,
+      "build_filter": "",
+      "worker_secrets": ["AGENT_DATABASE_URL"],
+      "post_deploy_secrets": [],
+      "depends_on": ["catalog"],
+      "deploy_eligible": true,
+      "rollback_eligible": false
+    },
+    "root": {
+      "working_directory": ".",
+      "worker_name": "animichi",
+      "wrangler_config": "workers/edge/wrangler.toml",
+      "environment": "production",
+      "pulumi_stack": "prod",
+      "run_pulumi": false,
+      "build_filter": "",
+      "worker_secrets": [
+        "SUPABASE_URL",
+        "SUPABASE_ANON_KEY",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "SUPABASE_DB_URL",
+        "MIMO_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "GOOGLE_MAPS_API_KEY",
+        "LOGFIRE_TOKEN",
+        "CORS_ALLOWED_ORIGIN"
+      ],
+      "post_deploy_secrets": ["TURNSTILE_SECRET", "ANON_ID_SECRET"],
+      "depends_on": ["users"],
+      "deploy_eligible": true,
+      "rollback_eligible": false
+    }
+  }
+}

--- a/.github/scripts/release-eligibility.sh
+++ b/.github/scripts/release-eligibility.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SAFE-1 Phase B2: judge a candidate SHA against the pinned production manifest.
+#
+# Reads the manifest content-addressed (pinned Git blob id, fetched via the
+# GitHub API — never from the working tree, so a campaign checkout that tampers
+# with the manifest cannot influence the verdict), validates it with the
+# resolver, and prints the resolver's typed verdict JSON on stdout.
+#
+# usage: release-eligibility.sh <component> <candidate_sha> [manifest_file]
+#   manifest_file  — when given, read the manifest from this local file
+#                    (test path); default reads the pinned blob from GitHub.
+#   stdout         — resolver verdict JSON (see release-manifest-resolver.rb)
+#   exit           — 0 when the manifest is valid and resolvable; 1 otherwise.
+
+PINNED_MANIFEST_BLOB_ID="2aef389878e321ddc3d4d86922fde30ad2ab6491"
+REPOSITORY="${GITHUB_REPOSITORY:-lifeodyssey/animichi}"
+
+component="${1:?component required}"
+candidate_sha="${2:?candidate_sha required}"
+manifest_file="${3:-}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+if [ -n "$manifest_file" ]; then
+  manifest_path="$manifest_file"
+else
+  manifest_path="$workdir/manifest.json"
+  gh api "repos/${REPOSITORY}/git/blobs/${PINNED_MANIFEST_BLOB_ID}" \
+    --jq .content | base64 -d > "$manifest_path"
+fi
+
+ruby "$(dirname "$0")/release-manifest-resolver.rb" \
+  "$manifest_path" "$component" "$candidate_sha"

--- a/.github/scripts/release-eligibility.sh
+++ b/.github/scripts/release-eligibility.sh
@@ -24,7 +24,7 @@ manifest_file="${3:-}"
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
-if [ -n "$manifest_file" ]; then
+if [[ -n "$manifest_file" ]]; then
   manifest_path="$manifest_file"
 else
   manifest_path="$workdir/manifest.json"

--- a/.github/scripts/release-eligibility.test.sh
+++ b/.github/scripts/release-eligibility.test.sh
@@ -21,7 +21,7 @@ fail() {
 verdict="$(bash "$SCRIPT" root "$PINNED_REVISION" "$MANIFEST")"
 echo "$verdict" | grep -q '"deploy":true' || fail "matching revision must be deploy eligible"
 echo "$verdict" | grep -q '"rollback":false' || fail "rollback must be ineligible"
-test "$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["component"]["worker_name"])')" = "animichi" || fail "verdict must carry the resolved worker name"
+[[ "$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["component"]["worker_name"])')" == "animichi" ]] || fail "verdict must carry the resolved worker name"
 echo "PASS: matching revision is deploy-eligible"
 
 # Green: stale candidate → deploy ineligible, still exit 0.

--- a/.github/scripts/release-eligibility.test.sh
+++ b/.github/scripts/release-eligibility.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Behavioral tests for release-eligibility.sh (SAFE-1 Phase B2), run against
+# throwaway manifest copies in the local-file test path (no GitHub API, no
+# network). The gh-api path is exercised by the workflows themselves in CI.
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/.github/scripts/release-eligibility.sh"
+MANIFEST="$ROOT/.github/release-manifests/production-pre-campaign.json"
+PINNED_REVISION="b94c30ab6a519f1cce9eb0a3f7885953f8ff54cf"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# Green: matching candidate → deploy eligible, rollback ineligible, typed fields.
+verdict="$(bash "$SCRIPT" root "$PINNED_REVISION" "$MANIFEST")"
+echo "$verdict" | grep -q '"deploy":true' || fail "matching revision must be deploy eligible"
+echo "$verdict" | grep -q '"rollback":false' || fail "rollback must be ineligible"
+test "$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["component"]["worker_name"])')" = "animichi" || fail "verdict must carry the resolved worker name"
+echo "PASS: matching revision is deploy-eligible"
+
+# Green: stale candidate → deploy ineligible, still exit 0.
+verdict="$(bash "$SCRIPT" root "0000000000000000000000000000000000000000" "$MANIFEST")"
+echo "$verdict" | grep -q '"deploy":false' || fail "stale revision must be deploy ineligible"
+echo "PASS: stale revision is deploy-ineligible"
+
+# Red: tampered manifest copy must fail (pinned identity).
+cp "$MANIFEST" "$TMP/tampered.json"
+python3 - "$TMP/tampered.json" <<'EOF'
+import json, sys
+p = sys.argv[1]
+m = json.load(open(p))
+m["atlas"]["target"] = "20260909000000"
+json.dump(m, open(p, "w"))
+EOF
+if bash "$SCRIPT" root "$PINNED_REVISION" "$TMP/tampered.json" >/dev/null 2>&1; then
+  fail "tampered manifest must fail closed"
+fi
+echo "PASS: tampered manifest fails closed"
+
+# Red: unknown component must fail.
+if bash "$SCRIPT" sidecar "$PINNED_REVISION" "$MANIFEST" >/dev/null 2>&1; then
+  fail "unknown component must fail"
+fi
+echo "PASS: unknown component fails closed"
+
+# Red: missing manifest file must fail.
+if bash "$SCRIPT" root "$PINNED_REVISION" "$TMP/does-not-exist.json" >/dev/null 2>&1; then
+  fail "missing manifest must fail"
+fi
+echo "PASS: missing manifest fails closed"
+
+# Red: missing args must fail.
+if bash "$SCRIPT" root >/dev/null 2>&1; then
+  fail "missing args must fail"
+fi
+echo "PASS: missing args fail closed"
+
+echo "All release-eligibility.sh behavioral tests passed."

--- a/.github/scripts/release-manifest-resolver.rb
+++ b/.github/scripts/release-manifest-resolver.rb
@@ -128,6 +128,41 @@ def add_error(errors, message)
   errors << "error: #{message}"
 end
 
+def validate_component_fields(errors, key, comp, expected)
+  unknown_comp = comp.keys - ALLOWED_COMPONENT_KEYS
+  add_error(errors, "component #{key}: unknown field(s): #{unknown_comp.sort.join(', ')}") unless unknown_comp.empty?
+  expected.each do |field, value|
+    actual = comp[field.to_s]
+    unless actual == value
+      add_error(errors, "component #{key}: #{field} must be #{value.inspect}, got #{actual.inspect}")
+    end
+  end
+end
+
+def validate_component_names(errors, key, comp)
+  (comp["worker_secrets"] || []).each do |name|
+    unless name.is_a?(String) && name.match?(SECRET_NAME_RE)
+      add_error(errors, "component #{key}: secret name #{name.inspect} must match #{SECRET_NAME_RE}")
+    end
+  end
+  (comp["post_deploy_secrets"] || []).each do |name|
+    unless name.is_a?(String) && name.match?(SECRET_NAME_RE)
+      add_error(errors, "component #{key}: post-deploy secret name #{name.inspect} must match #{SECRET_NAME_RE}")
+    end
+  end
+  (comp["depends_on"] || []).each do |dep|
+    add_error(errors, "component #{key}: depends_on #{dep.inspect} is not a known component") unless EXPECTED_COMPONENTS.key?(dep)
+  end
+end
+
+def validate_component_eligibility(errors, key, comp)
+  %w[deploy_eligible rollback_eligible].each do |field|
+    unless comp[field] == true || comp[field] == false
+      add_error(errors, "component #{key}: #{field} must be a boolean, got #{comp[field].inspect}")
+    end
+  end
+end
+
 unless MANIFEST_PATH && COMPONENT_KEY
   warn "usage: ruby release-manifest-resolver.rb <manifest.json> <component> [source_revision]"
   exit 1
@@ -215,35 +250,9 @@ if manifest.is_a?(Hash)
         add_error(errors, "component #{key} must be an object")
         next
       end
-      unknown_comp = comp.keys - ALLOWED_COMPONENT_KEYS
-      add_error(errors, "component #{key}: unknown field(s): #{unknown_comp.sort.join(', ')}") unless unknown_comp.empty?
-
-      expected.each do |field, value|
-        actual = comp[field.to_s]
-        if field == :worker_secrets || field == :post_deploy_secrets || field == :depends_on
-          unless actual.is_a?(Array) && actual == value
-            add_error(errors, "component #{key}: #{field} must be #{value.inspect}, got #{actual.inspect}")
-          end
-        elsif field == :run_pulumi
-          add_error(errors, "component #{key}: #{field} must be #{value}, got #{actual.inspect}") unless actual == value
-        else
-          add_error(errors, "component #{key}: #{field} must be #{value.inspect}, got #{actual.inspect}") unless actual == value
-        end
-      end
-
-      (comp["worker_secrets"] || []).each do |name|
-        add_error(errors, "component #{key}: secret name #{name.inspect} must match #{SECRET_NAME_RE}") unless name.is_a?(String) && name.match?(SECRET_NAME_RE)
-      end
-      (comp["post_deploy_secrets"] || []).each do |name|
-        add_error(errors, "component #{key}: post-deploy secret name #{name.inspect} must match #{SECRET_NAME_RE}") unless name.is_a?(String) && name.match?(SECRET_NAME_RE)
-      end
-      (comp["depends_on"] || []).each do |dep|
-        add_error(errors, "component #{key}: depends_on #{dep.inspect} is not a known component") unless EXPECTED_COMPONENTS.key?(dep)
-      end
-
-      %w[deploy_eligible rollback_eligible].each do |field|
-        add_error(errors, "component #{key}: #{field} must be a boolean, got #{comp[field].inspect}") unless comp[field] == true || comp[field] == false
-      end
+      validate_component_fields(errors, key, comp, expected)
+      validate_component_names(errors, key, comp)
+      validate_component_eligibility(errors, key, comp)
     end
 
     unless EXPECTED_COMPONENTS.key?(COMPONENT_KEY)
@@ -258,11 +267,18 @@ if errors.any?
 end
 
 component = manifest.fetch("components").fetch(COMPONENT_KEY)
-deploy_eligible = SOURCE_REVISION.nil? ? nil : (SOURCE_REVISION == manifest.fetch("source_revision"))
+# Deploy eligibility requires BOTH the candidate match AND the manifest's own
+# per-component deploy_eligible flag — a manifest that marks a component
+# ineligible must never deploy, even with a matching revision.
+deploy_eligible = if SOURCE_REVISION.nil?
+  nil
+else
+  SOURCE_REVISION == manifest.fetch("source_revision") && component.fetch("deploy_eligible")
+end
 
 output = {
   manifest_sha256: file_sha256,
-  manifest_blob_id: PINNED_MANIFEST_BLOB_ID,
+  manifest_blob_id: blob_id,
   source_revision: manifest.fetch("source_revision"),
   atlas: manifest.fetch("atlas"),
   component: {

--- a/.github/scripts/release-manifest-resolver.rb
+++ b/.github/scripts/release-manifest-resolver.rb
@@ -5,9 +5,9 @@
 #
 # Reads .github/release-manifests/production-pre-campaign.json (a closed-schema,
 # content-addressed pin of the pre-campaign production surface), validates every
-# field against the pinned schema + expected component table below, and emits a
-# typed public output document. It never reads, prints, or forwards secret
-# values — the manifest carries secret NAMES only.
+# field against the pinned schema + expected component table, and emits a typed
+# public output document. It never reads, prints, or forwards secret values —
+# the manifest carries secret NAMES only.
 #
 # A squash merge may replace commit identities, but the referenced manifest
 # blob stays content-addressed: this resolver hard-pins both the file SHA-256
@@ -23,6 +23,7 @@
 require "json"
 require "digest"
 require "shellwords"
+require_relative "release-manifest-validation"
 
 MANIFEST_PATH = ARGV[0]
 COMPONENT_KEY = ARGV[1]
@@ -32,136 +33,6 @@ SOURCE_REVISION = ARGV[2]
 #    manifest version and a deliberate re-pin) ──────────────────────────────
 PINNED_MANIFEST_SHA256 = "1ffcfe1bf4815e0e0e890193cbfdeb28d9748f94bb98db88106000af708f536c"
 PINNED_MANIFEST_BLOB_ID = "2aef389878e321ddc3d4d86922fde30ad2ab6491"
-PINNED_ATLAS_DIGEST_SHA256 = "e0428e7a9b25745a8d1f22f8fbcec5c915a8e18d56a7a45f5fe3554158b6ab80"
-PINNED_ATLAS_TARGET = "20260809000031"
-
-SCHEMA_VERSION = 1
-FULL_SHA_RE = /\A[0-9a-f]{40}\z/
-SHA256_RE = /\A[0-9a-f]{64}\z/
-ATLAS_TARGET_RE = /\A\d{14}\z/
-SECRET_NAME_RE = /\A[A-Z][A-Z0-9_]*\z/
-
-# Expected component surface (from SAFE-1 §2 and the ci.yml/deploy.yml
-# production jobs). The manifest must match this exactly — a drift in worker
-# name, directory, config, flags, or secret list fails closed.
-EXPECTED_COMPONENTS = {
-  "catalog" => {
-    working_directory: "workers/catalog",
-    worker_name: "catalog",
-    wrangler_config: "workers/catalog/wrangler.toml",
-    environment: "production",
-    pulumi_stack: "prod",
-    run_pulumi: true,
-    build_filter: "",
-    worker_secrets: %w[DATABASE_URL],
-    post_deploy_secrets: [],
-    depends_on: []
-  },
-  "web" => {
-    working_directory: "apps/web",
-    worker_name: "animichi-web",
-    wrangler_config: "apps/web/wrangler.jsonc",
-    environment: "production",
-    pulumi_stack: "prod",
-    run_pulumi: false,
-    build_filter: "web",
-    worker_secrets: [],
-    post_deploy_secrets: [],
-    depends_on: []
-  },
-  "users" => {
-    working_directory: "workers/users",
-    worker_name: "users",
-    wrangler_config: "workers/users/wrangler.toml",
-    environment: "production",
-    pulumi_stack: "prod",
-    run_pulumi: false,
-    build_filter: "",
-    worker_secrets: %w[DATABASE_URL NEON_AUTH_JWKS_URL],
-    post_deploy_secrets: [],
-    depends_on: %w[catalog]
-  },
-  "maintenance" => {
-    working_directory: "workers/jobs",
-    worker_name: "jobs",
-    wrangler_config: "workers/jobs/wrangler.toml",
-    environment: "production",
-    pulumi_stack: "prod",
-    run_pulumi: false,
-    build_filter: "",
-    worker_secrets: %w[AGENT_DATABASE_URL],
-    post_deploy_secrets: [],
-    depends_on: %w[catalog]
-  },
-  "root" => {
-    working_directory: ".",
-    worker_name: "animichi",
-    wrangler_config: "workers/edge/wrangler.toml",
-    environment: "production",
-    pulumi_stack: "prod",
-    run_pulumi: false,
-    build_filter: "",
-    worker_secrets: %w[
-      SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY SUPABASE_DB_URL
-      MIMO_API_KEY DEEPSEEK_API_KEY GOOGLE_MAPS_API_KEY LOGFIRE_TOKEN
-      CORS_ALLOWED_ORIGIN
-    ],
-    post_deploy_secrets: %w[TURNSTILE_SECRET ANON_ID_SECRET],
-    depends_on: %w[users]
-  }
-}.freeze
-
-# Allowed top-level keys. Closed schema: anything else is a validation failure.
-ALLOWED_TOP_LEVEL_KEYS = %w[
-  schema_version release_name description source_revision atlas components
-].freeze
-
-ALLOWED_COMPONENT_KEYS = %w[
-  working_directory worker_name wrangler_config environment pulumi_stack
-  run_pulumi build_filter worker_secrets post_deploy_secrets depends_on
-  deploy_eligible rollback_eligible
-].freeze
-
-errors = []
-
-def add_error(errors, message)
-  errors << "error: #{message}"
-end
-
-def validate_component_fields(errors, key, comp, expected)
-  unknown_comp = comp.keys - ALLOWED_COMPONENT_KEYS
-  add_error(errors, "component #{key}: unknown field(s): #{unknown_comp.sort.join(', ')}") unless unknown_comp.empty?
-  expected.each do |field, value|
-    actual = comp[field.to_s]
-    unless actual == value
-      add_error(errors, "component #{key}: #{field} must be #{value.inspect}, got #{actual.inspect}")
-    end
-  end
-end
-
-def validate_component_names(errors, key, comp)
-  (comp["worker_secrets"] || []).each do |name|
-    unless name.is_a?(String) && name.match?(SECRET_NAME_RE)
-      add_error(errors, "component #{key}: secret name #{name.inspect} must match #{SECRET_NAME_RE}")
-    end
-  end
-  (comp["post_deploy_secrets"] || []).each do |name|
-    unless name.is_a?(String) && name.match?(SECRET_NAME_RE)
-      add_error(errors, "component #{key}: post-deploy secret name #{name.inspect} must match #{SECRET_NAME_RE}")
-    end
-  end
-  (comp["depends_on"] || []).each do |dep|
-    add_error(errors, "component #{key}: depends_on #{dep.inspect} is not a known component") unless EXPECTED_COMPONENTS.key?(dep)
-  end
-end
-
-def validate_component_eligibility(errors, key, comp)
-  %w[deploy_eligible rollback_eligible].each do |field|
-    unless comp[field] == true || comp[field] == false
-      add_error(errors, "component #{key}: #{field} must be a boolean, got #{comp[field].inspect}")
-    end
-  end
-end
 
 unless MANIFEST_PATH && COMPONENT_KEY
   warn "usage: ruby release-manifest-resolver.rb <manifest.json> <component> [source_revision]"
@@ -182,6 +53,8 @@ rescue JSON::ParserError => e
   exit 1
 end
 
+errors = []
+
 # ── Pinned identity checks ──────────────────────────────────────────────────
 file_sha256 = Digest::SHA256.file(MANIFEST_PATH).hexdigest
 unless file_sha256 == PINNED_MANIFEST_SHA256
@@ -198,68 +71,8 @@ if blob_id && blob_id != PINNED_MANIFEST_BLOB_ID
   add_error(errors, "manifest Git blob #{blob_id} does not match pinned #{PINNED_MANIFEST_BLOB_ID}")
 end
 
-# ── Closed-schema validation ────────────────────────────────────────────────
-unless manifest.is_a?(Hash)
-  add_error(errors, "manifest root must be an object")
-end
-
-if manifest.is_a?(Hash)
-  unknown = manifest.keys - ALLOWED_TOP_LEVEL_KEYS
-  add_error(errors, "unknown top-level field(s): #{unknown.sort.join(', ')}") unless unknown.empty?
-
-  unless manifest["schema_version"] == SCHEMA_VERSION
-    add_error(errors, "schema_version must be #{SCHEMA_VERSION}, got #{manifest['schema_version'].inspect}")
-  end
-
-  revision = manifest["source_revision"]
-  unless revision.is_a?(String) && revision.match?(FULL_SHA_RE)
-    add_error(errors, "source_revision must be a full 40-hex SHA, got #{revision.inspect}")
-  end
-
-  atlas = manifest["atlas"]
-  unless atlas.is_a?(Hash)
-    add_error(errors, "atlas must be an object")
-  else
-    unknown_atlas = atlas.keys - %w[directory target digest_sha256]
-    add_error(errors, "unknown atlas field(s): #{unknown_atlas.sort.join(', ')}") unless unknown_atlas.empty?
-    add_error(errors, "atlas.directory must be migrations/neon, got #{atlas['directory'].inspect}") unless atlas["directory"] == "migrations/neon"
-    target = atlas["target"]
-    unless target.is_a?(String) && target.match?(ATLAS_TARGET_RE)
-      add_error(errors, "atlas.target must be a 14-digit migration timestamp, got #{target.inspect}")
-    end
-    add_error(errors, "atlas.target must be pinned #{PINNED_ATLAS_TARGET}, got #{target.inspect}") unless target == PINNED_ATLAS_TARGET
-    digest = atlas["digest_sha256"]
-    unless digest.is_a?(String) && digest.match?(SHA256_RE)
-      add_error(errors, "atlas.digest_sha256 must be a 64-hex SHA-256, got #{digest.inspect}")
-    end
-    add_error(errors, "atlas.digest_sha256 must be pinned #{PINNED_ATLAS_DIGEST_SHA256}, got #{digest.inspect}") unless digest == PINNED_ATLAS_DIGEST_SHA256
-  end
-
-  components = manifest["components"]
-  unless components.is_a?(Hash)
-    add_error(errors, "components must be an object")
-  else
-    unknown_components = components.keys - EXPECTED_COMPONENTS.keys
-    add_error(errors, "unknown component(s): #{unknown_components.sort.join(', ')}") unless unknown_components.empty?
-    missing_components = EXPECTED_COMPONENTS.keys - components.keys
-    add_error(errors, "missing component(s): #{missing_components.sort.join(', ')}") unless missing_components.empty?
-
-    EXPECTED_COMPONENTS.each do |key, expected|
-      comp = components[key]
-      unless comp.is_a?(Hash)
-        add_error(errors, "component #{key} must be an object")
-        next
-      end
-      validate_component_fields(errors, key, comp, expected)
-      validate_component_names(errors, key, comp)
-      validate_component_eligibility(errors, key, comp)
-    end
-
-    unless EXPECTED_COMPONENTS.key?(COMPONENT_KEY)
-      add_error(errors, "requested component #{COMPONENT_KEY.inspect} is not in the manifest; known: #{EXPECTED_COMPONENTS.keys.sort.join(', ')}")
-    end
-  end
-end
+# ── Closed-schema validation (helpers in release-manifest-validation.rb) ────
+validate_manifest(errors, manifest, COMPONENT_KEY)
 
 if errors.any?
   warn errors.join("\n")
@@ -267,13 +80,24 @@ if errors.any?
 end
 
 component = manifest.fetch("components").fetch(COMPONENT_KEY)
+revision_matches = !SOURCE_REVISION.nil? && SOURCE_REVISION == manifest.fetch("source_revision")
 # Deploy eligibility requires BOTH the candidate match AND the manifest's own
 # per-component deploy_eligible flag — a manifest that marks a component
 # ineligible must never deploy, even with a matching revision.
 deploy_eligible = if SOURCE_REVISION.nil?
   nil
 else
-  SOURCE_REVISION == manifest.fetch("source_revision") && component.fetch("deploy_eligible")
+  revision_matches && component.fetch("deploy_eligible")
+end
+
+reason = if SOURCE_REVISION.nil?
+  "no candidate supplied; deploy verdict not computed"
+elsif !revision_matches
+  "candidate #{SOURCE_REVISION} is not the pinned pre-campaign source #{manifest.fetch('source_revision')}"
+elsif !component.fetch("deploy_eligible")
+  "component #{COMPONENT_KEY} is marked deploy-ineligible by the pinned manifest"
+else
+  "candidate matches pinned pre-campaign source #{manifest.fetch('source_revision')}"
 end
 
 output = {
@@ -298,7 +122,8 @@ output = {
   },
   eligibility: {
     deploy: deploy_eligible,
-    rollback: component.fetch("rollback_eligible")
+    rollback: component.fetch("rollback_eligible"),
+    reason: reason
   }
 }
 

--- a/.github/scripts/release-manifest-resolver.rb
+++ b/.github/scripts/release-manifest-resolver.rb
@@ -1,0 +1,290 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# SAFE-1 Phase B1: immutable production release manifest resolver.
+#
+# Reads .github/release-manifests/production-pre-campaign.json (a closed-schema,
+# content-addressed pin of the pre-campaign production surface), validates every
+# field against the pinned schema + expected component table below, and emits a
+# typed public output document. It never reads, prints, or forwards secret
+# values — the manifest carries secret NAMES only.
+#
+# A squash merge may replace commit identities, but the referenced manifest
+# blob stays content-addressed: this resolver hard-pins both the file SHA-256
+# and the Git blob object ID, so altering any manifest field (even while keeping
+# the pinned identities) fails closed.
+#
+# Usage:
+#   ruby release-manifest-resolver.rb <manifest.json> <component> [source_revision]
+#
+# Exit 0 + one JSON document on stdout when valid; exit 1 with one `error:`
+# line per failure class on stderr otherwise (never partial stdout output).
+
+require "json"
+require "digest"
+require "shellwords"
+
+MANIFEST_PATH = ARGV[0]
+COMPONENT_KEY = ARGV[1]
+SOURCE_REVISION = ARGV[2]
+
+# ── Pinned identities (computed at B1 creation; recompute only with a new
+#    manifest version and a deliberate re-pin) ──────────────────────────────
+PINNED_MANIFEST_SHA256 = "1ffcfe1bf4815e0e0e890193cbfdeb28d9748f94bb98db88106000af708f536c"
+PINNED_MANIFEST_BLOB_ID = "2aef389878e321ddc3d4d86922fde30ad2ab6491"
+PINNED_ATLAS_DIGEST_SHA256 = "e0428e7a9b25745a8d1f22f8fbcec5c915a8e18d56a7a45f5fe3554158b6ab80"
+PINNED_ATLAS_TARGET = "20260809000031"
+
+SCHEMA_VERSION = 1
+FULL_SHA_RE = /\A[0-9a-f]{40}\z/
+SHA256_RE = /\A[0-9a-f]{64}\z/
+ATLAS_TARGET_RE = /\A\d{14}\z/
+SECRET_NAME_RE = /\A[A-Z][A-Z0-9_]*\z/
+
+# Expected component surface (from SAFE-1 §2 and the ci.yml/deploy.yml
+# production jobs). The manifest must match this exactly — a drift in worker
+# name, directory, config, flags, or secret list fails closed.
+EXPECTED_COMPONENTS = {
+  "catalog" => {
+    working_directory: "workers/catalog",
+    worker_name: "catalog",
+    wrangler_config: "workers/catalog/wrangler.toml",
+    environment: "production",
+    pulumi_stack: "prod",
+    run_pulumi: true,
+    build_filter: "",
+    worker_secrets: %w[DATABASE_URL],
+    post_deploy_secrets: [],
+    depends_on: []
+  },
+  "web" => {
+    working_directory: "apps/web",
+    worker_name: "animichi-web",
+    wrangler_config: "apps/web/wrangler.jsonc",
+    environment: "production",
+    pulumi_stack: "prod",
+    run_pulumi: false,
+    build_filter: "web",
+    worker_secrets: [],
+    post_deploy_secrets: [],
+    depends_on: []
+  },
+  "users" => {
+    working_directory: "workers/users",
+    worker_name: "users",
+    wrangler_config: "workers/users/wrangler.toml",
+    environment: "production",
+    pulumi_stack: "prod",
+    run_pulumi: false,
+    build_filter: "",
+    worker_secrets: %w[DATABASE_URL NEON_AUTH_JWKS_URL],
+    post_deploy_secrets: [],
+    depends_on: %w[catalog]
+  },
+  "maintenance" => {
+    working_directory: "workers/jobs",
+    worker_name: "jobs",
+    wrangler_config: "workers/jobs/wrangler.toml",
+    environment: "production",
+    pulumi_stack: "prod",
+    run_pulumi: false,
+    build_filter: "",
+    worker_secrets: %w[AGENT_DATABASE_URL],
+    post_deploy_secrets: [],
+    depends_on: %w[catalog]
+  },
+  "root" => {
+    working_directory: ".",
+    worker_name: "animichi",
+    wrangler_config: "workers/edge/wrangler.toml",
+    environment: "production",
+    pulumi_stack: "prod",
+    run_pulumi: false,
+    build_filter: "",
+    worker_secrets: %w[
+      SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY SUPABASE_DB_URL
+      MIMO_API_KEY DEEPSEEK_API_KEY GOOGLE_MAPS_API_KEY LOGFIRE_TOKEN
+      CORS_ALLOWED_ORIGIN
+    ],
+    post_deploy_secrets: %w[TURNSTILE_SECRET ANON_ID_SECRET],
+    depends_on: %w[users]
+  }
+}.freeze
+
+# Allowed top-level keys. Closed schema: anything else is a validation failure.
+ALLOWED_TOP_LEVEL_KEYS = %w[
+  schema_version release_name description source_revision atlas components
+].freeze
+
+ALLOWED_COMPONENT_KEYS = %w[
+  working_directory worker_name wrangler_config environment pulumi_stack
+  run_pulumi build_filter worker_secrets post_deploy_secrets depends_on
+  deploy_eligible rollback_eligible
+].freeze
+
+errors = []
+
+def add_error(errors, message)
+  errors << "error: #{message}"
+end
+
+unless MANIFEST_PATH && COMPONENT_KEY
+  warn "usage: ruby release-manifest-resolver.rb <manifest.json> <component> [source_revision]"
+  exit 1
+end
+
+begin
+  manifest_text = File.read(MANIFEST_PATH)
+rescue Errno::ENOENT
+  warn "error: manifest not found: #{MANIFEST_PATH}"
+  exit 1
+end
+
+begin
+  manifest = JSON.parse(manifest_text)
+rescue JSON::ParserError => e
+  warn "error: manifest is not valid JSON: #{e.message}"
+  exit 1
+end
+
+# ── Pinned identity checks ──────────────────────────────────────────────────
+file_sha256 = Digest::SHA256.file(MANIFEST_PATH).hexdigest
+unless file_sha256 == PINNED_MANIFEST_SHA256
+  add_error(errors, "manifest SHA-256 #{file_sha256} does not match pinned #{PINNED_MANIFEST_SHA256}; altering any field while keeping the pinned identity is not allowed")
+end
+
+begin
+  blob_id = `git hash-object #{MANIFEST_PATH.shellescape}`.strip
+  blob_id = nil unless blob_id.match?(/\A[0-9a-f]{40}\z/)
+rescue StandardError
+  blob_id = nil
+end
+if blob_id && blob_id != PINNED_MANIFEST_BLOB_ID
+  add_error(errors, "manifest Git blob #{blob_id} does not match pinned #{PINNED_MANIFEST_BLOB_ID}")
+end
+
+# ── Closed-schema validation ────────────────────────────────────────────────
+unless manifest.is_a?(Hash)
+  add_error(errors, "manifest root must be an object")
+end
+
+if manifest.is_a?(Hash)
+  unknown = manifest.keys - ALLOWED_TOP_LEVEL_KEYS
+  add_error(errors, "unknown top-level field(s): #{unknown.sort.join(', ')}") unless unknown.empty?
+
+  unless manifest["schema_version"] == SCHEMA_VERSION
+    add_error(errors, "schema_version must be #{SCHEMA_VERSION}, got #{manifest['schema_version'].inspect}")
+  end
+
+  revision = manifest["source_revision"]
+  unless revision.is_a?(String) && revision.match?(FULL_SHA_RE)
+    add_error(errors, "source_revision must be a full 40-hex SHA, got #{revision.inspect}")
+  end
+
+  atlas = manifest["atlas"]
+  unless atlas.is_a?(Hash)
+    add_error(errors, "atlas must be an object")
+  else
+    unknown_atlas = atlas.keys - %w[directory target digest_sha256]
+    add_error(errors, "unknown atlas field(s): #{unknown_atlas.sort.join(', ')}") unless unknown_atlas.empty?
+    add_error(errors, "atlas.directory must be migrations/neon, got #{atlas['directory'].inspect}") unless atlas["directory"] == "migrations/neon"
+    target = atlas["target"]
+    unless target.is_a?(String) && target.match?(ATLAS_TARGET_RE)
+      add_error(errors, "atlas.target must be a 14-digit migration timestamp, got #{target.inspect}")
+    end
+    add_error(errors, "atlas.target must be pinned #{PINNED_ATLAS_TARGET}, got #{target.inspect}") unless target == PINNED_ATLAS_TARGET
+    digest = atlas["digest_sha256"]
+    unless digest.is_a?(String) && digest.match?(SHA256_RE)
+      add_error(errors, "atlas.digest_sha256 must be a 64-hex SHA-256, got #{digest.inspect}")
+    end
+    add_error(errors, "atlas.digest_sha256 must be pinned #{PINNED_ATLAS_DIGEST_SHA256}, got #{digest.inspect}") unless digest == PINNED_ATLAS_DIGEST_SHA256
+  end
+
+  components = manifest["components"]
+  unless components.is_a?(Hash)
+    add_error(errors, "components must be an object")
+  else
+    unknown_components = components.keys - EXPECTED_COMPONENTS.keys
+    add_error(errors, "unknown component(s): #{unknown_components.sort.join(', ')}") unless unknown_components.empty?
+    missing_components = EXPECTED_COMPONENTS.keys - components.keys
+    add_error(errors, "missing component(s): #{missing_components.sort.join(', ')}") unless missing_components.empty?
+
+    EXPECTED_COMPONENTS.each do |key, expected|
+      comp = components[key]
+      unless comp.is_a?(Hash)
+        add_error(errors, "component #{key} must be an object")
+        next
+      end
+      unknown_comp = comp.keys - ALLOWED_COMPONENT_KEYS
+      add_error(errors, "component #{key}: unknown field(s): #{unknown_comp.sort.join(', ')}") unless unknown_comp.empty?
+
+      expected.each do |field, value|
+        actual = comp[field.to_s]
+        if field == :worker_secrets || field == :post_deploy_secrets || field == :depends_on
+          unless actual.is_a?(Array) && actual == value
+            add_error(errors, "component #{key}: #{field} must be #{value.inspect}, got #{actual.inspect}")
+          end
+        elsif field == :run_pulumi
+          add_error(errors, "component #{key}: #{field} must be #{value}, got #{actual.inspect}") unless actual == value
+        else
+          add_error(errors, "component #{key}: #{field} must be #{value.inspect}, got #{actual.inspect}") unless actual == value
+        end
+      end
+
+      (comp["worker_secrets"] || []).each do |name|
+        add_error(errors, "component #{key}: secret name #{name.inspect} must match #{SECRET_NAME_RE}") unless name.is_a?(String) && name.match?(SECRET_NAME_RE)
+      end
+      (comp["post_deploy_secrets"] || []).each do |name|
+        add_error(errors, "component #{key}: post-deploy secret name #{name.inspect} must match #{SECRET_NAME_RE}") unless name.is_a?(String) && name.match?(SECRET_NAME_RE)
+      end
+      (comp["depends_on"] || []).each do |dep|
+        add_error(errors, "component #{key}: depends_on #{dep.inspect} is not a known component") unless EXPECTED_COMPONENTS.key?(dep)
+      end
+
+      %w[deploy_eligible rollback_eligible].each do |field|
+        add_error(errors, "component #{key}: #{field} must be a boolean, got #{comp[field].inspect}") unless comp[field] == true || comp[field] == false
+      end
+    end
+
+    unless EXPECTED_COMPONENTS.key?(COMPONENT_KEY)
+      add_error(errors, "requested component #{COMPONENT_KEY.inspect} is not in the manifest; known: #{EXPECTED_COMPONENTS.keys.sort.join(', ')}")
+    end
+  end
+end
+
+if errors.any?
+  warn errors.join("\n")
+  exit 1
+end
+
+component = manifest.fetch("components").fetch(COMPONENT_KEY)
+deploy_eligible = SOURCE_REVISION.nil? ? nil : (SOURCE_REVISION == manifest.fetch("source_revision"))
+
+output = {
+  manifest_sha256: file_sha256,
+  manifest_blob_id: PINNED_MANIFEST_BLOB_ID,
+  source_revision: manifest.fetch("source_revision"),
+  atlas: manifest.fetch("atlas"),
+  component: {
+    key: COMPONENT_KEY,
+    working_directory: component.fetch("working_directory"),
+    worker_name: component.fetch("worker_name"),
+    wrangler_config: component.fetch("wrangler_config"),
+    environment: component.fetch("environment"),
+    pulumi_stack: component.fetch("pulumi_stack"),
+    run_pulumi: component.fetch("run_pulumi"),
+    build_filter: component.fetch("build_filter"),
+    worker_secrets: component.fetch("worker_secrets"),
+    post_deploy_secrets: component.fetch("post_deploy_secrets"),
+    depends_on: component.fetch("depends_on"),
+    deploy_eligible: component.fetch("deploy_eligible"),
+    rollback_eligible: component.fetch("rollback_eligible")
+  },
+  eligibility: {
+    deploy: deploy_eligible,
+    rollback: component.fetch("rollback_eligible")
+  }
+}
+
+puts JSON.generate(output)
+exit 0

--- a/.github/scripts/release-manifest-resolver.test.rb
+++ b/.github/scripts/release-manifest-resolver.test.rb
@@ -172,9 +172,9 @@ puts "PASS: resolver enforces component.deploy_eligible in the deploy verdict"
 #    verified constant when the computation was unavailable) ─────────────────
 # Args passed as a vector (never interpolated into a shell string) so a
 # checkout path with shell metacharacters cannot break out of git -C.
-_, blob_out, = Open3.capture2("git", "-C", ROOT, "hash-object",
-                              ".github/release-manifests/production-pre-campaign.json")
-computed = blob_out.strip
+stdout, = Open3.capture2("git", "-C", ROOT, "hash-object",
+                         ".github/release-manifests/production-pre-campaign.json")
+computed = stdout.strip
 parsed = green_case("computed blob id reported", MANIFEST, "root")
 abort "FAIL: manifest_blob_id must be the computed #{computed}, got #{parsed['manifest_blob_id'].inspect}" \
   unless parsed["manifest_blob_id"] == computed

--- a/.github/scripts/release-manifest-resolver.test.rb
+++ b/.github/scripts/release-manifest-resolver.test.rb
@@ -1,0 +1,192 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Behavioral tests for release-manifest-resolver.rb (SAFE-1 Phase B1).
+#
+# The resolver is content-addressed: the checked-in manifest is pinned by
+# SHA-256 (and Git blob id). Green cases run against the real pinned manifest;
+# red cases mutate a throwaway COPY (tmpdir) so the real pinned blob is never
+# altered, and assert the resolver fails closed on the exact error class.
+
+require "open3"
+require "tmpdir"
+require "fileutils"
+require "json"
+
+ROOT = File.expand_path("../..", __dir__)
+SCRIPT = File.join(ROOT, ".github/scripts/release-manifest-resolver.rb")
+MANIFEST = File.join(ROOT, ".github/release-manifests/production-pre-campaign.json")
+PINNED_SOURCE_REVISION = "b94c30ab6a519f1cce9eb0a3f7885953f8ff54cf"
+
+def run_resolver(manifest, component, revision = PINNED_SOURCE_REVISION)
+  args = [RbConfig.ruby, SCRIPT, manifest, component]
+  args << revision unless revision.nil?
+  out, err, status = Open3.capture3(*args)
+  [status.exitstatus, out, err]
+end
+
+def green_case(name, manifest, component, revision = PINNED_SOURCE_REVISION)
+  rc, out, err = run_resolver(manifest, component, revision)
+  abort "FAIL: #{name}: expected exit 0, got #{rc}\n#{err}" unless rc.zero?
+  parsed = JSON.parse(out)
+  abort "FAIL: #{name}: output must carry manifest_sha256" unless parsed["manifest_sha256"].is_a?(String)
+  abort "FAIL: #{name}: output component key must be #{component}" unless parsed.dig("component", "key") == component
+  puts "PASS: #{name}"
+  parsed
+end
+
+def red_case(name, manifest, component, expected_lines, revision = PINNED_SOURCE_REVISION)
+  rc, out, err = run_resolver(manifest, component, revision)
+  abort "FAIL: #{name}: expected non-zero exit, got #{rc}\nstdout: #{out}\nstderr: #{err}" if rc.zero?
+  expected_lines.each do |line|
+    abort "FAIL: #{name}: expected #{line.inspect} in stderr:\n#{err}" unless err.include?(line)
+  end
+  abort "FAIL: #{name}: must not print partial stdout on failure\nstdout: #{out}" unless out.empty?
+  puts "PASS: #{name} fails with #{expected_lines.size} expected error line(s)"
+end
+
+def mutate_manifest(copy_path, &block)
+  manifest = JSON.parse(File.read(copy_path))
+  block.call(manifest)
+  File.write(copy_path, JSON.generate(manifest))
+end
+
+# ── Green: the real pinned manifest, every component ─────────────────────────
+%w[catalog web users maintenance root].each do |component|
+  green_case("pinned manifest resolves #{component}", MANIFEST, component)
+end
+
+# ── Green: eligibility verdict — matching revision → deploy true ────────────
+green = green_case("matching revision is deploy-eligible", MANIFEST, "root")
+abort "FAIL: matching revision must be deploy eligible" unless green.dig("eligibility", "deploy") == true
+abort "FAIL: rollback must be ineligible per manifest policy" unless green.dig("eligibility", "rollback") == false
+
+# ── Green: non-matching revision → deploy ineligible (typed, not an error) ──
+stale = green_case("stale revision is deploy-ineligible", MANIFEST, "root", "0" * 40)
+abort "FAIL: stale revision must be deploy ineligible" unless stale.dig("eligibility", "deploy") == false
+
+# ── Green: no revision argument → eligibility.deploy omitted ────────────────
+no_rev = green_case("revision omitted omits deploy verdict", MANIFEST, "catalog", nil)
+abort "FAIL: omitted revision must omit deploy verdict" unless no_rev["eligibility"].key?("deploy") && no_rev.dig("eligibility", "deploy").nil?
+
+# ── Red: tampered manifest — altering any field fails the pinned identity ───
+Dir.mktmpdir("b1-tamper") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["atlas"]["target"] = "20260909000000" }
+  red_case("altered atlas target fails pinned identity", copy, "root",
+           ["manifest SHA-256", "atlas.target must be pinned 20260809000031"])
+end
+
+# ── Red: unknown top-level field ────────────────────────────────────────────
+Dir.mktmpdir("b1-unknown-top") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["surprise"] = true }
+  red_case("unknown top-level field", copy, "root",
+           ["manifest SHA-256", "unknown top-level field(s): surprise"])
+end
+
+# ── Red: unknown component key ──────────────────────────────────────────────
+Dir.mktmpdir("b1-unknown-comp") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["components"]["sidecar"] = m["components"]["root"] }
+  red_case("unknown component key", copy, "root",
+           ["manifest SHA-256", "unknown component(s): sidecar"])
+end
+
+# ── Red: requested component not in manifest ────────────────────────────────
+red_case("unknown requested component", MANIFEST, "sidecar",
+         ["requested component \"sidecar\" is not in the manifest"])
+
+# ── Red: schema_version must be exactly 1 ───────────────────────────────────
+Dir.mktmpdir("b1-schema") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["schema_version"] = 2 }
+  red_case("schema_version 2 rejected", copy, "root",
+           ["manifest SHA-256", "schema_version must be 1, got 2"])
+end
+
+# ── Red: source_revision must be a full 40-hex SHA ──────────────────────────
+Dir.mktmpdir("b1-rev") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["source_revision"] = "deadbeef" }
+  red_case("short source_revision rejected", copy, "root",
+           ["manifest SHA-256", "source_revision must be a full 40-hex SHA"])
+end
+
+# ── Red: atlas digest must match the pinned digest exactly ──────────────────
+Dir.mktmpdir("b1-digest") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["atlas"]["digest_sha256"] = "e" * 64 }
+  red_case("altered atlas digest rejected", copy, "root",
+           ["manifest SHA-256", "atlas.digest_sha256 must be pinned"])
+end
+
+# ── Red: atlas directory must be migrations/neon ────────────────────────────
+Dir.mktmpdir("b1-atlas-dir") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["atlas"]["directory"] = "db/migrations" }
+  red_case("altered atlas directory rejected", copy, "root",
+           ["manifest SHA-256", "atlas.directory must be migrations/neon"])
+end
+
+# ── Red: non-boolean eligibility ────────────────────────────────────────────
+Dir.mktmpdir("b1-elig") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["components"]["root"]["rollback_eligible"] = "maybe" }
+  red_case("non-boolean rollback_eligible rejected", copy, "root",
+           ["manifest SHA-256", "component root: rollback_eligible must be a boolean"])
+end
+
+# ── Red: invalid secret name ────────────────────────────────────────────────
+Dir.mktmpdir("b1-secret") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["components"]["catalog"]["worker_secrets"] = ["bad-name!"] }
+  red_case("invalid secret name rejected", copy, "root",
+           ["manifest SHA-256", "component catalog: secret name \"bad-name!\" must match"])
+end
+
+# ── Red: depends_on referencing an unknown component ────────────────────────
+Dir.mktmpdir("b1-dep") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["components"]["root"]["depends_on"] = ["phantom"] }
+  red_case("depends_on unknown component rejected", copy, "root",
+           ["manifest SHA-256", "component root: depends_on \"phantom\" is not a known component"])
+end
+
+# ── Red: component drift from the expected surface (worker name) ────────────
+Dir.mktmpdir("b1-drift") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["components"]["web"]["worker_name"] = "animichi-web-renamed" }
+  red_case("worker-name drift rejected", copy, "root",
+           ["manifest SHA-256", "component web: worker_name must be \"animichi-web\""])
+end
+
+# ── Red: missing component ──────────────────────────────────────────────────
+Dir.mktmpdir("b1-missing") do |dir|
+  copy = File.join(dir, "manifest.json")
+  FileUtils.cp(MANIFEST, copy)
+  mutate_manifest(copy) { |m| m["components"].delete("maintenance") }
+  red_case("missing component rejected", copy, "root",
+           ["manifest SHA-256", "missing component(s): maintenance"])
+end
+
+# ── Red: manifest must be valid JSON ────────────────────────────────────────
+Dir.mktmpdir("b1-json") do |dir|
+  copy = File.join(dir, "manifest.json")
+  File.write(copy, "{ not json")
+  red_case("invalid JSON rejected", copy, "root",
+           ["manifest is not valid JSON"])
+end
+
+puts "All release-manifest-resolver.rb behavioral tests passed."

--- a/.github/scripts/release-manifest-resolver.test.rb
+++ b/.github/scripts/release-manifest-resolver.test.rb
@@ -51,160 +51,125 @@ def mutate_manifest(copy_path, &block)
   File.write(copy_path, JSON.generate(manifest))
 end
 
+
+def with_copy(name)
+  Dir.mktmpdir(name) do |dir|
+    copy = File.join(dir, "manifest.json")
+    FileUtils.cp(MANIFEST, copy)
+    yield copy
+  end
+end
+
 # ── Green: the real pinned manifest, every component ─────────────────────────
 %w[catalog web users maintenance root].each do |component|
   green_case("pinned manifest resolves #{component}", MANIFEST, component)
 end
 
-# ── Green: eligibility verdict — matching revision → deploy true ────────────
+# ── Green: eligibility verdicts ──────────────────────────────────────────────
 green = green_case("matching revision is deploy-eligible", MANIFEST, "root")
 abort "FAIL: matching revision must be deploy eligible" unless green.dig("eligibility", "deploy") == true
 abort "FAIL: rollback must be ineligible per manifest policy" unless green.dig("eligibility", "rollback") == false
 
-# ── Green: non-matching revision → deploy ineligible (typed, not an error) ──
 stale = green_case("stale revision is deploy-ineligible", MANIFEST, "root", "0" * 40)
 abort "FAIL: stale revision must be deploy ineligible" unless stale.dig("eligibility", "deploy") == false
 
-# ── Green: no revision argument → eligibility.deploy omitted ────────────────
 no_rev = green_case("revision omitted omits deploy verdict", MANIFEST, "catalog", nil)
 abort "FAIL: omitted revision must omit deploy verdict" unless no_rev["eligibility"].key?("deploy") && no_rev.dig("eligibility", "deploy").nil?
 
 # ── Red: tampered manifest — altering any field fails the pinned identity ───
-Dir.mktmpdir("b1-tamper") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-tamper") do |copy|
   mutate_manifest(copy) { |m| m["atlas"]["target"] = "20260909000000" }
-  red_case("altered atlas target fails pinned identity", copy, "root",
-           ["manifest SHA-256", "atlas.target must be pinned 20260809000031"])
+  red_case("altered atlas target fails pinned identity", copy, "root", ["manifest SHA-256", "atlas.target must be pinned 20260809000031"])
 end
 
 # ── Red: unknown top-level field ────────────────────────────────────────────
-Dir.mktmpdir("b1-unknown-top") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-unknown-top") do |copy|
   mutate_manifest(copy) { |m| m["surprise"] = true }
-  red_case("unknown top-level field", copy, "root",
-           ["manifest SHA-256", "unknown top-level field(s): surprise"])
+  red_case("unknown top-level field", copy, "root", ["manifest SHA-256", "unknown top-level field(s): surprise"])
 end
 
 # ── Red: unknown component key ──────────────────────────────────────────────
-Dir.mktmpdir("b1-unknown-comp") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-unknown-comp") do |copy|
   mutate_manifest(copy) { |m| m["components"]["sidecar"] = m["components"]["root"] }
-  red_case("unknown component key", copy, "root",
-           ["manifest SHA-256", "unknown component(s): sidecar"])
+  red_case("unknown component key", copy, "root", ["manifest SHA-256", "unknown component(s): sidecar"])
 end
 
 # ── Red: requested component not in manifest ────────────────────────────────
-red_case("unknown requested component", MANIFEST, "sidecar",
-         ["requested component \"sidecar\" is not in the manifest"])
+red_case("unknown requested component", MANIFEST, "sidecar", ["requested component \"sidecar\" is not in the manifest"])
 
 # ── Red: schema_version must be exactly 1 ───────────────────────────────────
-Dir.mktmpdir("b1-schema") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-schema") do |copy|
   mutate_manifest(copy) { |m| m["schema_version"] = 2 }
-  red_case("schema_version 2 rejected", copy, "root",
-           ["manifest SHA-256", "schema_version must be 1, got 2"])
+  red_case("schema_version 2 rejected", copy, "root", ["manifest SHA-256", "schema_version must be 1, got 2"])
 end
 
 # ── Red: source_revision must be a full 40-hex SHA ──────────────────────────
-Dir.mktmpdir("b1-rev") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-rev") do |copy|
   mutate_manifest(copy) { |m| m["source_revision"] = "deadbeef" }
-  red_case("short source_revision rejected", copy, "root",
-           ["manifest SHA-256", "source_revision must be a full 40-hex SHA"])
+  red_case("short source_revision rejected", copy, "root", ["manifest SHA-256", "source_revision must be a full 40-hex SHA"])
 end
 
 # ── Red: atlas digest must match the pinned digest exactly ──────────────────
-Dir.mktmpdir("b1-digest") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-digest") do |copy|
   mutate_manifest(copy) { |m| m["atlas"]["digest_sha256"] = "e" * 64 }
-  red_case("altered atlas digest rejected", copy, "root",
-           ["manifest SHA-256", "atlas.digest_sha256 must be pinned"])
+  red_case("altered atlas digest rejected", copy, "root", ["manifest SHA-256", "atlas.digest_sha256 must be pinned"])
 end
 
 # ── Red: atlas directory must be migrations/neon ────────────────────────────
-Dir.mktmpdir("b1-atlas-dir") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-atlas-dir") do |copy|
   mutate_manifest(copy) { |m| m["atlas"]["directory"] = "db/migrations" }
-  red_case("altered atlas directory rejected", copy, "root",
-           ["manifest SHA-256", "atlas.directory must be migrations/neon"])
+  red_case("altered atlas directory rejected", copy, "root", ["manifest SHA-256", "atlas.directory must be migrations/neon"])
 end
 
 # ── Red: non-boolean eligibility ────────────────────────────────────────────
-Dir.mktmpdir("b1-elig") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-elig") do |copy|
   mutate_manifest(copy) { |m| m["components"]["root"]["rollback_eligible"] = "maybe" }
-  red_case("non-boolean rollback_eligible rejected", copy, "root",
-           ["manifest SHA-256", "component root: rollback_eligible must be a boolean"])
+  red_case("non-boolean rollback_eligible rejected", copy, "root", ["manifest SHA-256", "component root: rollback_eligible must be a boolean"])
 end
 
 # ── Red: invalid secret name ────────────────────────────────────────────────
-Dir.mktmpdir("b1-secret") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-secret") do |copy|
   mutate_manifest(copy) { |m| m["components"]["catalog"]["worker_secrets"] = ["bad-name!"] }
-  red_case("invalid secret name rejected", copy, "root",
-           ["manifest SHA-256", "component catalog: secret name \"bad-name!\" must match"])
+  red_case("invalid secret name rejected", copy, "root", ["manifest SHA-256", "component catalog: secret name \"bad-name!\" must match"])
 end
 
 # ── Red: depends_on referencing an unknown component ────────────────────────
-Dir.mktmpdir("b1-dep") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-dep") do |copy|
   mutate_manifest(copy) { |m| m["components"]["root"]["depends_on"] = ["phantom"] }
-  red_case("depends_on unknown component rejected", copy, "root",
-           ["manifest SHA-256", "component root: depends_on \"phantom\" is not a known component"])
+  red_case("depends_on unknown component rejected", copy, "root", ["manifest SHA-256", "component root: depends_on \"phantom\" is not a known component"])
 end
 
 # ── Red: component drift from the expected surface (worker name) ────────────
-Dir.mktmpdir("b1-drift") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-drift") do |copy|
   mutate_manifest(copy) { |m| m["components"]["web"]["worker_name"] = "animichi-web-renamed" }
-  red_case("worker-name drift rejected", copy, "root",
-           ["manifest SHA-256", "component web: worker_name must be \"animichi-web\""])
+  red_case("worker-name drift rejected", copy, "root", ["manifest SHA-256", "component web: worker_name must be \"animichi-web\""])
 end
 
 # ── Red: missing component ──────────────────────────────────────────────────
-Dir.mktmpdir("b1-missing") do |dir|
-  copy = File.join(dir, "manifest.json")
-  FileUtils.cp(MANIFEST, copy)
+with_copy("b1-missing") do |copy|
   mutate_manifest(copy) { |m| m["components"].delete("maintenance") }
-  red_case("missing component rejected", copy, "root",
-           ["manifest SHA-256", "missing component(s): maintenance"])
+  red_case("missing component rejected", copy, "root", ["manifest SHA-256", "missing component(s): maintenance"])
 end
 
 # ── Red: manifest must be valid JSON ────────────────────────────────────────
 Dir.mktmpdir("b1-json") do |dir|
   copy = File.join(dir, "manifest.json")
   File.write(copy, "{ not json")
-  red_case("invalid JSON rejected", copy, "root",
-           ["manifest is not valid JSON"])
+  red_case("invalid JSON rejected", copy, "root", ["manifest is not valid JSON"])
 end
 
 # ── Red: component marked deploy_eligible=false stays ineligible even with a
-#    matching revision (the flag is enforced, not just validated) ────────────
-# NOTE: the pinned-manifest path cannot hold a deploy_eligible=false component
-# (the pinned blob is immutable), so this behavior is verified structurally
-# here: the resolver's eligibility.deploy must AND the flag with the revision
-# match. Asserted via source inspection rather than a fixture (a tampered copy
-# fails on the pinned identity before reaching the verdict).
+#    matching revision. The pinned blob cannot hold such a component, so this
+#    is verified structurally: eligibility.deploy must AND the flag with the
+#    revision match (a tampered copy fails on the pinned identity first).
 resolver_source = File.read(SCRIPT)
-unless resolver_source.include?("SOURCE_REVISION == manifest.fetch(\"source_revision\") && component.fetch(\"deploy_eligible\")")
+unless resolver_source.include?("revision_matches && component.fetch(\"deploy_eligible\")")
   abort "FAIL: resolver must enforce component.deploy_eligible in the deploy verdict"
 end
 puts "PASS: resolver enforces component.deploy_eligible in the deploy verdict"
 
-# ── Green: manifest_blob_id in the verdict is the COMPUTED blob id (observed
-#    value), so consumers never mistake an unavailable computation for a
-#    verified one ─────────────────────────────────────────────────────────────
+# ── Green: manifest_blob_id is the COMPUTED blob id (never mistaken for a
+#    verified constant when the computation was unavailable) ─────────────────
 computed = `git -C "#{ROOT}" hash-object .github/release-manifests/production-pre-campaign.json`.strip
 parsed = green_case("computed blob id reported", MANIFEST, "root")
 abort "FAIL: manifest_blob_id must be the computed #{computed}, got #{parsed['manifest_blob_id'].inspect}" \

--- a/.github/scripts/release-manifest-resolver.test.rb
+++ b/.github/scripts/release-manifest-resolver.test.rb
@@ -170,7 +170,11 @@ puts "PASS: resolver enforces component.deploy_eligible in the deploy verdict"
 
 # ── Green: manifest_blob_id is the COMPUTED blob id (never mistaken for a
 #    verified constant when the computation was unavailable) ─────────────────
-computed = `git -C "#{ROOT}" hash-object .github/release-manifests/production-pre-campaign.json`.strip
+# Args passed as a vector (never interpolated into a shell string) so a
+# checkout path with shell metacharacters cannot break out of git -C.
+_, blob_out, = Open3.capture2("git", "-C", ROOT, "hash-object",
+                              ".github/release-manifests/production-pre-campaign.json")
+computed = blob_out.strip
 parsed = green_case("computed blob id reported", MANIFEST, "root")
 abort "FAIL: manifest_blob_id must be the computed #{computed}, got #{parsed['manifest_blob_id'].inspect}" \
   unless parsed["manifest_blob_id"] == computed

--- a/.github/scripts/release-manifest-resolver.test.rb
+++ b/.github/scripts/release-manifest-resolver.test.rb
@@ -189,4 +189,26 @@ Dir.mktmpdir("b1-json") do |dir|
            ["manifest is not valid JSON"])
 end
 
+# ── Red: component marked deploy_eligible=false stays ineligible even with a
+#    matching revision (the flag is enforced, not just validated) ────────────
+# NOTE: the pinned-manifest path cannot hold a deploy_eligible=false component
+# (the pinned blob is immutable), so this behavior is verified structurally
+# here: the resolver's eligibility.deploy must AND the flag with the revision
+# match. Asserted via source inspection rather than a fixture (a tampered copy
+# fails on the pinned identity before reaching the verdict).
+resolver_source = File.read(SCRIPT)
+unless resolver_source.include?("SOURCE_REVISION == manifest.fetch(\"source_revision\") && component.fetch(\"deploy_eligible\")")
+  abort "FAIL: resolver must enforce component.deploy_eligible in the deploy verdict"
+end
+puts "PASS: resolver enforces component.deploy_eligible in the deploy verdict"
+
+# ── Green: manifest_blob_id in the verdict is the COMPUTED blob id (observed
+#    value), so consumers never mistake an unavailable computation for a
+#    verified one ─────────────────────────────────────────────────────────────
+computed = `git -C "#{ROOT}" hash-object .github/release-manifests/production-pre-campaign.json`.strip
+parsed = green_case("computed blob id reported", MANIFEST, "root")
+abort "FAIL: manifest_blob_id must be the computed #{computed}, got #{parsed['manifest_blob_id'].inspect}" \
+  unless parsed["manifest_blob_id"] == computed
+puts "PASS: manifest_blob_id is the computed blob id"
+
 puts "All release-manifest-resolver.rb behavioral tests passed."

--- a/.github/scripts/release-manifest-validation.rb
+++ b/.github/scripts/release-manifest-validation.rb
@@ -107,7 +107,11 @@ def validate_component_fields(errors, key, comp, expected)
 end
 
 def validate_secret_names(errors, key, names, field)
-  (names || []).each do |name|
+  unless names.is_a?(Array)
+    add_error(errors, "component #{key}: #{field} names must be an array, got #{names.inspect}")
+    return
+  end
+  names.each do |name|
     unless name.is_a?(String) && name.match?(SECRET_NAME_RE)
       add_error(errors, "component #{key}: #{field} name #{name.inspect} must match #{SECRET_NAME_RE}")
     end
@@ -115,7 +119,11 @@ def validate_secret_names(errors, key, names, field)
 end
 
 def validate_depends_on(errors, key, deps)
-  (deps || []).each do |dep|
+  unless deps.is_a?(Array)
+    add_error(errors, "component #{key}: depends_on must be an array, got #{deps.inspect}")
+    return
+  end
+  deps.each do |dep|
     add_error(errors, "component #{key}: depends_on #{dep.inspect} is not a known component") unless EXPECTED_COMPONENTS.key?(dep)
   end
 end

--- a/.github/scripts/release-manifest-validation.rb
+++ b/.github/scripts/release-manifest-validation.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+# SAFE-1 Phase B1: manifest validation helpers shared with
+# release-manifest-resolver.rb (kept under the repo's 300-line file limit).
+# This module owns the closed-schema rules; the resolver owns reading,
+# pinned-identity checks, and typed output.
+
+SCHEMA_VERSION = 1
+FULL_SHA_RE = /\A[0-9a-f]{40}\z/
+SHA256_RE = /\A[0-9a-f]{64}\z/
+ATLAS_TARGET_RE = /\A\d{14}\z/
+SECRET_NAME_RE = /\A[A-Z][A-Z0-9_]*\z/
+
+PINNED_ATLAS_TARGET = "20260809000031"
+PINNED_ATLAS_DIGEST_SHA256 = "e0428e7a9b25745a8d1f22f8fbcec5c915a8e18d56a7a45f5fe3554158b6ab80"
+
+# Expected component surface (from SAFE-1 §2 and the ci.yml/deploy.yml
+# production jobs). The manifest must match this exactly — a drift in worker
+# name, directory, config, flags, or secret list fails closed.
+EXPECTED_COMPONENTS = {
+  "catalog" => {
+    working_directory: "workers/catalog",
+    worker_name: "catalog",
+    wrangler_config: "workers/catalog/wrangler.toml",
+    environment: "production",
+    pulumi_stack: "prod",
+    run_pulumi: true,
+    build_filter: "",
+    worker_secrets: %w[DATABASE_URL],
+    post_deploy_secrets: [],
+    depends_on: []
+  },
+  "web" => {
+    working_directory: "apps/web",
+    worker_name: "animichi-web",
+    wrangler_config: "apps/web/wrangler.jsonc",
+    environment: "production",
+    pulumi_stack: "prod",
+    run_pulumi: false,
+    build_filter: "web",
+    worker_secrets: [],
+    post_deploy_secrets: [],
+    depends_on: []
+  },
+  "users" => {
+    working_directory: "workers/users",
+    worker_name: "users",
+    wrangler_config: "workers/users/wrangler.toml",
+    environment: "production",
+    pulumi_stack: "prod",
+    run_pulumi: false,
+    build_filter: "",
+    worker_secrets: %w[DATABASE_URL NEON_AUTH_JWKS_URL],
+    post_deploy_secrets: [],
+    depends_on: %w[catalog]
+  },
+  "maintenance" => {
+    working_directory: "workers/jobs",
+    worker_name: "jobs",
+    wrangler_config: "workers/jobs/wrangler.toml",
+    environment: "production",
+    pulumi_stack: "prod",
+    run_pulumi: false,
+    build_filter: "",
+    worker_secrets: %w[AGENT_DATABASE_URL],
+    post_deploy_secrets: [],
+    depends_on: %w[catalog]
+  },
+  "root" => {
+    working_directory: ".",
+    worker_name: "animichi",
+    wrangler_config: "workers/edge/wrangler.toml",
+    environment: "production",
+    pulumi_stack: "prod",
+    run_pulumi: false,
+    build_filter: "",
+    worker_secrets: %w[
+      SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY SUPABASE_DB_URL
+      MIMO_API_KEY DEEPSEEK_API_KEY GOOGLE_MAPS_API_KEY LOGFIRE_TOKEN
+      CORS_ALLOWED_ORIGIN
+    ],
+    post_deploy_secrets: %w[TURNSTILE_SECRET ANON_ID_SECRET],
+    depends_on: %w[users]
+  }
+}.freeze
+
+ALLOWED_TOP_LEVEL_KEYS = %w[
+  schema_version release_name description source_revision atlas components
+].freeze
+
+ALLOWED_COMPONENT_KEYS = %w[
+  working_directory worker_name wrangler_config environment pulumi_stack
+  run_pulumi build_filter worker_secrets post_deploy_secrets depends_on
+  deploy_eligible rollback_eligible
+].freeze
+
+def add_error(errors, message)
+  errors << "error: #{message}"
+end
+
+def validate_component_fields(errors, key, comp, expected)
+  unknown_comp = comp.keys - ALLOWED_COMPONENT_KEYS
+  add_error(errors, "component #{key}: unknown field(s): #{unknown_comp.sort.join(', ')}") unless unknown_comp.empty?
+  expected.each do |field, value|
+    add_error(errors, "component #{key}: #{field} must be #{value.inspect}, got #{comp[field.to_s].inspect}") unless comp[field.to_s] == value
+  end
+end
+
+def validate_secret_names(errors, key, names, field)
+  (names || []).each do |name|
+    unless name.is_a?(String) && name.match?(SECRET_NAME_RE)
+      add_error(errors, "component #{key}: #{field} name #{name.inspect} must match #{SECRET_NAME_RE}")
+    end
+  end
+end
+
+def validate_depends_on(errors, key, deps)
+  (deps || []).each do |dep|
+    add_error(errors, "component #{key}: depends_on #{dep.inspect} is not a known component") unless EXPECTED_COMPONENTS.key?(dep)
+  end
+end
+
+def validate_component_eligibility(errors, key, comp)
+  %w[deploy_eligible rollback_eligible].each do |field|
+    unless comp[field] == true || comp[field] == false
+      add_error(errors, "component #{key}: #{field} must be a boolean, got #{comp[field].inspect}")
+    end
+  end
+end
+
+def validate_atlas(errors, atlas)
+  unknown_atlas = atlas.keys - %w[directory target digest_sha256]
+  add_error(errors, "unknown atlas field(s): #{unknown_atlas.sort.join(', ')}") unless unknown_atlas.empty?
+  add_error(errors, "atlas.directory must be migrations/neon, got #{atlas['directory'].inspect}") unless atlas["directory"] == "migrations/neon"
+  target = atlas["target"]
+  unless target.is_a?(String) && target.match?(ATLAS_TARGET_RE)
+    add_error(errors, "atlas.target must be a 14-digit migration timestamp, got #{target.inspect}")
+  end
+  add_error(errors, "atlas.target must be pinned #{PINNED_ATLAS_TARGET}, got #{target.inspect}") unless target == PINNED_ATLAS_TARGET
+  digest = atlas["digest_sha256"]
+  unless digest.is_a?(String) && digest.match?(SHA256_RE)
+    add_error(errors, "atlas.digest_sha256 must be a 64-hex SHA-256, got #{digest.inspect}")
+  end
+  add_error(errors, "atlas.digest_sha256 must be pinned #{PINNED_ATLAS_DIGEST_SHA256}, got #{digest.inspect}") unless digest == PINNED_ATLAS_DIGEST_SHA256
+end
+
+def validate_components(errors, components, requested_key)
+  return add_error(errors, "components must be an object") unless components.is_a?(Hash)
+
+  unknown = components.keys - EXPECTED_COMPONENTS.keys
+  add_error(errors, "unknown component(s): #{unknown.sort.join(', ')}") unless unknown.empty?
+  missing = EXPECTED_COMPONENTS.keys - components.keys
+  add_error(errors, "missing component(s): #{missing.sort.join(', ')}") unless missing.empty?
+  unless EXPECTED_COMPONENTS.key?(requested_key)
+    add_error(errors, "requested component #{requested_key.inspect} is not in the manifest; known: #{EXPECTED_COMPONENTS.keys.sort.join(', ')}")
+  end
+
+  EXPECTED_COMPONENTS.each do |key, expected|
+    comp = components[key]
+    unless comp.is_a?(Hash)
+      add_error(errors, "component #{key} must be an object")
+      next
+    end
+    validate_component_fields(errors, key, comp, expected)
+    validate_secret_names(errors, key, comp["worker_secrets"], "secret")
+    validate_secret_names(errors, key, comp["post_deploy_secrets"], "post-deploy secret")
+    validate_depends_on(errors, key, comp["depends_on"])
+    validate_component_eligibility(errors, key, comp)
+  end
+end
+
+def validate_manifest(errors, manifest, requested_key)
+  return add_error(errors, "manifest root must be an object") unless manifest.is_a?(Hash)
+
+  unknown = manifest.keys - ALLOWED_TOP_LEVEL_KEYS
+  add_error(errors, "unknown top-level field(s): #{unknown.sort.join(', ')}") unless unknown.empty?
+  unless manifest["schema_version"] == SCHEMA_VERSION
+    add_error(errors, "schema_version must be #{SCHEMA_VERSION}, got #{manifest['schema_version'].inspect}")
+  end
+  revision = manifest["source_revision"]
+  unless revision.is_a?(String) && revision.match?(FULL_SHA_RE)
+    add_error(errors, "source_revision must be a full 40-hex SHA, got #{revision.inspect}")
+  end
+
+  atlas = manifest["atlas"]
+  if atlas.is_a?(Hash)
+    validate_atlas(errors, atlas)
+  else
+    add_error(errors, "atlas must be an object")
+  end
+  validate_components(errors, manifest["components"], requested_key)
+end

--- a/.github/scripts/test_safe1_production_contract.rb
+++ b/.github/scripts/test_safe1_production_contract.rb
@@ -1,12 +1,12 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# SAFE-1 Phase A: characterization of today's production release behavior.
+# SAFE-1 production freeze contract (Phase A characterization → target
+# invariants after Phase B2 wired the guard).
 #
-# This pins the public release semantics of the production deploy surface as
-# they exist today, BEFORE the SAFE-1 promotion-eligibility changes land. It
-# must pass on the current tree; Phase B (PromotionEligibility) is expected to
-# have to update it. Semantics only — never whitespace trivia:
+# This pins the release semantics of the production deploy surface after the
+# SAFE-1 promotion-eligibility changes land. Semantics only — never whitespace
+# trivia:
 #
 #   1. ci.yml and deploy.yml expose the same five production component
 #      mappings (component -> working directory), root included, with root's
@@ -15,11 +15,12 @@
 #      AGENT_DATABASE_URL, the jobs_svc grants, and both cron schedules.
 #   3. Atlas head is 20260809000031 and migrations/neon/atlas.sum hashes to
 #      the pinned SHA-256.
-#   4. The three current unsafe release behaviors, so their replacement is
-#      observable: rollback.yml accepts and forwards a caller-supplied
-#      version_id; the reusable deploy checks out the caller workflow's SHA
-#      implicitly (no ref input, no checkout ref); post-deploy asserts the
-#      deployed commit equals github.sha.
+#   4. The SAFE-1 target invariants (replacing the Phase A unsafe-behavior
+#      characterizations): every production entry point routes through the
+#      eligibility workflow and gates on the pinned manifest; rollback has no
+#      caller-supplied version_id and stops before Wrangler when ineligible;
+#      production checkout, Atlas target, build metadata, and smoke
+#      expectations resolve from the pinned revision, never github.sha.
 
 require "yaml"
 require "digest"

--- a/.github/scripts/test_safe1_production_contract.rb
+++ b/.github/scripts/test_safe1_production_contract.rb
@@ -1,0 +1,157 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# SAFE-1 Phase A: characterization of today's production release behavior.
+#
+# This pins the public release semantics of the production deploy surface as
+# they exist today, BEFORE the SAFE-1 promotion-eligibility changes land. It
+# must pass on the current tree; Phase B (PromotionEligibility) is expected to
+# have to update it. Semantics only — never whitespace trivia:
+#
+#   1. ci.yml and deploy.yml expose the same five production component
+#      mappings (component -> working directory), root included, with root's
+#      config at workers/edge/wrangler.toml.
+#   2. The retained Jobs production surface: maintenance -> workers/jobs,
+#      AGENT_DATABASE_URL, the jobs_svc grants, and both cron schedules.
+#   3. Atlas head is 20260809000031 and migrations/neon/atlas.sum hashes to
+#      the pinned SHA-256.
+#   4. The three current unsafe release behaviors, so their replacement is
+#      observable: rollback.yml accepts and forwards a caller-supplied
+#      version_id; the reusable deploy checks out the caller workflow's SHA
+#      implicitly (no ref input, no checkout ref); post-deploy asserts the
+#      deployed commit equals github.sha.
+
+require "yaml"
+require "digest"
+
+WORKFLOWS = ".github/workflows"
+
+# The five production component mappings (component -> working directory),
+# shared verbatim by ci.yml and deploy.yml. catalog's job is `deploy-prod`,
+# not `deploy-catalog-prod`; every other component uses `deploy-<name>-prod`.
+PROD_COMPONENT_DIRS = {
+  "catalog" => "workers/catalog",
+  "web" => "apps/web",
+  "users" => "workers/users",
+  "maintenance" => "workers/jobs",
+  "root" => "."
+}.freeze
+
+def prod_job_id(component)
+  component == "catalog" ? "deploy-prod" : "deploy-#{component}-prod"
+end
+
+# `on:` is a YAML 1.1 boolean, so old psych parses it as the key `true`;
+# accept both spellings (same stance as test_ci_contract.rb).
+def load_workflow(file)
+  text = File.read(File.join(WORKFLOWS, file)).sub(/^on:(?=[ \t#]|$)/, '"on":')
+  YAML.safe_load(text, aliases: true)
+end
+
+def triggers(wf)
+  wf["on"] || wf[true]
+end
+
+def fetch_prod_job(jobs, component)
+  job = jobs.fetch(prod_job_id(component))
+  abort "deploy-#{component}-prod must call reusable-deploy-component.yml" \
+    unless job.fetch("uses") == "./.github/workflows/reusable-deploy-component.yml"
+  job
+end
+
+# ── 1. The five production component mappings, identical in both callers ──
+%w[ci.yml deploy.yml].each do |file|
+  jobs = load_workflow(file).fetch("jobs")
+  PROD_COMPONENT_DIRS.each do |component, dir|
+    with = fetch_prod_job(jobs, component).fetch("with")
+    abort "#{file}: #{component} must map to #{dir}, got #{with['working_directory'].inspect}" \
+      unless with["working_directory"] == dir
+    abort "#{file}: #{component} must target environment production" unless with["environment"] == "production"
+    abort "#{file}: #{component} must target pulumi stack prod" unless with["pulumi_stack"] == "prod"
+    abort "#{file}: #{component} must declare component #{component}" unless with["component"] == component
+  end
+end
+
+# Root's config lives at workers/edge/wrangler.toml while its working
+# directory stays "." — wrangler is pointed at it explicitly (#853).
+deploy_source = File.read(File.join(WORKFLOWS, "reusable-deploy-component.yml"))
+abort "reusable deploy must point root at workers/edge/wrangler.toml" \
+  unless deploy_source.include?("deploy -c workers/edge/wrangler.toml")
+rollback_source = File.read(File.join(WORKFLOWS, "rollback.yml"))
+abort "rollback must point root at workers/edge/wrangler.toml" \
+  unless rollback_source.include?("-c workers/edge/wrangler.toml")
+
+# ── 2. Retained Jobs production surface (maintenance -> workers/jobs) ──
+%w[ci.yml deploy.yml].each do |file|
+  with = load_workflow(file).fetch("jobs").fetch("deploy-maintenance-prod").fetch("with")
+  abort "#{file}: maintenance prod must keep worker_secrets AGENT_DATABASE_URL" \
+    unless with["worker_secrets"] == "AGENT_DATABASE_URL"
+end
+
+grants = File.read("migrations/neon/20260809000030_grants.sql")
+abort "jobs_svc must exist as a role" \
+  unless File.read("migrations/neon/20260809000001_roles.sql").include?("CREATE ROLE jobs_svc")
+expected_grants = [
+  "GRANT SELECT,DELETE ON TABLE public.anon_daily_message_count TO jobs_svc;",
+  "GRANT SELECT,DELETE ON TABLE public.conversation_messages TO jobs_svc;",
+  "GRANT SELECT,DELETE ON TABLE public.conversations TO jobs_svc;",
+  "GRANT SELECT ON TABLE public.saved_routes TO jobs_svc;",
+  "GRANT SELECT,DELETE ON TABLE public.sessions TO jobs_svc;"
+]
+missing = expected_grants.reject { |line| grants.include?(line) }
+abort "jobs_svc grants missing: #{missing.join('; ')}" unless missing.empty?
+
+jobs_toml = File.read("workers/jobs/wrangler.toml")
+abort "jobs wrangler.toml must declare both crons in base, staging, and production" \
+  unless jobs_toml.scan('crons = ["37 18 * * *", "37 19 * * *"]').size == 3
+
+# Production identity, scoped to the [env.production] subtree: the worker
+# deployed to production must be named `jobs`, and its secrets.required must
+# be exactly the AGENT_DATABASE_URL upload chain (#912 keeps production off
+# the staging Secrets Store so prod can never bind staging-role DSNs).
+prod_section = jobs_toml.lines
+  .drop_while { |line| line.chomp != "[env.production]" }
+  .take_while { |line| line.start_with?("[env.production") || !line.start_with?("[") }
+  .join
+abort "jobs wrangler.toml must declare [env.production]" if prod_section.empty?
+abort "jobs production Worker name must be exactly \"jobs\"" \
+  unless prod_section[/^\s*name\s*=\s*"([^"]+)"/, 1] == "jobs"
+abort "jobs production secrets.required must be exactly AGENT_DATABASE_URL" \
+  unless prod_section[/^\s*required\s*=\s*\[(.*?)\]/, 1]&.strip == '"AGENT_DATABASE_URL"'
+
+# ── 3. Atlas head + pinned atlas.sum integrity ──
+heads = Dir[File.join("migrations/neon", "*.sql")].map { |f| File.basename(f)[/\A\d+/] }.compact
+abort "Atlas head must be 20260809000031, got #{heads.max.inspect}" unless heads.max == "20260809000031"
+sum = Digest::SHA256.file("migrations/neon/atlas.sum").hexdigest
+abort "atlas.sum SHA-256 must be e0428e7a9b25745a8d1f22f8fbcec5c915a8e18d56a7a45f5fe3554158b6ab80, got #{sum}" \
+  unless sum == "e0428e7a9b25745a8d1f22f8fbcec5c915a8e18d56a7a45f5fe3554158b6ab80"
+
+# ── 4. Current unsafe release behaviors, characterized as they are today ──
+rollback = load_workflow("rollback.yml")
+version_id = triggers(rollback).fetch("workflow_dispatch").fetch("inputs").fetch("version_id")
+abort "rollback.yml version_id input must accept a caller-supplied value" \
+  unless version_id["type"] == "string" && version_id["required"] == false
+rollback_step = rollback.fetch("jobs").fetch("rollback").fetch("steps")
+  .find { |step| step["run"]&.include?("wrangler rollback") }
+abort "rollback.yml must forward the caller version_id to wrangler rollback" \
+  unless rollback_step && rollback_step.dig("env", "VERSION_ID") == "${{ inputs.version_id }}"
+abort "rollback.yml rollback command must send VERSION_ID verbatim" \
+  unless rollback_step.fetch("run").include?('wrangler rollback "$VERSION_ID"')
+
+reusable = load_workflow("reusable-deploy-component.yml")
+call_inputs = triggers(reusable).fetch("workflow_call").fetch("inputs")
+abort "reusable deploy must accept no ref input (caller SHA checked out implicitly)" \
+  if call_inputs.key?("ref")
+checkout = reusable.fetch("jobs").fetch("deploy").fetch("steps")
+  .find { |step| step["uses"].to_s.start_with?("actions/checkout") }
+abort "reusable deploy checkout must not pin a ref (implicit caller SHA)" \
+  if checkout.fetch("with", {}).key?("ref")
+
+%w[reusable-deploy-component.yml reusable-post-deploy-test.yml].each do |file|
+  source = File.read(File.join(WORKFLOWS, file))
+  abort "#{file} must expect the deployed commit to equal github.sha" \
+    unless source.include?("EXPECTED_GIT_COMMIT: ${{ github.sha }}")
+end
+
+puts "SAFE-1 Phase A contract: #{PROD_COMPONENT_DIRS.size} prod component mappings in ci.yml + deploy.yml; " \
+     "jobs surface, atlas head 20260809000031, and unsafe-release behaviors pinned"

--- a/.github/scripts/test_safe1_production_contract.rb
+++ b/.github/scripts/test_safe1_production_contract.rb
@@ -4,7 +4,7 @@
 # SAFE-1 production freeze contract (Phase A characterization → target
 # invariants after Phase B2 wired the guard).
 #
-# This pins the release semantics of the production deploy surface after the
+# Pins the release semantics of the production deploy surface after the
 # SAFE-1 promotion-eligibility changes land. Semantics only — never whitespace
 # trivia:
 #
@@ -15,12 +15,11 @@
 #      AGENT_DATABASE_URL, the jobs_svc grants, and both cron schedules.
 #   3. Atlas head is 20260809000031 and migrations/neon/atlas.sum hashes to
 #      the pinned SHA-256.
-#   4. The SAFE-1 target invariants (replacing the Phase A unsafe-behavior
-#      characterizations): every production entry point routes through the
-#      eligibility workflow and gates on the pinned manifest; rollback has no
-#      caller-supplied version_id and stops before Wrangler when ineligible;
-#      production checkout, Atlas target, build metadata, and smoke
-#      expectations resolve from the pinned revision, never github.sha.
+#   4. SAFE-1 target invariants: every production entry point gates on the
+#      eligibility workflow; rollback has no caller version_id and stops
+#      before Wrangler when ineligible; production checkout, Atlas target,
+#      build metadata, and smoke expectations resolve from the pinned
+#      revision, never github.sha.
 
 require "yaml"
 require "digest"
@@ -127,8 +126,7 @@ sum = Digest::SHA256.file("migrations/neon/atlas.sum").hexdigest
 abort "atlas.sum SHA-256 must be e0428e7a9b25745a8d1f22f8fbcec5c915a8e18d56a7a45f5fe3554158b6ab80, got #{sum}" \
   unless sum == "e0428e7a9b25745a8d1f22f8fbcec5c915a8e18d56a7a45f5fe3554158b6ab80"
 
-# ── 4. SAFE-1 target invariants (replaces the Phase A unsafe-behavior
-#        characterizations — the guard is now wired) ─────────────────────────
+# ── 4. SAFE-1 target invariants (the guard is now wired) ────────────────────
 # 4a. Every production entry point routes through the eligibility workflow and
 #     only runs when the pinned manifest marks the candidate eligible.
 eligibility_source = File.read(File.join(WORKFLOWS, "reusable-production-eligibility.yml"))
@@ -157,23 +155,22 @@ abort "eligibility workflow must expose eligible/source_revision/reason outputs"
     unless post.fetch("with")["expected_source_revision"] == "${{ needs.production-eligibility.outputs.source_revision }}"
 end
 
-# 4b. Rollback: caller-supplied version_id is gone; component/config/rollback
-#     eligibility resolve from the pinned manifest, and rollback-ineligible
-#     components stop before any Wrangler command.
+# 4b. Rollback: no caller version_id; eligibility resolves from the pinned
+#     manifest BEFORE checkout; ineligible stops before checkout or Wrangler.
 rollback = load_workflow("rollback.yml")
+rollback_source = File.read(File.join(WORKFLOWS, "rollback.yml"))
 abort "rollback.yml must not accept a caller-supplied version_id input" \
   if triggers(rollback).fetch("workflow_dispatch").fetch("inputs").key?("version_id")
-rollback_source = File.read(File.join(WORKFLOWS, "rollback.yml"))
-abort "rollback.yml must resolve eligibility from the pinned manifest" \
-  unless rollback_source.include?("release-eligibility.sh")
+abort "rollback.yml must verify the pinned manifest SHA-256 inline" \
+  unless rollback_source.include?("PINNED_MANIFEST_SHA256")
+abort "rollback.yml must gate BEFORE checkout" \
+  unless rollback_source.index("Resolve manifest rollback eligibility") < rollback_source.index("actions/checkout")
 abort "rollback.yml must fail closed on rollback-ineligible components" \
   unless rollback_source.include?("rollback-ineligible")
-abort "rollback.yml must never forward a caller version_id to wrangler" \
-  if rollback_source.include?("wrangler rollback \"$VERSION_ID\"")
 
-# 4c. The reusable deploy resolves the pinned manifest for production, checks
-#     out the pinned source revision, verifies HEAD + atlas.sum, and applies
-#     the pinned Atlas target — staging keeps caller-SHA behavior.
+# 4c. The reusable deploy resolves the pinned manifest, checks out the pinned
+#     source revision, verifies HEAD + atlas.sum, applies the pinned Atlas
+#     target — staging keeps caller-SHA behavior.
 reusable = load_workflow("reusable-deploy-component.yml")
 reusable_source = File.read(File.join(WORKFLOWS, "reusable-deploy-component.yml"))
 abort "reusable deploy must resolve the pinned manifest for production" \
@@ -187,8 +184,8 @@ abort "reusable deploy must verify atlas.sum against the pinned digest" \
 abort "reusable deploy must apply the pinned Atlas target for production" \
   unless reusable_source.include?("--to-version")
 
-# 4d. Post-deploy smoke expectations: production uses the resolved revision,
-#     never the campaign github.sha; the healthz contract is revision-based.
+# 4d. Post-deploy smokes: production expects the resolved revision, never the
+#     campaign github.sha.
 %w[reusable-deploy-component.yml reusable-post-deploy-test.yml].each do |file|
   source = File.read(File.join(WORKFLOWS, file))
   abort "#{file} must not expect github.sha unconditionally as the deployed commit" \
@@ -199,6 +196,5 @@ end
 abort "reusable deploy must bake the pinned revision for production" \
   unless reusable_source.include?("pinned-pre-campaign")
 
-puts "SAFE-1 production freeze contract: eligibility gate on all production entry points; " \
-     "rollback version_id removed; pinned manifest resolution for production checkout, " \
-     "Atlas target, build metadata, and smoke expectations"
+puts "SAFE-1 freeze: eligibility gate on all production entry points; rollback version_id " \
+     "removed; pinned manifest resolution for checkout, Atlas target, build metadata, smokes"

--- a/.github/scripts/test_safe1_production_contract.rb
+++ b/.github/scripts/test_safe1_production_contract.rb
@@ -126,32 +126,78 @@ sum = Digest::SHA256.file("migrations/neon/atlas.sum").hexdigest
 abort "atlas.sum SHA-256 must be e0428e7a9b25745a8d1f22f8fbcec5c915a8e18d56a7a45f5fe3554158b6ab80, got #{sum}" \
   unless sum == "e0428e7a9b25745a8d1f22f8fbcec5c915a8e18d56a7a45f5fe3554158b6ab80"
 
-# ── 4. Current unsafe release behaviors, characterized as they are today ──
-rollback = load_workflow("rollback.yml")
-version_id = triggers(rollback).fetch("workflow_dispatch").fetch("inputs").fetch("version_id")
-abort "rollback.yml version_id input must accept a caller-supplied value" \
-  unless version_id["type"] == "string" && version_id["required"] == false
-rollback_step = rollback.fetch("jobs").fetch("rollback").fetch("steps")
-  .find { |step| step["run"]&.include?("wrangler rollback") }
-abort "rollback.yml must forward the caller version_id to wrangler rollback" \
-  unless rollback_step && rollback_step.dig("env", "VERSION_ID") == "${{ inputs.version_id }}"
-abort "rollback.yml rollback command must send VERSION_ID verbatim" \
-  unless rollback_step.fetch("run").include?('wrangler rollback "$VERSION_ID"')
+# ── 4. SAFE-1 target invariants (replaces the Phase A unsafe-behavior
+#        characterizations — the guard is now wired) ─────────────────────────
+# 4a. Every production entry point routes through the eligibility workflow and
+#     only runs when the pinned manifest marks the candidate eligible.
+eligibility_source = File.read(File.join(WORKFLOWS, "reusable-production-eligibility.yml"))
+abort "eligibility workflow must resolve the pinned manifest via the GitHub API" \
+  unless eligibility_source.include?("release-eligibility.sh")
+abort "eligibility workflow must expose eligible/source_revision/reason outputs" \
+  unless %w[eligible source_revision reason].all? { |o| eligibility_source.include?(o) }
 
-reusable = load_workflow("reusable-deploy-component.yml")
-call_inputs = triggers(reusable).fetch("workflow_call").fetch("inputs")
-abort "reusable deploy must accept no ref input (caller SHA checked out implicitly)" \
-  if call_inputs.key?("ref")
-checkout = reusable.fetch("jobs").fetch("deploy").fetch("steps")
-  .find { |step| step["uses"].to_s.start_with?("actions/checkout") }
-abort "reusable deploy checkout must not pin a ref (implicit caller SHA)" \
-  if checkout.fetch("with", {}).key?("ref")
-
-%w[reusable-deploy-component.yml reusable-post-deploy-test.yml].each do |file|
-  source = File.read(File.join(WORKFLOWS, file))
-  abort "#{file} must expect the deployed commit to equal github.sha" \
-    unless source.include?("EXPECTED_GIT_COMMIT: ${{ github.sha }}")
+%w[ci.yml deploy.yml].each do |file|
+  jobs = load_workflow(file).fetch("jobs")
+  abort "#{file}: must call reusable-production-eligibility.yml" \
+    unless jobs.fetch("production-eligibility").fetch("uses") == "./.github/workflows/reusable-production-eligibility.yml"
+  PROD_COMPONENT_DIRS.each_key do |component|
+    job = fetch_prod_job(jobs, component)
+    abort "#{file}: #{prod_job_id(component)} must depend on production-eligibility" \
+      unless job.fetch("needs").include?("production-eligibility")
+    abort "#{file}: #{prod_job_id(component)} must gate on eligible == 'true'" \
+      unless job.fetch("if") == "${{ needs.production-eligibility.outputs.eligible == 'true' }}"
+  end
+  post = jobs.fetch("post-prod")
+  abort "#{file}: post-prod must depend on production-eligibility" \
+    unless post.fetch("needs").include?("production-eligibility")
+  abort "#{file}: post-prod must gate on eligible == 'true'" \
+    unless post.fetch("if") == "${{ needs.production-eligibility.outputs.eligible == 'true' }}"
+  abort "#{file}: post-prod must pass the resolved source revision" \
+    unless post.fetch("with")["expected_source_revision"] == "${{ needs.production-eligibility.outputs.source_revision }}"
 end
 
-puts "SAFE-1 Phase A contract: #{PROD_COMPONENT_DIRS.size} prod component mappings in ci.yml + deploy.yml; " \
-     "jobs surface, atlas head 20260809000031, and unsafe-release behaviors pinned"
+# 4b. Rollback: caller-supplied version_id is gone; component/config/rollback
+#     eligibility resolve from the pinned manifest, and rollback-ineligible
+#     components stop before any Wrangler command.
+rollback = load_workflow("rollback.yml")
+abort "rollback.yml must not accept a caller-supplied version_id input" \
+  if triggers(rollback).fetch("workflow_dispatch").fetch("inputs").key?("version_id")
+rollback_source = File.read(File.join(WORKFLOWS, "rollback.yml"))
+abort "rollback.yml must resolve eligibility from the pinned manifest" \
+  unless rollback_source.include?("release-eligibility.sh")
+abort "rollback.yml must fail closed on rollback-ineligible components" \
+  unless rollback_source.include?("rollback-ineligible")
+abort "rollback.yml must never forward a caller version_id to wrangler" \
+  if rollback_source.include?("wrangler rollback \"$VERSION_ID\"")
+
+# 4c. The reusable deploy resolves the pinned manifest for production, checks
+#     out the pinned source revision, verifies HEAD + atlas.sum, and applies
+#     the pinned Atlas target — staging keeps caller-SHA behavior.
+reusable = load_workflow("reusable-deploy-component.yml")
+reusable_source = File.read(File.join(WORKFLOWS, "reusable-deploy-component.yml"))
+abort "reusable deploy must resolve the pinned manifest for production" \
+  unless reusable_source.include?("Resolve pinned production release manifest")
+abort "reusable deploy must check out the pinned production source" \
+  unless reusable_source.include?("Checkout pinned production source")
+abort "reusable deploy must verify HEAD against the pinned source revision" \
+  unless reusable_source.include?("does not match pinned source revision")
+abort "reusable deploy must verify atlas.sum against the pinned digest" \
+  unless reusable_source.include?("Verify pinned atlas.sum")
+abort "reusable deploy must apply the pinned Atlas target for production" \
+  unless reusable_source.include?("--to-version")
+
+# 4d. Post-deploy smoke expectations: production uses the resolved revision,
+#     never the campaign github.sha; the healthz contract is revision-based.
+%w[reusable-deploy-component.yml reusable-post-deploy-test.yml].each do |file|
+  source = File.read(File.join(WORKFLOWS, file))
+  abort "#{file} must not expect github.sha unconditionally as the deployed commit" \
+    if source.include?("EXPECTED_GIT_COMMIT: ${{ github.sha }}")
+  abort "#{file} must resolve the expected deployed commit for production" \
+    unless source.include?("expected_source_revision") || source.include?("steps.release.outputs.source_revision")
+end
+abort "reusable deploy must bake the pinned revision for production" \
+  unless reusable_source.include?("pinned-pre-campaign")
+
+puts "SAFE-1 production freeze contract: eligibility gate on all production entry points; " \
+     "rollback version_id removed; pinned manifest resolution for production checkout, " \
+     "Atlas target, build metadata, and smoke expectations"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,11 +494,25 @@ jobs:
       # left the name unfilled and every staging smoke 403'd.
       STAGING_GATE_TOKEN: ${{ secrets.STAGING_GATE_TOKEN }}
 
+  # SAFE-1 (#937): production eligibility gate. Every production job depends on
+  # this job and only runs when the candidate (github.sha) is the pinned
+  # pre-campaign source revision. A campaign revision therefore records an
+  # ineligible no-op here and every production job is skipped before checkout,
+  # Atlas, Pulumi, or Wrangler can mutate production.
+  production-eligibility:
+    name: Production eligibility (SAFE-1)
+    needs: post-staging
+    uses: ./.github/workflows/reusable-production-eligibility.yml
+    with:
+      candidate_sha: ${{ github.sha }}
+      component: root
+
   # staging validated → production (human approve via environment: production in
   # reusable-deploy-component.yml). needs: post-staging guarantees staging passed api tests.
   deploy-prod:
     name: Deploy production
-    needs: post-staging
+    needs: [post-staging, production-eligibility]
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-deploy-component.yml
     with:
       component: catalog
@@ -519,7 +533,8 @@ jobs:
 
   deploy-web-prod:
     name: Deploy web production
-    needs: post-staging
+    needs: [post-staging, production-eligibility]
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-deploy-component.yml
     with:
       component: web
@@ -536,7 +551,8 @@ jobs:
 
   deploy-users-prod:
     name: Deploy users production
-    needs: [post-staging, deploy-prod]
+    needs: [post-staging, production-eligibility, deploy-prod]
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-deploy-component.yml
     with:
       component: users
@@ -557,7 +573,8 @@ jobs:
 
   deploy-maintenance-prod:
     name: Deploy maintenance production
-    needs: [post-staging, deploy-prod]
+    needs: [post-staging, production-eligibility, deploy-prod]
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-deploy-component.yml
     with:
       component: maintenance
@@ -574,7 +591,8 @@ jobs:
 
   deploy-root-prod:
     name: Deploy root production
-    needs: [post-staging, deploy-users-prod]
+    needs: [post-staging, production-eligibility, deploy-users-prod]
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-deploy-component.yml
     with:
       component: root
@@ -620,11 +638,13 @@ jobs:
 
   post-prod:
     name: Post-deploy (production)
-    needs: [deploy-prod, deploy-web-prod, deploy-users-prod, deploy-maintenance-prod, deploy-root-prod]
+    needs: [production-eligibility, deploy-prod, deploy-web-prod, deploy-users-prod, deploy-maintenance-prod, deploy-root-prod]
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-post-deploy-test.yml
     with:
       environment: production
       suite: smoke
+      expected_source_revision: ${{ needs.production-eligibility.outputs.source_revision }}
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,25 @@ env:
 
 jobs:
 
+  # SAFE-1 (#937): production eligibility gate. The manual path mirrors the CI
+  # promotion path: the dispatch's github.sha is judged against the pinned
+  # pre-campaign source revision. Once a campaign revision lands on main, this
+  # resolves ineligible and every production job is skipped before checkout,
+  # Atlas, Pulumi, or Wrangler can mutate production. Only an explicit
+  # pre-campaign invocation (dispatch while main == source_revision) resolves
+  # the manifest, and the GitHub `production` environment approval remains
+  # mandatory inside reusable-deploy-component.yml.
+  production-eligibility:
+    name: Production eligibility (SAFE-1)
+    uses: ./.github/workflows/reusable-production-eligibility.yml
+    with:
+      candidate_sha: ${{ github.sha }}
+      component: root
+
   deploy-prod:
     name: Deploy production
+    needs: production-eligibility
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-deploy-component.yml
     with:
       component: catalog
@@ -53,6 +70,8 @@ jobs:
 
   deploy-web-prod:
     name: Deploy web production
+    needs: production-eligibility
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-deploy-component.yml
     with:
       component: web
@@ -70,7 +89,8 @@ jobs:
   deploy-users-prod:
     name: Deploy users production
     # mirrors ci.yml's intra-prod ordering (root routes to users; users must be live first)
-    needs: [deploy-prod]
+    needs: [production-eligibility, deploy-prod]
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-deploy-component.yml
     with:
       component: users
@@ -92,7 +112,8 @@ jobs:
   deploy-maintenance-prod:
     name: Deploy maintenance production
     # mirrors ci.yml's intra-prod ordering (root routes to users; users must be live first)
-    needs: [deploy-prod]
+    needs: [production-eligibility, deploy-prod]
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-deploy-component.yml
     with:
       component: maintenance
@@ -110,7 +131,8 @@ jobs:
   deploy-root-prod:
     name: Deploy root production
     # mirrors ci.yml's intra-prod ordering (root routes to users; users must be live first)
-    needs: [deploy-users-prod]
+    needs: [production-eligibility, deploy-users-prod]
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-deploy-component.yml
     with:
       component: root
@@ -156,11 +178,13 @@ jobs:
 
   post-prod:
     name: Post-deploy (production)
-    needs: [deploy-prod, deploy-web-prod, deploy-users-prod, deploy-maintenance-prod, deploy-root-prod]
+    needs: [production-eligibility, deploy-prod, deploy-web-prod, deploy-users-prod, deploy-maintenance-prod, deploy-root-prod]
+    if: ${{ needs.production-eligibility.outputs.eligible == 'true' }}
     uses: ./.github/workflows/reusable-post-deploy-test.yml
     with:
       environment: production
       suite: smoke
+      expected_source_revision: ${{ needs.production-eligibility.outputs.source_revision }}
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/pipeline-quality.yml
+++ b/.github/workflows/pipeline-quality.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
       - name: Ruby syntax check workflow meta scripts
         run: |
-          for f in .github/scripts/assert-workflow-invariants.rb .github/scripts/assert-workflow-invariants-expression.rb .github/scripts/assert-workflow-invariants.test.rb; do
+          for f in .github/scripts/assert-workflow-invariants.rb .github/scripts/assert-workflow-invariants-expression.rb .github/scripts/assert-workflow-invariants.test.rb .github/scripts/release-manifest-resolver.rb .github/scripts/release-manifest-resolver.test.rb .github/scripts/test_safe1_production_contract.rb; do
             ruby -c "${f}"
           done
         shell: bash
@@ -45,6 +45,20 @@ jobs:
         shell: bash
       - name: Assert workflow invariants
         run: ruby .github/scripts/assert-workflow-invariants.rb
+        shell: bash
+      # SAFE-1 (#937): the production freeze contract — the eligibility gate on
+      # every production entry point, the removed rollback version_id, and the
+      # pinned manifest resolution (checkout, Atlas target, build metadata, and
+      # smoke expectations). Unfiltered like every check in this lane, so any
+      # PR or merge-group candidate that could change release code runs it.
+      - name: SAFE-1 production freeze contract
+        run: ruby .github/scripts/test_safe1_production_contract.rb
+        shell: bash
+      - name: SAFE-1 release manifest resolver self-tests
+        run: ruby .github/scripts/release-manifest-resolver.test.rb
+        shell: bash
+      - name: SAFE-1 release eligibility self-tests
+        run: bash .github/scripts/release-eligibility.test.sh
         shell: bash
       # S0-v2 B4: the retired repository-quality-gate's contents moved here —
       # this lane is the fixed point that never path-filters, so the checks

--- a/.github/workflows/reusable-deploy-component.yml
+++ b/.github/workflows/reusable-deploy-component.yml
@@ -502,6 +502,13 @@ jobs:
         # consideration, not the safety check itself.
         run: |
           if [ -z "$NEON_DATABASE_URL" ]; then
+            # SAFE-1 (#937): a production run MUST apply the pinned Atlas
+            # target before deploying — an empty URL is a fail-closed error,
+            # not a skip. Staging keeps the pre-campaign skip behavior.
+            if [ "$TARGET_ENVIRONMENT" = "production" ]; then
+              echo "::error::NEON_DATABASE_URL not set — production requires the pinned Atlas apply before deploy; refusing to continue"
+              exit 1
+            fi
             echo "NEON_DATABASE_URL not set — skipping atlas migrate"; exit 0
           fi
           curl -sSfL --proto '=https' --proto-redir '=https' "https://release.ariga.io/atlas/atlas-community-linux-amd64-v0.30.0" -o /usr/local/bin/atlas

--- a/.github/workflows/reusable-deploy-component.yml
+++ b/.github/workflows/reusable-deploy-component.yml
@@ -132,15 +132,36 @@ jobs:
         run: |
           set -euo pipefail
           verdict="$(bash .github/scripts/release-eligibility.sh "$TARGET_COMPONENT" "${{ github.sha }}")"
-          deploy="$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["eligibility"]["deploy"])')"
+          # jq emits JSON literals ("true"/"false") — never Python's
+          # "True"/"False" — matching the caller-side gate comparison.
+          deploy="$(echo "$verdict" | jq -r .eligibility.deploy)"
           if [ "$deploy" != "true" ]; then
             echo "::error::production ineligible: candidate ${{ github.sha }} is not the pinned pre-campaign source revision (SAFE-1). Refusing to deploy before any production mutation."
             exit 1
           fi
+          # The manifest is the only authority for the production deployment
+          # mapping: a caller that drifts from it (working directory, Pulumi
+          # stack, build filter, Pulumi run flag) fails closed rather than
+          # deploying a component under caller-selected settings.
+          check_matches() {
+            local field="$1" expected="$2" actual="$3"
+            if [ "$expected" != "$actual" ]; then
+              echo "::error::caller $field='$actual' does not match pinned manifest '$expected' for component '$TARGET_COMPONENT'"
+              exit 1
+            fi
+          }
+          check_matches working_directory \
+            "$(echo "$verdict" | jq -r .component.working_directory)" "${{ inputs.working_directory }}"
+          check_matches pulumi_stack \
+            "$(echo "$verdict" | jq -r .component.pulumi_stack)" "${{ inputs.pulumi_stack }}"
+          check_matches build_filter \
+            "$(echo "$verdict" | jq -r .component.build_filter)" "${{ inputs.build_filter }}"
+          check_matches run_pulumi \
+            "$(echo "$verdict" | jq -r .component.run_pulumi)" "${{ inputs.run_pulumi }}"
           {
-            echo "source_revision=$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["source_revision"])')"
-            echo "atlas_target=$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["atlas"]["target"])')"
-            echo "atlas_digest=$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["atlas"]["digest_sha256"])')"
+            echo "source_revision=$(echo "$verdict" | jq -r .source_revision)"
+            echo "atlas_target=$(echo "$verdict" | jq -r .atlas.target)"
+            echo "atlas_digest=$(echo "$verdict" | jq -r .atlas.digest_sha256)"
           } >> "$GITHUB_OUTPUT"
       - name: Checkout pinned production source
         if: ${{ inputs.environment == 'production' }}
@@ -164,12 +185,15 @@ jobs:
         run: |
           set -euo pipefail
           cd migrations/neon
-          shasum -a 256 -c atlas.sum
+          # atlas.sum is an Atlas checksum ledger (h1: entries), NOT a standard
+          # shasum -c checkfile — compare the file's own SHA-256 against the
+          # manifest pin instead (same digest the Phase A contract asserts).
           actual="$(shasum -a 256 atlas.sum | awk '{print $1}')"
           test "$actual" = "$ATLAS_DIGEST" || {
             echo "::error::atlas.sum SHA-256 $actual does not match pinned manifest digest $ATLAS_DIGEST"
             exit 1
           }
+          echo "atlas.sum matches pinned digest $ATLAS_DIGEST"
       - uses: ./.github/actions/setup
       # #527/#528: this job declares `environment: ${{ inputs.environment }}`
       # above, which is what makes environment-scoped secrets resolve here

--- a/.github/workflows/reusable-deploy-component.yml
+++ b/.github/workflows/reusable-deploy-component.yml
@@ -113,6 +113,63 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Full history so the production path can detach onto the pinned
+          # pre-campaign source revision without a second network fetch.
+          fetch-depth: 0
+      # SAFE-1 (#937): production only — resolve the pinned pre-campaign
+      # release manifest (content-addressed GitHub blob, never the working
+      # tree), then detach the worktree onto the pinned source revision and
+      # verify HEAD and atlas.sum BEFORE any mutation can start. A campaign
+      # revision is ineligible and fails here, before Atlas/Pulumi/Wrangler.
+      # Staging keeps the caller-SHA behavior (no resolve, implicit checkout).
+      - name: Resolve pinned production release manifest
+        if: ${{ inputs.environment == 'production' }}
+        id: release
+        shell: bash
+        env:
+          TARGET_COMPONENT: ${{ inputs.component }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          verdict="$(bash .github/scripts/release-eligibility.sh "$TARGET_COMPONENT" "${{ github.sha }}")"
+          deploy="$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["eligibility"]["deploy"])')"
+          if [ "$deploy" != "true" ]; then
+            echo "::error::production ineligible: candidate ${{ github.sha }} is not the pinned pre-campaign source revision (SAFE-1). Refusing to deploy before any production mutation."
+            exit 1
+          fi
+          {
+            echo "source_revision=$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["source_revision"])')"
+            echo "atlas_target=$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["atlas"]["target"])')"
+            echo "atlas_digest=$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["atlas"]["digest_sha256"])')"
+          } >> "$GITHUB_OUTPUT"
+      - name: Checkout pinned production source
+        if: ${{ inputs.environment == 'production' }}
+        shell: bash
+        env:
+          SOURCE_REVISION: ${{ steps.release.outputs.source_revision }}
+        run: |
+          set -euo pipefail
+          git checkout --detach "$SOURCE_REVISION"
+          head="$(git rev-parse HEAD)"
+          test "$head" = "$SOURCE_REVISION" || {
+            echo "::error::production HEAD $head does not match pinned source revision $SOURCE_REVISION"
+            exit 1
+          }
+          echo "Checked out pinned pre-campaign source $SOURCE_REVISION (detached)"
+      - name: Verify pinned atlas.sum
+        if: ${{ inputs.environment == 'production' }}
+        shell: bash
+        env:
+          ATLAS_DIGEST: ${{ steps.release.outputs.atlas_digest }}
+        run: |
+          set -euo pipefail
+          cd migrations/neon
+          shasum -a 256 -c atlas.sum
+          actual="$(shasum -a 256 atlas.sum | awk '{print $1}')"
+          test "$actual" = "$ATLAS_DIGEST" || {
+            echo "::error::atlas.sum SHA-256 $actual does not match pinned manifest digest $ATLAS_DIGEST"
+            exit 1
+          }
       - uses: ./.github/actions/setup
       # #527/#528: this job declares `environment: ${{ inputs.environment }}`
       # above, which is what makes environment-scoped secrets resolve here
@@ -440,9 +497,19 @@ jobs:
           esac
           # 486: the manual thin-caller path has no db-validate job, so validate here (cheap, seconds) before mutating.
           atlas migrate validate --dir "file://migrations/neon"
-          atlas migrate apply --dir "file://migrations/neon" --url "$scoped_url" --revisions-schema public
+          # SAFE-1 (#937): production applies the PINNED pre-campaign Atlas
+          # target from the release manifest (never the campaign head); staging
+          # keeps applying the caller SHA's migrations as before.
+          if [ "$TARGET_ENVIRONMENT" = "production" ]; then
+            atlas migrate apply --dir "file://migrations/neon" --url "$scoped_url" \
+              --revisions-schema public --to-version "$ATLAS_TARGET"
+          else
+            atlas migrate apply --dir "file://migrations/neon" --url "$scoped_url" --revisions-schema public
+          fi
         env:
           NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
+          ATLAS_TARGET: ${{ steps.release.outputs.atlas_target }}
       # Installs the Pulumi CLI onto PATH without running a command (omitting
       # `command:` is the documented install-only mode) so the plain `pulumi`
       # steps below can use it.
@@ -649,16 +716,27 @@ jobs:
       - name: Bake git build info for root container
         if: ${{ inputs.component == 'root' }}
         shell: bash
+        env:
+          # SAFE-1 (#937): production bakes the pinned pre-campaign revision,
+          # never the campaign github.sha; staging keeps the caller SHA.
+          SOURCE_REVISION: ${{ steps.release.outputs.source_revision }}
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           set -euo pipefail
           # Whitelist-sanitize: a ref name may contain characters that break a
-          # quoted Python literal; GITHUB_SHA is hex and safe as-is.
-          branch="${GITHUB_REF_NAME//[^A-Za-z0-9._\/-]/-}"
+          # quoted Python literal; a full hex SHA is safe as-is.
+          if [ "$TARGET_ENVIRONMENT" = "production" ]; then
+            baked_commit="${SOURCE_REVISION:0:7}"
+            branch="pinned-pre-campaign"
+          else
+            baked_commit="${GITHUB_SHA::7}"
+            branch="${GITHUB_REF_NAME//[^A-Za-z0-9._\/-]/-}"
+          fi
           mkdir -p apps/agent/src/animichi
           cat > apps/agent/src/animichi/build_info.py <<EOF
           """Build-time git metadata baked by CI (#494). Do not edit."""
 
-          GIT_COMMIT = "${GITHUB_SHA::7}"
+          GIT_COMMIT = "${baked_commit}"
           GIT_BRANCH = "${branch}"
           EOF
       - name: Deploy Worker
@@ -798,7 +876,9 @@ jobs:
           # run's SHA (baked by the "Bake git build info" step) — the P7
           # deploy-verification proof. `github.sha` in a workflow_call is
           # the caller's commit, i.e. exactly what the bake wrote.
-          EXPECTED_GIT_COMMIT: ${{ github.sha }}
+          # SAFE-1 (#937): production expects the PINNED pre-campaign
+          # revision (the bake wrote that), never the campaign github.sha.
+          EXPECTED_GIT_COMMIT: ${{ inputs.environment == 'production' && steps.release.outputs.source_revision || github.sha }}
           # First cold start after an image change takes minutes; base 12 →
           # sleep budget 12*(1+2+3+4)=120s plus 5×20s request timeouts ≈ 220s ceiling, still bounded.
           POST_DEPLOY_ASSERT_RETRY_BACKOFF_BASE_SECONDS: "12"

--- a/.github/workflows/reusable-deploy-component.yml
+++ b/.github/workflows/reusable-deploy-component.yml
@@ -129,14 +129,21 @@ jobs:
         env:
           TARGET_COMPONENT: ${{ inputs.component }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # All expressions arrive via env (never inlined into run) so zizmor
+          # cannot flag template injection, and values cannot reach argv.
+          CANDIDATE_SHA: ${{ github.sha }}
+          CALLER_WORKING_DIRECTORY: ${{ inputs.working_directory }}
+          CALLER_PULUMI_STACK: ${{ inputs.pulumi_stack }}
+          CALLER_BUILD_FILTER: ${{ inputs.build_filter }}
+          CALLER_RUN_PULUMI: ${{ inputs.run_pulumi }}
         run: |
           set -euo pipefail
-          verdict="$(bash .github/scripts/release-eligibility.sh "$TARGET_COMPONENT" "${{ github.sha }}")"
+          verdict="$(bash .github/scripts/release-eligibility.sh "$TARGET_COMPONENT" "$CANDIDATE_SHA")"
           # jq emits JSON literals ("true"/"false") — never Python's
           # "True"/"False" — matching the caller-side gate comparison.
           deploy="$(echo "$verdict" | jq -r .eligibility.deploy)"
           if [ "$deploy" != "true" ]; then
-            echo "::error::production ineligible: candidate ${{ github.sha }} is not the pinned pre-campaign source revision (SAFE-1). Refusing to deploy before any production mutation."
+            echo "::error::production ineligible: candidate $CANDIDATE_SHA is not the pinned pre-campaign source revision (SAFE-1). Refusing to deploy before any production mutation."
             exit 1
           fi
           # The manifest is the only authority for the production deployment
@@ -151,13 +158,13 @@ jobs:
             fi
           }
           check_matches working_directory \
-            "$(echo "$verdict" | jq -r .component.working_directory)" "${{ inputs.working_directory }}"
+            "$(echo "$verdict" | jq -r .component.working_directory)" "$CALLER_WORKING_DIRECTORY"
           check_matches pulumi_stack \
-            "$(echo "$verdict" | jq -r .component.pulumi_stack)" "${{ inputs.pulumi_stack }}"
+            "$(echo "$verdict" | jq -r .component.pulumi_stack)" "$CALLER_PULUMI_STACK"
           check_matches build_filter \
-            "$(echo "$verdict" | jq -r .component.build_filter)" "${{ inputs.build_filter }}"
+            "$(echo "$verdict" | jq -r .component.build_filter)" "$CALLER_BUILD_FILTER"
           check_matches run_pulumi \
-            "$(echo "$verdict" | jq -r .component.run_pulumi)" "${{ inputs.run_pulumi }}"
+            "$(echo "$verdict" | jq -r .component.run_pulumi)" "$CALLER_RUN_PULUMI"
           {
             echo "source_revision=$(echo "$verdict" | jq -r .source_revision)"
             echo "atlas_target=$(echo "$verdict" | jq -r .atlas.target)"

--- a/.github/workflows/reusable-post-deploy-test.yml
+++ b/.github/workflows/reusable-post-deploy-test.yml
@@ -47,6 +47,13 @@ on:
       suite:
         required: true
         type: string  # api | e2e | smoke — informational label, see header
+      # SAFE-1 (#937): production callers pass the pinned pre-campaign source
+      # revision so the /healthz git_commit assertion expects the resolved
+      # revision, never the campaign github.sha. Staging omits it (caller SHA).
+      expected_source_revision:
+        required: false
+        type: string
+        default: ""
     secrets:
       CLOUDFLARE_API_TOKEN:
         required: true
@@ -176,7 +183,9 @@ jobs:
           ROOT_URL: ${{ steps.urls.outputs.root_url }}
           STAGING_GATE_TOKEN: ${{ secrets.STAGING_GATE_TOKEN }}
           # #494: hard-assert the deployed git_commit equals this run's SHA.
-          EXPECTED_GIT_COMMIT: ${{ github.sha }}
+          # SAFE-1 (#937): production expects the pinned pre-campaign revision
+          # (production builds bake that, not the campaign github.sha).
+          EXPECTED_GIT_COMMIT: ${{ inputs.expected_source_revision != '' && inputs.expected_source_revision || github.sha }}
         run: bash .github/scripts/post-deploy-assert.sh healthz
 
       - name: "edge rejects an invalid bearer token (401; 403 showcase_denied in showcase mode)"

--- a/.github/workflows/reusable-production-eligibility.yml
+++ b/.github/workflows/reusable-production-eligibility.yml
@@ -55,8 +55,10 @@ jobs:
           # gh-api path: the manifest is read from the pinned blob id, never
           # from the checkout, so a tampered working tree cannot win.
           verdict="$(bash .github/scripts/release-eligibility.sh "$COMPONENT" "$CANDIDATE_SHA")"
-          source_revision="$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["source_revision"])')"
-          deploy="$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["eligibility"]["deploy"])')"
+          source_revision="$(echo "$verdict" | jq -r .source_revision)"
+          # jq emits JSON literals ("true"/"false"), which the gate compares
+          # against the lowercase strings — never Python's "True"/"False".
+          deploy="$(echo "$verdict" | jq -r .eligibility.deploy)"
           if [ "$deploy" = "true" ]; then
             reason="candidate $CANDIDATE_SHA matches pinned pre-campaign source $source_revision"
           else

--- a/.github/workflows/reusable-production-eligibility.yml
+++ b/.github/workflows/reusable-production-eligibility.yml
@@ -1,0 +1,70 @@
+# Reusable workflow: judge a candidate SHA against the SAFE-1 pinned
+# production manifest (called by ci.yml and deploy.yml; not triggered
+# directly). '_' prefix = internal.
+#
+# Every production entry point must route through this workflow so the
+# eligibility verdict is computed BEFORE any checkout, Atlas, Pulumi, Wrangler,
+# or rollback of production. It reads the manifest content-addressed (pinned
+# Git blob id via the GitHub API — never from the working tree), so a campaign
+# checkout that tampers with the manifest cannot influence the verdict.
+name: production-eligibility
+permissions:
+  contents: read
+on:
+  workflow_call:
+    inputs:
+      candidate_sha:
+        description: SHA to judge (caller's github.sha for push/dispatch).
+        required: true
+        type: string
+      component:
+        description: Component whose typed verdict should be reported.
+        required: true
+        type: string
+    outputs:
+      eligible:
+        description: "true when the candidate is deploy-eligible for production."
+        value: ${{ jobs.eligibility.outputs.eligible }}
+      source_revision:
+        description: Pinned pre-campaign production source revision.
+        value: ${{ jobs.eligibility.outputs.source_revision }}
+      reason:
+        description: Human-readable eligibility reason (ineligible cases).
+        value: ${{ jobs.eligibility.outputs.reason }}
+jobs:
+  eligibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      eligible: ${{ steps.verdict.outputs.eligible }}
+      source_revision: ${{ steps.verdict.outputs.source_revision }}
+      reason: ${{ steps.verdict.outputs.reason }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Resolve production eligibility
+        id: verdict
+        shell: bash
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          COMPONENT: ${{ inputs.component }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # gh-api path: the manifest is read from the pinned blob id, never
+          # from the checkout, so a tampered working tree cannot win.
+          verdict="$(bash .github/scripts/release-eligibility.sh "$COMPONENT" "$CANDIDATE_SHA")"
+          source_revision="$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["source_revision"])')"
+          deploy="$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["eligibility"]["deploy"])')"
+          if [ "$deploy" = "true" ]; then
+            reason="candidate $CANDIDATE_SHA matches pinned pre-campaign source $source_revision"
+          else
+            reason="candidate $CANDIDATE_SHA is not the pinned pre-campaign source $source_revision — campaign revisions cannot mutate production"
+          fi
+          {
+            echo "eligible=$deploy"
+            echo "source_revision=$source_revision"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice title=production eligibility::$reason"

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -31,12 +31,54 @@ jobs:
     timeout-minutes: 10
     steps:
       # SAFE-1 (#937): the caller-supplied `version_id` input is removed. The
-      # component/config mapping and rollback eligibility now resolve from the
-      # pinned production manifest (content-addressed GitHub blob — never the
-      # working tree). The manifest represents rollback as ineligible today,
-      # so every rollback stops here, before any Wrangler command; only a
-      # future owner-approved manifest revision can mark a component
-      # rollback-eligible with an exact version pair.
+      # component/config mapping and rollback eligibility resolve from the
+      # pinned production manifest — read content-addressed from the GitHub
+      # API here, WITHOUT checking out any source, so rollback-ineligible
+      # components stop before checkout, dependency install, or Wrangler. The
+      # manifest represents rollback as ineligible today, so every rollback
+      # stops at this first step; only a future owner-approved manifest
+      # revision can mark a component rollback-eligible with an exact version
+      # pair.
+      - name: Resolve manifest rollback eligibility
+        id: resolve
+        shell: bash
+        env:
+          COMPONENT: ${{ inputs.component }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PINNED_MANIFEST_BLOB_ID: 2aef389878e321ddc3d4d86922fde30ad2ab6491
+          PINNED_MANIFEST_SHA256: 1ffcfe1bf4815e0e0e890193cbfdeb28d9748f94bb98db88106000af708f536c
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          gh api "repos/${GITHUB_REPOSITORY}/git/blobs/${PINNED_MANIFEST_BLOB_ID}" \
+            --jq .content | base64 -d > "$tmp/manifest.json"
+          # Inline pinned-identity check (mirrors release-manifest-resolver.rb;
+          # the contract test asserts these pins stay in sync). Never trust a
+          # checkout copy of the manifest here.
+          actual_sha="$(shasum -a 256 "$tmp/manifest.json" | awk '{print $1}')"
+          if [ "$actual_sha" != "$PINNED_MANIFEST_SHA256" ]; then
+            echo "::error::pinned manifest SHA-256 mismatch ($actual_sha) — refusing any rollback"
+            exit 1
+          fi
+          verdict="$(COMPONENT="$COMPONENT" python3 - "$tmp/manifest.json" <<'PY'
+          import json, os, sys
+          manifest = json.load(open(sys.argv[1]))
+          comp = manifest["components"][os.environ["COMPONENT"]]
+          print(f"{comp['rollback_eligible']} {comp['working_directory']}")
+          PY
+          )"
+          eligible="${verdict%% *}"
+          directory="${verdict#* }"
+          if [ "$eligible" != "True" ] && [ "$eligible" != "true" ]; then
+            echo "::error::rollback-ineligible: the pinned SAFE-1 manifest marks component '$COMPONENT' rollback-ineligible (no approved component/version pair exists). No checkout or Wrangler rollback was attempted."
+            exit 1
+          fi
+          echo "working_directory=$directory" >> "$GITHUB_OUTPUT"
+          echo "config_flag=$([ "$COMPONENT" = "root" ] && echo '-c workers/edge/wrangler.toml' || echo '')" >> "$GITHUB_OUTPUT"
+      # Reachable only after a future owner-approved manifest marks a
+      # component rollback-eligible with an exact version pair; the current
+      # manifest cannot reach these steps.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -50,25 +92,6 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Resolve manifest rollback eligibility
-        id: resolve
-        shell: bash
-        env:
-          COMPONENT: ${{ inputs.component }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          verdict="$(bash .github/scripts/release-eligibility.sh "$COMPONENT" "${{ github.sha }}")"
-          eligible="$(echo "$verdict" | jq -r .component.rollback_eligible)"
-          if [ "$eligible" != "true" ]; then
-            echo "::error::rollback-ineligible: the pinned SAFE-1 manifest marks component '$COMPONENT' rollback-ineligible (no approved component/version pair exists). No Wrangler rollback was attempted."
-            exit 1
-          fi
-          echo "working_directory=$(echo "$verdict" | jq -r .component.working_directory)" >> "$GITHUB_OUTPUT"
-          echo "config_flag=$([ "$COMPONENT" = "root" ] && echo '-c workers/edge/wrangler.toml' || echo '')" >> "$GITHUB_OUTPUT"
-      # Reachable only after a future owner-approved manifest marks a
-      # component rollback-eligible with an exact version pair; the current
-      # manifest cannot reach these steps.
       - name: List versions
         working-directory: ${{ steps.resolve.outputs.working_directory }}
         env:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -40,6 +40,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.33.2
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Resolve manifest rollback eligibility
         id: resolve
         shell: bash
@@ -49,12 +59,12 @@ jobs:
         run: |
           set -euo pipefail
           verdict="$(bash .github/scripts/release-eligibility.sh "$COMPONENT" "${{ github.sha }}")"
-          eligible="$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["component"]["rollback_eligible"])')"
+          eligible="$(echo "$verdict" | jq -r .component.rollback_eligible)"
           if [ "$eligible" != "true" ]; then
             echo "::error::rollback-ineligible: the pinned SAFE-1 manifest marks component '$COMPONENT' rollback-ineligible (no approved component/version pair exists). No Wrangler rollback was attempted."
             exit 1
           fi
-          echo "working_directory=$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["component"]["working_directory"])')" >> "$GITHUB_OUTPUT"
+          echo "working_directory=$(echo "$verdict" | jq -r .component.working_directory)" >> "$GITHUB_OUTPUT"
           echo "config_flag=$([ "$COMPONENT" = "root" ] && echo '-c workers/edge/wrangler.toml' || echo '')" >> "$GITHUB_OUTPUT"
       # Reachable only after a future owner-approved manifest marks a
       # component rollback-eligible with an exact version pair; the current

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -13,11 +13,6 @@ on:
           - catalog
           - users
           - maintenance
-      version_id:
-        description: Worker Version ID to roll back to
-        required: false
-        default: ""
-        type: string
 
 permissions:
   contents: read
@@ -35,61 +30,43 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # SAFE-1 (#937): the caller-supplied `version_id` input is removed. The
+      # component/config mapping and rollback eligibility now resolve from the
+      # pinned production manifest (content-addressed GitHub blob — never the
+      # working tree). The manifest represents rollback as ineligible today,
+      # so every rollback stops here, before any Wrangler command; only a
+      # future owner-approved manifest revision can mark a component
+      # rollback-eligible with an exact version pair.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 10.33.2
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Resolve working directory
-        id: resolve-directory
+      - name: Resolve manifest rollback eligibility
+        id: resolve
         shell: bash
         env:
           COMPONENT: ${{ inputs.component }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # root's config moved to workers/edge/wrangler.toml (#853) while its
-          # working directory stays "." — wrangler must be pointed at it with
-          # `-c` explicitly; every other component discovers its own config
-          # in its working directory.
-          case "$COMPONENT" in
-            root) directory="."; config_flag="-c workers/edge/wrangler.toml" ;;
-            web) directory="apps/web"; config_flag="" ;;
-            catalog) directory="workers/catalog"; config_flag="" ;;
-            users) directory="workers/users"; config_flag="" ;;
-            maintenance) directory="workers/jobs"; config_flag="" ;;
-            *)
-              echo "::error::Unsupported component: $COMPONENT"
-              exit 1
-              ;;
-          esac
-          echo "working_directory=$directory" >> "$GITHUB_OUTPUT"
-          echo "config_flag=$config_flag" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          verdict="$(bash .github/scripts/release-eligibility.sh "$COMPONENT" "${{ github.sha }}")"
+          eligible="$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["component"]["rollback_eligible"])')"
+          if [ "$eligible" != "true" ]; then
+            echo "::error::rollback-ineligible: the pinned SAFE-1 manifest marks component '$COMPONENT' rollback-ineligible (no approved component/version pair exists). No Wrangler rollback was attempted."
+            exit 1
+          fi
+          echo "working_directory=$(echo "$verdict" | python3 -c 'import json,sys; print(json.load(sys.stdin)["component"]["working_directory"])')" >> "$GITHUB_OUTPUT"
+          echo "config_flag=$([ "$COMPONENT" = "root" ] && echo '-c workers/edge/wrangler.toml' || echo '')" >> "$GITHUB_OUTPUT"
+      # Reachable only after a future owner-approved manifest marks a
+      # component rollback-eligible with an exact version pair; the current
+      # manifest cannot reach these steps.
       - name: List versions
-        working-directory: ${{ steps.resolve-directory.outputs.working_directory }}
+        working-directory: ${{ steps.resolve.outputs.working_directory }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER_CONFIG_FLAG: ${{ steps.resolve-directory.outputs.config_flag }}
+          WRANGLER_CONFIG_FLAG: ${{ steps.resolve.outputs.config_flag }}
         run: |
           read -r -a config_args <<< "$WRANGLER_CONFIG_FLAG"
           pnpm exec wrangler versions list "${config_args[@]}" --env production
-      - name: Rollback
-        if: ${{ inputs.version_id != '' }}
-        working-directory: ${{ steps.resolve-directory.outputs.working_directory }}
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          VERSION_ID: ${{ inputs.version_id }}
-          WRANGLER_CONFIG_FLAG: ${{ steps.resolve-directory.outputs.config_flag }}
-        run: |
-          read -r -a config_args <<< "$WRANGLER_CONFIG_FLAG"
-          pnpm exec wrangler rollback "$VERSION_ID" "${config_args[@]}" --env production --message "manual rollback via rollback.yml" --yes
       - name: Verification reminder
-        run: echo "Rollback submitted. Verify via the URLs in docs/ops/deployment.md"
+        run: echo "Rollback resolved from the pinned manifest. Verify via the URLs in docs/ops/deployment.md"

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -6,6 +6,30 @@ The old root `DEPLOYMENT.md` compatibility pointer was removed in iter6 A6 (#640
 This file covers non-secret runtime config. For what each GitHub secret is, who consumes it,
 and rotation impact, see [`secrets.md`](./secrets.md).
 
+## SAFE-1: production freeze (2026-08-10)
+
+Every production entry point (`ci.yml` promotion, manual `deploy.yml`, and `rollback.yml`) routes
+through the SAFE-1 eligibility workflow. It resolves the immutable pre-campaign release manifest
+(`.github/release-manifests/production-pre-campaign.json`, content-addressed by pinned Git blob id
+and SHA-256) from the GitHub API — never from the working tree — and judges the candidate SHA.
+
+- **Eligible** when the candidate `github.sha` equals the pinned pre-campaign source revision
+  `b94c30ab6a519f1cce9eb0a3f7885953f8ff54cf` (Atlas target `20260809000031`). Production jobs then
+  check out that pinned revision, verify `HEAD` and `atlas.sum`, and apply Atlas with the pinned
+  target.
+- **Ineligible** otherwise: every production job is skipped (CI records the reason in the
+  `production-eligibility` job's log as a notice: "candidate <sha> is not the pinned pre-campaign
+  source <sha> — campaign revisions cannot mutate production"). The reusable deploy additionally
+  fails closed before Atlas/Pulumi/Wrangler if an ineligible caller somehow reaches it.
+- **Rollback** has no caller-supplied `version_id` anymore: eligibility resolves from the manifest,
+  and every component is rollback-ineligible until an owner-approved manifest revision marks a
+  component/version pair eligible.
+
+Operator notes: the freeze is a self-referential GitHub Actions guard — it makes ordinary campaign
+revisions technically unable to mutate production, and it cannot stop someone who deliberately
+edits the freeze's own workflows or resolver pins. Staging behavior and DAG are unchanged.
+
+
 ## Edge Topology
 
 ```text
@@ -393,19 +417,18 @@ Its current order is:
 
 1. install workspace dependencies (`pnpm install --frozen-lockfile`); there is no app build
    step — the root Worker ships as TypeScript source
-2. validate the checked-in Neon migration directory with pinned Atlas (the manual path does not
-   mutate the database)
-3. deploy the catalog Worker first, because the root Worker service binding depends on it
-4. deploy the users Worker before the root Worker, because the root `USERS` binding depends on it
-5. deploy the scheduled maintenance Worker (DSN supplied by its Secrets Store binding on
+2. deploy the catalog Worker first, because the root Worker service binding depends on it
+3. deploy the users Worker before the root Worker, because the root `USERS` binding depends on it
+4. deploy the scheduled maintenance Worker (DSN supplied by its Secrets Store binding on
    staging; GitHub-environment secret on production)
-6. verify `Dockerfile` exists
-7. deploy the root Worker/container with Wrangler
+5. verify `Dockerfile` exists
+6. deploy the root Worker/container with Wrangler
 
-The approval-gated main promotion (`reusable-deploy-component.yml`) applies `migrations/neon/` before its
-catalog/users rollout. This manual path does not apply either the Neon or frozen Supabase
-compatibility directory; an explicitly approved auth migration follows the separate Supabase
-owner/runbook and must not be used to change Neon catalog or user tables.
+The manual path runs the same `reusable-deploy-component.yml` as the CI promotion, so it applies
+`migrations/neon/` (when `NEON_DATABASE_URL` is set) exactly like the CI path — it is not a
+migration-free path. The frozen Supabase compatibility directory is never applied by either path;
+an explicitly approved auth migration follows the separate Supabase owner/runbook and must not be
+used to change Neon catalog or user tables.
 
 Do not use version tags as a deploy trigger for the current pipeline.
 

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -469,10 +469,11 @@ step itself. This is the instant-rollback side of the same versions primitive us
 
 ### CI one-command path (rollback.yml)
 
-Run a production rollback through CI with:
-`gh workflow run rollback.yml -f component=<name> -f version_id=<id>`
+SAFE-1 removed the caller-supplied `version_id` input: rollback eligibility now resolves from the
+pinned release manifest, and every component is rollback-ineligible until an owner-approved manifest
+revision marks a component/version pair eligible. Running the workflow today fails closed before any
+Wrangler command:
 
-For inspection only, use the same command without `version_id`; it lists versions only:
 `gh workflow run rollback.yml -f component=<name>`
 
 The workflow waits on the `production` environment approval and shares the prod deploy concurrency


### PR DESCRIPTION
Closes #937 (parent #936).

## What

SAFE-1 makes every deep-refactor revision technically unable to mutate production. Three phases:

**Phase B1 — immutable release manifest + narrow resolver** (`b1123695`)
- `.github/release-manifests/production-pre-campaign.json`: closed schema v1, content-addressed pin of the pre-campaign production surface (source revision `b94c30ab…`, Atlas dir/target/digest, 5 component mappings, dependencies, Wrangler config, Pulumi/build flags, secret *names* only).
- `.github/scripts/release-manifest-resolver.rb`: validates every field, rejects unknown fields/components, validates full SHAs/digests, hard-pins file SHA-256 + Git blob id (altering any field while keeping pinned identities fails closed), emits typed public outputs.
- 22 behavioral tests.

**Phase B2 — wire all production entry points** (`dc7f728d`)
- `reusable-production-eligibility.yml`: judges the candidate SHA against the pinned manifest (GitHub-API blob read, never the working tree).
- `ci.yml` / `deploy.yml`: `production-eligibility` job; all five deploy jobs + post-prod gate on `eligible == 'true'`; post-prod smokes expect the resolved revision.
- `rollback.yml`: caller-supplied `version_id` removed; eligibility resolves from the manifest; all components rollback-ineligible today → stops before any Wrangler command.
- `reusable-deploy-component.yml`: production resolves the manifest, detaches onto the pinned revision, verifies HEAD + `atlas.sum`, applies Atlas `--to-version` pinned target, bakes the pinned revision, expects it in smokes. Staging unchanged.
- `reusable-post-deploy-test.yml`: optional `expected_source_revision`.

**Phase B3 — docs + invariant closure** (`6b1daa56`)
- `docs/ops/deployment.md`: corrected stale "manual path does not mutate the database" claim; added SAFE-1 freeze section.
- `pipeline-quality.yml`: SAFE-1 contract + resolver/eligibility self-tests wired into the unfiltered Quality / invariants lane.

## Evidence

- Mutations killed (red → green): removing the eligibility gate from a production job; restoring caller-supplied rollback `version_id`; restoring unconditional `github.sha` smoke expectations.
- Gates: resolver tests (22), eligibility tests (6), SAFE-1 contract, CI contract, workflow invariants (+ tests), config read sets, deploy model env consistency, jobs worker tests, actionlint, `git diff --check`.
- `make check`: 152 passed, 22 skipped, 1 failed — `test_cluster_version_allows_one_current_per_work` (`work_id` UndefinedColumn), **reproduced on untouched base `b94c30ab`** (PREEXISTING_FAIL per GATES-AND-EVIDENCE §3.4; documented before this card).
- Live inventory: only root production Worker `animichi` exists; manifest represents rollback as ineligible (SAFE-1 §3).

## Notes

- No production operation was executed during verification.
- Freeze is a self-referential Actions guard: stops ordinary campaign revisions; cannot stop deliberate edits to the freeze's own workflows/pins (documented in runbook).
- Existing upstream staging deploy fix `fix/root-secrets-upload` (`f72e779b`) intentionally NOT absorbed here (WORKSPACE-BASELINE rule 3 — later CI/CD campaign).

## Summary by Sourcery

Introduce a SAFE-1 production freeze that routes all production entry points through a pinned, immutable release manifest and eligibility gate so only the pre-campaign revision can mutate production.

New Features:
- Add a reusable production eligibility workflow that evaluates candidate SHAs against a content-addressed production release manifest and exposes typed eligibility outputs.
- Wire production deploy, manual deploy, rollback, and post-deploy smoke workflows to use the eligibility gate and the resolved pinned source revision.
- Introduce a release manifest resolver and eligibility script that validate a closed-schema manifest, enforce pinned identities, and emit typed component/eligibility metadata.

Enhancements:
- Update reusable deploy, rollback, and post-deploy workflows so production resolves and checks out the pinned pre-campaign revision, applies the pinned Atlas target, bakes the pinned commit, and bases health checks on the resolved revision.
- Remove manual rollback version IDs in favor of manifest-driven rollback eligibility, currently making all components rollback-ineligible until explicitly approved.
- Add SAFE-1 production freeze documentation and wire resolver, eligibility, and contract self-tests into the unfiltered pipeline-quality lane to guard CI and workflow invariants.

Documentation:
- Document the SAFE-1 production freeze, aligning manual and CI deploy semantics and clarifying that the manual path now runs the same migration behavior as CI.

Tests:
- Add behavioral tests for the release manifest resolver and eligibility scripts plus a SAFE-1 production contract test to ensure all production entry points honor the freeze and pinned manifest semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added production release eligibility checks using a pinned release manifest.
  * Production deployments now verify the approved source revision and migration target before proceeding.
  * Rollbacks now require manifest-approved eligibility and no longer accept arbitrary version IDs.
  * Post-deployment checks validate the deployed revision.

* **Documentation**
  * Updated deployment guidance for production freezes, approved releases, migrations, and rollbacks.

* **Tests**
  * Added automated coverage for release validation, deployment contracts, manifest integrity, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->